### PR TITLE
feat: UI improvements, last.fm fix, telegram refresh, and update channel

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1817,7 +1817,9 @@ class MainActivity : ComponentActivity() {
                                                 },
                                                 actions = {
                                                     var profileMenuExpanded by remember { mutableStateOf(false) }
-                                                    Box {
+                                                    Box(
+                                                        modifier = Modifier.padding(end = 4.dp),
+                                                    ) {
                                                         IconButton(
                                                             onClick = { profileMenuExpanded = true },
                                                             colors = IconButtonDefaults.iconButtonColors(
@@ -1855,13 +1857,15 @@ class MainActivity : ComponentActivity() {
                                                         DropdownMenu(
                                                             expanded = profileMenuExpanded,
                                                             onDismissRequest = { profileMenuExpanded = false },
+                                                            shape = RoundedCornerShape(20.dp),
                                                         ) {
                                                             // Optional header line showing the signed-in account name (or "Not signed in")
                                                             if (accountName.isNotBlank()) {
                                                                 Text(
                                                                     text = accountName,
-                                                                    style = MaterialTheme.typography.labelMedium,
-                                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                                    style = MaterialTheme.typography.titleSmall,
+                                                                    fontWeight = FontWeight.SemiBold,
+                                                                    color = MaterialTheme.colorScheme.onSurface,
                                                                     modifier = Modifier.padding(
                                                                         start = 16.dp,
                                                                         end = 16.dp,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlaylistMenu.kt
@@ -67,6 +67,7 @@ import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.LocalSyncUtils
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.SpeedDialSongIdsKey
+import moe.rukamori.archivetune.constants.TelegramLosslessOnlyKey
 import moe.rukamori.archivetune.db.entities.Playlist
 import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
@@ -86,6 +87,7 @@ import moe.rukamori.archivetune.ui.component.NewActionGrid
 import moe.rukamori.archivetune.ui.component.PlaylistListItem
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadItem
 import moe.rukamori.archivetune.ui.utils.sendAddMissingDownloads
+import moe.rukamori.archivetune.telegram.TelegramChannelSync
 import moe.rukamori.archivetune.utils.SpeedDialPin
 import moe.rukamori.archivetune.utils.SpeedDialPinType
 import moe.rukamori.archivetune.utils.parseSpeedDialPins
@@ -910,6 +912,37 @@ public fun PlaylistMenu(
 
             item {
                 MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
+                    val isTelegramPlaylist = playlist.playlist.id.startsWith("LPtg")
+                    if (isTelegramPlaylist) {
+                        val losslessOnly by rememberPreference(TelegramLosslessOnlyKey, defaultValue = false)
+                        ListItem(
+                            headlineContent = { Text(text = stringResource(R.string.refresh_telegram_playlist)) },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.sync),
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier =
+                                Modifier.clickable {
+                                    onDismiss()
+                                    val chatId = playlist.playlist.id.removePrefix("LPtg").toLongOrNull() ?: return@clickable
+                                    TelegramChannelSync.syncAsync(
+                                        database = database,
+                                        chatId = chatId,
+                                        title = playlist.playlist.name,
+                                        losslessOnly = losslessOnly,
+                                    )
+                                },
+                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        )
+
+                        HorizontalDivider(
+                            modifier = dividerModifier,
+                            color = MaterialTheme.colorScheme.outlineVariant,
+                        )
+                    }
+
                     ListItem(
                         headlineContent = { Text(text = stringResource(R.string.sync_playlist)) },
                         leadingContent = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -203,7 +203,7 @@ fun LastFmDashboardScreen(
             if (recent.isEmpty() && recentTracks != null && !isRefreshing) {
                 item(key = "recent_empty") { EmptyHint(text = stringResource(R.string.lastfm_no_recent_tracks)) }
             } else {
-                items(recent, key = { "recent_${it.name}_${it.date?.uts ?: it.nowPlaying ?: ""}" }) { track ->
+                items(recent, key = { "recent_${it.name}_${it.date?.uts ?: it.attr?.nowplaying ?: ""}" }) { track ->
                     RecentTrackRow(track)
                 }
             }
@@ -415,7 +415,7 @@ private fun RecentTrackRow(track: RecentTrack) {
                 overflow = TextOverflow.Ellipsis,
             )
         }
-        if (track.nowPlaying == "true") {
+        if (track.isNowPlaying) {
             Text(
                 text = stringResource(R.string.lastfm_now_playing),
                 style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -35,6 +35,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.account),
             subtitle = stringResource(R.string.settings_account_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
+            keywords = listOf("account", "profile", "youtube", "sign in", "login", "logout"),
             onClick = { navController.navigate("settings/account") },
         )
     val stats =
@@ -44,6 +45,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_stats_title),
             subtitle = stringResource(R.string.settings_stats_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
+            keywords = listOf("stats", "statistics", "listening", "history", "top", "most played", "time"),
             onClick = { navController.navigate("stats") },
         )
     val appearance =
@@ -53,6 +55,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.appearance),
             subtitle = stringResource(R.string.settings_appearance_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("appearance", "theme", "dark", "light", "color", "palette", "style", "design"),
             onClick = { navController.navigate("settings/appearance") },
         )
     val playback =
@@ -62,6 +65,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_playback_title),
             subtitle = stringResource(R.string.settings_playback_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("playback", "player", "audio", "quality", "equalizer", "eq", "volume", "crossfade", "gapless"),
             onClick = { navController.navigate("settings/player") },
         )
     val sources =
@@ -71,6 +75,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.source_settings),
             subtitle = stringResource(R.string.source_settings_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("source", "music source", "youtube music", "tidal", "qobuz", "provider", "streaming"),
             onClick = { navController.navigate("settings/sources") },
         )
     val lyrics =
@@ -80,6 +85,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.lyrics),
             subtitle = stringResource(R.string.settings_lyrics_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("lyrics", "lyric", "subtitle", "text", "sing along", "lrc"),
             onClick = { navController.navigate("settings/lyrics") },
         )
     val content =
@@ -89,6 +95,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.content),
             subtitle = stringResource(R.string.settings_content_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
+            keywords = listOf("content", "language", "locale", "country", "region", "app language"),
             onClick = { navController.navigate("settings/content") },
         )
     val languagePacks =
@@ -98,6 +105,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.language_packs),
             subtitle = stringResource(R.string.settings_language_packs_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("language pack", "translation", "translate", "localization", "i18n"),
             onClick = { navController.navigate("settings/language_packs") },
         )
     val behavior =
@@ -107,6 +115,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_behavior_title),
             subtitle = stringResource(R.string.settings_behavior_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
+            keywords = listOf("behavior", "privacy", "swipe", "gesture", "history", "cache", "data"),
             onClick = { navController.navigate("settings/privacy") },
         )
     val integration =
@@ -116,6 +125,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.integration),
             subtitle = stringResource(R.string.settings_integration_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("integration", "lastfm", "last.fm", "scrobble", "scrobbling", "discord"),
             onClick = { navController.navigate("settings/integration") },
         )
     val aiIntegration =
@@ -125,6 +135,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.ai_integration),
             subtitle = stringResource(R.string.ai_integration_desc),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("ai", "artificial intelligence", "chatgpt", "openai", "gemini", "llm", "ai integration"),
             onClick = { navController.navigate("settings/ai_integration") },
         )
     val internet =
@@ -134,6 +145,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.internet),
             subtitle = stringResource(R.string.settings_internet_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("internet", "proxy", "vpn", "network", "wifi", "connection", "traffic"),
             onClick = { navController.navigate("settings/internet") },
         )
     val poToken =
@@ -143,6 +155,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.po_token_generation),
             subtitle = stringResource(R.string.settings_po_token_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("po token", "potoken", "botguard", "youtube token", "playability"),
             onClick = { navController.navigate(PO_TOKEN_ROUTE) },
         )
     val storage =
@@ -152,6 +165,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.storage),
             subtitle = stringResource(R.string.settings_storage_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
+            keywords = listOf("storage", "download", "cache", "disk", "space", "memory", "path", "location"),
             onClick = { navController.navigate("settings/storage") },
         )
     val backupRestore =
@@ -161,6 +175,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.backup_restore),
             subtitle = stringResource(R.string.settings_backup_restore_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
+            keywords = listOf("backup", "restore", "export", "import", "data", "save"),
             onClick = { navController.navigate("settings/backup_restore") },
         )
     val developerOptions =
@@ -170,6 +185,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_developer_options_title),
             subtitle = stringResource(R.string.settings_developer_options_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("developer", "debug", "experimental", "advanced", "logcat", "dev"),
             onClick = { navController.navigate("settings/misc") },
         )
     val defaultLinks =
@@ -180,6 +196,7 @@ fun buildSettingsGroups(
                 title = stringResource(R.string.default_links),
                 subtitle = stringResource(R.string.open_supported_links),
                 accentColor = MaterialTheme.colorScheme.secondary,
+                keywords = listOf("default links", "links", "urls", "deep link", "supported links"),
                 onClick = {
                     try {
                         val intent =
@@ -224,6 +241,7 @@ fun buildSettingsGroups(
                 key = "updates",
                 icon = painterResource(R.drawable.update),
                 title = stringResource(R.string.updates),
+                keywords = listOf("update", "upgrade", "version", "new version", "release", "canary", "stable"),
                 subtitle =
                     if (hasUpdate) {
                         stringResource(R.string.new_version_available)
@@ -250,6 +268,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.about),
             subtitle = stringResource(R.string.settings_about_subtitle),
             accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("about", "info", "version", "license", "credits", "contributors", "changelog"),
             onClick = { navController.navigate("settings/about") },
         )
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsModels.kt
@@ -24,6 +24,7 @@ data class SettingsProfileState(
 data class SettingsGroup(
     val title: String,
     val items: List<SettingsItem>,
+    val showWhenFiltered: Boolean = true,
 )
 
 @Immutable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -273,7 +273,9 @@ fun SettingsScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
+            item(key = "search_spacing", contentType = "spacing") {
+                Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
+            }
 
             filteredGroups.forEachIndexed { groupIndex, group ->
                 if (groupIndex > 0) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -14,6 +14,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -33,6 +34,8 @@ import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -108,13 +111,29 @@ fun SettingsScreen(
             }
         }
 
+    var searchQuery by remember { mutableStateOf("") }
     val scrollBehavior = appBarScrollBehavior()
     val shouldShowPermissionHint = !isStorageGranted || !isNotificationGranted
     val hasUpdate =
         BuildConfig.UPDATER_AVAILABLE &&
             Updater.isUpdateAvailable(latestVersionName, BuildConfig.VERSION_NAME)
     var isUpdateDismissed by remember { mutableStateOf(false) }
-    val settingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
+    val allSettingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
+    val filteredGroups = remember(searchQuery, allSettingsGroups) {
+        if (searchQuery.isBlank()) {
+            allSettingsGroups
+        } else {
+            val query = searchQuery.trim().lowercase()
+            allSettingsGroups.map { group ->
+                val filteredItems = group.items.filter { item ->
+                    item.title.lowercase().contains(query) ||
+                        item.subtitle?.lowercase()?.contains(query) == true ||
+                        item.keywords.any { keyword -> keyword.lowercase().contains(query) }
+                }
+                group.copy(items = filteredItems, showWhenFiltered = filteredItems.isNotEmpty())
+            }.filter { it.items.isNotEmpty() }
+        }
+    }
 
     // Material 3 Expressive: when any settings dialog (history duration,
     // lyrics preload count, etc.) is showing, apply a backdrop blur to
@@ -186,7 +205,7 @@ fun SettingsScreen(
                     bottom = SettingsDimensions.ScreenBottomPadding,
                 ),
         ) {
-            if (hasUpdate && !isUpdateDismissed) {
+            if (hasUpdate && !isUpdateDismissed && searchQuery.isBlank()) {
                 item(key = "update", contentType = "settings_banner") {
                     SettingsUpdateBanner(
                         latestVersion = latestVersionName,
@@ -200,7 +219,7 @@ fun SettingsScreen(
                 }
             }
 
-            if (shouldShowPermissionHint) {
+            if (shouldShowPermissionHint && searchQuery.isBlank()) {
                 item(key = "permission", contentType = "settings_banner") {
                     SettingsPermissionBanner(
                         onRequestPermission = {
@@ -223,7 +242,40 @@ fun SettingsScreen(
                 }
             }
 
-            settingsGroups.forEachIndexed { groupIndex, group ->
+            item(key = "search_bar", contentType = "search_bar") {
+                TextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.search_settings),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.search),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    singleLine = true,
+                    shape = RoundedCornerShape(28.dp),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.transparent,
+                    ),
+                    modifier = Modifier
+                        .padding(horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding)
+                        .fillMaxWidth(),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
+
+            filteredGroups.forEachIndexed { groupIndex, group ->
                 if (groupIndex > 0) {
                     item(
                         key = "settings_group_spacing_$groupIndex",

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -56,11 +56,12 @@ object Updater {
     private val client = HttpClient()
     private const val ReleaseCacheCheckIntervalMs: Long = 6 * 60 * 60 * 1000L
     private const val CanaryCacheCheckIntervalMs: Long = 15 * 60 * 1000L
-    private const val StableReleaseBaseUrl = "https://github.com/vossgraves/ArchiveTune/releases"
+    private const val OWNER = "4nx3b/ArchiveTune"
+    private const val StableReleaseBaseUrl = "https://github.com/$OWNER/releases"
     private const val CanaryReleaseBaseUrl =
-        "https://github.com/vossgraves/ArchiveTune/releases"
+        "https://github.com/$OWNER/releases"
     private const val CanaryWorkflowRunsUrl =
-        "https://api.github.com/repos/vossgraves/ArchiveTune/actions/workflows/nightly.yml/runs" +
+        "https://api.github.com/repos/$OWNER/actions/workflows/nightly.yml/runs" +
             "?branch=dev&status=success&per_page=1&exclude_pull_requests=true"
     var lastCheckTime = -1L
         private set
@@ -99,7 +100,7 @@ object Updater {
 
     private fun workflowArtifactDownloadUrl(): String {
         val artifactUrl =
-            "https://nightly.link/vossgraves/ArchiveTune/workflows/nightly/dev/${workflowArtifactName()}"
+            "https://nightly.link/$OWNER/workflows/nightly/dev/${workflowArtifactName()}"
         return if (canDownloadUpdatesDirectly) "$artifactUrl.zip" else artifactUrl
     }
 
@@ -342,7 +343,7 @@ object Updater {
         cachedEtag: String?,
     ): ReleasesNetworkResult {
         val response: HttpResponse =
-            client.get("https://api.github.com/repos/vossgraves/ArchiveTune/releases?per_page=$perPage") {
+            client.get("https://api.github.com/repos/$OWNER/releases?per_page=$perPage") {
                 headers {
                     append("Accept", "application/vnd.github+json")
                     append("User-Agent", "ArchiveTune")
@@ -414,7 +415,7 @@ object Updater {
 
             val response =
                 client
-                    .get("https://api.github.com/repos/vossgraves/ArchiveTune/commits?sha=$branch&per_page=$count")
+                    .get("https://api.github.com/repos/$OWNER/commits?sha=$branch&per_page=$count")
                     .bodyAsText()
             val jsonArray = JSONArray(response)
             val commits = mutableListOf<GitCommit>()
@@ -662,7 +663,7 @@ object Updater {
         cachedEtag: String?,
     ): ReleasesNetworkResult {
         val response: HttpResponse =
-            client.get("https://api.github.com/repos/vossgraves/ArchiveTune/releases?per_page=$perPage") {
+            client.get("https://api.github.com/repos/$OWNER/releases?per_page=$perPage") {
                 headers {
                     append("Accept", "application/vnd.github+json")
                     append("User-Agent", "ArchiveTune")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -889,7 +889,8 @@
     <string name="lastfm_playcount">%1$d scrobbles</string>
     <string name="lastfm_playcount_short">%1$d plays</string>
     <string name="enable_scrobbling">Enable Scrobbling</string>
-    <string name="lastfm_now_playing">Update Now Playing</string>
+    <string name="lastfm_now_playing">Now playing</string>
+    <string name="refresh_telegram_playlist">Refresh from Telegram</string>
     <string name="scrobbling_configuration">Scrobbling Configuration</string>
     <string name="scrobble_min_track_duration">Minimum Track Duration</string>
     <string name="scrobble_delay_percent">Scrobble Delay Percent</string>

--- a/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfo.kt
+++ b/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfo.kt
@@ -27,10 +27,12 @@ data class UserInfo(
     val age: Int? = null,
     val gender: String? = null,
     val subscriber: Int? = null,
-    val playcount: Int? = null,
+    @SerialName("playcount") private val _playcount: String? = null,
     val playlists: Int? = null,
     val registered: UserRegistered? = null,
-)
+) {
+    val playcount: Int? get() = _playcount?.toIntOrNull()
+}
 
 @Serializable
 data class UserImage(
@@ -74,7 +76,14 @@ data class RecentTrack(
     val album: RecentTrackAlbum? = null,
     val url: String? = null,
     val date: RecentTrackDate? = null,
-    @SerialName("@attr") val nowPlaying: String? = null,
+    @SerialName("@attr") val attr: RecentTrackAttr? = null,
+) {
+    val isNowPlaying: Boolean get() = attr?.nowplaying == "true"
+}
+
+@Serializable
+data class RecentTrackAttr(
+    val nowplaying: String? = null,
 )
 
 @Serializable
@@ -121,11 +130,19 @@ data class TopTracksAttr(
 @Serializable
 data class TopTrack(
     val name: String? = null,
-    val playcount: Int? = null,
+    @SerialName("playcount") private val _playcount: String? = null,
     val artist: RecentTrackArtist? = null,
     val url: String? = null,
     val image: List<UserImage>? = null,
-    @SerialName("@attr") val rank: String? = null,
+    @SerialName("@attr") val attr: TopTrackAttr? = null,
+) {
+    val playcount: Int? get() = _playcount?.toIntOrNull()
+    val rank: String? get() = attr?.rank
+}
+
+@Serializable
+data class TopTrackAttr(
+    val rank: String? = null,
 )
 
 /**


### PR DESCRIPTION
## Summary

This PR includes 6 changes:

### 1. Fix last.fm dashboard error
The dashboard was crashing due to deserialization failures. Last.fm API returns `playcount` as a string (e.g. `"12345"`) but the model defined it as `Int?`. Also, `@attr` fields in `RecentTrack` and `TopTrack` are JSON objects, not strings.

### 2. Add search bar in Settings
A search bar with keyword-based filtering has been added to the top of the Settings screen. Each settings item now includes searchable keywords.

### 3. Adjust account button and dropdown
- Account button moved slightly left (4dp padding)
- Dropdown menu shape changed to `RoundedCornerShape(20dp)`
- Account name text changed from `labelMedium` to `titleSmall` with `SemiBold` weight

### 4. Add refresh button for Telegram playlists
Playlists synced from Telegram (with `LPtg` prefix) now show a "Refresh from Telegram" option in their menu.

### 5. Change update channel to 4nx3b/ArchiveTune
All update URLs (stable releases, canary releases, workflow runs, nightly.link, commits API) now point to `4nx3b/ArchiveTune` instead of `vossgraves/ArchiveTune`.

### 6. Minor fixes
- Fixed `lastfm_now_playing` string (was "Update Now Playing", now "Now playing")
- Fixed recent track key to use new `attr` model