### PR TITLE
fix(settings): add missing fillMaxWidth import and fix transparent color

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -265,7 +266,7 @@ fun SettingsScreen(
                         focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                         unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                         focusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                        unfocusedIndicatorColor = MaterialTheme.colorScheme.transparent,
+                        unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
                     ),
                     modifier = Modifier
                         .padding(horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding)


### PR DESCRIPTION
## Fixes

Two compile errors in SettingsScreen.kt search bar code:

1. **Line 268 - Unresolved reference `transparent`**: `MaterialTheme.colorScheme.transparent` does not exist. Replaced with `Color.Transparent`.
2. **Line 272 - Unresolved reference `fillMaxWidth`**: Missing import. Added `androidx.compose.foundation.layout.fillMaxWidth`.