### PR TITLE
feat: Apple Music player style, nav bar styles, lyrics perf + Telegram canvas/lyrics, 52 MB smaller APK

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -370,7 +370,11 @@ android {
 
     packaging {
         jniLibs {
-            useLegacyPackaging = false
+            // Compress native libs inside the APK and extract only the device's ABI at install.
+            // TDLib ships ~87 MiB of libtdjni.so across four ABIs; stored uncompressed that alone
+            // made the universal APK ~142 MiB. Compressed packaging cuts the universal APK by
+            // ~51 MiB (and each per-ABI APK by ~12 MiB) at the cost of a slightly slower install.
+            useLegacyPackaging = true
             keepDebugSymbols += listOf(
                 "**/libandroidx.graphics.path.so",
                 "**/libdatastore_shared_counter.so"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -125,6 +125,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
@@ -210,6 +215,8 @@ import moe.rukamori.archivetune.constants.MiniPlayerBottomSpacing
 import moe.rukamori.archivetune.constants.MiniPlayerHeight
 import moe.rukamori.archivetune.constants.MiniPlayerLastAnchorKey
 import moe.rukamori.archivetune.constants.NavigationBarAnimationSpec
+import moe.rukamori.archivetune.constants.FloatingNavigationBarBottomPadding
+import moe.rukamori.archivetune.constants.FloatingNavigationBarHorizontalPadding
 import moe.rukamori.archivetune.constants.NavigationBarBottomPadding
 import moe.rukamori.archivetune.constants.NavigationBarHeight
 import moe.rukamori.archivetune.constants.NavigationBarHorizontalPadding
@@ -218,6 +225,9 @@ import moe.rukamori.archivetune.constants.PlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.PlayerBackgroundStyleKey
 import moe.rukamori.archivetune.constants.PlayerDesignStyle
 import moe.rukamori.archivetune.constants.PlayerDesignStyleKey
+import moe.rukamori.archivetune.constants.NavigationBarFrostedBlurKey
+import moe.rukamori.archivetune.constants.NavigationBarStyle
+import moe.rukamori.archivetune.constants.NavigationBarStyleKey
 import moe.rukamori.archivetune.constants.PureBlackKey
 import moe.rukamori.archivetune.constants.RemindAfterKey
 import moe.rukamori.archivetune.constants.SYSTEM_DEFAULT
@@ -260,6 +270,7 @@ import moe.rukamori.archivetune.ui.component.COLLAPSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.DISMISSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.EXPANDED_ANCHOR
 import moe.rukamori.archivetune.ui.component.FloatingNavigationToolbar
+import moe.rukamori.archivetune.ui.component.NavigationBarBackdrop
 import moe.rukamori.archivetune.ui.component.AutoResizeText
 import moe.rukamori.archivetune.ui.component.FontSizeRange
 import moe.rukamori.archivetune.ui.component.IconButton
@@ -718,6 +729,14 @@ class MainActivity : ComponentActivity() {
                 }
             val pureBlackEnabled by rememberPreference(PureBlackKey, defaultValue = false)
             val pureBlack = pureBlackEnabled && useDarkTheme
+            val navigationBarStyle by rememberEnumPreference(
+                NavigationBarStyleKey,
+                defaultValue = NavigationBarStyle.DEFAULT,
+            )
+            val navigationBarFrostedBlur by rememberPreference(
+                NavigationBarFrostedBlurKey,
+                defaultValue = false,
+            )
 
             val customThemeSeedPalette =
                 remember(customThemeColorValue) {
@@ -1001,8 +1020,28 @@ class MainActivity : ComponentActivity() {
                             0.dp
                         }
 
-                    val floatingBarsBottomPadding = NavigationBarBottomPadding
+                    // FLOATING detaches the bar into a pill: bigger bottom margin, tighter width.
+                    // Every consumer below (collapsed player anchor, slide distance, insets, FAB
+                    // padding) derives from these two values so the styles stay in sync.
+                    val isFloatingNavBar = navigationBarStyle == NavigationBarStyle.FLOATING
+                    val floatingBarsBottomPadding =
+                        if (isFloatingNavBar) FloatingNavigationBarBottomPadding else NavigationBarBottomPadding
                     val navVisibleHeight = NavigationBarHeight
+                    val navBarHorizontalPadding =
+                        if (isFloatingNavBar) FloatingNavigationBarHorizontalPadding else NavigationBarHorizontalPadding
+
+                    // Frosted nav-bar backdrop: only allocated when the effect can actually run
+                    // (setting on, RenderEffect available, bottom bar in use).
+                    val navBarFrostedBackdrop =
+                        if (navigationBarFrostedBlur &&
+                            !useRail &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                        ) {
+                            val frostedLayer = rememberGraphicsLayer()
+                            remember(frostedLayer) { NavigationBarBackdrop(frostedLayer) }
+                        } else {
+                            null
+                        }
 
                     val bottomNavigationBarHeight by animateDpAsState(
                         targetValue = if (shouldShowNavigationBar && !useRail) navVisibleHeight else 0.dp,
@@ -1160,6 +1199,7 @@ class MainActivity : ComponentActivity() {
                             bottomInset,
                             shouldShowNavigationBar,
                             playerBottomSheetState.isDismissed,
+                            navigationBarStyle,
                         ) {
                             var bottom = bottomInset
                             if (shouldShowNavigationBar && !useRail) {
@@ -2072,9 +2112,11 @@ class MainActivity : ComponentActivity() {
                                 },
                                 bottomBar = {
                                     Box {
+                                        // A floating pill never docks with the mini player.
                                         val areBottomBarsPaired =
                                             shouldShowNavigationBar &&
                                                 !useRail &&
+                                                !isFloatingNavBar &&
                                                 playerBottomSheetState.isCollapsed
 
                                         BottomSheetPlayer(
@@ -2125,12 +2167,15 @@ class MainActivity : ComponentActivity() {
                                                 items = navigationItems,
                                                 pureBlack = pureBlack,
                                                 isPairedWithMiniPlayer = areBottomBarsPaired,
+                                                style = navigationBarStyle,
+                                                frostedBlur = navigationBarFrostedBlur,
+                                                frostedBackdrop = navBarFrostedBackdrop,
                                                 modifier =
                                                     Modifier
                                                         .align(Alignment.BottomCenter)
                                                         .padding(
-                                                            start = NavigationBarHorizontalPadding,
-                                                            end = NavigationBarHorizontalPadding,
+                                                            start = navBarHorizontalPadding,
+                                                            end = navBarHorizontalPadding,
                                                             bottom = bottomInset + floatingBarsBottomPadding,
                                                         ).height(navVisibleHeight),
                                                 isSelected = { screen ->
@@ -2369,6 +2414,23 @@ class MainActivity : ComponentActivity() {
                                                         .focusRequester(contentAreaFocusRequester)
                                                         .focusGroup()
                                                         .focusable()
+                                                } else {
+                                                    Modifier
+                                                },
+                                            ).then(
+                                                // Frosted nav bar: capture the app content into a
+                                                // layer each frame so the bar can draw it blurred.
+                                                if (navBarFrostedBackdrop != null) {
+                                                    Modifier
+                                                        .onGloballyPositioned { coordinates ->
+                                                            navBarFrostedBackdrop.contentOffsetInRoot =
+                                                                coordinates.positionInRoot()
+                                                        }.drawWithContent {
+                                                            navBarFrostedBackdrop.layer.record {
+                                                                this@drawWithContent.drawContent()
+                                                            }
+                                                            drawLayer(navBarFrostedBackdrop.layer)
+                                                        }
                                                 } else {
                                                     Modifier
                                                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/Dimensions.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/Dimensions.kt
@@ -23,6 +23,11 @@ val NavigationBarHorizontalPadding = 12.dp
 val NavigationBarBottomPadding = 10.dp
 val NavigationBarMaxWidth = 420.dp
 val NavigationBarHeight = 78.dp
+
+// FLOATING navigation-bar style: a detached pill with larger margins and a tighter width.
+val FloatingNavigationBarHorizontalPadding = 24.dp
+val FloatingNavigationBarBottomPadding = 16.dp
+val FloatingNavigationBarMaxWidth = 360.dp
 val MiniPlayerHeight = 70.dp
 val MiniPlayerBottomSpacing = 4.dp
 val QueuePeekHeight = 64.dp

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -206,6 +206,9 @@ val AiApiValidationStatusKey = stringPreferencesKey("ai_api_validation_status")
 val AiSelectedModelKey = stringPreferencesKey("ai_selected_model")
 val AiCustomModelKey = stringPreferencesKey("ai_custom_model")
 
+// Hides the AI-generated "Top mixes" section in the library Mix tab (and stops auto-generation).
+val HideAiMixKey = booleanPreferencesKey("hide_ai_mix")
+
 enum class AiProvider {
     CHATGPT,
     GEMINI,
@@ -642,6 +645,7 @@ enum class PlayerDesignStyle {
     V7,
     V8,
     V9,
+    APPLE_MUSIC,
 }
 
 enum class PlayerBackgroundStyle {
@@ -674,6 +678,19 @@ enum class MiniPlayerBackgroundStyle {
     GRADIENT,
     GLOW,
 }
+
+// Bottom navigation bar look: DEFAULT keeps the docked full-width bar; FLOATING detaches it into
+// a pill with larger margins that never pairs with the mini player.
+enum class NavigationBarStyle {
+    DEFAULT,
+    FLOATING,
+}
+
+val NavigationBarStyleKey = stringPreferencesKey("navigationBarStyle")
+
+// Draws a frosted (blurred app content) backdrop behind the navigation bar. True backdrop blur on
+// Android 12+; a translucent surface fallback below that.
+val NavigationBarFrostedBlurKey = booleanPreferencesKey("navigationBarFrostedBlur")
 
 // Keys for customized background
 val PlayerCustomImageUriKey = stringPreferencesKey("playerCustomImageUri")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -24,7 +24,9 @@ import moe.rukamori.archivetune.constants.PreferredLyricsProvider
 import moe.rukamori.archivetune.constants.deserializeLyricsProviderOrder
 import moe.rukamori.archivetune.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
 import moe.rukamori.archivetune.models.MediaMetadata
+import moe.rukamori.archivetune.telegram.isTelegramMediaId
 import moe.rukamori.archivetune.utils.GlobalLog
+import moe.rukamori.archivetune.utils.isLocalMediaId
 import moe.rukamori.archivetune.utils.NetworkConnectivityObserver
 import moe.rukamori.archivetune.utils.dataStore
 import moe.rukamori.archivetune.utils.reportException
@@ -99,7 +101,10 @@ class LyricsHelper
                 return LYRICS_NOT_FOUND
             }
 
-            val ordered = orderedProviders().filter { it.isEnabled(context) }
+            val ordered =
+                orderedProviders()
+                    .filter { it.isEnabled(context) }
+                    .filter { supportsMediaId(it, mediaMetadata.id) }
             val providers = if (preferredProviderOnly) ordered.take(1) else ordered
             val lyrics = fetchPriorityLyrics(providers, mediaMetadata)
             if (isMeaningfulLyrics(lyrics)) {
@@ -241,6 +246,21 @@ class LyricsHelper
         }
 
         private fun isMeaningfulLyrics(lyrics: String): Boolean = LyricsUtils.hasMeaningfulLyricsContent(lyrics)
+
+        /**
+         * Providers that treat the media id as a YouTube video id can never match local or
+         * Telegram tracks — skip them so the priority race isn't padded with guaranteed misses.
+         */
+        private fun supportsMediaId(
+            provider: LyricsProvider,
+            mediaId: String,
+        ): Boolean {
+            val isNonYouTubeId = mediaId.isTelegramMediaId() || mediaId.isLocalMediaId()
+            if (!isNonYouTubeId) return true
+            return provider !is SimpMusicLyricsProvider &&
+                provider !is YouTubeLyricsProvider &&
+                provider !is YouTubeSubtitleLyricsProvider
+        }
 
         fun clearCache() {
             cache.evictAll()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -229,6 +229,7 @@ import moe.rukamori.archivetune.db.entities.AlbumEntity
 import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.Event
 import moe.rukamori.archivetune.db.entities.FormatEntity
+import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.db.entities.RelatedSongMap
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.db.entities.SongEntity
@@ -1340,13 +1341,19 @@ class MusicService :
         ) { mediaMetadata, showLyrics ->
             mediaMetadata to showLyrics
         }.collectLatest(ioScope) { (mediaMetadata, showLyrics) ->
-            if (showLyrics && mediaMetadata != null && database
-                    .lyrics(mediaMetadata.id)
-                    .first() == null
-            ) {
+            if (mediaMetadata == null) return@collectLatest
+            // Telegram tracks have no embedded lyrics, so fetch through the provider chain on
+            // every play (not only once the lyrics panel has been opened), and retry a stored
+            // LYRICS_NOT_FOUND — early plays can fail while metadata/network are still settling.
+            val isTelegram = mediaMetadata.id.isTelegramMediaId()
+            if (!showLyrics && !isTelegram) return@collectLatest
+            val stored = database.lyrics(mediaMetadata.id).first()
+            val shouldFetch =
+                stored == null || (isTelegram && stored.lyrics == LyricsEntity.LYRICS_NOT_FOUND)
+            if (shouldFetch) {
                 val lyrics = lyricsHelper.getLyrics(mediaMetadata)
                 database.query {
-                    insertLyricsIfAbsent(
+                    replaceLyricsIfAbsentOrNotFound(
                         id = mediaMetadata.id,
                         lyrics = lyrics,
                     )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/PlayerConnection.kt
@@ -389,6 +389,7 @@ class PlayerConnection(
                     artistNameRaw = metadata.artists.firstOrNull()?.name.orEmpty(),
                     storefront = storefront,
                     requireVertical = requireVertical,
+                    albumTitle = metadata.album?.title,
                 ) ?: return CanvasArtworkRefetchResult.Failure
 
             _canvasArtworkUpdates.emit(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaItems.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramMediaItems.kt
@@ -14,15 +14,18 @@ import moe.rukamori.archivetune.models.MediaMetadata
  * Bridges a Telegram channel track into the app's playback model. The media id is the encoded
  * telegram:// URI, so the player's scheme router hands the item straight to [TelegramDataSource].
  */
-fun TelegramTrack.toMediaMetadata(channelTitle: String? = null): MediaMetadata =
-    MediaMetadata(
+fun TelegramTrack.toMediaMetadata(channelTitle: String? = null): MediaMetadata {
+    // Prefer tag metadata, fall back to "Artist - Title" parsed from the file name — this is what
+    // lyrics/canvas/cover lookups match against, so a real artist beats the channel name.
+    val metadata = lookupMetadata
+    return MediaMetadata(
         id = mediaId,
-        title = displayTitle,
+        title = metadata.title,
         artists =
             listOf(
                 MediaMetadata.Artist(
                     id = null,
-                    name = performer ?: channelTitle ?: "Telegram",
+                    name = metadata.artist ?: channelTitle ?: "Telegram",
                 ),
             ),
         duration = durationSeconds,
@@ -30,12 +33,13 @@ fun TelegramTrack.toMediaMetadata(channelTitle: String? = null): MediaMetadata =
         // up by title/artist online, falling back to the embedded Telegram cover, then the tiny
         // minithumbnail.
         thumbnailUrl =
-            telegramArtworkModel(thumbnailFileId, displayTitle, performer)
+            telegramArtworkModel(thumbnailFileId, metadata.title, metadata.artist)
                 ?: TelegramClient.cacheArtwork(
                     uniqueKey = fileUniqueId.ifEmpty { "$chatId-$messageId" },
                     data = albumCoverMinithumbnail,
                 ),
     )
+}
 
 /**
  * Seed a [FormatEntity] for a Telegram track so the player-details / Nerd Stats screen shows file

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramModels.kt
@@ -64,6 +64,14 @@ data class TelegramTrack(
                 fileName.substringBeforeLast('.').ifBlank { fileName }
             }
 
+    /**
+     * Title/artist for metadata lookups (lyrics, canvas, cover art) and library rows. Prefers the
+     * audio tags; when the performer tag is missing, tries to split the file name as
+     * "Artist - Title" (with track numbers and noise stripped) so provider lookups can match.
+     */
+    val lookupMetadata: TelegramTrackMetadata
+        get() = deriveTrackMetadata(tagTitle = title, tagPerformer = performer, fileName = fileName)
+
     override fun equals(other: Any?): Boolean =
         other is TelegramTrack && other.chatId == chatId && other.messageId == messageId
 
@@ -139,4 +147,55 @@ fun isAudioDocument(
     val mime = mimeType.trim().lowercase(Locale.US)
     if (mime.startsWith("audio/")) return true
     return fileExtension(fileName) in AUDIO_EXTENSIONS
+}
+
+/** Cleaned-up title + optional artist derived from a track's tags/file name. */
+data class TelegramTrackMetadata(
+    val title: String,
+    val artist: String?,
+)
+
+private val NOISE_SUFFIX_REGEX =
+    Regex("\\((?:official|lyric|audio|video|hd|hq|visualizer)[^)]*\\)", RegexOption.IGNORE_CASE)
+private val BRACKET_TAG_REGEX = Regex("\\[[^\\]]*\\]")
+private val LEADING_TRACK_NUMBER_REGEX = Regex("^\\s*\\d{1,3}\\s*[.\\-]\\s*")
+private val WHITESPACE_REGEX = Regex("\\s+")
+
+/** Strips bracketed tags, "(official …)" noise and leading track numbers from a raw name. */
+fun cleanTrackName(raw: String): String =
+    raw
+        .replace(NOISE_SUFFIX_REGEX, " ")
+        .replace(BRACKET_TAG_REGEX, " ")
+        .replace(LEADING_TRACK_NUMBER_REGEX, "")
+        .replace(WHITESPACE_REGEX, " ")
+        .trim()
+
+/**
+ * Derives lookup metadata from tags + file name. When the performer tag is missing, a file name
+ * shaped like "Artist - Title.flac" is split so the artist isn't lost (many channels tag nothing).
+ */
+fun deriveTrackMetadata(
+    tagTitle: String,
+    tagPerformer: String?,
+    fileName: String,
+): TelegramTrackMetadata {
+    val performer = tagPerformer?.trim()?.takeIf(String::isNotEmpty)
+    if (tagTitle.isNotBlank()) {
+        return TelegramTrackMetadata(title = cleanTrackName(tagTitle).ifBlank { tagTitle.trim() }, artist = performer)
+    }
+    val base = cleanTrackName(fileName.substringBeforeLast('.').ifBlank { fileName })
+    if (performer == null) {
+        val separators = listOf(" - ", " – ", " — ")
+        for (separator in separators) {
+            val index = base.indexOf(separator)
+            if (index > 0 && index < base.length - separator.length) {
+                val artist = base.substring(0, index).trim()
+                val title = base.substring(index + separator.length).trim()
+                if (artist.isNotEmpty() && title.isNotEmpty()) {
+                    return TelegramTrackMetadata(title = title, artist = artist)
+                }
+            }
+        }
+    }
+    return TelegramTrackMetadata(title = base.ifBlank { fileName }, artist = performer)
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -50,13 +50,20 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import android.os.Build
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
@@ -66,14 +73,30 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.constants.DisableAnimationsKey
+import moe.rukamori.archivetune.constants.FloatingNavigationBarMaxWidth
 import moe.rukamori.archivetune.constants.NavigationBarHeight
 import moe.rukamori.archivetune.constants.NavigationBarMaxWidth
+import moe.rukamori.archivetune.constants.NavigationBarStyle
 import moe.rukamori.archivetune.ui.screens.Screens
 import moe.rukamori.archivetune.utils.rememberPreference
 import kotlin.math.roundToInt
 
+/**
+ * Shared handle for the frosted navigation bar: the app records its content into [layer] each
+ * frame, and the bar draws that layer (offset by the recorded content's root position) behind a
+ * blur so the pixels underneath show through frosted.
+ */
+class NavigationBarBackdrop(
+    val layer: GraphicsLayer,
+) {
+    var contentOffsetInRoot: Offset = Offset.Zero
+}
+
 private val NavigationItemsMaxWidth = 360.dp
 private val NavigationItemVerticalPadding = 8.dp
+
+// Frosted nav-bar backdrop blur radius, in px (RenderEffect works in raw pixels).
+private const val FrostedNavBarBlurRadiusPx = 60f
 
 // The sliding pill wraps just the icon (like the stock indicator), so the label sits below it,
 // outside the bubble. These are the standard Material3 active-indicator dimensions.
@@ -96,25 +119,40 @@ fun FloatingNavigationToolbar(
     pureBlack: Boolean,
     modifier: Modifier = Modifier,
     isPairedWithMiniPlayer: Boolean = false,
+    style: NavigationBarStyle = NavigationBarStyle.DEFAULT,
+    frostedBlur: Boolean = false,
+    frostedBackdrop: NavigationBarBackdrop? = null,
     isSelected: (Screens) -> Boolean,
     onItemClick: (Screens, Boolean) -> Unit,
     onSearchItemDoubleClick: (() -> Unit)? = null,
 ) {
+    val isFloating = style == NavigationBarStyle.FLOATING
     val navigationShape =
-        remember(isPairedWithMiniPlayer) {
-            if (isPairedWithMiniPlayer) {
-                RoundedCornerShape(
-                    topStart = 12.dp,
-                    topEnd = 12.dp,
-                    bottomStart = 28.dp,
-                    bottomEnd = 28.dp,
-                )
-            } else {
-                null
+        remember(isPairedWithMiniPlayer, isFloating) {
+            when {
+                // A detached pill keeps the full radius; it never docks with the mini player.
+                isFloating -> RoundedCornerShape(percent = 50)
+                isPairedWithMiniPlayer ->
+                    RoundedCornerShape(
+                        topStart = 12.dp,
+                        topEnd = 12.dp,
+                        bottomStart = 28.dp,
+                        bottomEnd = 28.dp,
+                    )
+                else -> null
             }
         } ?: MaterialTheme.shapes.extraLarge
-    val navigationContainerColor =
+    // True backdrop blur needs RenderEffect (Android 12+); otherwise a translucent surface still
+    // reads as frosted over scrolling content.
+    val canBlurBackdrop = frostedBlur && frostedBackdrop != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val opaqueContainerColor =
         if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
+    val navigationContainerColor =
+        when {
+            canBlurBackdrop -> opaqueContainerColor.copy(alpha = 0.55f)
+            frostedBlur -> opaqueContainerColor.copy(alpha = 0.85f)
+            else -> opaqueContainerColor
+        }
     val motionScheme = MaterialTheme.motionScheme
     val (disableAnimations) = rememberPreference(DisableAnimationsKey, defaultValue = false)
     val density = LocalDensity.current
@@ -180,17 +218,49 @@ fun FloatingNavigationToolbar(
                 .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)),
         contentAlignment = Alignment.Center,
     ) {
+        var barPositionInRoot by remember { mutableStateOf(Offset.Zero) }
         Surface(
             modifier =
                 Modifier
-                    .widthIn(max = NavigationBarMaxWidth)
+                    .widthIn(max = if (isFloating) FloatingNavigationBarMaxWidth else NavigationBarMaxWidth)
                     .fillMaxWidth()
-                    .height(NavigationBarHeight),
+                    .height(NavigationBarHeight)
+                    .onGloballyPositioned { barPositionInRoot = it.positionInRoot() },
             shape = navigationShape,
-            color = navigationContainerColor,
-            tonalElevation = NavigationBarDefaults.Elevation,
-            shadowElevation = NavigationBarDefaults.Elevation,
+            color = if (canBlurBackdrop) Color.Transparent else navigationContainerColor,
+            tonalElevation = if (canBlurBackdrop) 0.dp else NavigationBarDefaults.Elevation,
+            shadowElevation = if (isFloating) 8.dp else NavigationBarDefaults.Elevation,
         ) {
+            if (canBlurBackdrop && frostedBackdrop != null) {
+                // Draw the app content captured this frame, shifted so the region underneath the
+                // bar lines up, inside a blurred layer — a real frosted-glass backdrop. A tint on
+                // top keeps icon contrast.
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .graphicsLayer {
+                                renderEffect =
+                                    BlurEffect(
+                                        radiusX = FrostedNavBarBlurRadiusPx,
+                                        radiusY = FrostedNavBarBlurRadiusPx,
+                                        edgeTreatment = TileMode.Clamp,
+                                    )
+                                clip = true
+                            }.drawBehind {
+                                val offset = frostedBackdrop.contentOffsetInRoot - barPositionInRoot
+                                translate(offset.x, offset.y) {
+                                    drawLayer(frostedBackdrop.layer)
+                                }
+                            },
+                )
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .background(navigationContainerColor),
+                )
+            }
             ShortNavigationBar(
                 modifier = Modifier.fillMaxSize(),
                 containerColor = Color.Transparent,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -63,7 +63,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -98,6 +97,7 @@ import com.mocharealm.accompanist.lyrics.core.model.karaoke.KaraokeLine
 import com.mocharealm.accompanist.lyrics.core.model.karaoke.KaraokeSyllable
 import com.mocharealm.accompanist.lyrics.core.model.synced.SyncedLine
 import com.mocharealm.accompanist.lyrics.ui.composable.lyrics.KaraokeLyricsView
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
@@ -105,6 +105,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
@@ -265,14 +266,14 @@ fun LyricsEnhanced(
     var syncedLyrics by remember(lyricsEntries, isTtmlFormat) {
         mutableStateOf(buildSyncedLyrics(lyricsEntries, isTtmlFormat, emptyMap()))
     }
-    var syncedLyricsRenderVersion by remember(lyricsEntries, isTtmlFormat) {
-        mutableIntStateOf(0)
-    }
 
     LaunchedEffect(lyricsEntries, romanizationPreferences) {
+        // Everything below (scanning + romanizing every line, often one job per word for TTML)
+        // used to inherit the main dispatcher and could stutter the karaoke animation on track
+        // change; run the whole batch on Default and only publish the results back.
+        withContext(Dispatchers.Default) {
         syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, emptyMap())
-        syncedLyricsRenderVersion += 1
-        if (!romanizationPreferences.isEnabled) return@LaunchedEffect
+        if (!romanizationPreferences.isEnabled) return@withContext
 
         val toRomanize =
             lyricsEntries.mapIndexedNotNull { index, entry ->
@@ -284,7 +285,7 @@ fun LyricsEnhanced(
                     null
                 }
             }
-        if (toRomanize.isEmpty()) return@LaunchedEffect
+        if (toRomanize.isEmpty()) return@withContext
 
         val jobs =
             toRomanize.map { (index, entry) ->
@@ -320,8 +321,10 @@ fun LyricsEnhanced(
         jobs.awaitAll().forEach { (index, romanized) ->
             tempMap[index] = romanized
         }
+        // Publishing new lyrics as state (instead of bumping a key that tears the whole karaoke
+        // subtree down mid-playback) lets the view pick up romanization without a re-layout hitch.
         syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, tempMap)
-        syncedLyricsRenderVersion += 1
+        }
     }
 
     val leadMs = if (isTtmlFormat) TTML_LEAD_MS else LRC_LEAD_MS
@@ -523,22 +526,31 @@ fun LyricsEnhanced(
         }
     }
 
+    // Remembered: fresh TextStyle identities every recomposition forced the karaoke view to
+    // re-measure all lines on unrelated state changes (scroll flags, selection, etc.).
+    val typography = MaterialTheme.typography
     val normalTextStyle =
-        MaterialTheme.typography.headlineMedium.copy(
-            fontSize = lyricsTextSize.sp,
-            fontWeight = FontWeight.Bold,
-            fontFamily = lyricsFontFamily ?: MaterialTheme.typography.headlineMedium.fontFamily,
-        )
+        remember(typography, lyricsTextSize, lyricsFontFamily) {
+            typography.headlineMedium.copy(
+                fontSize = lyricsTextSize.sp,
+                fontWeight = FontWeight.Bold,
+                fontFamily = lyricsFontFamily ?: typography.headlineMedium.fontFamily,
+            )
+        }
     val accompanimentTextStyle =
-        MaterialTheme.typography.titleLarge.copy(
-            fontSize = (lyricsTextSize * 0.82f).sp,
-            fontFamily = lyricsFontFamily ?: MaterialTheme.typography.titleLarge.fontFamily,
-        )
+        remember(typography, lyricsTextSize, lyricsFontFamily) {
+            typography.titleLarge.copy(
+                fontSize = (lyricsTextSize * 0.82f).sp,
+                fontFamily = lyricsFontFamily ?: typography.titleLarge.fontFamily,
+            )
+        }
     val phoneticTextStyle =
-        MaterialTheme.typography.bodyMedium.copy(
-            fontSize = (lyricsTextSize * 0.55f).sp,
-            fontWeight = FontWeight.Normal,
-        )
+        remember(typography, lyricsTextSize) {
+            typography.bodyMedium.copy(
+                fontSize = (lyricsTextSize * 0.55f).sp,
+                fontWeight = FontWeight.Normal,
+            )
+        }
     val plainLyrics =
         remember(lyricsEntries, isSynced) {
             PlainLyrics(
@@ -704,7 +716,9 @@ fun LyricsEnhanced(
                 ) {
                     val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.38f }
 
-                    key(lyricsSessionKey, syncedLyricsRenderVersion) {
+                    // Keyed on the session only: romanization updates flow in as new state instead
+                    // of disposing and rebuilding the whole karaoke view mid-playback.
+                    key(lyricsSessionKey) {
                         KaraokeLyricsView(
                             listState = listState,
                             lyrics = syncedLyrics,
@@ -732,7 +746,9 @@ fun LyricsEnhanced(
                             accompanimentLineTextStyle = accompanimentTextStyle,
                             phoneticTextStyle = phoneticTextStyle,
                             blendMode = BlendMode.SrcOver,
-                            useBlurEffect = lyricsLineBlur,
+                            // Per-line RenderEffect blur is the single heaviest per-frame cost in
+                            // this view; drop it when animations are disabled (low-RAM default).
+                            useBlurEffect = lyricsLineBlur && !animationsDisabled,
                             showTranslation = showTranslations,
                             showPhonetic = romanizationPreferences.isEnabled,
                             offset = lyricsViewportOffset,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -97,10 +97,12 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.LyricsClickKey
@@ -207,10 +209,17 @@ fun LyricsV2(
     val (lyricsTextSize) = rememberPreference(LyricsTextSizeKey, defaultValue = 26f)
     val (lyricsLineSpacing) = rememberPreference(LyricsLineSpacingKey, defaultValue = 1.3f)
     val (lyricsLineBlurPreference) = rememberPreference(LyricsLineBlurKey, defaultValue = true)
-    val (bounceFactor) = rememberPreference(LyricsV2BounceFactorKey, defaultValue = 1f)
-    val (glowFactor) = rememberPreference(LyricsV2GlowFactorKey, defaultValue = 1f)
+    val (bounceFactorPreference) = rememberPreference(LyricsV2BounceFactorKey, defaultValue = 1f)
+    val (glowFactorPreference) = rememberPreference(LyricsV2GlowFactorKey, defaultValue = 1f)
     val (fillTransitionWidth) = rememberPreference(LyricsV2FillTransitionWidthKey, defaultValue = 8f)
-    val (lrcBounceEnabled) = rememberPreference(LyricsV2LrcBounceEnabledKey, defaultValue = true)
+    val (lrcBounceEnabledPreference) = rememberPreference(LyricsV2LrcBounceEnabledKey, defaultValue = true)
+    // The V2 renderer never honored the reduce-animations setting: on low-RAM devices (where it
+    // defaults on) the per-word glow shadows, bounce springs and line blur are the difference
+    // between smooth and stuttering karaoke, so gate them all here.
+    val v2AnimationsDisabled = LocalAnimationsDisabled.current
+    val bounceFactor = if (v2AnimationsDisabled) 0f else bounceFactorPreference
+    val glowFactor = if (v2AnimationsDisabled) 0f else glowFactorPreference
+    val lrcBounceEnabled = lrcBounceEnabledPreference && !v2AnimationsDisabled
     val (romanizeChinese) = rememberPreference(LyricsRomanizeChineseKey, defaultValue = true)
     val (romanizeHindi) = rememberPreference(LyricsRomanizeHindiKey, defaultValue = true)
     val (romanizeJapanese) = rememberPreference(LyricsRomanizeJapaneseKey, defaultValue = true)
@@ -242,7 +251,7 @@ fun LyricsV2(
         } else {
             Color.White
         }
-    val lyricsLineBlur = lyricsLineBlurOverride ?: lyricsLineBlurPreference
+    val lyricsLineBlur = (lyricsLineBlurOverride ?: lyricsLineBlurPreference) && !v2AnimationsDisabled
 
     val inactiveAlpha = 0.35f
 
@@ -326,7 +335,9 @@ fun LyricsV2(
                 return@forEach
             }
 
-            launch {
+            // Off the UI thread: one romanization per line on Main used to queue dozens of
+            // dispatcher hops right as the karaoke animation started.
+            launch(Dispatchers.Default) {
                 val romanized =
                     try {
                         romanizeLyricsLine(entry.text, romanizationPreferences)
@@ -349,7 +360,14 @@ fun LyricsV2(
 
     LaunchedEffect(entriesWithWords, isSynced, leadMs, lyricsSyncOffset) {
         if (!isSynced || entriesWithWords.isEmpty()) return@LaunchedEffect
-        val pollIntervalMs = if (isTtmlFormat) 16L else 50L
+        // 16 ms recomposes every visible word ~60×/s; with animations disabled a coarser tick is
+        // indistinguishable (fills snap anyway) and much cheaper.
+        val pollIntervalMs =
+            when {
+                v2AnimationsDisabled -> 100L
+                isTtmlFormat -> 16L
+                else -> 50L
+            }
         while (isActive) {
             val sliderPos = sliderPositionProvider()
             val pos = sliderPos ?: player.currentPosition

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -1,0 +1,732 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * "Apple Music" player design: edge-to-edge artwork on top with a blurred continuation of the
+ * artwork behind the lower controls (progressive-blur look), bold white title/artist with star and
+ * "more" chips, a thin scrubber with elapsed/-remaining times, bare oversized transport glyphs, a
+ * flat volume slider, and a bottom lyrics / output / queue icon row. Everything is tinted by the
+ * artwork itself (no palette extraction needed — the blur provides the color).
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ripple
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.Player.STATE_ENDED
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.extensions.togglePlayPause
+import moe.rukamori.archivetune.models.MediaMetadata
+import moe.rukamori.archivetune.playback.PlayerConnection
+import moe.rukamori.archivetune.ui.component.BottomSheetPageState
+import moe.rukamori.archivetune.ui.component.BottomSheetState
+import moe.rukamori.archivetune.ui.component.LocalMenuState
+import moe.rukamori.archivetune.ui.menu.PlayerMenu
+import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
+import moe.rukamori.archivetune.ui.utils.highRes
+import moe.rukamori.archivetune.utils.makeTimeString
+import moe.rukamori.archivetune.utils.rememberLowDataModeActive
+
+private val AppleMusicContentPadding = 28.dp
+private val AppleMusicChipSize = 34.dp
+private val AppleMusicTransportIconSize = 44.dp
+private val AppleMusicPlayPauseIconSize = 52.dp
+private val AppleMusicBottomIconSize = 24.dp
+
+@Composable
+fun AppleMusicPlayerContent(
+    mediaMetadata: MediaMetadata,
+    playbackState: Int,
+    isPlaying: Boolean,
+    isLoading: Boolean,
+    canSkipPrevious: Boolean,
+    canSkipNext: Boolean,
+    sliderPosition: Long?,
+    position: Long,
+    duration: Long,
+    playerConnection: PlayerConnection,
+    navController: NavController,
+    state: BottomSheetState,
+    bottomSheetPageState: BottomSheetPageState,
+    currentSongLiked: Boolean,
+    volume: Float,
+    onVolumeChange: (Float) -> Unit,
+    canvasPrimaryUrl: String?,
+    canvasFallbackUrl: String?,
+    contentBottomPadding: Dp,
+    onQueueClick: () -> Unit,
+    onLyricsClick: () -> Unit,
+    onSliderValueChange: (Long) -> Unit,
+    onSliderValueChangeFinished: () -> Unit,
+    modifier: Modifier = Modifier,
+    landscape: Boolean = false,
+) {
+    val baseArtworkUrl = mediaMetadata.thumbnailUrl?.highRes()
+    val thumbnailSwapState =
+        rememberThumbnailSwapState(
+            videoId = mediaMetadata.id,
+            ytmUrl = baseArtworkUrl,
+            lowDataMode = rememberLowDataModeActive(),
+            isMusicVideo = mediaMetadata.isMusicVideo,
+        )
+    val artworkUrl = thumbnailSwapState.displayUrl
+    val artworkRequest = rememberOfflineArtworkImageRequest(artworkUrl)
+    val titleActions = rememberPlayerTitleActions(mediaMetadata, navController, state)
+    val menuState = LocalMenuState.current
+    val context = LocalContext.current
+
+    val onPlayPauseClick = {
+        if (playbackState == STATE_ENDED) {
+            playerConnection.player.seekTo(0, 0)
+            playerConnection.player.playWhenReady = true
+        } else {
+            playerConnection.player.togglePlayPause()
+        }
+    }
+    val onMoreClick = {
+        menuState.show {
+            PlayerMenu(
+                mediaMetadata = mediaMetadata,
+                navController = navController,
+                playerBottomSheetState = state,
+                onShowDetailsDialog = {
+                    mediaMetadata.id.let {
+                        bottomSheetPageState.show {
+                            ShowMediaInfo(it)
+                        }
+                    }
+                },
+                onDismiss = menuState::dismiss,
+            )
+        }
+    }
+    val onOutputClick = {
+        // Best-effort media output switcher (the "AirPlay" slot): the system output panel where
+        // available, else the volume panel.
+        val launched =
+            runCatching {
+                context.startActivity(Intent("com.android.settings.panel.action.MEDIA_OUTPUT"))
+            }.isSuccess
+        if (!launched) {
+            runCatching {
+                context.startActivity(Intent(Settings.Panel.ACTION_VOLUME))
+            }
+        }
+    }
+
+    BoxWithConstraints(modifier = modifier) {
+        val sharpArtworkHeight = if (landscape) maxHeight else maxHeight * 0.55f
+
+        // 1. Blurred artwork fills the whole player as the base layer. On Android 12+ this is a
+        // real gaussian blur; below that the scrim alone carries the contrast.
+        AsyncImage(
+            model = artworkRequest ?: artworkUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .then(
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                            Modifier.blur(72.dp)
+                        } else {
+                            Modifier
+                        },
+                    ).graphicsLayer {
+                        scaleX = 1.2f
+                        scaleY = 1.2f
+                    },
+        )
+        // Contrast scrim over the blur, heavier at the bottom where the controls sit.
+        Box(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .background(
+                        Brush.verticalGradient(
+                            0f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.10f else 0.35f),
+                            0.55f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.28f else 0.55f),
+                            1f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.45f else 0.7f),
+                        ),
+                    ),
+        )
+
+        if (landscape) {
+            Row(Modifier.fillMaxSize()) {
+                AppleMusicSharpArtwork(
+                    artworkRequest = artworkRequest,
+                    artworkUrl = artworkUrl,
+                    canvasPrimaryUrl = canvasPrimaryUrl,
+                    canvasFallbackUrl = canvasFallbackUrl,
+                    isPlaying = isPlaying,
+                    fadeBottom = false,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                )
+                AppleMusicControlsColumn(
+                    mediaMetadata = mediaMetadata,
+                    isPlaying = isPlaying,
+                    isLoading = isLoading,
+                    canSkipPrevious = canSkipPrevious,
+                    canSkipNext = canSkipNext,
+                    sliderPosition = sliderPosition,
+                    position = position,
+                    duration = duration,
+                    playerConnection = playerConnection,
+                    currentSongLiked = currentSongLiked,
+                    volume = volume,
+                    onVolumeChange = onVolumeChange,
+                    titleActions = titleActions,
+                    onPlayPauseClick = onPlayPauseClick,
+                    onMoreClick = onMoreClick,
+                    onOutputClick = onOutputClick,
+                    onQueueClick = onQueueClick,
+                    onLyricsClick = onLyricsClick,
+                    onSliderValueChange = onSliderValueChange,
+                    onSliderValueChangeFinished = onSliderValueChangeFinished,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .padding(bottom = contentBottomPadding),
+                )
+            }
+        } else {
+            // 2. Sharp artwork occupies the top, fading into the blurred continuation below it.
+            AppleMusicSharpArtwork(
+                artworkRequest = artworkRequest,
+                artworkUrl = artworkUrl,
+                canvasPrimaryUrl = canvasPrimaryUrl,
+                canvasFallbackUrl = canvasFallbackUrl,
+                isPlaying = isPlaying,
+                fadeBottom = true,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(sharpArtworkHeight)
+                        .align(Alignment.TopCenter),
+            )
+
+            // 3. Controls anchored to the bottom.
+            AppleMusicControlsColumn(
+                mediaMetadata = mediaMetadata,
+                isPlaying = isPlaying,
+                isLoading = isLoading,
+                canSkipPrevious = canSkipPrevious,
+                canSkipNext = canSkipNext,
+                sliderPosition = sliderPosition,
+                position = position,
+                duration = duration,
+                playerConnection = playerConnection,
+                currentSongLiked = currentSongLiked,
+                volume = volume,
+                onVolumeChange = onVolumeChange,
+                titleActions = titleActions,
+                onPlayPauseClick = onPlayPauseClick,
+                onMoreClick = onMoreClick,
+                onOutputClick = onOutputClick,
+                onQueueClick = onQueueClick,
+                onLyricsClick = onLyricsClick,
+                onSliderValueChange = onSliderValueChange,
+                onSliderValueChangeFinished = onSliderValueChangeFinished,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight(0.5f)
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = contentBottomPadding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppleMusicSharpArtwork(
+    artworkRequest: coil3.request.ImageRequest?,
+    artworkUrl: String?,
+    canvasPrimaryUrl: String?,
+    canvasFallbackUrl: String?,
+    isPlaying: Boolean,
+    fadeBottom: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier.then(
+                if (fadeBottom) {
+                    // Fade the sharp artwork's lower edge into the blurred layer beneath.
+                    Modifier
+                        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                        .drawWithContent {
+                            drawContent()
+                            drawRect(
+                                brush =
+                                    Brush.verticalGradient(
+                                        0.62f to Color.Black,
+                                        1f to Color.Transparent,
+                                    ),
+                                blendMode = androidx.compose.ui.graphics.BlendMode.DstIn,
+                            )
+                        }
+                } else {
+                    Modifier
+                },
+            ),
+    ) {
+        AsyncImage(
+            model = artworkRequest ?: artworkUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.matchParentSize(),
+        )
+        if (!canvasPrimaryUrl.isNullOrBlank() || !canvasFallbackUrl.isNullOrBlank()) {
+            CanvasArtworkPlayer(
+                primaryUrl = canvasPrimaryUrl,
+                fallbackUrl = canvasFallbackUrl,
+                isPlaying = isPlaying,
+                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM,
+                modifier = Modifier.matchParentSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppleMusicControlsColumn(
+    mediaMetadata: MediaMetadata,
+    isPlaying: Boolean,
+    isLoading: Boolean,
+    canSkipPrevious: Boolean,
+    canSkipNext: Boolean,
+    sliderPosition: Long?,
+    position: Long,
+    duration: Long,
+    playerConnection: PlayerConnection,
+    currentSongLiked: Boolean,
+    volume: Float,
+    onVolumeChange: (Float) -> Unit,
+    titleActions: PlayerTitleActions,
+    onPlayPauseClick: () -> Unit,
+    onMoreClick: () -> Unit,
+    onOutputClick: () -> Unit,
+    onQueueClick: () -> Unit,
+    onLyricsClick: () -> Unit,
+    onSliderValueChange: (Long) -> Unit,
+    onSliderValueChangeFinished: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(horizontal = AppleMusicContentPadding),
+        verticalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        // Title / artist row with star + more chips.
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = mediaMetadata.title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier =
+                        Modifier.clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = titleActions.onTitleClick,
+                        ),
+                )
+                Text(
+                    text = mediaMetadata.artists.joinToString { it.name },
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Color.White.copy(alpha = 0.64f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier =
+                        Modifier.clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                        ) {
+                            mediaMetadata.artists.firstOrNull()?.id?.let(titleActions.onArtistClick)
+                        },
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            AppleMusicChip(
+                iconRes = R.drawable.star,
+                tint = if (currentSongLiked) Color(0xFFFFD60A) else Color.White,
+                contentDescription = null,
+                onClick = playerConnection::toggleLike,
+            )
+            Spacer(Modifier.width(10.dp))
+            AppleMusicChip(
+                iconRes = R.drawable.more_horiz,
+                tint = Color.White,
+                contentDescription = null,
+                onClick = onMoreClick,
+            )
+        }
+
+        // Thin scrubber + elapsed / -remaining.
+        Column {
+            AppleMusicSeekBar(
+                position = sliderPosition ?: position,
+                duration = duration,
+                onScrub = onSliderValueChange,
+                onScrubFinished = onSliderValueChangeFinished,
+            )
+            Spacer(Modifier.height(6.dp))
+            Row(Modifier.fillMaxWidth()) {
+                Text(
+                    text = makeTimeString(sliderPosition ?: position),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Color.White.copy(alpha = 0.55f),
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = "-" + makeTimeString((duration - (sliderPosition ?: position)).coerceAtLeast(0L)),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = Color.White.copy(alpha = 0.55f),
+                )
+            }
+        }
+
+        // Bare transport glyphs.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AppleMusicTransportButton(
+                iconRes = R.drawable.fast_forward,
+                enabled = canSkipPrevious,
+                mirrored = true,
+                iconSize = AppleMusicTransportIconSize,
+                onClick = playerConnection::seekToPrevious,
+            )
+            Box(contentAlignment = Alignment.Center) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        color = Color.White,
+                        modifier = Modifier.size(AppleMusicPlayPauseIconSize),
+                        strokeWidth = 3.dp,
+                    )
+                } else {
+                    AppleMusicTransportButton(
+                        iconRes = if (isPlaying) R.drawable.pause else R.drawable.play,
+                        enabled = true,
+                        mirrored = false,
+                        iconSize = AppleMusicPlayPauseIconSize,
+                        onClick = onPlayPauseClick,
+                    )
+                }
+            }
+            AppleMusicTransportButton(
+                iconRes = R.drawable.fast_forward,
+                enabled = canSkipNext,
+                mirrored = false,
+                iconSize = AppleMusicTransportIconSize,
+                onClick = playerConnection::seekToNext,
+            )
+        }
+
+        // Flat volume slider with speaker glyphs.
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.volume_off),
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.55f),
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            AppleMusicVolumeSlider(
+                volume = volume,
+                onVolumeChange = onVolumeChange,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(12.dp))
+            Icon(
+                painter = painterResource(R.drawable.volume_up),
+                contentDescription = null,
+                tint = Color.White.copy(alpha = 0.55f),
+                modifier = Modifier.size(18.dp),
+            )
+        }
+
+        // Bottom action row: lyrics / media output / queue.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AppleMusicBottomButton(
+                iconRes = R.drawable.lyrics,
+                contentDescription = stringResource(R.string.lyrics),
+                onClick = onLyricsClick,
+            )
+            AppleMusicBottomButton(
+                iconRes = R.drawable.airplay,
+                contentDescription = null,
+                onClick = onOutputClick,
+            )
+            AppleMusicBottomButton(
+                iconRes = R.drawable.queue_music,
+                contentDescription = stringResource(R.string.queue),
+                onClick = onQueueClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppleMusicChip(
+    iconRes: Int,
+    tint: Color,
+    contentDescription: String?,
+    onClick: () -> Unit,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+            Modifier
+                .size(AppleMusicChipSize)
+                .clip(CircleShape)
+                .background(Color.White.copy(alpha = 0.14f))
+                .clickable(onClick = onClick),
+    ) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+@Composable
+private fun AppleMusicTransportButton(
+    iconRes: Int,
+    enabled: Boolean,
+    mirrored: Boolean,
+    iconSize: Dp,
+    onClick: () -> Unit,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+            Modifier
+                .size(iconSize + 20.dp)
+                .clip(CircleShape)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = ripple(bounded = false, radius = iconSize / 2 + 10.dp),
+                    enabled = enabled,
+                    onClick = onClick,
+                ),
+    ) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = null,
+            tint = Color.White.copy(alpha = if (enabled) 1f else 0.4f),
+            modifier =
+                Modifier
+                    .size(iconSize)
+                    .graphicsLayer { if (mirrored) scaleX = -1f },
+        )
+    }
+}
+
+@Composable
+private fun AppleMusicBottomButton(
+    iconRes: Int,
+    contentDescription: String?,
+    onClick: () -> Unit,
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier =
+            Modifier
+                .size(44.dp)
+                .clip(CircleShape)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = ripple(bounded = false, radius = 26.dp),
+                    onClick = onClick,
+                ),
+    ) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = contentDescription,
+            tint = Color.White.copy(alpha = 0.85f),
+            modifier = Modifier.size(AppleMusicBottomIconSize),
+        )
+    }
+}
+
+/** Thin Apple-Music-style scrubber: rounded 6dp track, no thumb, tap + drag to seek. */
+@Composable
+private fun AppleMusicSeekBar(
+    position: Long,
+    duration: Long,
+    onScrub: (Long) -> Unit,
+    onScrubFinished: () -> Unit,
+) {
+    val enabled = duration > 0L
+    var dragging by remember { mutableStateOf(false) }
+    var dragFraction by remember { mutableFloatStateOf(0f) }
+    val playedFraction =
+        if (duration > 0L) (position.toFloat() / duration).coerceIn(0f, 1f) else 0f
+    val shownFraction = if (dragging) dragFraction else playedFraction
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(26.dp)
+                .pointerInput(enabled, duration) {
+                    if (!enabled) return@pointerInput
+                    detectTapGestures { offset ->
+                        val fraction = (offset.x / size.width).coerceIn(0f, 1f)
+                        onScrub((fraction * duration).toLong())
+                        onScrubFinished()
+                    }
+                }.pointerInput(enabled, duration) {
+                    if (!enabled) return@pointerInput
+                    detectHorizontalDragGestures(
+                        onDragStart = { offset ->
+                            dragging = true
+                            dragFraction = (offset.x / size.width).coerceIn(0f, 1f)
+                            onScrub((dragFraction * duration).toLong())
+                        },
+                        onDragEnd = {
+                            dragging = false
+                            onScrubFinished()
+                        },
+                        onDragCancel = { dragging = false },
+                        onHorizontalDrag = { change, _ ->
+                            change.consume()
+                            dragFraction = (change.position.x / size.width).coerceIn(0f, 1f)
+                            onScrub((dragFraction * duration).toLong())
+                        },
+                    )
+                }.drawWithContent {
+                    val trackHeight = if (dragging) 10.dp.toPx() else 7.dp.toPx()
+                    val top = (size.height - trackHeight) / 2f
+                    val radius = CornerRadius(trackHeight / 2f)
+                    drawRoundRect(
+                        color = Color.White.copy(alpha = 0.28f),
+                        topLeft = Offset(0f, top),
+                        size = Size(size.width, trackHeight),
+                        cornerRadius = radius,
+                    )
+                    drawRoundRect(
+                        color = Color.White.copy(alpha = if (dragging) 1f else 0.85f),
+                        topLeft = Offset(0f, top),
+                        size = Size(size.width * shownFraction, trackHeight),
+                        cornerRadius = radius,
+                    )
+                },
+    )
+}
+
+/** Flat volume slider matching the scrubber's look. */
+@Composable
+private fun AppleMusicVolumeSlider(
+    volume: Float,
+    onVolumeChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .height(26.dp)
+                .pointerInput(Unit) {
+                    detectTapGestures { offset ->
+                        onVolumeChange((offset.x / size.width).coerceIn(0f, 1f))
+                    }
+                }.pointerInput(Unit) {
+                    detectHorizontalDragGestures { change, _ ->
+                        change.consume()
+                        onVolumeChange((change.position.x / size.width).coerceIn(0f, 1f))
+                    }
+                }.drawWithContent {
+                    val trackHeight = 6.dp.toPx()
+                    val top = (size.height - trackHeight) / 2f
+                    val radius = CornerRadius(trackHeight / 2f)
+                    drawRoundRect(
+                        color = Color.White.copy(alpha = 0.28f),
+                        topLeft = Offset(0f, top),
+                        size = Size(size.width, trackHeight),
+                        cornerRadius = radius,
+                    )
+                    drawRoundRect(
+                        color = Color.White.copy(alpha = 0.85f),
+                        topLeft = Offset(0f, top),
+                        size = Size(size.width * volume.coerceIn(0f, 1f), trackHeight),
+                        cornerRadius = radius,
+                    )
+                },
+    )
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/CanvasArtworkResolver.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/CanvasArtworkResolver.kt
@@ -11,7 +11,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.canvas.ArchiveTuneCanvas
 import moe.rukamori.archivetune.canvas.models.CanvasArtwork
+import moe.rukamori.archivetune.canvas.models.looselyMatchesSongIdentity
 import moe.rukamori.archivetune.canvas.models.matchesSongIdentity
+import moe.rukamori.archivetune.telegram.isTelegramMediaId
+import moe.rukamori.archivetune.utils.isLocalMediaId
 import timber.log.Timber
 
 internal suspend fun resolveCanvasArtworkForPlayback(
@@ -21,7 +24,11 @@ internal suspend fun resolveCanvasArtworkForPlayback(
     storefront: String,
     requireVertical: Boolean,
     allowNetwork: Boolean,
+    albumTitle: String? = null,
 ): CanvasArtwork? {
+    // Telegram/local files have tag-derived (often noisy) metadata — use fuzzy identity matching
+    // so a real canvas isn't discarded over a "(2019)" suffix or a channel-name artist.
+    val strictIdentity = !(mediaId.isTelegramMediaId() || mediaId.isLocalMediaId())
     val cachedArtwork =
         withContext(Dispatchers.IO) {
             CanvasArtworkPlaybackCache.get(
@@ -32,7 +39,7 @@ internal suspend fun resolveCanvasArtworkForPlayback(
     if (cachedArtwork != null) {
         val isValid =
             cachedArtwork.hasRequiredCanvasVariant(requireVertical) &&
-                cachedArtwork.matchesSongIdentity(songTitleRaw, artistNameRaw)
+                cachedArtwork.matchesIdentity(songTitleRaw, artistNameRaw, strictIdentity)
         if (isValid) return cachedArtwork
         withContext(Dispatchers.IO) {
             CanvasArtworkPlaybackCache.remove(mediaId)
@@ -51,6 +58,8 @@ internal suspend fun resolveCanvasArtworkForPlayback(
                 artistNameRaw = artistNameRaw,
                 storefront = storefront,
                 requireVertical = requireVertical,
+                strictIdentity = strictIdentity,
+                albumTitle = albumTitle,
             )
 
         if (fetched == null) {
@@ -68,6 +77,8 @@ internal suspend fun fetchCanvasArtworkForPlayback(
     storefront: String,
     requireVertical: Boolean,
     forceRefresh: Boolean = false,
+    strictIdentity: Boolean = true,
+    albumTitle: String? = null,
 ): CanvasArtwork? {
     val songTitle = normalizeCanvasSongTitle(songTitleRaw)
     val artistName = normalizeCanvasArtistName(artistNameRaw)
@@ -88,8 +99,10 @@ internal suspend fun fetchCanvasArtworkForPlayback(
                 artist = artist,
                 storefront = storefront,
                 forceRefresh = forceRefresh,
+                strict = strictIdentity,
+                album = albumTitle,
             )?.takeIf { artwork ->
-                artwork.matchesSongIdentity(songTitleRaw, artistNameRaw) &&
+                artwork.matchesIdentity(songTitleRaw, artistNameRaw, strictIdentity) &&
                     artwork.hasRequiredCanvasVariant(requireVertical)
             }
     }
@@ -101,6 +114,7 @@ internal suspend fun refetchCanvasArtworkForPlayback(
     artistNameRaw: String,
     storefront: String,
     requireVertical: Boolean,
+    albumTitle: String? = null,
 ): CanvasArtwork? {
     if (mediaId.isBlank()) return null
 
@@ -112,11 +126,26 @@ internal suspend fun refetchCanvasArtworkForPlayback(
                 storefront = storefront,
                 requireVertical = requireVertical,
                 forceRefresh = true,
+                strictIdentity = !(mediaId.isTelegramMediaId() || mediaId.isLocalMediaId()),
+                albumTitle = albumTitle,
             ) ?: return@withContext null
 
         CanvasArtworkPlaybackCache.replace(mediaId, fetched)
     }
 }
+
+private fun CanvasArtwork.matchesIdentity(
+    songTitleRaw: String,
+    artistNameRaw: String,
+    strict: Boolean,
+): Boolean =
+    if (strict) {
+        matchesSongIdentity(songTitleRaw, artistNameRaw)
+    } else {
+        // Album-level motion artwork carries the album name in `name`, so an exact/fuzzy song
+        // match may legitimately fail; accept it when the song lookup already vouched for it.
+        looselyMatchesSongIdentity(songTitleRaw, artistNameRaw) || !albumName.isNullOrBlank()
+    }
 
 private fun CanvasArtwork.hasRequiredCanvasVariant(requireVertical: Boolean): Boolean =
     if (requireVertical) {
@@ -130,6 +159,8 @@ private const val CanvasArtworkLogTag = "CanvasArtwork"
 private fun normalizeCanvasSongTitle(raw: String): String {
     val stripped =
         raw
+            // Leading track numbers ("01. ", "12 - ") common in files shared on Telegram.
+            .replace(Regex("^\\s*\\d{1,3}\\s*[.\\-]\\s*"), "")
             .replace(Regex("\\s*\\[[^]]*]"), "")
             .replace(
                 Regex(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -83,6 +83,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -93,6 +94,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -376,7 +378,9 @@ fun BottomSheetPlayer(
         defaultValue = PlayerBackgroundStyle.DEFAULT,
     )
     val playerUsesFixedBackground =
-        playerDesignStyle == PlayerDesignStyle.V8 || playerDesignStyle == PlayerDesignStyle.V9
+        playerDesignStyle == PlayerDesignStyle.V8 ||
+            playerDesignStyle == PlayerDesignStyle.V9 ||
+            playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC
     val playerBackground =
         if (playerUsesFixedBackground) PlayerBackgroundStyle.DEFAULT else storedPlayerBackground
 
@@ -1093,7 +1097,11 @@ fun BottomSheetPlayer(
                 !aodModeEnabled
         val shouldUseArtworkCanvas =
             archiveTuneCanvasEnabled &&
-                (playerDesignStyle == PlayerDesignStyle.V8 || playerDesignStyle == PlayerDesignStyle.V9) &&
+                (
+                    playerDesignStyle == PlayerDesignStyle.V8 ||
+                        playerDesignStyle == PlayerDesignStyle.V9 ||
+                        playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC
+                ) &&
                 !aodModeEnabled
         val shouldFetchV7Canvas = shouldUseV7Canvas && !lowDataModeActive
         val shouldFetchArtworkCanvas = shouldUseArtworkCanvas && !lowDataModeActive
@@ -1155,6 +1163,7 @@ fun BottomSheetPlayer(
                         storefront = storefront,
                         requireVertical = true,
                         allowNetwork = shouldFetchV7Canvas,
+                        albumTitle = metadata.album?.title,
                     )
                 if (requestRevision == canvasArtworkRevision) {
                     v7CanvasArtwork = resolvedArtwork
@@ -1192,6 +1201,7 @@ fun BottomSheetPlayer(
                         storefront = storefront,
                         requireVertical = false,
                         allowNetwork = shouldFetchArtworkCanvas,
+                        albumTitle = metadata.album?.title,
                     )
                 if (requestRevision == canvasArtworkRevision) {
                     artworkCanvas = resolvedArtwork
@@ -1236,7 +1246,8 @@ fun BottomSheetPlayer(
             playerDesignStyle != PlayerDesignStyle.V5 &&
             playerDesignStyle != PlayerDesignStyle.V7 &&
             playerDesignStyle != PlayerDesignStyle.V8 &&
-            playerDesignStyle != PlayerDesignStyle.V9
+            playerDesignStyle != PlayerDesignStyle.V9 &&
+            playerDesignStyle != PlayerDesignStyle.APPLE_MUSIC
         ) {
             PlayerBackground(
                 playerBackground = playerBackground,
@@ -1488,6 +1499,39 @@ fun BottomSheetPlayer(
                                             WindowInsetsSides.Top + WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                                         ),
                                     ).nestedScroll(state.preUpPostDownNestedScrollConnection),
+                        )
+                    }
+                } else if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
+                    enrichedMetadata?.let { metadata ->
+                        AppleMusicPlayerContent(
+                            mediaMetadata = metadata,
+                            playbackState = playbackState,
+                            isPlaying = isPlaying,
+                            isLoading = isLoading,
+                            canSkipPrevious = canSkipPrevious,
+                            canSkipNext = canSkipNext,
+                            sliderPosition = sliderPosition,
+                            position = position,
+                            duration = duration,
+                            playerConnection = playerConnection,
+                            navController = navController,
+                            state = state,
+                            bottomSheetPageState = bottomSheetPageState,
+                            currentSongLiked = currentSongLiked,
+                            volume = deviceMusicVolumeController.volumeFraction,
+                            onVolumeChange = onPlayerVolumeChange,
+                            canvasPrimaryUrl = artworkCanvas?.animated,
+                            canvasFallbackUrl = artworkCanvas?.videoUrl,
+                            contentBottomPadding = queueSheetState.collapsedBound,
+                            onQueueClick = openQueue,
+                            onLyricsClick = { isLyricsScreenVisible = true },
+                            onSliderValueChange = onSliderValueChange,
+                            onSliderValueChangeFinished = onSliderValueChangeFinished,
+                            landscape = true,
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .nestedScroll(state.preUpPostDownNestedScrollConnection),
                         )
                     }
                 } else {
@@ -1763,6 +1807,40 @@ fun BottomSheetPlayer(
                                     ).nestedScroll(state.preUpPostDownNestedScrollConnection),
                         )
                     }
+                } else if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
+                    enrichedMetadata?.let { metadata ->
+                        AppleMusicPlayerContent(
+                            mediaMetadata = metadata,
+                            playbackState = playbackState,
+                            isPlaying = isPlaying,
+                            isLoading = isLoading,
+                            canSkipPrevious = canSkipPrevious,
+                            canSkipNext = canSkipNext,
+                            sliderPosition = sliderPosition,
+                            position = position,
+                            duration = duration,
+                            playerConnection = playerConnection,
+                            navController = navController,
+                            state = state,
+                            bottomSheetPageState = bottomSheetPageState,
+                            currentSongLiked = currentSongLiked,
+                            volume = deviceMusicVolumeController.volumeFraction,
+                            onVolumeChange = onPlayerVolumeChange,
+                            canvasPrimaryUrl = artworkCanvas?.animated,
+                            canvasFallbackUrl = artworkCanvas?.videoUrl,
+                            contentBottomPadding = queueSheetState.collapsedBound,
+                            onQueueClick = openQueue,
+                            onLyricsClick = { isLyricsScreenVisible = true },
+                            onSliderValueChange = onSliderValueChange,
+                            onSliderValueChangeFinished = onSliderValueChangeFinished,
+                            // Full-bleed: the artwork runs under the status bar by design, so no
+                            // top inset here (mirrors the reference layout).
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .nestedScroll(state.preUpPostDownNestedScrollConnection),
+                        )
+                    }
                 } else {
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -1907,43 +1985,49 @@ private fun MikoLyricsTransition(
     onQueueClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val progress by animateFloatAsState(
-        targetValue = if (visible) 1f else 0f,
-        animationSpec =
-            spring(
-                dampingRatio = 0.82f,
-                stiffness = Spring.StiffnessMediumLow,
-            ),
-        label = "mikoLyricsTransition",
-    )
+    // Apple-Music-style sheet motion: an interruptible spring with a light settle. All derived
+    // transforms are read inside graphicsLayer/draw lambdas so the animation runs entirely in the
+    // draw phase — zero recomposition per frame (the old version recomposed the whole subtree and
+    // rebuilt a clip path every frame, which is what made opening feel janky).
+    val progressState =
+        animateFloatAsState(
+            targetValue = if (visible) 1f else 0f,
+            animationSpec =
+                spring(
+                    dampingRatio = 0.9f,
+                    stiffness = 420f,
+                    visibilityThreshold = 0.001f,
+                ),
+            label = "mikoLyricsTransition",
+        )
+    val showContent by remember {
+        derivedStateOf { visible || progressState.value > 0.001f }
+    }
 
-    val boundedProgress = progress.coerceIn(0f, 1f)
-
-    if (visible || boundedProgress > 0.001f) {
-        val scaleX = 0.92f + (0.08f * boundedProgress)
-        val scaleY = 0.78f + (0.22f * boundedProgress)
-        val alpha = (0.2f + (0.8f * boundedProgress)).coerceIn(0f, 1f)
-        val cornerRadius = 32.dp * (1f - boundedProgress)
-
+    if (showContent) {
+        val surfaceColor = MaterialTheme.colorScheme.surface
         Box(
             modifier =
                 modifier
                     .fillMaxSize()
-                    .graphicsLayer { this.alpha = boundedProgress }
-                    .background(Color.Black.copy(alpha = 0.24f * boundedProgress)),
+                    .graphicsLayer { alpha = progressState.value.coerceIn(0f, 1f) }
+                    .drawBehind {
+                        drawRect(Color.Black.copy(alpha = 0.24f * progressState.value.coerceIn(0f, 1f)))
+                    },
         ) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxSize()
                         .graphicsLayer {
+                            val p = progressState.value.coerceIn(0f, 1f)
                             transformOrigin = TransformOrigin(0.5f, 1f)
-                            this.scaleX = scaleX
-                            this.scaleY = scaleY
-                            this.alpha = alpha
-                            translationY = size.height * 0.16f * (1f - boundedProgress)
-                        }.clip(RoundedCornerShape(cornerRadius))
-                        .background(MaterialTheme.colorScheme.surface),
+                            scaleX = 0.94f + (0.06f * p)
+                            scaleY = 0.82f + (0.18f * p)
+                            translationY = size.height * 0.14f * (1f - p)
+                            shape = RoundedCornerShape(36.dp * (1f - p))
+                            clip = true
+                        }.background(surfaceColor),
             ) {
                 LyricsScreen(
                     mediaMetadata = mediaMetadata,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -702,7 +702,7 @@ fun PlayerTopActions(
             }
         }
 
-        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9 -> {
+        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9, PlayerDesignStyle.APPLE_MUSIC -> {
             Unit
         }
     }
@@ -1761,7 +1761,7 @@ fun PlayerPlaybackControls(
             }
         }
 
-        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9 -> {
+        PlayerDesignStyle.V7, PlayerDesignStyle.V8, PlayerDesignStyle.V9, PlayerDesignStyle.APPLE_MUSIC -> {
             Unit
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -592,7 +592,7 @@ fun Queue(
                     )
                 }
 
-                PlayerDesignStyle.V9 -> {
+                PlayerDesignStyle.V9, PlayerDesignStyle.APPLE_MUSIC -> {
                     val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
                     QueueCollapsedContentV9(
                         showCodecOnPlayer = showCodecOnPlayer,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
@@ -404,6 +404,18 @@ fun Thumbnail(
                             }
                         }
 
+                        // Apply manual "Refetch canvas" results — without this the refetch menu
+                        // action silently no-ops on the pager styles (V1–V6).
+                        LaunchedEffect(shouldUseCanvas, item.mediaId) {
+                            if (!shouldUseCanvas) return@LaunchedEffect
+                            playerConnection.canvasArtworkUpdates.collect { update ->
+                                if (update.mediaId != item.mediaId) return@collect
+                                if (!update.artwork.preferredAnimationUrl.isNullOrBlank()) {
+                                    canvasArtwork = update.artwork
+                                }
+                            }
+                        }
+
                         LaunchedEffect(shouldUseCanvas, shouldFetchCanvas, item.mediaId) {
                             if (!shouldUseCanvas) return@LaunchedEffect
 
@@ -436,6 +448,7 @@ fun Thumbnail(
                                         storefront = storefront,
                                         requireVertical = false,
                                         allowNetwork = shouldFetchCanvas,
+                                        albumTitle = itemMetadata?.album?.title,
                                     )
                             } finally {
                                 canvasFetchInFlight = false

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
@@ -83,6 +83,7 @@ import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.HideAiMixKey
 import moe.rukamori.archivetune.constants.LibraryFilter
 import moe.rukamori.archivetune.constants.ShowSpotifyPlaylistsKey
 import moe.rukamori.archivetune.extensions.toMediaItem
@@ -136,6 +137,7 @@ fun LibraryMixScreen(
     val topMixesUiState by viewModel.topMixesUiState.collectAsStateWithLifecycle()
     val spotifyPlaylists by spotifyLibraryViewModel.playlists.collectAsStateWithLifecycle()
     val (showSpotifyPlaylists) = rememberPreference(ShowSpotifyPlaylistsKey, false)
+    val (hideAiMix) = rememberPreference(HideAiMixKey, false)
 
     val filteredPlaylistIds by database
         .playlistIdsByTags(
@@ -387,19 +389,21 @@ fun LibraryMixScreen(
                     }
                 }
 
-                item(key = "top_mixes") {
-                    TopMixesForYouSection(
-                        state = topMixesUiState,
-                        onRefresh = viewModel::refreshTopMixes,
-                        onConfigureAi = { navController.navigate("settings/ai_integration") },
-                        onPlayMix = { mix ->
-                            playerConnection.playQueue(
-                                ListQueue(
-                                    items = mix.tracks.map { it.toMediaItem() },
-                                ),
-                            )
-                        },
-                    )
+                if (!hideAiMix) {
+                    item(key = "top_mixes") {
+                        TopMixesForYouSection(
+                            state = topMixesUiState,
+                            onRefresh = viewModel::refreshTopMixes,
+                            onConfigureAi = { navController.navigate("settings/ai_integration") },
+                            onPlayMix = { mix ->
+                                playerConnection.playQueue(
+                                    ListQueue(
+                                        items = mix.tracks.map { it.toMediaItem() },
+                                    ),
+                                )
+                            },
+                        )
+                    }
                 }
 
                 val playlistTagFilterContent = filterContent

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
@@ -97,12 +97,14 @@ import moe.rukamori.archivetune.constants.AiCustomModelKey
 import moe.rukamori.archivetune.constants.AiProvider
 import moe.rukamori.archivetune.constants.AiProviderKey
 import moe.rukamori.archivetune.constants.AiSelectedModelKey
+import moe.rukamori.archivetune.constants.HideAiMixKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EditTextPreference
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
+import moe.rukamori.archivetune.ui.component.SwitchPreference
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
@@ -125,6 +127,7 @@ fun AiIntegrationSettings(
         rememberEnumPreference(AiApiValidationStatusKey, AiApiValidationStatus.UNKNOWN)
     val (selectedModel, setSelectedModel) = rememberPreference(AiSelectedModelKey, "")
     val (customModel, setCustomModel) = rememberPreference(AiCustomModelKey, "")
+    val (hideAiMix, onHideAiMixChange) = rememberPreference(HideAiMixKey, defaultValue = false)
     var showApiKeyDialog by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
@@ -338,6 +341,16 @@ fun AiIntegrationSettings(
                     },
                     onClick = viewModel::testApi,
                     isEnabled = canTestApi,
+                )
+            }
+
+            item {
+                SwitchPreference(
+                    title = { Text(stringResource(R.string.hide_ai_mix)) },
+                    description = stringResource(R.string.hide_ai_mix_desc),
+                    icon = { Icon(painterResource(R.drawable.auto_awesome), null) },
+                    checked = hideAiMix,
+                    onCheckedChange = onHideAiMixChange,
                 )
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -77,6 +77,9 @@ import moe.rukamori.archivetune.constants.CustomFontNameKey
 import moe.rukamori.archivetune.constants.CustomFontUriKey
 import moe.rukamori.archivetune.constants.DarkModeKey
 import moe.rukamori.archivetune.constants.DefaultOpenTabKey
+import moe.rukamori.archivetune.constants.NavigationBarFrostedBlurKey
+import moe.rukamori.archivetune.constants.NavigationBarStyle
+import moe.rukamori.archivetune.constants.NavigationBarStyleKey
 import moe.rukamori.archivetune.constants.DisableAnimationsKey
 import moe.rukamori.archivetune.constants.DisableBlurKey
 import moe.rukamori.archivetune.constants.DynamicThemeKey
@@ -213,6 +216,13 @@ fun AppearanceSettings(navController: NavController) {
             DefaultOpenTabKey,
             defaultValue = NavigationTab.HOME,
         )
+    val (navigationBarStyle, onNavigationBarStyleChange) =
+        rememberEnumPreference(
+            NavigationBarStyleKey,
+            defaultValue = NavigationBarStyle.DEFAULT,
+        )
+    val (navigationBarFrostedBlur, onNavigationBarFrostedBlurChange) =
+        rememberPreference(NavigationBarFrostedBlurKey, defaultValue = false)
     val (playerButtonsStyle, onPlayerButtonsStyleChange) =
         rememberEnumPreference(
             PlayerButtonsStyleKey,
@@ -322,6 +332,7 @@ fun AppearanceSettings(navController: NavController) {
             PlayerDesignStyle.V7,
             PlayerDesignStyle.V8,
             PlayerDesignStyle.V9,
+            PlayerDesignStyle.APPLE_MUSIC,
             -> false
 
             else -> true
@@ -644,6 +655,8 @@ fun AppearanceSettings(navController: NavController) {
                                 PlayerDesignStyle.V7 -> stringResource(R.string.player_design_v7)
                                 PlayerDesignStyle.V8 -> stringResource(R.string.player_design_v8)
                                 PlayerDesignStyle.V9 -> stringResource(R.string.player_design_v9)
+                                PlayerDesignStyle.APPLE_MUSIC ->
+                                    stringResource(R.string.player_design_apple_music)
                             }
                         },
                     )
@@ -916,6 +929,33 @@ fun AppearanceSettings(navController: NavController) {
                                 QuickPicksDisplayMode.LIST -> stringResource(R.string.quick_picks_display_mode_list)
                             }
                         },
+                    )
+                }
+
+                item {
+                    EnumListPreference(
+                        title = { Text(stringResource(R.string.navigation_bar_style)) },
+                        icon = { Icon(painterResource(R.drawable.nav_bar), null) },
+                        selectedValue = navigationBarStyle,
+                        onValueSelected = onNavigationBarStyleChange,
+                        valueText = {
+                            when (it) {
+                                NavigationBarStyle.DEFAULT ->
+                                    stringResource(R.string.navigation_bar_style_default)
+                                NavigationBarStyle.FLOATING ->
+                                    stringResource(R.string.navigation_bar_style_floating)
+                            }
+                        },
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.navigation_bar_frosted_blur)) },
+                        description = stringResource(R.string.navigation_bar_frosted_blur_desc),
+                        icon = { Icon(painterResource(R.drawable.blur_on), null) },
+                        checked = navigationBarFrostedBlur,
+                        onCheckedChange = onNavigationBarFrostedBlurChange,
                     )
                 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LibraryViewModels.kt
@@ -42,6 +42,7 @@ import moe.rukamori.archivetune.constants.AiApiValidationStatus
 import moe.rukamori.archivetune.constants.AiApiValidationStatusKey
 import moe.rukamori.archivetune.constants.AiCustomEndpointKey
 import moe.rukamori.archivetune.constants.AiProvider
+import moe.rukamori.archivetune.constants.HideAiMixKey
 import moe.rukamori.archivetune.constants.AiProviderKey
 import moe.rukamori.archivetune.constants.AlbumFilter
 import moe.rukamori.archivetune.constants.AlbumFilterKey
@@ -506,6 +507,8 @@ class LibraryMixViewModel
                 .map { prefs ->
                     val provider = prefs[AiProviderKey].toEnum(AiProvider.NONE)
                     provider != AiProvider.NONE &&
+                        // The user hid AI Mix — also stop auto-generating mixes in the background.
+                        !(prefs[HideAiMixKey] ?: false) &&
                         prefs[AiApiKeyKey].orEmpty().isNotBlank() &&
                         (provider != AiProvider.CUSTOM || prefs[AiCustomEndpointKey].orEmpty().isNotBlank()) &&
                         prefs[AiApiValidationStatusKey].toEnum(AiApiValidationStatus.UNKNOWN) != AiApiValidationStatus.FAILED

--- a/app/src/main/res/drawable/airplay.xml
+++ b/app/src/main/res/drawable/airplay.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,22h12l-6,-6z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,3H3c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h4v-2H3V5h18v12h-4v2h4c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -292,6 +292,7 @@
     <string name="player_design_v7">Immersive</string>
     <string name="player_design_v8">Immersive Extended</string>
     <string name="player_design_v9">Material Extended</string>
+    <string name="player_design_apple_music">Apple Music</string>
     <string name="player_background_blur">Blur</string>
     <string name="coloring">Coloring</string>
     <string name="blur_gradient">Blur Gradient</string>
@@ -623,6 +624,8 @@
     <string name="ai_api_connected">API connected</string>
     <string name="ai_api_test_failed">API test failed</string>
     <string name="ai_translation_menu">AI Translation</string>
+    <string name="hide_ai_mix">Hide AI Mix</string>
+    <string name="hide_ai_mix_desc">Hide the AI-generated mixes section in your library and stop generating new mixes</string>
     <string name="about_lead_developer">Lead Developer</string>
     <string name="about_archive_tune_team">Team</string>
     <string name="about_respecter">Respecter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -489,6 +489,11 @@
     <string name="haptics">Vibration</string>
     <string name="haptics_desc">Enable haptic feedback on interactive elements</string>
     <string name="default_open_tab">Default open tab</string>
+    <string name="navigation_bar_style">Navigation bar style</string>
+    <string name="navigation_bar_style_default">Default</string>
+    <string name="navigation_bar_style_floating">Floating</string>
+    <string name="navigation_bar_frosted_blur">Frosted navigation bar</string>
+    <string name="navigation_bar_frosted_blur_desc">Apply a frosted blur behind the navigation bar</string>
     <string name="lyrics_animation_style">Lyrics animation style</string>
     <string name="lyrics_mode">Lyrics mode</string>
     <string name="lyrics_mode_v2">V2 Legacy</string>

--- a/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/ArchiveTuneCanvas.kt
+++ b/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/ArchiveTuneCanvas.kt
@@ -24,6 +24,8 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import moe.rukamori.archivetune.canvas.models.CanvasArtwork
+import moe.rukamori.archivetune.canvas.models.looselyMatchesSongIdentity
+import moe.rukamori.archivetune.canvas.models.matchesAlbumIdentity
 import moe.rukamori.archivetune.canvas.models.matchesSongIdentity
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
@@ -100,8 +102,12 @@ object ArchiveTuneCanvas {
         artist: String,
         storefront: String = "us",
         forceRefresh: Boolean = false,
+        // Fuzzy identity matching for sources with unreliable tags (e.g. Telegram files).
+        strict: Boolean = true,
+        // Optional album title enabling an album-level animated-artwork fallback.
+        album: String? = null,
     ): CanvasArtwork? {
-        val key = cacheKey("sa", song, artist, storefront)
+        val key = cacheKey("sa", song, artist, storefront, if (strict) "s" else "l", album.orEmpty())
         if (forceRefresh) {
             cache.remove(key)
         } else {
@@ -111,9 +117,51 @@ object ArchiveTuneCanvas {
             }
         }
 
+        fun CanvasArtwork.matchesIdentity(): Boolean =
+            if (strict) matchesSongIdentity(song, artist) else looselyMatchesSongIdentity(song, artist)
+
+        // BetterLyrics artwork API first (the richest animated-cover source), then the primary
+        // ArchiveTune artwork mirror, then the Apple Music catalogue.
+        val fromBetterLyrics =
+            fetchFromEndpoint(fallbackClient, song, artist, storefront, forceRefresh)
+                ?.takeIf { artwork -> artwork.matchesIdentity() }
+
+        val value =
+            fromBetterLyrics
+                ?: fetchFromEndpoint(client, song, artist, storefront, forceRefresh)
+                    ?.takeIf { artwork -> artwork.matchesIdentity() }
+                ?: AppleMusicProvider
+                    .getBySongArtist(song, artist, null, storefront, forceRefresh)
+                    ?.takeIf { artwork -> artwork.matchesIdentity() }
+                ?: album
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { albumTitle ->
+                        // Album-level animated cover (Apple-Music-style motion art) as a last
+                        // chance when no song-level canvas exists.
+                        AppleMusicProvider
+                            .getByAlbumArtist(albumTitle, artist, storefront)
+                            ?.takeIf { artwork -> artwork.matchesAlbumIdentity(albumTitle) }
+                    }
+
+        cache[key] =
+            CacheEntry(
+                value = value,
+                expiresAtMs = System.currentTimeMillis() + ttlMs,
+            )
+
+        return value
+    }
+
+    private suspend fun fetchFromEndpoint(
+        endpointClient: HttpClient,
+        song: String,
+        artist: String,
+        storefront: String,
+        forceRefresh: Boolean,
+    ): CanvasArtwork? {
         val response =
             try {
-                client.get {
+                endpointClient.get {
                     parameter("s", song)
                     parameter("a", artist)
                     parameter("storefront", storefront)
@@ -124,43 +172,10 @@ object ArchiveTuneCanvas {
             } catch (_: Exception) {
                 null
             }
-
-        val primary =
-            when (response?.status) {
-                HttpStatusCode.OK -> runCatching { response.body<CanvasArtwork>() }.getOrNull()
-                else -> null
-            }?.takeIf { artwork -> artwork.matchesSongIdentity(song, artist) }
-
-        val value =
-            primary ?: run {
-                val fallbackResponse =
-                    try {
-                        fallbackClient.get {
-                            parameter("s", song)
-                            parameter("a", artist)
-                            parameter("storefront", storefront)
-                            if (forceRefresh) header(HttpHeaders.CacheControl, "no-cache")
-                        }
-                    } catch (error: CancellationException) {
-                        throw error
-                    } catch (_: Exception) {
-                        null
-                    }
-                when (fallbackResponse?.status) {
-                    HttpStatusCode.OK -> runCatching { fallbackResponse.body<CanvasArtwork>() }.getOrNull()
-                    else -> null
-                }?.takeIf { artwork -> artwork.matchesSongIdentity(song, artist) }
-            } ?: AppleMusicProvider
-                .getBySongArtist(song, artist, null, storefront, forceRefresh)
-                ?.takeIf { artwork -> artwork.matchesSongIdentity(song, artist) }
-
-        cache[key] =
-            CacheEntry(
-                value = value,
-                expiresAtMs = System.currentTimeMillis() + ttlMs,
-            )
-
-        return value
+        return when (response?.status) {
+            HttpStatusCode.OK -> runCatching { response.body<CanvasArtwork>() }.getOrNull()
+            else -> null
+        }
     }
 
     suspend fun getByAlbumId(albumId: String): CanvasArtwork? {

--- a/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/models/CanvasArtworkIdentity.kt
+++ b/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/models/CanvasArtworkIdentity.kt
@@ -25,6 +25,41 @@ fun CanvasArtwork.matchesSongIdentity(
         resolvedArtist == requestedArtist
 }
 
+/**
+ * Fuzzy variant of [matchesSongIdentity] for sources with unreliable tags (e.g. files streamed
+ * from Telegram channels, whose "artist" may be a channel name and whose title carries extra
+ * qualifiers). Accepts containment either way on the normalized song title, and requires the
+ * artists to be equal, contain each other, or the requested artist to be unusable (blank).
+ */
+fun CanvasArtwork.looselyMatchesSongIdentity(
+    song: String,
+    artist: String,
+): Boolean {
+    val requestedSong = song.toCanvasSongIdentity()
+    val resolvedSong = name?.toCanvasSongIdentity().orEmpty()
+    if (requestedSong.isEmpty() || resolvedSong.isEmpty()) return false
+    val songMatches =
+        resolvedSong == requestedSong ||
+            resolvedSong.contains(requestedSong) ||
+            requestedSong.contains(resolvedSong)
+    if (!songMatches) return false
+
+    val requestedArtist = artist.toCanvasPrimaryArtistIdentity()
+    if (requestedArtist.isEmpty()) return true
+    val resolvedArtist = this.artist?.toCanvasPrimaryArtistIdentity().orEmpty()
+    return resolvedArtist == requestedArtist ||
+        resolvedArtist.contains(requestedArtist) ||
+        requestedArtist.contains(resolvedArtist)
+}
+
+/** Whether this artwork's album matches the requested album title (normalized containment). */
+fun CanvasArtwork.matchesAlbumIdentity(album: String): Boolean {
+    val requested = album.toCanvasSongIdentity()
+    val resolved = albumName?.toCanvasSongIdentity().orEmpty()
+    if (requested.isEmpty() || resolved.isEmpty()) return false
+    return resolved == requested || resolved.contains(requested) || requested.contains(resolved)
+}
+
 private fun String.toCanvasSongIdentity(): String =
     replace(CanvasFeaturingQualifierRegex, "")
         .replace(CanvasPresentationQualifierRegex, "")


### PR DESCRIPTION
# Pull Request

## Summary

Ten changes in one round: the APK shrinks by ~52 MB (compressed native libs — TDLib was stored uncompressed), Telegram tracks now auto-fetch lyrics through the provider-priority chain and auto-play canvases/animated album art (BetterLyrics-first with Apple Music and album-level fallbacks), a new **Apple Music** player design style replicates the reference layout (edge-to-edge art, blurred artwork behind the controls, thin scrubber with −remaining, bare transport glyphs, volume row, lyrics/output/queue row), the lyrics view's word-by-word + romanization jank is fixed at its root causes, the lyrics sheet opens with a fluid draw-phase spring, and Appearance gains **Navigation bar style** (Default/Floating) plus a **Frosted navigation bar** backdrop-blur toggle. AI integration gains a **Hide AI Mix** switch.

## Linked Work

- Closes:
- Related: #1, #2, #3, #4

## Change Type

- [x] Feature
- [x] Bug fix
- [x] UI / UX
- [x] Performance / memory
- [x] Playback / Media3
- [x] Lyrics / provider integration
- [x] Settings / preferences / DataStore
- [x] Build / Gradle / CI / release packaging

## Affected Surfaces

- [x] `:app`
- [x] Other: `:canvas`

## Screenshots / Recordings

| Area | Before | After |
| --- | --- | --- |
| APK (universal debug) | 148.6 MB | 96.4 MB (−52 MB; per-ABI builds shrink ~12 MB) |
| Telegram lyrics | Never auto-fetched | Fetches via provider priority on play, retries NOT_FOUND |
| Telegram canvas | Never matched (strict identity + filename tags) | Auto-plays via fuzzy identity + "Artist - Title" filename parsing |
| Player | — | New "Apple Music" design style (portrait + landscape, canvas-capable) |
| Lyrics | Stutter when word-sync + romanization animate together | Root causes fixed (see notes) |
| Nav bar | Single docked style | Default / Floating pill + optional frosted backdrop blur |

## Behavior Notes

**1. APK size** — `packaging.jniLibs.useLegacyPackaging = true`: native libs are deflated inside the APK and only the device's ABI is extracted at install. TDLib's four `libtdjni.so` (87 MB raw / 35 MB compressed) dominated the fat APK. Trade-off: slightly slower install/update; devices no longer mmap the .so straight from the APK.

**2. Telegram lyrics autofetch** (`MusicService`, `LyricsHelper`, `telegram/TelegramModels`) — the play-time fetch no longer requires the lyrics panel to have been opened for `telegram://` ids, persists via `replaceLyricsIfAbsentOrNotFound` so one early failure isn't sticky, and the provider race skips the YouTube-video-id-only providers (SimpMusic, YouTube, YouTube Subtitle) for telegram/local ids. `deriveTrackMetadata` now splits untagged filenames as "Artist - Title" and strips track numbers/noise — this feeds lyrics, canvas, cover art, and the DB rows.

**3+4. Canvas / animated album art** (`:canvas`, `CanvasArtworkResolver`) — provider order is now **BetterLyrics artwork API → ArchiveTune mirror → Apple Music song-level → Apple Music album-level motion art** (album fallback guarded by normalized album-name match). Telegram/local ids use `looselyMatchesSongIdentity` (normalized containment) instead of exact equality, threaded end-to-end via a `strict` flag so strict matching is unchanged for YouTube tracks. Also fixed: manual "Refetch canvas" results were silently dropped on styles V1–V6 (Thumbnail never collected `canvasArtworkUpdates`). Note: there is no Tidal canvas API anywhere (the existing "Tidal animated covers" toggle was already a no-op), so "BetterLyrics or Tidal" resolves as BetterLyrics-first; Tidal serves static art only.

**5. Hide AI Mix** — `HideAiMixKey` toggle in AI integration settings; hides the library Top Mixes section and also folds into `isTopMixAiAvailable` so background AI mix generation stops.

**6. Apple Music player style** — `PlayerDesignStyle.APPLE_MUSIC` + `ui/player/AppleMusicPlayer.kt`. Blurred-artwork base layer (real gaussian on 12+, scrim-compensated below), sharp artwork fading into the blur, star (like) + ••• (player menu) chips, hand-rolled thin scrubber (tap + drag, thickens while scrubbing) with elapsed/−remaining, bare rewind/play/forward glyphs, flat volume slider bound to the device volume controller, and a lyrics / media-output / queue row (output launches the system media-output panel, falling back to the volume panel). Registered in every exhaustive `when` (settings label, top actions, transport, collapsed queue bar) and excluded from the shared `PlayerBackground`; canvas resolution includes the style so animated art plays in the artwork slot.

**7. Lyrics performance** — root-cause fixes in the default (ENHANCED) renderer: romanization batches (often one job per word) now run on `Dispatchers.Default` instead of the UI thread; the karaoke subtree is no longer disposed and rebuilt mid-playback when romanization lands (state update instead of a `key()` bump); the three per-recomposition `TextStyle` allocations are remembered; per-line RenderEffect blur is dropped when reduce-animations is on. The V2 renderer now honors `LocalAnimationsDisabled` at all (glow shadows, bounce springs, line blur off; 100 ms position polling) and romanizes off-main.

**8. Lyrics sheet opening** — the transition now computes every transform (scale, translation, corner clip, scrim) inside `graphicsLayer`/draw lambdas, so it animates entirely in the draw phase with zero per-frame recomposition, uses a snappier interruptible spring, and no longer double-applies alpha.

**9+10. Navigation bar** — `NavigationBarStyle` (DEFAULT keeps today's geometry; FLOATING is a detached pill: 50% corners, tighter width, larger margins, never docks with the mini player) and `NavigationBarFrostedBlur`. Frosted mode records the app content into a `GraphicsLayer` each frame and draws it translated + blurred (`RenderEffect`, 12+) behind the bar with a translucent tint — a true frosted-glass backdrop; below 12 it falls back to a translucent surface. All four dependent layout computations (collapsed-player anchor, slide distance, player-aware insets, FAB padding) derive from shared values, and the insets `remember` keys include the new style.

## Architecture / Compose / Concurrency Checklists

- [x] UDF preserved; no business work from composition; exceptions surfaced or logged.
- [x] No `runBlocking` introduced.
- [x] Per-frame state reads moved to draw phase (lyrics sheet, seek bars); remembered styles/brushes; stable keys retained.
- [x] Heavy work (romanization, canvas/cover lookups, DB writes) on `Dispatchers.Default`/`IO`; cancellation-safe (`CancellationException` rethrown).
- [x] Reduce-animations settings honored (new V2 support; frosted blur inert when RenderEffect unavailable).

## Data / Persistence Checklist

- [x] New DataStore keys only (`HideAiMixKey`, `NavigationBarStyleKey`, `NavigationBarFrostedBlurKey`); enum prefs stored by name with safe fallback — backward compatible, no Room change.

## Playback / Integration Checklist

- [x] The multi-source resolver chain and DataSource routing are untouched; the new style plugs into the existing dispatch.
- [x] Canvas/cover providers degrade gracefully on network failure; strict matching unchanged for YouTube content.
- [x] ABI-sensitive change (`useLegacyPackaging`) applies uniformly to all flavors/variants; per-ABI flavors unaffected in content.

## Localization / Assets Checklist

- [x] New strings in base `values/` only (`navigation_bar_style*`, `navigation_bar_frosted_blur*`, `hide_ai_mix*`, `player_design_apple_music`); new drawables `airplay.xml`.

## Privacy / Security Checklist

- [x] No secrets committed. New network calls are the existing canvas/cover endpoints only; the media-output button launches system panels via public intent actions.

## Verification

- [x] `assembleGmsMobileUniversalDebug` builds; APK measured 96.4 MB vs 148.6 MB before.
- [x] `:canvas:compileKotlin` (pure-JVM module) builds standalone.
- [x] Unit tests: 70/71 pass — the one failure (`TitleMatchTest.rejectsIdenticalTitleByDifferentArtist`) is pre-existing and reproduces on unmodified `main` (verified in an earlier session round).
- [ ] Manual device verification: not possible in this environment — the Apple Music style, frosted nav bar, and lyrics-fluidity changes especially deserve an on-device pass (they've been compile-verified and reviewed, not screen-verified).
- [x] CI expectation: fork contract tests + universal debug build pass; release reproducibility job unaffected (packaging change is deterministic).

## Reviewer Focus

- `app/build.gradle.kts` — the one-line `useLegacyPackaging` flip and its trade-off comment.
- `ui/player/AppleMusicPlayer.kt` — new style layout; check the scrubber gestures and the media-output intent fallbacks.
- `ui/component/FloatingNavigationToolbar.kt` + `MainActivity.kt` — the GraphicsLayer record/draw pair for the frosted backdrop (watch for any draw-order artifacts on device).
- `canvas/ArchiveTuneCanvas.kt` — provider reorder + `strict`/`album` params; `CanvasArtworkIdentity.looselyMatchesSongIdentity`.
- `ui/component/LyricsEnhanced.kt` — the removed `syncedLyricsRenderVersion` re-key and the `Dispatchers.Default` wrap.

## Release Notes

New Apple Music player style, floating and frosted navigation bar options, much smoother lyrics, lyrics and animated artwork for Telegram tracks, a Hide-AI-Mix switch — and the app download is ~50 MB smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScVyT1G7bbZaCJTCddf3BG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScVyT1G7bbZaCJTCddf3BG)_