### PR TITLE
Refine Apple player icons and reduce lyrics animation jank

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -494,7 +494,7 @@ private fun AppleMusicControlsColumn(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Icon(
-                painter = painterResource(R.drawable.player_volume_off),
+                painter = painterResource(R.drawable.player_volume_min),
                 contentDescription = null,
                 tint = Color.White.copy(alpha = 0.55f),
                 modifier = Modifier.size(18.dp),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -14,11 +14,9 @@ import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
@@ -579,13 +577,11 @@ fun LyricsScreen(
                 AnimatedVisibility(
                     visible = controlsVisible,
                     enter =
-                        fadeIn(tween(180)) +
-                            slideInVertically(tween(240)) { fullHeight -> fullHeight / 6 } +
-                            expandVertically(tween(240)),
+                        fadeIn(tween(120)) +
+                            slideInVertically(tween(180)) { fullHeight -> fullHeight / 6 },
                     exit =
-                        fadeOut(tween(120)) +
-                            slideOutVertically(tween(180)) { fullHeight -> fullHeight / 8 } +
-                            shrinkVertically(tween(180)),
+                        fadeOut(tween(90)) +
+                            slideOutVertically(tween(140)) { fullHeight -> fullHeight / 8 },
                     label = "lyrics-player-controls",
                 ) {
                     AppleMusicControls(
@@ -978,8 +974,8 @@ private fun AppleMusicControls(
 
         AnimatedVisibility(
             visible = controlsExpanded,
-            enter = fadeIn(tween(180)) + expandVertically(tween(220)),
-            exit = fadeOut(tween(120)) + shrinkVertically(tween(180)),
+            enter = fadeIn(tween(120)) + slideInVertically(tween(160)) { fullHeight -> fullHeight / 8 },
+            exit = fadeOut(tween(90)) + slideOutVertically(tween(120)) { fullHeight -> fullHeight / 10 },
             label = "lyrics-expanded-player-controls",
         ) {
             Column(
@@ -998,11 +994,12 @@ private fun AppleMusicControls(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     AppleMusicTransportButton(
-                        iconRes = R.drawable.player_skip_previous,
+                        iconRes = R.drawable.player_fast_forward,
                         contentDescription = stringResource(R.string.widget_previous),
                         iconSize = 44.dp,
                         touchSize = 68.dp,
                         foregroundColor = foregroundColor,
+                        mirrored = true,
                         onClick = onPreviousClick,
                     )
                     IconButton(
@@ -1029,11 +1026,12 @@ private fun AppleMusicControls(
                         }
                     }
                     AppleMusicTransportButton(
-                        iconRes = R.drawable.player_skip_next,
+                        iconRes = R.drawable.player_fast_forward,
                         contentDescription = stringResource(R.string.next),
                         iconSize = 44.dp,
                         touchSize = 68.dp,
                         foregroundColor = foregroundColor,
+                        mirrored = false,
                         onClick = onNextClick,
                     )
                 }
@@ -1046,7 +1044,7 @@ private fun AppleMusicControls(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.player_volume_off),
+                        painter = painterResource(R.drawable.player_volume_min),
                         contentDescription = stringResource(R.string.minimum_volume),
                         tint = foregroundColor.copy(alpha = 0.66f),
                         modifier = Modifier.size(17.dp),
@@ -1083,6 +1081,7 @@ private fun AppleMusicTransportButton(
     iconSize: Dp,
     touchSize: Dp,
     foregroundColor: Color,
+    mirrored: Boolean = false,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -1094,7 +1093,10 @@ private fun AppleMusicTransportButton(
             painter = painterResource(iconRes),
             contentDescription = contentDescription,
             tint = foregroundColor,
-            modifier = Modifier.size(iconSize),
+            modifier =
+                Modifier
+                    .size(iconSize)
+                    .graphicsLayer { if (mirrored) scaleX = -1f },
         )
     }
 }

--- a/app/src/main/res/drawable/player_fast_forward.xml
+++ b/app/src/main/res/drawable/player_fast_forward.xml
@@ -1,9 +1,12 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960">
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M100,720L100,240L460,480L100,720ZM500,720L500,240L860,480L500,720ZM180,480L180,480L180,480ZM580,480L580,480L580,480ZM180,570L316,480L180,390L180,570ZM580,570L716,480L580,390L580,570Z" />
+        android:pathData="M3.5,5.1C3.5,4.2 4.52,3.67 5.26,4.19L12.08,8.98C12.72,9.43 12.72,10.38 12.08,10.83L5.26,15.62C4.52,16.14 3.5,15.61 3.5,14.71V5.1Z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10.8,5.1C10.8,4.2 11.82,3.67 12.56,4.19L19.38,8.98C20.02,9.43 20.02,10.38 19.38,10.83L12.56,15.62C11.82,16.14 10.8,15.61 10.8,14.71V5.1Z" />
 </vector>

--- a/app/src/main/res/drawable/player_volume_min.xml
+++ b/app/src/main/res/drawable/player_volume_min.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="false"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,9.2C3,8.54 3.54,8 4.2,8H7.4L12.38,3.56C13.03,2.98 14,3.44 14,4.31V19.69C14,20.56 13.03,21.02 12.38,20.44L7.4,16H4.2C3.54,16 3,15.46 3,14.8V9.2Z" />
+</vector>


### PR DESCRIPTION
### Motivation
- Match the Apple-music-style player visuals to the provided screenshot by using the exact solid double-triangle transport glyphs and a minimum-volume speaker icon. 
- Reduce perceptible lag when the lyrics player control row slides up on low-end devices by simplifying the transitions and shortening timings.

### Description
- Replaced transport icons with a shared double-triangle drawable and added mirroring support so the previous button reuses the same asset (`app/src/main/res/drawable/player_fast_forward.xml`, `AppleMusicTransportButton` signature change). 
- Swapped the muted volume glyph for a minimum-volume speaker drawable and updated usages in both the Apple player and lyrics player (`app/src/main/res/drawable/player_volume_min.xml`, `AppleMusicPlayer.kt`, `LyricsScreen.kt`). 
- Simplified the lyrics controls enter/exit animations by removing expand/shrink transitions and using shorter fade/slide-only transitions to avoid layout-expansion work (`app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt`). 
- Minor UI wiring: added `mirrored` flag and `graphicsLayer` flip to the transport button so one icon can act as previous/next without duplicate assets (`AppleMusicTransportButton` changes in `LyricsScreen.kt` and `AppleMusicPlayer.kt`).

### Testing
- `git diff --check` ran and reported no whitespace/diff issues (success). 
- `./gradlew :app:compileGmsMobileUniversalDebugKotlin` was attempted but the build is blocked in this checkout due to a missing configured subproject directory `lyrics/betterlyrics` (blocked). 
- Changes were committed locally (`Refine Apple player icons and lyrics animation`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66c75e479083258bc6eb0e3ba62474)