### PR TITLE
feat(telegram): stream lossless audio from Telegram channels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,20 @@ the fork invariants below — especially when merging upstream changes.
    through `resolveMultiSourceDataSpec` in
    `playback/MusicService.kt` — YouTube is the final fallback. Do not rewire
    playback around this.
-3. **Fork CI signing patch** — workflows sign with the committed
+3. **Telegram channel streaming** —
+   `app/src/main/kotlin/moe/rukamori/archivetune/telegram/` (`TelegramClient`
+   TDLib wrapper, `TelegramDataSource` Media3 streaming source, media-id codec
+   + models), UI `ui/screens/TelegramBrowseScreen.kt` +
+   `ui/screens/settings/TelegramSettings.kt` + `TelegramLoginScreen.kt`.
+   Playback is routed by the `telegram://` scheme branch in `MusicService`'s
+   `SchemeRoutingDataSource` (independent of the multi-source resolver chain).
+   Depends on the prebuilt TDLib AAR `com.github.tdlibx:td` (JitPack group
+   allow-listed in `settings.gradle.kts`).
+4. **Fork CI signing patch** — workflows sign with the committed
    `app/persistent-debug.keystore` when the `KEYSTORE` secret is absent
    (forks have no release keystore). Upstream's workflows must not overwrite
    this logic (see `build.yml`, `release.yml`).
-4. **Protected files** — `Koiverse.jks`, `Koiverse.jks.base64`,
+5. **Protected files** — `Koiverse.jks`, `Koiverse.jks.base64`,
    `ArchiveTuneKoiverseServer.txt`, `DataServer.txt`, and the `applicationId`
    (`moe.rukamori.archivetune`) in `app/build.gradle.kts` are fork-identity
    files: do not adopt upstream changes to them without explicit instruction.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -437,6 +437,10 @@ dependencies {
     add("gmsImplementation", libs.mediarouter)
     implementation(libs.squigglyslider)
 
+    // Prebuilt TDLib (Telegram MTProto client) with bundled JNI natives for all ABIs.
+    // Powers the Telegram channel lossless-streaming integration (telegram/ package).
+    implementation("com.github.tdlibx:td:1.8.56")
+
 
     implementation(libs.room.runtime)
     implementation(libs.kuromoji.ipadic)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -157,3 +157,7 @@
 
 # engine HTTP Android/OkHttp Ktor
 -dontwarn kotlinx.coroutines.**
+
+# TDLib (Telegram) — JNI bridges into these classes by reflection; must not be renamed/stripped
+-keep class org.drinkless.tdlib.** { *; }
+-dontwarn org.drinkless.tdlib.**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -890,6 +890,23 @@ fun QobuzAudioQuality.toFormatId(): Int =
     }
 
 // ---------------------------------------------------------------------------
+// Telegram channel streaming integration
+// ---------------------------------------------------------------------------
+// Streams audio files (lossless-first) directly from Telegram channels via TDLib. The user logs in
+// with their own Telegram account (phone + code + optional 2FA password) and their own API
+// credentials from https://my.telegram.org — the app never bundles Telegram API keys. Session
+// state itself lives in TDLib's encrypted database under filesDir; these keys only hold the API
+// credentials and display metadata.
+val TelegramApiIdKey = stringPreferencesKey("telegramApiId")
+val TelegramApiHashKey = stringPreferencesKey("telegramApiHash")
+val TelegramAccountNameKey = stringPreferencesKey("telegramAccountName")
+val TelegramAccountPhoneKey = stringPreferencesKey("telegramAccountPhone")
+
+// When ON (default) the channel browser only lists lossless files (FLAC/WAV/AIFF/APE/ALAC/…);
+// when OFF every audio message and audio-typed document in the channel is shown.
+val TelegramLosslessOnlyKey = booleanPreferencesKey("telegramLosslessOnly")
+
+// ---------------------------------------------------------------------------
 // Multi-source audio framework
 // ---------------------------------------------------------------------------
 // A configurable set of lossless/stream sources. The user can reorder them (priority for playback

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MediaLibrarySessionCallback.kt
@@ -69,6 +69,7 @@ import moe.rukamori.archivetune.spotify.SpotifyMapper
 import moe.rukamori.archivetune.spotify.SpotifyPlaybackResolver
 import moe.rukamori.archivetune.utils.dataStore
 import moe.rukamori.archivetune.utils.get
+import moe.rukamori.archivetune.telegram.isTelegramMediaId
 import moe.rukamori.archivetune.utils.isLocalMediaId
 import java.io.ObjectInputStream
 import java.text.Collator
@@ -1391,7 +1392,10 @@ class MediaLibrarySessionCallback
                                     playlistEntity.isEditable &&
                                     currentSongId != null &&
                                     database.checkInPlaylist(playlistId, currentSongId) == 0 &&
-                                    (playlistEntity.browseId == null || !currentSongId.isLocalMediaId())
+                                    (
+                                        playlistEntity.browseId == null ||
+                                            !(currentSongId.isLocalMediaId() || currentSongId.isTelegramMediaId())
+                                    )
                             if (canAddCurrentSong) {
                                 add(
                                     queueMediaItem(
@@ -1827,7 +1831,7 @@ class MediaLibrarySessionCallback
                 val browseId = playlist.playlist.browseId
                 val setVideoId =
                     if (browseId != null) {
-                        if (songId.isLocalMediaId()) return@withContext false
+                        if (songId.isLocalMediaId() || songId.isTelegramMediaId()) return@withContext false
                         YouTube.addToPlaylist(browseId, songId).getOrNull() ?: return@withContext false
                     } else {
                         null

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -292,6 +292,8 @@ import moe.rukamori.archivetune.utils.dataStore
 import moe.rukamori.archivetune.utils.enumPreference
 import moe.rukamori.archivetune.utils.get
 import moe.rukamori.archivetune.utils.getAsync
+import moe.rukamori.archivetune.telegram.TelegramDataSource
+import moe.rukamori.archivetune.telegram.isTelegramMediaId
 import moe.rukamori.archivetune.utils.isLocalMediaId
 import moe.rukamori.archivetune.utils.isLowDataModeActive
 import moe.rukamori.archivetune.utils.reportException
@@ -4146,7 +4148,10 @@ class MusicService :
 
         val currentIndex = player.currentMediaItemIndex
         val currentMediaId = currentMediaMetadata.id
-        if (currentSong.value?.song?.isLocal == true || currentMediaId.isLocalMediaId()) {
+        if (currentSong.value?.song?.isLocal == true ||
+            currentMediaId.isLocalMediaId() ||
+            currentMediaId.isTelegramMediaId()
+        ) {
             return
         }
 
@@ -7475,11 +7480,13 @@ class MusicService :
                 )
             }
         val directFactory = createResolvedUpstreamDataSourceFactory()
+        val telegramFactory = TelegramDataSource.Factory()
 
         return DataSource.Factory {
             SchemeRoutingDataSource(
                 cachedFactory = cachedFactory,
                 directFactory = directFactory,
+                telegramFactory = telegramFactory,
             )
         }
     }
@@ -7672,8 +7679,8 @@ class MusicService :
         mediaId: String,
         lowDataModeActive: Boolean,
     ): DataSpec? {
-        if (mediaId.isLocalMediaId()) {
-            Timber.tag("MusicService").d("Multi-source skip: %s is a local media id", mediaId)
+        if (mediaId.isLocalMediaId() || mediaId.isTelegramMediaId()) {
+            Timber.tag("MusicService").d("Multi-source skip: %s is a local/telegram media id", mediaId)
             return null
         }
         // A per-song "play from" override (set via the player's Source chooser) takes precedence over
@@ -8701,6 +8708,7 @@ class MusicService :
         return normalizedScheme == "content" ||
             normalizedScheme == "file" ||
             normalizedScheme == "android.resource" ||
+            normalizedScheme == "telegram" ||
             normalizedScheme == "http" ||
             normalizedScheme == "https"
     }
@@ -8709,7 +8717,8 @@ class MusicService :
         val normalizedScheme = scheme?.lowercase(Locale.US)
         return normalizedScheme == "content" ||
             normalizedScheme == "file" ||
-            normalizedScheme == "android.resource"
+            normalizedScheme == "android.resource" ||
+            normalizedScheme == "telegram"
     }
 
     private fun deviceSupportsMimeType(mimeType: String): Boolean =
@@ -8729,6 +8738,7 @@ class MusicService :
     private class SchemeRoutingDataSource(
         private val cachedFactory: DataSource.Factory,
         private val directFactory: DataSource.Factory,
+        private val telegramFactory: DataSource.Factory,
     ) : DataSource {
         private val transferListeners = mutableListOf<TransferListener>()
         private var delegate: DataSource? = null
@@ -8741,7 +8751,11 @@ class MusicService :
         override fun open(dataSpec: DataSpec): Long {
             val normalizedScheme = dataSpec.uri.scheme?.lowercase(Locale.US)
             val selectedFactory =
-                if (
+                if (normalizedScheme == "telegram") {
+                    // Telegram tracks stream through TDLib's own partial-file cache; Media3's
+                    // caches and the YouTube resolver chain must both stay out of the way.
+                    telegramFactory
+                } else if (
                     normalizedScheme == "content" ||
                     normalizedScheme == "file" ||
                     normalizedScheme == "android.resource"
@@ -9036,6 +9050,7 @@ class MusicService :
     private fun String?.isRemotePresenceId(): Boolean {
         val id = this?.trim()?.takeIf { it.isNotBlank() } ?: return false
         return !id.isLocalMediaId() &&
+            !id.isTelegramMediaId() &&
             !id.startsWith("LOCAL_ARTIST_") &&
             !id.startsWith("LA") &&
             !id.contains("privately_owned_artist", ignoreCase = true)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
@@ -1,0 +1,468 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Singleton wrapper around TDLib (org.drinkless.tdlib) that powers the Telegram channel streaming
+ * integration: account login (phone → code → optional 2FA password), public channel search,
+ * paging through a channel's audio/document messages, and partial-file access for streaming
+ * playback (see TelegramDataSource).
+ *
+ * The user supplies their own api_id/api_hash from https://my.telegram.org (stored in DataStore);
+ * the actual session lives in TDLib's own database under filesDir/telegram and survives restarts,
+ * so login is a one-time flow.
+ */
+
+package moe.rukamori.archivetune.telegram
+
+import android.content.Context
+import android.os.Build
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import moe.rukamori.archivetune.BuildConfig
+import moe.rukamori.archivetune.constants.TelegramApiHashKey
+import moe.rukamori.archivetune.constants.TelegramApiIdKey
+import moe.rukamori.archivetune.utils.dataStore
+import moe.rukamori.archivetune.utils.get
+import org.drinkless.tdlib.Client
+import org.drinkless.tdlib.TdApi
+import timber.log.Timber
+import java.io.File
+import java.io.IOException
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/** Authorization progress of the Telegram session, driven by TDLib's UpdateAuthorizationState. */
+sealed interface TelegramAuthState {
+    /** No TDLib client running (missing API credentials, or the session was closed). */
+    data object Idle : TelegramAuthState
+
+    /** Client created, waiting for TDLib to report the first authorization state. */
+    data object Connecting : TelegramAuthState
+
+    data object WaitPhoneNumber : TelegramAuthState
+
+    data class WaitCode(
+        val phoneNumber: String,
+    ) : TelegramAuthState
+
+    data class WaitPassword(
+        val passwordHint: String?,
+    ) : TelegramAuthState
+
+    data object Ready : TelegramAuthState
+
+    data object LoggingOut : TelegramAuthState
+
+    /** A TDLib auth state this integration doesn't implement (QR login, registration, …). */
+    data class Unsupported(
+        val stateName: String,
+    ) : TelegramAuthState
+}
+
+class TelegramApiException(
+    val code: Int,
+    message: String,
+) : IOException("Telegram error $code: $message")
+
+object TelegramClient {
+    private const val TAG = "TelegramClient"
+
+    /** TDLib download priority for actively-playing streams (1..32, higher = sooner). */
+    const val STREAM_DOWNLOAD_PRIORITY = 32
+
+    private val lock = Any()
+
+    @Volatile
+    private var client: Client? = null
+
+    @Volatile
+    private var appContext: Context? = null
+
+    private val _authState = MutableStateFlow<TelegramAuthState>(TelegramAuthState.Idle)
+    val authState: StateFlow<TelegramAuthState> = _authState.asStateFlow()
+
+    /** Chats TDLib has pushed via UpdateNewChat, so channel lookups avoid extra round trips. */
+    private val chatCache = ConcurrentHashMap<Long, TdApi.Chat>()
+
+    val isReady: Boolean
+        get() = _authState.value is TelegramAuthState.Ready
+
+    fun hasCredentials(context: Context): Boolean {
+        val store = context.applicationContext.dataStore
+        val apiId = store.get(TelegramApiIdKey, "").trim().toIntOrNull() ?: 0
+        val apiHash = store.get(TelegramApiHashKey, "").trim()
+        return apiId > 0 && apiHash.isNotEmpty()
+    }
+
+    /**
+     * Starts the TDLib client if it isn't running yet. Safe to call from any thread; returns false
+     * when API credentials are missing. The authorization flow then advances via [authState].
+     */
+    fun ensureStarted(context: Context): Boolean {
+        val ctx = context.applicationContext
+        synchronized(lock) {
+            if (client != null) return true
+            if (!hasCredentials(ctx)) return false
+            appContext = ctx
+            runCatching { Client.execute(TdApi.SetLogVerbosityLevel(1)) }
+            _authState.value = TelegramAuthState.Connecting
+            client =
+                Client.create(
+                    { update -> onUpdate(update) },
+                    { throwable -> Timber.tag(TAG).e(throwable, "TDLib update handler exception") },
+                    { throwable -> Timber.tag(TAG).e(throwable, "TDLib exception") },
+                )
+            return true
+        }
+    }
+
+    /**
+     * Stops the client and wipes the on-device Telegram session (TDLib LogOut deletes its own
+     * database). API credentials in DataStore are left untouched.
+     */
+    suspend fun logOut() {
+        runCatching { send(TdApi.LogOut()) }
+            .onFailure { Timber.tag(TAG).w(it, "logOut failed") }
+    }
+
+    /** Restarts the client after API credentials change. */
+    fun restart(context: Context) {
+        val currentClient = synchronized(lock) { client }
+        if (currentClient != null) {
+            currentClient.send(TdApi.Close()) { }
+        }
+        // The Closed auth state resets `client`; ensureStarted picks the new credentials up
+        // lazily on the next call. Nothing else to do here.
+        ensureStarted(context)
+    }
+
+    // ------------------------------------------------------------------
+    // Auth flow
+    // ------------------------------------------------------------------
+
+    suspend fun submitPhoneNumber(phoneNumber: String) {
+        send(TdApi.SetAuthenticationPhoneNumber(phoneNumber.trim(), null))
+    }
+
+    suspend fun submitCode(code: String) {
+        send(TdApi.CheckAuthenticationCode(code.trim()))
+    }
+
+    suspend fun submitPassword(password: String) {
+        send(TdApi.CheckAuthenticationPassword(password))
+    }
+
+    suspend fun resendCode() {
+        send(TdApi.ResendAuthenticationCode(null))
+    }
+
+    suspend fun getMe(): TdApi.User = send(TdApi.GetMe())
+
+    // ------------------------------------------------------------------
+    // Channel search + audio listing
+    // ------------------------------------------------------------------
+
+    /**
+     * Searches public chats and keeps only channels/supergroups. Accepts plain queries, @usernames
+     * and t.me links.
+     */
+    suspend fun searchChannels(query: String): List<TelegramChannel> {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) return emptyList()
+
+        val chatIds = linkedSetOf<Long>()
+
+        // Exact username / t.me link lookup first so pasting a link always works.
+        extractUsername(trimmed)?.let { username ->
+            runCatching { send(TdApi.SearchPublicChat(username)) }
+                .onSuccess { chatIds += it.id }
+        }
+        runCatching { send(TdApi.SearchPublicChats(trimmed)) }
+            .onSuccess { chatIds += it.chatIds.toList() }
+
+        return chatIds.mapNotNull { chatId ->
+            runCatching { toChannel(getChat(chatId)) }.getOrNull()
+        }
+    }
+
+    suspend fun getChat(chatId: Long): TdApi.Chat = chatCache[chatId] ?: send(TdApi.GetChat(chatId))
+
+    suspend fun channelInfo(chatId: Long): TelegramChannel? =
+        runCatching { toChannel(getChat(chatId)) }.getOrNull()
+
+    /**
+     * Fetches one page of a channel's audio files. Audio messages and (optionally) audio-typed
+     * document messages are two separate TDLib filters, so both are queried and merged newest
+     * first; the cursors advance independently.
+     */
+    suspend fun fetchAudioPage(
+        chatId: Long,
+        fromMessageId: Long,
+        limit: Int,
+        filter: TdApi.SearchMessagesFilter,
+    ): TelegramAudioPage {
+        val found =
+            send(
+                TdApi.SearchChatMessages(
+                    chatId,
+                    null,
+                    "",
+                    null,
+                    fromMessageId,
+                    0,
+                    limit,
+                    filter,
+                ),
+            )
+        return TelegramAudioPage(
+            tracks = found.messages.mapNotNull(::messageToTrack),
+            nextFromMessageId = found.nextFromMessageId,
+        )
+    }
+
+    fun messageToTrack(message: TdApi.Message): TelegramTrack? =
+        when (val content = message.content) {
+            is TdApi.MessageAudio -> {
+                val audio = content.audio
+                TelegramTrack(
+                    chatId = message.chatId,
+                    messageId = message.id,
+                    fileId = audio.audio.id,
+                    fileUniqueId = audio.audio.remote?.uniqueId.orEmpty(),
+                    title = audio.title.orEmpty(),
+                    performer = audio.performer?.takeIf(String::isNotBlank),
+                    fileName = audio.fileName.orEmpty(),
+                    mimeType = audio.mimeType.orEmpty(),
+                    durationSeconds = audio.duration,
+                    sizeBytes = audio.audio.size,
+                    dateSeconds = message.date,
+                    albumCoverMinithumbnail = audio.albumCoverMinithumbnail?.data,
+                )
+            }
+
+            is TdApi.MessageDocument -> {
+                val document = content.document
+                val fileName = document.fileName.orEmpty()
+                val mimeType = document.mimeType.orEmpty()
+                if (!isAudioDocument(mimeType, fileName)) {
+                    null
+                } else {
+                    TelegramTrack(
+                        chatId = message.chatId,
+                        messageId = message.id,
+                        fileId = document.document.id,
+                        fileUniqueId = document.document.remote?.uniqueId.orEmpty(),
+                        title = "",
+                        performer = null,
+                        fileName = fileName,
+                        mimeType = mimeType,
+                        durationSeconds = 0,
+                        sizeBytes = document.document.size,
+                        dateSeconds = message.date,
+                        albumCoverMinithumbnail = document.minithumbnail?.data,
+                    )
+                }
+            }
+
+            else -> null
+        }
+
+    // ------------------------------------------------------------------
+    // File access (streaming)
+    // ------------------------------------------------------------------
+
+    suspend fun getFile(fileId: Int): TdApi.File = send(TdApi.GetFile(fileId))
+
+    /**
+     * Re-resolves a track's file id from its message, for when a stored file id has gone stale
+     * (TDLib file ids are only valid per database generation).
+     */
+    suspend fun resolveTrackFile(
+        chatId: Long,
+        messageId: Long,
+    ): TdApi.File? {
+        runCatching { getChat(chatId) }
+        val message = runCatching { send(TdApi.GetMessage(chatId, messageId)) }.getOrNull() ?: return null
+        return when (val content = message.content) {
+            is TdApi.MessageAudio -> content.audio.audio
+            is TdApi.MessageDocument -> content.document.document
+            else -> null
+        }
+    }
+
+    suspend fun startDownload(
+        fileId: Int,
+        offset: Long,
+    ): TdApi.File =
+        send(
+            TdApi.DownloadFile(fileId, STREAM_DOWNLOAD_PRIORITY, offset, 0L, false),
+        )
+
+    suspend fun cancelDownload(fileId: Int) {
+        runCatching { send(TdApi.CancelDownloadFile(fileId, false)) }
+    }
+
+    suspend fun readFilePart(
+        fileId: Int,
+        offset: Long,
+        count: Long,
+    ): ByteArray = send(TdApi.ReadFilePart(fileId, offset, count)).data
+
+    /**
+     * Writes an inline album-cover minithumbnail to the cache dir and returns a file:// URI usable
+     * as artwork, or null when unavailable. Minithumbnails are tiny embedded JPEGs, so this is
+     * cheap enough to run while building a play queue.
+     */
+    fun cacheArtwork(
+        uniqueKey: String,
+        data: ByteArray?,
+    ): String? {
+        if (data == null || data.isEmpty()) return null
+        val context = appContext ?: return null
+        return runCatching {
+            val dir = File(context.cacheDir, "telegram_artwork").apply { mkdirs() }
+            val safeKey = uniqueKey.replace(Regex("[^A-Za-z0-9_-]"), "_")
+            val file = File(dir, "$safeKey.jpg")
+            if (!file.exists()) {
+                file.writeBytes(data)
+            }
+            "file://${file.absolutePath}"
+        }.getOrNull()
+    }
+
+    // ------------------------------------------------------------------
+    // Internals
+    // ------------------------------------------------------------------
+
+    suspend fun <T : TdApi.Object> send(function: TdApi.Function<T>): T {
+        val currentClient =
+            client ?: throw IOException("Telegram client is not running")
+        return suspendCancellableCoroutine { continuation ->
+            currentClient.send(function) { result ->
+                when (result) {
+                    is TdApi.Error ->
+                        continuation.resumeWithException(
+                            TelegramApiException(result.code, result.message),
+                        )
+
+                    else -> {
+                        @Suppress("UNCHECKED_CAST")
+                        continuation.resume(result as T)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onUpdate(update: TdApi.Object) {
+        when (update) {
+            is TdApi.UpdateAuthorizationState -> handleAuthorizationState(update.authorizationState)
+            is TdApi.UpdateNewChat -> chatCache[update.chat.id] = update.chat
+            is TdApi.UpdateChatTitle -> chatCache[update.chatId]?.title = update.title
+            is TdApi.UpdateChatPhoto -> chatCache[update.chatId]?.photo = update.photo
+        }
+    }
+
+    private fun handleAuthorizationState(state: TdApi.AuthorizationState) {
+        when (state) {
+            is TdApi.AuthorizationStateWaitTdlibParameters -> sendTdlibParameters()
+            is TdApi.AuthorizationStateWaitPhoneNumber -> _authState.value = TelegramAuthState.WaitPhoneNumber
+            is TdApi.AuthorizationStateWaitCode ->
+                _authState.value =
+                    TelegramAuthState.WaitCode(state.codeInfo?.phoneNumber.orEmpty())
+
+            is TdApi.AuthorizationStateWaitPassword ->
+                _authState.value =
+                    TelegramAuthState.WaitPassword(state.passwordHint?.takeIf(String::isNotBlank))
+
+            is TdApi.AuthorizationStateReady -> _authState.value = TelegramAuthState.Ready
+            is TdApi.AuthorizationStateLoggingOut -> _authState.value = TelegramAuthState.LoggingOut
+            is TdApi.AuthorizationStateClosed -> {
+                synchronized(lock) { client = null }
+                chatCache.clear()
+                _authState.value = TelegramAuthState.Idle
+            }
+
+            else -> _authState.value = TelegramAuthState.Unsupported(state.javaClass.simpleName)
+        }
+    }
+
+    private fun sendTdlibParameters() {
+        val context = appContext ?: return
+        val store = context.dataStore
+        val apiId = store.get(TelegramApiIdKey, "").trim().toIntOrNull() ?: 0
+        val apiHash = store.get(TelegramApiHashKey, "").trim()
+        val baseDir = File(context.filesDir, "telegram")
+        val parameters =
+            TdApi.SetTdlibParameters(
+                false,
+                File(baseDir, "db").absolutePath,
+                File(baseDir, "files").absolutePath,
+                ByteArray(0),
+                true,
+                true,
+                true,
+                false,
+                apiId,
+                apiHash,
+                Locale.getDefault().language.ifBlank { "en" },
+                Build.MODEL ?: "Android",
+                Build.VERSION.RELEASE ?: "0",
+                BuildConfig.VERSION_NAME,
+            )
+        client?.send(parameters) { result ->
+            if (result is TdApi.Error) {
+                Timber.tag(TAG).e("SetTdlibParameters failed: %s", result.message)
+                _authState.value = TelegramAuthState.Unsupported("InvalidApiCredentials")
+            }
+        }
+    }
+
+    private suspend fun toChannel(chat: TdApi.Chat): TelegramChannel? {
+        val type = chat.type as? TdApi.ChatTypeSupergroup ?: return null
+        val supergroup = runCatching { chatSupergroup(type.supergroupId) }.getOrNull()
+        return TelegramChannel(
+            chatId = chat.id,
+            title = chat.title,
+            username = supergroup?.username,
+            memberCount = supergroup?.memberCount ?: 0,
+            isBroadcastChannel = type.isChannel,
+            photoMinithumbnail = chat.photo?.minithumbnail?.data,
+        )
+    }
+
+    private data class SupergroupInfo(
+        val username: String?,
+        val memberCount: Int,
+    )
+
+    private suspend fun chatSupergroup(supergroupId: Long): SupergroupInfo {
+        val supergroup = send(TdApi.GetSupergroup(supergroupId))
+        val username =
+            supergroup.usernames
+                ?.activeUsernames
+                ?.firstOrNull()
+                ?.takeIf(String::isNotBlank)
+        return SupergroupInfo(username = username, memberCount = supergroup.memberCount)
+    }
+
+    private fun extractUsername(query: String): String? {
+        val trimmed = query.trim()
+        val fromLink =
+            Regex("(?:https?://)?t(?:elegram)?\\.me/([A-Za-z0-9_]{3,})", RegexOption.IGNORE_CASE)
+                .find(trimmed)
+                ?.groupValues
+                ?.get(1)
+        if (fromLink != null) return fromLink
+        if (trimmed.startsWith("@")) {
+            return trimmed.removePrefix("@").takeIf { it.matches(Regex("[A-Za-z0-9_]{3,}")) }
+        }
+        return null
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramDataSource.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramDataSource.kt
@@ -1,0 +1,219 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Media3 DataSource that streams a Telegram file through TDLib's partial-download cache.
+ * open() kicks off (or re-targets) a download at the requested byte offset; read() serves bytes
+ * out of the already-downloaded prefix via ReadFilePart, waiting for the download to catch up
+ * when the player reads faster than the network. Seeking simply re-opens the source at the new
+ * position, which TDLib translates into a new download offset — so FLAC seeking works without
+ * waiting for the whole file.
+ *
+ * TDLib keeps the partial file in its own cache, so pause/resume and replays don't re-download.
+ */
+
+package moe.rukamori.archivetune.telegram
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.drinkless.tdlib.TdApi
+import timber.log.Timber
+import java.io.IOException
+
+class TelegramDataSource : BaseDataSource(true) {
+    private var currentUri: Uri? = null
+    private var mediaId: TelegramMediaId? = null
+    private var fileId: Int = 0
+    private var fileSize: Long = 0
+    private var position: Long = 0
+    private var bytesRemaining: Long = C.LENGTH_UNSET.toLong()
+    private var opened = false
+
+    override fun open(dataSpec: DataSpec): Long {
+        val decoded =
+            TelegramMediaId.decode(dataSpec.uri.toString())
+                ?: throw IOException("Not a Telegram media id: ${dataSpec.uri}")
+        if (!TelegramClient.isReady) {
+            throw IOException("Telegram is not logged in")
+        }
+        currentUri = dataSpec.uri
+        mediaId = decoded
+        transferInitializing(dataSpec)
+
+        val file =
+            runBlocking {
+                resolveFile(decoded)
+            } ?: throw IOException("Telegram file unavailable for ${dataSpec.uri}")
+        fileId = file.id
+        fileSize = if (file.size > 0) file.size else file.expectedSize
+        position = dataSpec.position
+
+        if (fileSize in 1 until position) {
+            throw IOException("Position $position beyond Telegram file size $fileSize")
+        }
+
+        runBlocking {
+            ensureDownloading(position)
+        }
+
+        bytesRemaining =
+            when {
+                dataSpec.length != C.LENGTH_UNSET.toLong() -> dataSpec.length
+                fileSize > 0 -> fileSize - position
+                else -> C.LENGTH_UNSET.toLong()
+            }
+        opened = true
+        transferStarted(dataSpec)
+        return bytesRemaining
+    }
+
+    override fun read(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Int {
+        if (length == 0) return 0
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+
+        var toRead = length.toLong()
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) {
+            toRead = minOf(toRead, bytesRemaining)
+        }
+        if (fileSize > 0) {
+            val untilEof = fileSize - position
+            if (untilEof <= 0) return C.RESULT_END_OF_INPUT
+            toRead = minOf(toRead, untilEof)
+        }
+
+        val data =
+            try {
+                runBlocking {
+                    withTimeout(READ_TIMEOUT_MS) {
+                        awaitAndRead(position, toRead)
+                    }
+                }
+            } catch (e: Exception) {
+                throw IOException("Telegram stream read failed at $position", e)
+            }
+
+        if (data.isEmpty()) {
+            return if (fileSize > 0 && position >= fileSize) C.RESULT_END_OF_INPUT else 0
+        }
+
+        System.arraycopy(data, 0, buffer, offset, data.size)
+        position += data.size
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) {
+            bytesRemaining -= data.size
+        }
+        bytesTransferred(data.size)
+        return data.size
+    }
+
+    override fun getUri(): Uri? = currentUri
+
+    override fun close() {
+        if (opened) {
+            opened = false
+            transferEnded()
+            val id = fileId
+            runBlocking {
+                // Stop pulling data once the player lets go of the stream; the partial file stays
+                // in TDLib's cache, so resuming later picks up where this left off.
+                TelegramClient.cancelDownload(id)
+            }
+        }
+        currentUri = null
+        mediaId = null
+        fileId = 0
+        fileSize = 0
+        position = 0
+        bytesRemaining = C.LENGTH_UNSET.toLong()
+    }
+
+    /**
+     * Looks the file up by its stored TDLib file id, falling back to re-resolving the original
+     * channel message when the id has gone stale (file ids don't survive TDLib database rebuilds).
+     */
+    private suspend fun resolveFile(decoded: TelegramMediaId): TdApi.File? {
+        runCatching { TelegramClient.getFile(decoded.fileId) }
+            .onSuccess { file ->
+                if (decoded.fileUniqueId.isEmpty() || file.remote?.uniqueId == decoded.fileUniqueId) {
+                    return file
+                }
+            }
+        Timber.tag(TAG).i(
+            "Stale Telegram file id %d, re-resolving message %d in chat %d",
+            decoded.fileId,
+            decoded.messageId,
+            decoded.chatId,
+        )
+        return TelegramClient.resolveTrackFile(decoded.chatId, decoded.messageId)
+    }
+
+    private suspend fun ensureDownloading(offset: Long) {
+        val file = TelegramClient.getFile(fileId)
+        val local = file.local
+        if (local.isDownloadingCompleted) return
+        val covered =
+            local.downloadOffset <= offset &&
+                local.downloadOffset + local.downloadedPrefixSize > offset
+        if (!local.isDownloadingActive || !covered) {
+            TelegramClient.startDownload(fileId, offset)
+        }
+    }
+
+    /**
+     * Waits until [count] bytes at [offset] are present in TDLib's partial download, then reads
+     * them. Returns fewer bytes near EOF; the overall wait is bounded by the caller's timeout.
+     */
+    private suspend fun awaitAndRead(
+        offset: Long,
+        count: Long,
+    ): ByteArray {
+        while (true) {
+            val file = TelegramClient.getFile(fileId)
+            val local = file.local
+            if (file.size > 0) {
+                fileSize = file.size
+            }
+            var wanted = count
+            if (fileSize > 0) {
+                val untilEof = fileSize - offset
+                if (untilEof <= 0) return ByteArray(0)
+                wanted = minOf(wanted, untilEof)
+            }
+            val end = offset + wanted
+            val available =
+                local.isDownloadingCompleted ||
+                    (
+                        local.downloadOffset <= offset &&
+                            local.downloadOffset + local.downloadedPrefixSize >= end
+                    )
+            if (available) {
+                return TelegramClient.readFilePart(fileId, offset, wanted)
+            }
+            if (!local.isDownloadingActive) {
+                TelegramClient.startDownload(fileId, offset)
+            }
+            delay(POLL_INTERVAL_MS)
+        }
+    }
+
+    class Factory : DataSource.Factory {
+        override fun createDataSource(): DataSource = TelegramDataSource()
+    }
+
+    companion object {
+        private const val TAG = "TelegramDataSource"
+        private const val READ_TIMEOUT_MS = 40_000L
+        private const val POLL_INTERVAL_MS = 150L
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaId.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaId.kt
@@ -1,0 +1,64 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Media id codec for Telegram channel tracks. A Telegram track is addressed by its chat + message
+ * (stable across TDLib database rebuilds) plus the TDLib file id + remote unique id of the audio
+ * payload (a fast path that is only valid for the current TDLib database — TelegramDataSource
+ * falls back to re-resolving the message when the file id has gone stale).
+ *
+ * Kept free of Android imports so it can be covered by plain JVM unit tests.
+ */
+
+package moe.rukamori.archivetune.telegram
+
+const val TELEGRAM_MEDIA_ID_SCHEME = "telegram"
+
+private const val PREFIX = "$TELEGRAM_MEDIA_ID_SCHEME://track/"
+
+data class TelegramMediaId(
+    val chatId: Long,
+    val messageId: Long,
+    val fileId: Int,
+    val fileUniqueId: String = "",
+) {
+    fun encode(): String =
+        buildString {
+            append(PREFIX)
+            append(chatId)
+            append('/')
+            append(messageId)
+            append('/')
+            append(fileId)
+            if (fileUniqueId.isNotEmpty()) {
+                append('/')
+                append(fileUniqueId)
+            }
+        }
+
+    companion object {
+        fun decode(mediaId: String): TelegramMediaId? {
+            if (!mediaId.startsWith(PREFIX)) return null
+            val segments = mediaId.removePrefix(PREFIX).split('/')
+            if (segments.size < 3) return null
+            val chatId = segments[0].toLongOrNull() ?: return null
+            val messageId = segments[1].toLongOrNull() ?: return null
+            val fileId = segments[2].toIntOrNull() ?: return null
+            return TelegramMediaId(
+                chatId = chatId,
+                messageId = messageId,
+                fileId = fileId,
+                fileUniqueId = segments.getOrNull(3).orEmpty(),
+            )
+        }
+    }
+}
+
+/**
+ * True when this media id addresses a Telegram channel track. Telegram ids behave like local media
+ * ids for everything YouTube-specific (no YT metadata fetch, no remote scrobble id, no YT playlist
+ * sync) but are streamed through [TelegramDataSource] instead of the content resolver.
+ */
+fun String.isTelegramMediaId(): Boolean = startsWith(PREFIX) && TelegramMediaId.decode(this) != null

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaItems.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaItems.kt
@@ -1,0 +1,33 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.telegram
+
+import moe.rukamori.archivetune.models.MediaMetadata
+
+/**
+ * Bridges a Telegram channel track into the app's playback model. The media id is the encoded
+ * telegram:// URI, so the player's scheme router hands the item straight to [TelegramDataSource].
+ */
+fun TelegramTrack.toMediaMetadata(channelTitle: String? = null): MediaMetadata =
+    MediaMetadata(
+        id = mediaId,
+        title = displayTitle,
+        artists =
+            listOf(
+                MediaMetadata.Artist(
+                    id = null,
+                    name = performer ?: channelTitle ?: "Telegram",
+                ),
+            ),
+        duration = durationSeconds,
+        thumbnailUrl =
+            TelegramClient.cacheArtwork(
+                uniqueKey = fileUniqueId.ifEmpty { "$chatId-$messageId" },
+                data = albumCoverMinithumbnail,
+            ),
+    )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramModels.kt
@@ -1,0 +1,138 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Plain models for the Telegram channel browser plus the lossless-format detection used to filter
+ * channel content. Kept free of Android/TDLib imports so the detection logic is unit-testable.
+ */
+
+package moe.rukamori.archivetune.telegram
+
+import java.util.Locale
+
+/** A public Telegram channel (or supergroup) as shown in channel search results. */
+data class TelegramChannel(
+    val chatId: Long,
+    val title: String,
+    val username: String?,
+    val memberCount: Int,
+    val isBroadcastChannel: Boolean,
+    val photoMinithumbnail: ByteArray?,
+) {
+    override fun equals(other: Any?): Boolean = other is TelegramChannel && other.chatId == chatId
+
+    override fun hashCode(): Int = chatId.hashCode()
+}
+
+/** One playable audio file found in a Telegram channel. */
+data class TelegramTrack(
+    val chatId: Long,
+    val messageId: Long,
+    val fileId: Int,
+    val fileUniqueId: String,
+    val title: String,
+    val performer: String?,
+    val fileName: String,
+    val mimeType: String,
+    val durationSeconds: Int,
+    val sizeBytes: Long,
+    val dateSeconds: Int,
+    val albumCoverMinithumbnail: ByteArray?,
+) {
+    val mediaId: String
+        get() =
+            TelegramMediaId(
+                chatId = chatId,
+                messageId = messageId,
+                fileId = fileId,
+                fileUniqueId = fileUniqueId,
+            ).encode()
+
+    val isLossless: Boolean
+        get() = isLosslessAudio(mimeType, fileName)
+
+    /** Best-effort display title: audio tag title, else the file name without its extension. */
+    val displayTitle: String
+        get() =
+            title.ifBlank {
+                fileName.substringBeforeLast('.').ifBlank { fileName }
+            }
+
+    override fun equals(other: Any?): Boolean =
+        other is TelegramTrack && other.chatId == chatId && other.messageId == messageId
+
+    override fun hashCode(): Int = (chatId * 31 + messageId).hashCode()
+}
+
+/** One page of channel audio results plus the cursor for the next page (0 = exhausted). */
+data class TelegramAudioPage(
+    val tracks: List<TelegramTrack>,
+    val nextFromMessageId: Long,
+)
+
+private val LOSSLESS_MIME_TYPES =
+    setOf(
+        "audio/flac",
+        "audio/x-flac",
+        "audio/wav",
+        "audio/x-wav",
+        "audio/wave",
+        "audio/vnd.wave",
+        "audio/aiff",
+        "audio/x-aiff",
+        "audio/x-ape",
+        "audio/x-monkeys-audio",
+        "audio/x-wavpack",
+        "audio/wavpack",
+        "audio/x-tak",
+        "audio/x-tta",
+        "audio/x-dsd",
+        "audio/dsd",
+        "audio/x-dsf",
+        "audio/alac",
+    )
+
+private val LOSSLESS_EXTENSIONS =
+    setOf(
+        "flac",
+        "wav",
+        "wave",
+        "aiff",
+        "aif",
+        "ape",
+        "alac",
+        "wv",
+        "tak",
+        "tta",
+        "dsf",
+        "dff",
+        "shn",
+    )
+
+/** Extensions that make a document message count as audio at all (documents carry no duration). */
+private val AUDIO_EXTENSIONS =
+    LOSSLESS_EXTENSIONS +
+        setOf("mp3", "m4a", "aac", "ogg", "oga", "opus", "wma", "mka")
+
+fun fileExtension(fileName: String): String = fileName.substringAfterLast('.', "").lowercase(Locale.US)
+
+fun isLosslessAudio(
+    mimeType: String,
+    fileName: String,
+): Boolean {
+    val mime = mimeType.trim().lowercase(Locale.US)
+    if (mime in LOSSLESS_MIME_TYPES) return true
+    return fileExtension(fileName) in LOSSLESS_EXTENSIONS
+}
+
+/** Whether a document message (arbitrary file) looks like an audio file worth listing. */
+fun isAudioDocument(
+    mimeType: String,
+    fileName: String,
+): Boolean {
+    val mime = mimeType.trim().lowercase(Locale.US)
+    if (mime.startsWith("audio/")) return true
+    return fileExtension(fileName) in AUDIO_EXTENSIONS
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -70,6 +70,9 @@ import moe.rukamori.archivetune.ui.screens.settings.TidalLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.TIDAL_LOGIN_ROUTE
 import moe.rukamori.archivetune.ui.screens.settings.QobuzLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.QOBUZ_LOGIN_ROUTE
+import moe.rukamori.archivetune.ui.screens.settings.TELEGRAM_LOGIN_ROUTE
+import moe.rukamori.archivetune.ui.screens.settings.TelegramLoginScreen
+import moe.rukamori.archivetune.ui.screens.settings.TelegramSettings
 import moe.rukamori.archivetune.ui.screens.settings.LastFMSettings
 import moe.rukamori.archivetune.ui.screens.settings.LanguagePackSettings
 import moe.rukamori.archivetune.ui.screens.settings.LogcatScreen
@@ -458,6 +461,29 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable(QOBUZ_LOGIN_ROUTE) {
         QobuzLoginScreen(navController)
+    }
+    composable("settings/telegram") {
+        TelegramSettings(navController)
+    }
+    composable(TELEGRAM_LOGIN_ROUTE) {
+        TelegramLoginScreen(navController)
+    }
+    composable(TELEGRAM_BROWSE_ROUTE) {
+        TelegramBrowseScreen(navController)
+    }
+    composable(
+        route = TELEGRAM_CHANNEL_ROUTE,
+        arguments =
+            listOf(
+                navArgument("chatId") {
+                    type = NavType.LongType
+                },
+            ),
+    ) { backStackEntry ->
+        TelegramChannelScreen(
+            navController = navController,
+            chatId = backStackEntry.arguments?.getLong("chatId") ?: 0L,
+        )
     }
     composable("settings/ai_integration") {
         AiIntegrationSettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/TelegramBrowseScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/TelegramBrowseScreen.kt
@@ -1,0 +1,550 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Telegram channel browser: search public channels, open one, and stream its audio files.
+ * Audio messages and audio-typed documents are merged (two independent TDLib paging cursors);
+ * the "lossless only" preference filters the listing down to FLAC/WAV/AIFF/… files.
+ */
+
+package moe.rukamori.archivetune.ui.screens
+
+import android.text.format.Formatter
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import kotlinx.coroutines.launch
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.LocalPlayerConnection
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.TelegramLosslessOnlyKey
+import moe.rukamori.archivetune.extensions.toMediaItem
+import moe.rukamori.archivetune.playback.queues.ListQueue
+import moe.rukamori.archivetune.telegram.TelegramChannel
+import moe.rukamori.archivetune.telegram.TelegramClient
+import moe.rukamori.archivetune.telegram.TelegramTrack
+import moe.rukamori.archivetune.telegram.fileExtension
+import moe.rukamori.archivetune.telegram.toMediaMetadata
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.rememberPreference
+import org.drinkless.tdlib.TdApi
+import java.util.Locale
+
+const val TELEGRAM_BROWSE_ROUTE = "telegram/browse"
+const val TELEGRAM_CHANNEL_ROUTE = "telegram/channel/{chatId}"
+
+fun telegramChannelRoute(chatId: Long) = "telegram/channel/$chatId"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelegramBrowseScreen(navController: NavController) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    var query by rememberSaveable { mutableStateOf("") }
+    val results = remember { mutableStateListOf<TelegramChannel>() }
+    var searching by remember { mutableStateOf(false) }
+    var searched by remember { mutableStateOf(false) }
+
+    fun search() {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty() || searching) return
+        searching = true
+        coroutineScope.launch {
+            val found =
+                runCatching { TelegramClient.searchChannels(trimmed) }
+                    .onFailure { e ->
+                        Toast
+                            .makeText(
+                                context,
+                                context.getString(R.string.telegram_error, e.message ?: "?"),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                    }.getOrDefault(emptyList())
+            results.clear()
+            results.addAll(found)
+            searching = false
+            searched = true
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.telegram_browse_channels)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                        ),
+                    ),
+        ) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    placeholder = { Text(stringResource(R.string.telegram_search_channels_hint)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(onSearch = { search() }),
+                    trailingIcon = {
+                        IconButton(onClick = ::search, onLongClick = {}) {
+                            Icon(painterResource(R.drawable.search), contentDescription = null)
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            when {
+                searching -> {
+                    Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                searched && results.isEmpty() -> {
+                    Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                        Text(stringResource(R.string.telegram_no_results))
+                    }
+                }
+
+                else -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(results, key = TelegramChannel::chatId) { channel ->
+                            TelegramChannelRow(
+                                channel = channel,
+                                onClick = { navController.navigate(telegramChannelRoute(channel.chatId)) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TelegramChannelRow(
+    channel: TelegramChannel,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            val thumb = channel.photoMinithumbnail
+            if (thumb != null) {
+                AsyncImage(
+                    model = thumb,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else {
+                Icon(
+                    painterResource(R.drawable.provider_telegram),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        Spacer(Modifier.width(12.dp))
+
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = channel.title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val kind =
+                stringResource(
+                    if (channel.isBroadcastChannel) R.string.telegram_channel else R.string.telegram_group,
+                )
+            val details =
+                buildList {
+                    channel.username?.let { add("@$it") }
+                    add(kind)
+                    if (channel.memberCount > 0) {
+                        add(
+                            stringResource(
+                                R.string.telegram_members,
+                                String.format(Locale.getDefault(), "%,d", channel.memberCount),
+                            ),
+                        )
+                    }
+                }.joinToString(" • ")
+            Text(
+                text = details,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelegramChannelScreen(
+    navController: NavController,
+    chatId: Long,
+) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val (losslessOnly) = rememberPreference(TelegramLosslessOnlyKey, true)
+
+    var channel by remember { mutableStateOf<TelegramChannel?>(null) }
+    val tracks = remember { mutableStateListOf<TelegramTrack>() }
+    var loading by remember { mutableStateOf(false) }
+    var initialLoadDone by remember { mutableStateOf(false) }
+    var audioCursor by remember { mutableStateOf(0L) }
+    var docCursor by remember { mutableStateOf(0L) }
+    var audioExhausted by remember { mutableStateOf(false) }
+    var docExhausted by remember { mutableStateOf(false) }
+    val seenMessageIds = remember { mutableSetOf<Long>() }
+
+    val allExhausted = audioExhausted && docExhausted
+
+    suspend fun loadMore() {
+        if (loading) return
+        loading = true
+        try {
+            var added = 0
+            var rounds = 0
+            while (added < PAGE_TARGET && !(audioExhausted && docExhausted) && rounds < MAX_LOAD_ROUNDS) {
+                rounds++
+                if (!audioExhausted) {
+                    val page =
+                        TelegramClient.fetchAudioPage(
+                            chatId = chatId,
+                            fromMessageId = audioCursor,
+                            limit = PAGE_FETCH_LIMIT,
+                            filter = TdApi.SearchMessagesFilterAudio(),
+                        )
+                    audioCursor = page.nextFromMessageId
+                    if (page.nextFromMessageId == 0L) audioExhausted = true
+                    page.tracks.forEach { track ->
+                        if ((!losslessOnly || track.isLossless) && seenMessageIds.add(track.messageId)) {
+                            tracks.add(track)
+                            added++
+                        }
+                    }
+                }
+                if (!docExhausted) {
+                    val page =
+                        TelegramClient.fetchAudioPage(
+                            chatId = chatId,
+                            fromMessageId = docCursor,
+                            limit = PAGE_FETCH_LIMIT,
+                            filter = TdApi.SearchMessagesFilterDocument(),
+                        )
+                    docCursor = page.nextFromMessageId
+                    if (page.nextFromMessageId == 0L) docExhausted = true
+                    page.tracks.forEach { track ->
+                        if ((!losslessOnly || track.isLossless) && seenMessageIds.add(track.messageId)) {
+                            tracks.add(track)
+                            added++
+                        }
+                    }
+                }
+            }
+            tracks.sortWith(compareByDescending(TelegramTrack::dateSeconds).thenByDescending(TelegramTrack::messageId))
+        } catch (e: Exception) {
+            Toast
+                .makeText(
+                    context,
+                    context.getString(R.string.telegram_error, e.message ?: "?"),
+                    Toast.LENGTH_SHORT,
+                ).show()
+        } finally {
+            loading = false
+            initialLoadDone = true
+        }
+    }
+
+    fun playFrom(track: TelegramTrack?) {
+        val queueTracks = tracks.toList()
+        if (queueTracks.isEmpty()) return
+        val startIndex = track?.let(queueTracks::indexOf)?.coerceAtLeast(0) ?: 0
+        coroutineScope.launch {
+            val items =
+                queueTracks.map { it.toMediaMetadata(channel?.title).toMediaItem() }
+            playerConnection.playQueue(
+                ListQueue(
+                    title = channel?.title,
+                    items = items,
+                    startIndex = startIndex,
+                ),
+            )
+        }
+    }
+
+    LaunchedEffect(chatId) {
+        channel = TelegramClient.channelInfo(chatId)
+        if (tracks.isEmpty()) {
+            loadMore()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = channel?.title ?: stringResource(R.string.telegram_channel),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    }
+                },
+                actions = {
+                    if (tracks.isNotEmpty()) {
+                        IconButton(onClick = { playFrom(null) }, onLongClick = {}) {
+                            Icon(painterResource(R.drawable.play), contentDescription = stringResource(R.string.telegram_play_all))
+                        }
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                        ),
+                    ),
+        ) {
+            when {
+                !initialLoadDone -> {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                tracks.isEmpty() -> {
+                    Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+                        Text(stringResource(R.string.telegram_no_tracks))
+                    }
+                }
+
+                else -> {
+                    LazyColumn(modifier = Modifier.fillMaxSize()) {
+                        items(tracks, key = TelegramTrack::messageId) { track ->
+                            TelegramTrackRow(
+                                track = track,
+                                onClick = { playFrom(track) },
+                            )
+                        }
+                        if (!allExhausted) {
+                            item(key = "load_more") {
+                                Box(
+                                    Modifier.fillMaxWidth().padding(16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    if (loading) {
+                                        CircularProgressIndicator()
+                                    } else {
+                                        Button(onClick = { coroutineScope.launch { loadMore() } }) {
+                                            Text(stringResource(R.string.telegram_load_more))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TelegramTrackRow(
+    track: TelegramTrack,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            val thumb = track.albumCoverMinithumbnail
+            if (thumb != null) {
+                AsyncImage(
+                    model = thumb,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else {
+                Icon(
+                    painterResource(R.drawable.music_note),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        Spacer(Modifier.width(12.dp))
+
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = track.displayTitle,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val details =
+                buildList {
+                    track.performer?.let(::add)
+                    fileExtension(track.fileName).takeIf(String::isNotEmpty)?.let { add(it.uppercase(Locale.US)) }
+                    if (track.durationSeconds > 0) add(formatDuration(track.durationSeconds))
+                    if (track.sizeBytes > 0) add(Formatter.formatShortFileSize(context, track.sizeBytes))
+                }.joinToString(" • ")
+            Text(
+                text = details,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        if (track.isLossless) {
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.telegram_lossless_badge),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                        .padding(horizontal = 6.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+private fun formatDuration(seconds: Int): String {
+    val minutes = seconds / 60
+    val secs = seconds % 60
+    return String.format(Locale.US, "%d:%02d", minutes, secs)
+}
+
+private const val PAGE_TARGET = 25
+private const val PAGE_FETCH_LIMIT = 50
+private const val MAX_LOAD_ROUNDS = 6

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -95,6 +95,16 @@ fun IntegrationScreen(navController: NavController) {
                         },
                     )
                 }
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.telegram_integration)) },
+                        description = stringResource(R.string.telegram_integration_description),
+                        icon = { Icon(painterResource(R.drawable.provider_telegram), null) },
+                        onClick = {
+                            navController.navigate("settings/telegram")
+                        },
+                    )
+                }
             }
 
             if (manualSourceLogin) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramLoginScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramLoginScreen.kt
@@ -1,0 +1,242 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Telegram account sign-in: a stepped form (phone number → login code → optional 2FA password)
+ * driven directly by TDLib's authorization state machine via TelegramClient.authState.
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import kotlinx.coroutines.launch
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.telegram.TelegramApiException
+import moe.rukamori.archivetune.telegram.TelegramAuthState
+import moe.rukamori.archivetune.telegram.TelegramClient
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.utils.backToMain
+
+const val TELEGRAM_LOGIN_ROUTE = "settings/telegram/login"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelegramLoginScreen(navController: NavController) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    val authState by TelegramClient.authState.collectAsState()
+    var phoneNumber by rememberSaveable { mutableStateOf("") }
+    var code by rememberSaveable { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var busy by remember { mutableStateOf(false) }
+    var errorText by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        if (!TelegramClient.ensureStarted(context)) {
+            Toast.makeText(context, R.string.telegram_credentials_required, Toast.LENGTH_SHORT).show()
+            navController.navigateUp()
+        }
+    }
+
+    LaunchedEffect(authState) {
+        // Every state transition invalidates any in-flight error/busy indicator.
+        busy = false
+        if (authState is TelegramAuthState.Ready) {
+            Toast.makeText(context, R.string.telegram_login_success, Toast.LENGTH_SHORT).show()
+            navController.navigateUp()
+        }
+    }
+
+    fun submit(block: suspend () -> Unit) {
+        if (busy) return
+        busy = true
+        errorText = null
+        coroutineScope.launch {
+            try {
+                block()
+            } catch (e: Exception) {
+                errorText =
+                    when (e) {
+                        is TelegramApiException -> e.message
+                        else -> e.message ?: e.javaClass.simpleName
+                    }
+            } finally {
+                busy = false
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.telegram_login)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(top = innerPadding.calculateTopPadding())
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                        ),
+                    ).verticalScroll(rememberScrollState())
+                    .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            when (val state = authState) {
+                is TelegramAuthState.Idle, is TelegramAuthState.Connecting -> {
+                    CircularProgressIndicator()
+                    Text(stringResource(R.string.telegram_connecting))
+                }
+
+                is TelegramAuthState.WaitPhoneNumber -> {
+                    OutlinedTextField(
+                        value = phoneNumber,
+                        onValueChange = { phoneNumber = it },
+                        label = { Text(stringResource(R.string.telegram_phone_number)) },
+                        placeholder = { Text("+15550100") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Button(
+                        enabled = !busy && phoneNumber.isNotBlank(),
+                        onClick = { submit { TelegramClient.submitPhoneNumber(phoneNumber) } },
+                    ) {
+                        Text(stringResource(R.string.telegram_continue))
+                    }
+                }
+
+                is TelegramAuthState.WaitCode -> {
+                    Text(
+                        stringResource(R.string.telegram_code_sent, state.phoneNumber),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    OutlinedTextField(
+                        value = code,
+                        onValueChange = { code = it },
+                        label = { Text(stringResource(R.string.telegram_code)) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Button(
+                        enabled = !busy && code.isNotBlank(),
+                        onClick = { submit { TelegramClient.submitCode(code) } },
+                    ) {
+                        Text(stringResource(R.string.telegram_continue))
+                    }
+                    TextButton(
+                        enabled = !busy,
+                        onClick = { submit { TelegramClient.resendCode() } },
+                    ) {
+                        Text(stringResource(R.string.telegram_resend_code))
+                    }
+                }
+
+                is TelegramAuthState.WaitPassword -> {
+                    state.passwordHint?.let { hint ->
+                        Text(
+                            stringResource(R.string.telegram_password_hint_label, hint),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    OutlinedTextField(
+                        value = password,
+                        onValueChange = { password = it },
+                        label = { Text(stringResource(R.string.telegram_password)) },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Button(
+                        enabled = !busy && password.isNotEmpty(),
+                        onClick = { submit { TelegramClient.submitPassword(password) } },
+                    ) {
+                        Text(stringResource(R.string.telegram_continue))
+                    }
+                }
+
+                is TelegramAuthState.Ready, is TelegramAuthState.LoggingOut -> {
+                    CircularProgressIndicator()
+                }
+
+                is TelegramAuthState.Unsupported -> {
+                    Text(
+                        stringResource(R.string.telegram_auth_unsupported, state.stateName),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+
+            if (busy) {
+                Spacer(Modifier.height(4.dp))
+                CircularProgressIndicator()
+            }
+
+            errorText?.let { message ->
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
@@ -1,0 +1,272 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Telegram channel streaming settings: the user's own API credentials (my.telegram.org),
+ * account sign-in state, and the channel browser entry point.
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.navigation.NavController
+import kotlinx.coroutines.launch
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.TelegramAccountNameKey
+import moe.rukamori.archivetune.constants.TelegramAccountPhoneKey
+import moe.rukamori.archivetune.constants.TelegramApiHashKey
+import moe.rukamori.archivetune.constants.TelegramApiIdKey
+import moe.rukamori.archivetune.constants.TelegramLosslessOnlyKey
+import moe.rukamori.archivetune.telegram.TelegramAuthState
+import moe.rukamori.archivetune.telegram.TelegramClient
+import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.InfoLabel
+import moe.rukamori.archivetune.ui.component.PreferenceEntry
+import moe.rukamori.archivetune.ui.component.PreferenceGroup
+import moe.rukamori.archivetune.ui.component.SwitchPreference
+import moe.rukamori.archivetune.ui.component.TextFieldDialog
+import moe.rukamori.archivetune.ui.screens.TELEGRAM_BROWSE_ROUTE
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.rememberPreference
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelegramSettings(navController: NavController) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    val (apiId, onApiIdChange) = rememberPreference(TelegramApiIdKey, "")
+    val (apiHash, onApiHashChange) = rememberPreference(TelegramApiHashKey, "")
+    val (accountName, onAccountNameChange) = rememberPreference(TelegramAccountNameKey, "")
+    val (accountPhone, onAccountPhoneChange) = rememberPreference(TelegramAccountPhoneKey, "")
+    val (losslessOnly, onLosslessOnlyChange) = rememberPreference(TelegramLosslessOnlyKey, true)
+
+    val authState by TelegramClient.authState.collectAsState()
+    val hasCredentials = apiId.trim().toIntOrNull() != null && apiHash.isNotBlank()
+    val isReady = authState is TelegramAuthState.Ready
+
+    var showApiIdDialog by remember { mutableStateOf(false) }
+    var showApiHashDialog by remember { mutableStateOf(false) }
+    var showLogoutDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(hasCredentials) {
+        if (hasCredentials) {
+            TelegramClient.ensureStarted(context)
+        }
+    }
+
+    LaunchedEffect(isReady) {
+        if (isReady && accountName.isBlank()) {
+            runCatching { TelegramClient.getMe() }
+                .onSuccess { me ->
+                    val name = listOfNotNull(me.firstName, me.lastName).joinToString(" ").trim()
+                    if (name.isNotBlank()) onAccountNameChange(name)
+                    me.phoneNumber?.takeIf(String::isNotBlank)?.let { onAccountPhoneChange("+$it") }
+                }
+        }
+    }
+
+    if (showApiIdDialog) {
+        TextFieldDialog(
+            title = { Text(stringResource(R.string.telegram_api_id)) },
+            initialTextFieldValue = TextFieldValue(apiId),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            isInputValid = { it.trim().toIntOrNull() != null },
+            onDone = { onApiIdChange(it.trim()) },
+            onDismiss = { showApiIdDialog = false },
+        )
+    }
+
+    if (showApiHashDialog) {
+        TextFieldDialog(
+            title = { Text(stringResource(R.string.telegram_api_hash)) },
+            initialTextFieldValue = TextFieldValue(apiHash),
+            isInputValid = { it.trim().isNotEmpty() },
+            onDone = { onApiHashChange(it.trim()) },
+            onDismiss = { showApiHashDialog = false },
+        )
+    }
+
+    if (showLogoutDialog) {
+        DefaultDialog(
+            onDismiss = { showLogoutDialog = false },
+            content = {
+                Text(stringResource(R.string.telegram_logout_confirm))
+            },
+            buttons = {
+                androidx.compose.material3.TextButton(onClick = { showLogoutDialog = false }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+                androidx.compose.material3.TextButton(
+                    onClick = {
+                        showLogoutDialog = false
+                        coroutineScope.launch {
+                            TelegramClient.logOut()
+                            onAccountNameChange("")
+                            onAccountPhoneChange("")
+                        }
+                    },
+                ) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.telegram_integration)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            Modifier
+                .padding(top = innerPadding.calculateTopPadding())
+                .windowInsetsPadding(
+                    LocalPlayerAwareWindowInsets.current.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                    ),
+                ).verticalScroll(rememberScrollState()),
+        ) {
+            PreferenceGroup(title = stringResource(R.string.telegram_api_credentials)) {
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.telegram_api_id)) },
+                        description = if (apiId.isBlank()) null else apiId,
+                        icon = { Icon(painterResource(R.drawable.token), contentDescription = null) },
+                        onClick = { showApiIdDialog = true },
+                    )
+                }
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.telegram_api_hash)) },
+                        description = if (apiHash.isBlank()) null else "••••••••",
+                        icon = { Icon(painterResource(R.drawable.token), contentDescription = null) },
+                        onClick = { showApiHashDialog = true },
+                    )
+                }
+                item {
+                    InfoLabel(stringResource(R.string.telegram_api_credentials_info))
+                }
+            }
+
+            PreferenceGroup(title = stringResource(R.string.telegram_account)) {
+                if (isReady) {
+                    item {
+                        PreferenceEntry(
+                            title = {
+                                Text(
+                                    stringResource(
+                                        R.string.telegram_logged_in_as,
+                                        accountName.ifBlank { accountPhone.ifBlank { "Telegram" } },
+                                    ),
+                                )
+                            },
+                            description = accountPhone.takeIf { it.isNotBlank() && accountName.isNotBlank() },
+                            icon = { Icon(painterResource(R.drawable.provider_telegram), contentDescription = null) },
+                        )
+                    }
+                    item {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.telegram_logout)) },
+                            icon = { Icon(painterResource(R.drawable.logout), contentDescription = null) },
+                            onClick = { showLogoutDialog = true },
+                        )
+                    }
+                } else {
+                    item {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.telegram_login)) },
+                            description =
+                                if (hasCredentials) {
+                                    null
+                                } else {
+                                    stringResource(R.string.telegram_credentials_required)
+                                },
+                            icon = { Icon(painterResource(R.drawable.provider_telegram), contentDescription = null) },
+                            isEnabled = hasCredentials,
+                            onClick = {
+                                if (TelegramClient.ensureStarted(context)) {
+                                    navController.navigate(TELEGRAM_LOGIN_ROUTE)
+                                } else {
+                                    Toast
+                                        .makeText(
+                                            context,
+                                            R.string.telegram_credentials_required,
+                                            Toast.LENGTH_SHORT,
+                                        ).show()
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+
+            PreferenceGroup(title = stringResource(R.string.telegram_browse_channels)) {
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.telegram_browse_channels)) },
+                        description =
+                            if (isReady) {
+                                stringResource(R.string.telegram_browse_channels_description)
+                            } else {
+                                stringResource(R.string.telegram_login_required)
+                            },
+                        icon = { Icon(painterResource(R.drawable.search), contentDescription = null) },
+                        isEnabled = isReady,
+                        onClick = { navController.navigate(TELEGRAM_BROWSE_ROUTE) },
+                    )
+                }
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.telegram_lossless_only)) },
+                        description = stringResource(R.string.telegram_lossless_only_description),
+                        icon = { Icon(painterResource(R.drawable.graphic_eq), contentDescription = null) },
+                        checked = losslessOnly,
+                        onCheckedChange = onLosslessOnlyChange,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/DiscordAlbumUrl.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/DiscordAlbumUrl.kt
@@ -8,9 +8,10 @@
 package moe.rukamori.archivetune.utils
 
 import moe.rukamori.archivetune.db.entities.Song
+import moe.rukamori.archivetune.telegram.isTelegramMediaId
 
 internal fun Song.discordAlbumMusicUrl(): String? =
-    if (song.isLocal || song.id.isLocalMediaId()) {
+    if (song.isLocal || song.id.isLocalMediaId() || song.id.isTelegramMediaId()) {
         null
     } else {
         album

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/DiscordRPC.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/DiscordRPC.kt
@@ -37,6 +37,7 @@ import moe.rukamori.archivetune.constants.TranslatorContextsKey
 import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.discord.DiscordActivityPlatform
+import moe.rukamori.archivetune.telegram.isTelegramMediaId
 import moe.rukamori.archivetune.discord.DiscordActivityType
 import moe.rukamori.archivetune.discord.DiscordOnlineStatus
 import moe.rukamori.archivetune.discord.DiscordPresenceActivity
@@ -439,11 +440,11 @@ class DiscordRPC(
 
     private fun Song.youtubeMusicUrl(): String? =
         song.id
-            .takeUnless { song.isLocal || it.isLocalMediaId() }
+            .takeUnless { song.isLocal || it.isLocalMediaId() || it.isTelegramMediaId() }
             ?.let { "https://music.youtube.com/watch?v=$it" }
 
     private fun Song.discordArtistMusicUrl(): String? {
-        if (song.isLocal || song.id.isLocalMediaId()) return null
+        if (song.isLocal || song.id.isLocalMediaId() || song.id.isTelegramMediaId()) return null
 
         return artists.firstNotNullOfOrNull { artist ->
             (artist.channelId ?: artist.id)

--- a/app/src/main/res/drawable/provider_telegram.xml
+++ b/app/src/main/res/drawable/provider_telegram.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9.78,18.65l0.28,-4.23 7.68,-6.92c0.34,-0.31 -0.07,-0.46 -0.52,-0.19L7.74,13.3 3.64,12c-0.88,-0.25 -0.89,-0.86 0.2,-1.3l15.97,-6.16c0.73,-0.33 1.43,0.18 1.15,1.3l-2.72,12.81c-0.19,0.91 -0.74,1.13 -1.5,0.71L12.6,16.3l-1.99,1.93c-0.23,0.23 -0.42,0.42 -0.83,0.42z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1287,4 +1287,43 @@
     <string name="language_pack_optional_data">Optional language data</string>
     <string name="language_pack_other_romanization">Korean, Chinese, Hindi, and other romanization</string>
     <string name="language_pack_other_romanization_description">Built in · no additional data or download required</string>
+
+    <!-- Telegram channel streaming integration -->
+    <string name="telegram_integration">Telegram</string>
+    <string name="telegram_integration_description">Stream lossless audio files from Telegram channels</string>
+    <string name="telegram_api_credentials">API credentials</string>
+    <string name="telegram_api_id">API ID</string>
+    <string name="telegram_api_hash">API hash</string>
+    <string name="telegram_api_credentials_info">Create your personal api_id and api_hash at my.telegram.org → API development tools. They are stored only on this device.</string>
+    <string name="telegram_account">Account</string>
+    <string name="telegram_login">Sign in with Telegram</string>
+    <string name="telegram_logged_in_as">Signed in as %1$s</string>
+    <string name="telegram_logout">Sign out</string>
+    <string name="telegram_logout_confirm">Sign out of Telegram? The on-device session and file cache will be removed.</string>
+    <string name="telegram_phone_number">Phone number (international format)</string>
+    <string name="telegram_code">Login code</string>
+    <string name="telegram_code_sent">A login code was sent to %1$s — check your other Telegram sessions or SMS</string>
+    <string name="telegram_password">Two-step verification password</string>
+    <string name="telegram_password_hint_label">Hint: %1$s</string>
+    <string name="telegram_continue">Continue</string>
+    <string name="telegram_resend_code">Resend code</string>
+    <string name="telegram_connecting">Connecting to Telegram…</string>
+    <string name="telegram_login_success">Telegram connected</string>
+    <string name="telegram_auth_unsupported">Unsupported login step: %1$s. Try signing in with the official Telegram app first.</string>
+    <string name="telegram_browse_channels">Browse channels</string>
+    <string name="telegram_browse_channels_description">Search Telegram channels and stream their audio files</string>
+    <string name="telegram_search_channels_hint">Channel name, @username or t.me link</string>
+    <string name="telegram_channel">Channel</string>
+    <string name="telegram_group">Group</string>
+    <string name="telegram_members">%1$s members</string>
+    <string name="telegram_lossless_only">Lossless files only</string>
+    <string name="telegram_lossless_only_description">Only list FLAC, WAV, AIFF and other lossless files when browsing channels</string>
+    <string name="telegram_no_results">No channels found</string>
+    <string name="telegram_no_tracks">No matching audio files found in this channel</string>
+    <string name="telegram_login_required">Sign in with your Telegram account first</string>
+    <string name="telegram_credentials_required">Enter your API ID and API hash first</string>
+    <string name="telegram_play_all">Play all</string>
+    <string name="telegram_load_more">Load more</string>
+    <string name="telegram_lossless_badge">Lossless</string>
+    <string name="telegram_error">Telegram error: %1$s</string>
 </resources>

--- a/app/src/test/kotlin/moe/rukamori/archivetune/telegram/TelegramLosslessDetectionTest.kt
+++ b/app/src/test/kotlin/moe/rukamori/archivetune/telegram/TelegramLosslessDetectionTest.kt
@@ -1,0 +1,69 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.telegram
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TelegramLosslessDetectionTest {
+    @Test
+    fun detectsLosslessByMimeType() {
+        assertTrue(isLosslessAudio("audio/flac", "unknown.bin"))
+        assertTrue(isLosslessAudio("audio/x-flac", ""))
+        assertTrue(isLosslessAudio("AUDIO/WAV", ""))
+        assertTrue(isLosslessAudio("audio/x-wavpack", ""))
+    }
+
+    @Test
+    fun detectsLosslessByExtension() {
+        assertTrue(isLosslessAudio("application/octet-stream", "Album - 01 Track.flac"))
+        assertTrue(isLosslessAudio("", "track.WAV"))
+        assertTrue(isLosslessAudio("", "master.aiff"))
+        assertTrue(isLosslessAudio("", "rip.ape"))
+        assertTrue(isLosslessAudio("", "song.dsf"))
+    }
+
+    @Test
+    fun rejectsLossyAudio() {
+        assertFalse(isLosslessAudio("audio/mpeg", "track.mp3"))
+        assertFalse(isLosslessAudio("audio/mp4", "track.m4a"))
+        assertFalse(isLosslessAudio("audio/ogg", "track.opus"))
+        assertFalse(isLosslessAudio("", "document.pdf"))
+    }
+
+    @Test
+    fun audioDocumentDetectionCoversLossyAndLossless() {
+        assertTrue(isAudioDocument("application/octet-stream", "track.flac"))
+        assertTrue(isAudioDocument("application/octet-stream", "track.mp3"))
+        assertTrue(isAudioDocument("audio/flac", "weird_name"))
+        assertFalse(isAudioDocument("application/zip", "album.zip"))
+        assertFalse(isAudioDocument("video/mp4", "clip.mp4"))
+    }
+
+    @Test
+    fun trackDisplayTitleFallsBackToFileName() {
+        val track =
+            TelegramTrack(
+                chatId = -1L,
+                messageId = 1L,
+                fileId = 1,
+                fileUniqueId = "u",
+                title = "",
+                performer = null,
+                fileName = "01 - Intro.flac",
+                mimeType = "audio/flac",
+                durationSeconds = 0,
+                sizeBytes = 1L,
+                dateSeconds = 0,
+                albumCoverMinithumbnail = null,
+            )
+        assertTrue(track.isLossless)
+        assertTrue(track.displayTitle == "01 - Intro")
+    }
+}

--- a/app/src/test/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaIdTest.kt
+++ b/app/src/test/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaIdTest.kt
@@ -1,0 +1,60 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.telegram
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TelegramMediaIdTest {
+    @Test
+    fun roundTripsWithUniqueId() {
+        val id =
+            TelegramMediaId(
+                chatId = -1001234567890L,
+                messageId = 52428800L,
+                fileId = 4711,
+                fileUniqueId = "AgADBQADr6cxGw",
+            )
+        assertEquals(id, TelegramMediaId.decode(id.encode()))
+    }
+
+    @Test
+    fun roundTripsWithoutUniqueId() {
+        val id = TelegramMediaId(chatId = -100987L, messageId = 12L, fileId = 3)
+        val encoded = id.encode()
+        assertEquals("telegram://track/-100987/12/3", encoded)
+        assertEquals(id, TelegramMediaId.decode(encoded))
+    }
+
+    @Test
+    fun recognisesTelegramMediaIds() {
+        assertTrue("telegram://track/-100987/12/3".isTelegramMediaId())
+        assertTrue(
+            TelegramMediaId(-1L, 2L, 3, "u").encode().isTelegramMediaId(),
+        )
+    }
+
+    @Test
+    fun rejectsForeignIds() {
+        assertFalse("dQw4w9WgXcQ".isTelegramMediaId())
+        assertFalse("content://media/external/audio/1".isTelegramMediaId())
+        assertFalse("https://t.me/somechannel".isTelegramMediaId())
+        assertFalse("telegram://track/notanumber/12/3".isTelegramMediaId())
+        assertFalse("telegram://track/1/2".isTelegramMediaId())
+    }
+
+    @Test
+    fun decodeRejectsMalformedIds() {
+        assertNull(TelegramMediaId.decode("telegram://track/1/2"))
+        assertNull(TelegramMediaId.decode("telegram://chat/1/2/3"))
+        assertNull(TelegramMediaId.decode(""))
+    }
+}

--- a/scripts/upstream_sync.sh
+++ b/scripts/upstream_sync.sh
@@ -188,6 +188,11 @@ grep -q "resolveMultiSourceDataSpec" \
   || die "tidal package missing after merge"
 [ -d app/src/main/kotlin/moe/rukamori/archivetune/audiosource ] \
   || die "audiosource package missing after merge"
+[ -d app/src/main/kotlin/moe/rukamori/archivetune/telegram ] \
+  || die "telegram package missing after merge"
+grep -q "TelegramDataSource" \
+  app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt \
+  || die "telegram data source no longer wired in MusicService.kt"
 grep -q "persistent-debug.keystore" .github/workflows/build.yml \
   || die "fork CI signing patch (persistent-debug.keystore) lost in build.yml"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,9 @@ dependencyResolutionManagement {
             filter {
                 includeGroup("com.github.therealbush")
                 includeGroup("com.github.TeamNewPipe")
+                // Prebuilt TDLib (Telegram Database Library) AAR with bundled JNI natives,
+                // used by the Telegram channel streaming integration.
+                includeGroup("com.github.tdlibx")
             }
         }
     }


### PR DESCRIPTION
Adds a Telegram channel streaming integration built on TDLib
(prebuilt com.github.tdlibx:td AAR with bundled JNI natives):

- telegram/ package: TelegramClient (MTProto login via phone/code/2FA,
  public channel search, audio+document message paging, partial-file
  access), TelegramDataSource (Media3 source streaming through TDLib's
  download cache with seek support), media-id codec and lossless
  format detection.
- Login with the user's own Telegram account and API credentials
  (my.telegram.org); session persists in TDLib's database.
- Channel browser: search public channels (name/@username/t.me link),
  open a channel, list its audio files (lossless-only filter by
  default), play/queue them through the normal player.
- Playback wired via a telegram:// scheme branch in MusicService's
  SchemeRoutingDataSource; multi-source resolver chain untouched.
- Telegram media ids are guarded like local ids across YT-specific
  paths (radio bootstrap, presence, Discord RPC, YT playlist sync).
- Settings UI under Integrations, strings, icon, proguard keep rules,
  JVM unit tests for the id codec + lossless detection, fork
  invariants updated (AGENTS.md, upstream_sync.sh).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ScVyT1G7bbZaCJTCddf3BG