### PR TITLE
fix: Apple Music cast button, darker player, full-screen lyrics, frosted nav bar, slide-up lyrics

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1149,9 +1149,12 @@ class MainActivity : ComponentActivity() {
 
                     var yearInMusicSavedPlayerAnchor by rememberSaveable { mutableStateOf(-1) }
 
+                    var isPlayerLyricsFullScreen by remember { mutableStateOf(false) }
+
                     val shouldHideStatusBars =
                         isYearInMusicScreen ||
-                            (playerBottomSheetState.isExpandedOrExpanding && playerDesignStyle == PlayerDesignStyle.V7)
+                            (playerBottomSheetState.isExpandedOrExpanding && playerDesignStyle == PlayerDesignStyle.V7) ||
+                            (playerBottomSheetState.isExpandedOrExpanding && isPlayerLyricsFullScreen)
 
                     LaunchedEffect(shouldHideStatusBars, aodModeEnabled) {
                         if (aodModeEnabled) return@LaunchedEffect
@@ -2124,6 +2127,7 @@ class MainActivity : ComponentActivity() {
                                             navController = navController,
                                             pureBlack = pureBlack,
                                             isMiniPlayerPairedWithNavigation = areBottomBarsPaired,
+                                            onLyricsVisibilityChange = { isPlayerLyricsFullScreen = it },
                                         )
 
                                         if (useRail) return@Box

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -149,8 +149,11 @@ fun FloatingNavigationToolbar(
         if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
     val navigationContainerColor =
         when {
-            canBlurBackdrop -> opaqueContainerColor.copy(alpha = 0.55f)
-            frostedBlur -> opaqueContainerColor.copy(alpha = 0.85f)
+            // A lighter tint let bright pages (Home) bleed through and read far brighter than dark
+            // pages (Library). A heavier tint keeps the surface tone dominant so the bar looks the
+            // same over any content, while the blur underneath still shows as subtle frosted texture.
+            canBlurBackdrop -> opaqueContainerColor.copy(alpha = 0.78f)
+            frostedBlur -> opaqueContainerColor.copy(alpha = 0.9f)
             else -> opaqueContainerColor
         }
     val motionScheme = MaterialTheme.motionScheme

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -15,7 +15,6 @@ package moe.rukamori.archivetune.ui.player
 
 import android.content.Intent
 import android.os.Build
-import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -79,6 +78,7 @@ import moe.rukamori.archivetune.ui.component.BottomSheetPageState
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.menu.PlayerMenu
+import moe.rukamori.archivetune.ui.menu.rememberCastPlayerMenuAction
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
 import moe.rukamori.archivetune.ui.utils.highRes
 import moe.rukamori.archivetune.utils.makeTimeString
@@ -157,17 +157,14 @@ fun AppleMusicPlayerContent(
             )
         }
     }
-    val onOutputClick = {
-        // Best-effort media output switcher (the "AirPlay" slot): the system output panel where
-        // available, else the volume panel.
-        val launched =
-            runCatching {
-                context.startActivity(Intent("com.android.settings.panel.action.MEDIA_OUTPUT"))
-            }.isSuccess
-        if (!launched) {
-            runCatching {
-                context.startActivity(Intent(Settings.Panel.ACTION_VOLUME))
-            }
+    // The "AirPlay" slot opens the Cast route picker on flavors that ship Cast (gms). This also
+    // renders the route-picker bottom sheet when it becomes visible. On flavors without Cast (foss)
+    // rememberCastPlayerMenuAction() returns null and we fall back to the system output switcher.
+    val castAction = rememberCastPlayerMenuAction()
+    val onOutputClick: () -> Unit = castAction?.onClick ?: {
+        // Cast-less flavors (foss): open the system media-output switcher panel.
+        runCatching {
+            context.startActivity(Intent("android.settings.panel.action.MEDIA_OUTPUT"))
         }
     }
 
@@ -194,16 +191,18 @@ fun AppleMusicPlayerContent(
                         scaleY = 1.2f
                     },
         )
-        // Contrast scrim over the blur, heavier at the bottom where the controls sit.
+        // Deep contrast scrim over the blur: the Apple Music sheet reads as a dark, artwork-tinted
+        // panel rather than a bright blur, so the whole surface is pulled well down in brightness
+        // and pushed darker still toward the bottom where the controls sit.
         Box(
             modifier =
                 Modifier
                     .matchParentSize()
                     .background(
                         Brush.verticalGradient(
-                            0f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.10f else 0.35f),
-                            0.55f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.28f else 0.55f),
-                            1f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.45f else 0.7f),
+                            0f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.42f else 0.52f),
+                            0.5f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.60f else 0.68f),
+                            1f to Color.Black.copy(alpha = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.82f else 0.86f),
                         ),
                     ),
         )
@@ -413,7 +412,7 @@ private fun AppleMusicControlsColumn(
             Spacer(Modifier.width(12.dp))
             AppleMusicChip(
                 iconRes = R.drawable.star,
-                tint = if (currentSongLiked) Color(0xFFFFD60A) else Color.White,
+                tint = Color.White,
                 contentDescription = null,
                 onClick = playerConnection::toggleLike,
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -315,6 +315,7 @@ fun BottomSheetPlayer(
     modifier: Modifier = Modifier,
     pureBlack: Boolean,
     isMiniPlayerPairedWithNavigation: Boolean = false,
+    onLyricsVisibilityChange: (Boolean) -> Unit = {},
 ) {
     val context = LocalContext.current
     val menuState = LocalMenuState.current
@@ -817,7 +818,7 @@ fun BottomSheetPlayer(
     }
 
     val dynamicQueuePeekHeight =
-        if (playerDesignStyle == PlayerDesignStyle.V5) {
+        if (playerDesignStyle == PlayerDesignStyle.V5 || playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
             0.dp
         } else if (playerDesignStyle == PlayerDesignStyle.V9) {
             88.dp +
@@ -842,6 +843,17 @@ fun BottomSheetPlayer(
     var isLyricsScreenVisible by rememberSaveable {
         mutableStateOf(false)
     }
+
+    // Report full-screen lyrics visibility upward so the status bar can be hidden for every player
+    // style while the lyrics overlay is showing (previously only the Immersive style went edge-to-edge).
+    val lyricsFullScreenActive = isLyricsScreenVisible && state.isExpandedOrExpanding
+    LaunchedEffect(lyricsFullScreenActive) {
+        onLyricsVisibilityChange(lyricsFullScreenActive)
+    }
+    DisposableEffect(Unit) {
+        onDispose { onLyricsVisibilityChange(false) }
+    }
+
     val openQueue =
         remember(state, queueSheetState) {
             {
@@ -1985,10 +1997,10 @@ private fun MikoLyricsTransition(
     onQueueClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Apple-Music-style sheet motion: an interruptible spring with a light settle. All derived
-    // transforms are read inside graphicsLayer/draw lambdas so the animation runs entirely in the
-    // draw phase — zero recomposition per frame (the old version recomposed the whole subtree and
-    // rebuilt a clip path every frame, which is what made opening feel janky).
+    // Apple-Music-style sheet motion: the lyrics sheet slides straight up from the bottom edge on an
+    // interruptible spring, staying fully opaque the whole way (no cross-fade), while a dim scrim
+    // fades in behind it. All derived transforms are read inside graphicsLayer/draw lambdas so the
+    // animation runs entirely in the draw phase — zero recomposition per frame.
     val progressState =
         animateFloatAsState(
             targetValue = if (visible) 1f else 0f,
@@ -2010,9 +2022,8 @@ private fun MikoLyricsTransition(
             modifier =
                 modifier
                     .fillMaxSize()
-                    .graphicsLayer { alpha = progressState.value.coerceIn(0f, 1f) }
                     .drawBehind {
-                        drawRect(Color.Black.copy(alpha = 0.24f * progressState.value.coerceIn(0f, 1f)))
+                        drawRect(Color.Black.copy(alpha = 0.32f * progressState.value.coerceIn(0f, 1f)))
                     },
         ) {
             Box(
@@ -2021,11 +2032,11 @@ private fun MikoLyricsTransition(
                         .fillMaxSize()
                         .graphicsLayer {
                             val p = progressState.value.coerceIn(0f, 1f)
-                            transformOrigin = TransformOrigin(0.5f, 1f)
-                            scaleX = 0.94f + (0.06f * p)
-                            scaleY = 0.82f + (0.18f * p)
-                            translationY = size.height * 0.14f * (1f - p)
-                            shape = RoundedCornerShape(36.dp * (1f - p))
+                            // Pure slide-up: the whole sheet travels from just below the screen to
+                            // its resting position, with a small rounded top lip while in transit.
+                            translationY = size.height * (1f - p)
+                            val corner = 28.dp.toPx() * (1f - p)
+                            shape = RoundedCornerShape(topStart = corner, topEnd = corner)
                             clip = true
                         }.background(surfaceColor),
             ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -592,7 +592,12 @@ fun Queue(
                     )
                 }
 
-                PlayerDesignStyle.V9, PlayerDesignStyle.APPLE_MUSIC -> {
+                PlayerDesignStyle.APPLE_MUSIC -> {
+                    // The Apple Music style keeps its collapsed peek bar empty: the queue, lyrics and
+                    // output controls all live in the player's own bottom row, so no extra pills here.
+                }
+
+                PlayerDesignStyle.V9 -> {
                     val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
                     QueueCollapsedContentV9(
                         showCodecOnPlayer = showCodecOnPlayer,


### PR DESCRIPTION
# Pull Request

## Summary

Refines round-4 work against the provided references. The Apple Music player's middle "output" button now opens the Cast route picker (gms) — falling back to the system media-output panel on cast-less flavors — instead of the Sound & vibration screen; its background is deepened to a dark, artwork-tinted panel, the like star stays a plain white outline, and the collapsed queue peek bar (shuffle/repeat/more pills) is removed so nothing extra shows. Lyrics now go truly full screen for every player style (status bar hides while the overlay is visible, not only in Immersive). The frosted navigation bar gets a heavier surface tint so it reads consistently across pages instead of appearing bright on Home and dark on Library, and the lyrics sheet now opens with a pure slide-up instead of a fade/scale.

## Linked Work

- Closes:
- Related: round-4 Apple Music player / floating & frosted nav bar / fluid lyrics sheet

## Change Type

- [x] Bug fix
- [x] UI / UX

## Affected Surfaces

- [x] `:app`

## Screenshots / Recordings

| Before | After |
| --- | --- |
| Bright blurred AM player, filled yellow star, extra shuffle/repeat/more bar, middle button opened Sound & vibration; lyrics kept the status bar except in Immersive; frosted nav bright on Home; lyrics faded in | Dark artwork-tinted AM player, white outline star, no extra controls, middle button opens Cast; lyrics full screen for every style; frosted nav consistent across pages; lyrics slide up |

## Behavior Notes

- Apple Music output button: on gms it invokes `CastViewModel.showRoutePicker()` via `rememberCastPlayerMenuAction()` (which also renders the route-picker sheet); on foss that returns null and it opens `android.settings.panel.action.MEDIA_OUTPUT`.
- `PlayerDesignStyle.APPLE_MUSIC` now renders an empty queue collapsed bar and reserves 0dp peek height, so the queue is reached only through the player's own bottom queue button.
- Status bar hiding: `BottomSheetPlayer` reports full-screen lyrics visibility up to `MainActivity`, which hides the status bar whenever lyrics are shown and the player is expanded, for all styles.
- Frosted nav tint raised from 0.55 to 0.78 alpha over the blurred backdrop (0.85 → 0.9 for the non-blur fallback).
- Lyrics transition is a draw-phase slide-up: sheet stays opaque and travels from below the screen with a small rounded top lip; a dim scrim fades in behind it.

## Verification

- [x] Android Studio sync: `:app:assembleGmsMobileUniversalDebug` and `:app:compileFossMobileUniversalDebugKotlin` both succeed.
- [ ] Manual device/emulator verification: not run in this environment.
- [x] Regression areas checked: unit tests 70/71 pass; the sole failure (`TitleMatchTest.rejectsIdenticalTitleByDifferentArtist`) also fails on unmodified `main` and is unrelated to this change.
- [x] CI expectation: green apart from that pre-existing test.

## Reviewer Focus

- `ui/player/AppleMusicPlayer.kt` — cast wiring, scrim, star.
- `ui/player/Queue.kt` + `ui/player/Player.kt` — APPLE_MUSIC collapsed content and 0dp peek height.
- `MainActivity.kt` + `ui/player/Player.kt` — hoisted lyrics visibility and `shouldHideStatusBars`.
- `ui/component/FloatingNavigationToolbar.kt` — frosted tint alpha.
- `ui/player/Player.kt` — `MikoLyricsTransition` slide-up.

## Release Notes

Apple Music player style now matches its reference (Cast output button, darker background, no extra controls), lyrics open full screen with a slide-up, and the frosted navigation bar looks consistent across every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScVyT1G7bbZaCJTCddf3BG

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScVyT1G7bbZaCJTCddf3BG)_