### PR TITLE
fix(settings): resolve search bar compile errors

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -14,11 +14,13 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -33,6 +35,8 @@ import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -108,13 +112,29 @@ fun SettingsScreen(
             }
         }
 
+    var searchQuery by remember { mutableStateOf("") }
     val scrollBehavior = appBarScrollBehavior()
     val shouldShowPermissionHint = !isStorageGranted || !isNotificationGranted
     val hasUpdate =
         BuildConfig.UPDATER_AVAILABLE &&
             Updater.isUpdateAvailable(latestVersionName, BuildConfig.VERSION_NAME)
     var isUpdateDismissed by remember { mutableStateOf(false) }
-    val settingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
+    val allSettingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
+    val filteredGroups = remember(searchQuery, allSettingsGroups) {
+        if (searchQuery.isBlank()) {
+            allSettingsGroups
+        } else {
+            val query = searchQuery.trim().lowercase()
+            allSettingsGroups.map { group ->
+                val filteredItems = group.items.filter { item ->
+                    item.title.lowercase().contains(query) ||
+                        item.subtitle?.lowercase()?.contains(query) == true ||
+                        item.keywords.any { keyword -> keyword.lowercase().contains(query) }
+                }
+                group.copy(items = filteredItems, showWhenFiltered = filteredItems.isNotEmpty())
+            }.filter { it.items.isNotEmpty() }
+        }
+    }
 
     // Material 3 Expressive: when any settings dialog (history duration,
     // lyrics preload count, etc.) is showing, apply a backdrop blur to
@@ -186,7 +206,7 @@ fun SettingsScreen(
                     bottom = SettingsDimensions.ScreenBottomPadding,
                 ),
         ) {
-            if (hasUpdate && !isUpdateDismissed) {
+            if (hasUpdate && !isUpdateDismissed && searchQuery.isBlank()) {
                 item(key = "update", contentType = "settings_banner") {
                     SettingsUpdateBanner(
                         latestVersion = latestVersionName,
@@ -200,7 +220,7 @@ fun SettingsScreen(
                 }
             }
 
-            if (shouldShowPermissionHint) {
+            if (shouldShowPermissionHint && searchQuery.isBlank()) {
                 item(key = "permission", contentType = "settings_banner") {
                     SettingsPermissionBanner(
                         onRequestPermission = {
@@ -223,7 +243,42 @@ fun SettingsScreen(
                 }
             }
 
-            settingsGroups.forEachIndexed { groupIndex, group ->
+            item(key = "search_bar", contentType = "search_bar") {
+                TextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.search_settings),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.search),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    singleLine = true,
+                    shape = RoundedCornerShape(28.dp),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                        unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                    ),
+                    modifier = Modifier
+                        .padding(horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding)
+                        .fillMaxWidth(),
+                )
+            }
+
+            item(key = "search_spacing", contentType = "spacing") {
+                Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
+            }
+
+            filteredGroups.forEachIndexed { groupIndex, group ->
                 if (groupIndex > 0) {
                     item(
                         key = "settings_group_spacing_$groupIndex",


### PR DESCRIPTION
## Summary

Fixes 3 compile errors in SettingsScreen.kt introduced by the search bar addition:

1. **@Composable outside context** (line 276): `Spacer` was called directly in `LazyColumn` scope instead of inside an `item{}` block.
2. **Unresolved reference `fillMaxWidth`** (line 272): Missing import `androidx.compose.foundation.layout.fillMaxWidth`.
3. **Unresolved reference `transparent`** (line 268): `MaterialTheme.colorScheme.transparent` does not exist — replaced with `Color.Transparent`.