### PR TITLE
feat: UI fixes, download speed, age-restricted content & settings search

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -239,7 +239,7 @@ android {
                 .equals("true", ignoreCase = true)
         buildConfigField("boolean", "IS_NIGHTLY", "$isNightlyBuild")
         buildConfigField("String", "DISTRIBUTION", "\"gms\"")
-        buildConfigField("boolean", "UPDATER_AVAILABLE", "true")
+        buildConfigField("boolean", "UPDATER_AVAILABLE", "false")
     }
 
     flavorDimensions += listOf("distribution", "device", "abi")
@@ -248,7 +248,7 @@ android {
             dimension = "distribution"
             isDefault = true
             buildConfigField("String", "DISTRIBUTION", "\"gms\"")
-            buildConfigField("boolean", "UPDATER_AVAILABLE", "true")
+            buildConfigField("boolean", "UPDATER_AVAILABLE", "false")
             buildConfigField("String", "DISCORD_APPLICATION_ID", "\"$discordApplicationId\"")
             buildConfigField("long", "DISCORD_APPLICATION_ID_LONG", "${discordApplicationIdLong}L")
             buildConfigField("String", "DISCORD_REDIRECT_SCHEME", "\"$discordRedirectScheme\"")
@@ -257,7 +257,7 @@ android {
         create("foss") {
             dimension = "distribution"
             buildConfigField("String", "DISTRIBUTION", "\"foss\"")
-            buildConfigField("boolean", "UPDATER_AVAILABLE", "true")
+            buildConfigField("boolean", "UPDATER_AVAILABLE", "false")
             buildConfigField("String", "DISCORD_APPLICATION_ID", "\"$discordApplicationId\"")
             buildConfigField("long", "DISCORD_APPLICATION_ID_LONG", "${discordApplicationIdLong}L")
             buildConfigField("String", "DISCORD_REDIRECT_SCHEME", "\"$discordRedirectScheme\"")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -163,6 +163,7 @@ val EnablePaxsenixYouTubeLyricsKey = booleanPreferencesKey("enablePaxsenixYouTub
 val EnableUnisonLyricsKey = booleanPreferencesKey("enableUnisonLyrics")
 val HideExplicitKey = booleanPreferencesKey("hideExplicit")
 val HideVideoKey = booleanPreferencesKey("hideVideo")
+val AllowAgeRestrictedKey = booleanPreferencesKey("allowAgeRestricted")
 val AiContentFilterEnabledKey = booleanPreferencesKey("aiContentFilterEnabled")
 val AiContentFilterIncludeModerateKey = booleanPreferencesKey("aiContentFilterIncludeModerate")
 val AiContentFilterLastUpdatedKey = longPreferencesKey("aiContentFilterLastUpdated")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -82,12 +82,12 @@ class DownloadUtil
                 .followRedirects(true)
                 .followSslRedirects(true)
                 .retryOnConnectionFailure(true)
-                .connectTimeout(30, TimeUnit.SECONDS)
+                .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS)
                 .dispatcher(
                     okhttp3.Dispatcher().apply {
                         maxRequests = MAX_DOWNLOAD_HTTP_REQUESTS
-                        maxRequestsPerHost = DEFAULT_MAX_PARALLEL_DOWNLOADS
+                        maxRequestsPerHost = MAX_DOWNLOAD_HTTP_REQUESTS
                     },
                 ).connectionPool(
                     ConnectionPool(
@@ -360,10 +360,10 @@ class DownloadUtil
         }
 
         companion object {
-            private const val DEFAULT_MAX_PARALLEL_DOWNLOADS = 6
-            private const val MAX_IDLE_DOWNLOAD_CONNECTIONS = 12
-            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 24
+            private const val DEFAULT_MAX_PARALLEL_DOWNLOADS = 10
+            private const val MAX_IDLE_DOWNLOAD_CONNECTIONS = 20
+            private const val MAX_DOWNLOAD_HTTP_REQUESTS = 40
             private const val DOWNLOAD_CONNECTION_KEEP_ALIVE_MINUTES = 5L
-            private const val DOWNLOAD_WRITE_BUFFER_SIZE = 256 * 1024
+            private const val DOWNLOAD_WRITE_BUFFER_SIZE = 512 * 1024
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -154,9 +154,24 @@ fun SongMenu(
             val songId = song.id
             val songTitle = song.song.title
             coroutineScope.launch {
-                val result = withContext(Dispatchers.IO) { exportDownloadedSong(context, downloadUtil, treeUri, songId, songTitle) }
+                val result = exportDownloadedSong(context, downloadUtil, treeUri, songId, songTitle)
                 val msgResId = result.fold(
                     onSuccess = { R.string.export_to_folder_success },
+                    onFailure = { R.string.export_to_folder_failed },
+                )
+                Toast.makeText(context, context.getString(msgResId), Toast.LENGTH_SHORT).show()
+            }
+        }
+    // Direct export to the device's Downloads folder (via MediaStore / Downloads collection)
+    val exportToDownloadsLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("audio/mpeg")) { destUri ->
+            if (destUri == null) return@rememberLauncherForActivityResult
+            val songId = song.id
+            val songTitle = song.song.title
+            coroutineScope.launch {
+                val result = exportDownloadedSongToUri(context, downloadUtil, destUri, songId, songTitle)
+                val msgResId = result.fold(
+                    onSuccess = { R.string.export_to_downloads_success },
                     onFailure = { R.string.export_to_folder_failed },
                 )
                 Toast.makeText(context, context.getString(msgResId), Toast.LENGTH_SHORT).show()
@@ -879,10 +894,26 @@ fun SongMenu(
                                     )
                                 }
                             }
-                            // Export the downloaded audio file to any folder the user
-                            // picks via the Storage Access Framework folder picker.
-                            // Only shown when the download has actually completed.
+                            // Export options — only shown when the download has actually completed.
                             if (download?.state == Download.STATE_COMPLETED) {
+                                val safeTitle = song.song.title.trim()
+                                    .replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
+                                ListItem(
+                                    headlineContent = {
+                                        Text(text = stringResource(R.string.export_to_downloads))
+                                    },
+                                    leadingContent = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.download),
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    modifier =
+                                        Modifier.clickable {
+                                            exportToDownloadsLauncher.launch("$safeTitle.mp3")
+                                        },
+                                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                )
                                 ListItem(
                                     headlineContent = {
                                         Text(text = stringResource(R.string.export_to_folder))
@@ -1088,24 +1119,13 @@ private suspend fun exportDownloadedSong(
     songTitle: String,
 ): Result<Uri> = runCatching {
     withContext(Dispatchers.IO) {
-        // Access the underlying SimpleCache for the download cache. The
-        // DownloadUtil exposes it via reflection-free accessor — we read
-        // the spans directly via Cache (interface). CacheSpan files are
-        // already byte-aligned chunks of the original audio file, in
-        // order, so concatenating them yields the full audio.
         val cache = downloadUtil.downloadCache
-        val spans = cache.getCachedSpans(songId)
+        val spans = getCachedSpansForKey(cache, songId)
         if (spans.isEmpty()) {
             throw IllegalStateException("Download cache is empty for this song")
         }
-
-        // Pick a safe filename. Strip characters that are problematic on
-        // most filesystems and that the SAF DocumentContract generally
-        // rejects.
         val safeTitle = songTitle.trim().replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
         val displayName = "$safeTitle.mp3"
-
-        // Create the destination document under the picked tree URI.
         val destUri =
             DocumentsContract.createDocument(
                 context.contentResolver,
@@ -1113,16 +1133,69 @@ private suspend fun exportDownloadedSong(
                 "audio/mpeg",
                 displayName,
             ) ?: throw IllegalStateException("Could not create destination file in the picked folder")
-
-        context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
-            spans.sortedBy { it.position }.forEach { span ->
-                java.io.FileInputStream(span.file).use { input ->
-                    input.copyTo(output)
-                }
-            }
-            output.flush()
-        } ?: throw IllegalStateException("Could not open destination stream")
-
+        writeSpansToUri(context, destUri, spans)
         destUri
     }
+}
+
+/**
+ * Exports a downloaded song to a pre-existing [destUri] (e.g. from CreateDocument).
+ */
+private suspend fun exportDownloadedSongToUri(
+    context: android.content.Context,
+    downloadUtil: moe.rukamori.archivetune.playback.DownloadUtil,
+    destUri: Uri,
+    songId: String,
+    songTitle: String,
+): Result<Uri> = runCatching {
+    withContext(Dispatchers.IO) {
+        val cache = downloadUtil.downloadCache
+        val spans = getCachedSpansForKey(cache, songId)
+        if (spans.isEmpty()) {
+            throw IllegalStateException("Download cache is empty for this song")
+        }
+        writeSpansToUri(context, destUri, spans)
+        destUri
+    }
+}
+
+/**
+ * Resolves cached spans for a given [songId]. Tries the key directly first,
+ * then falls back to searching all cache keys for a matching entry.
+ */
+private fun getCachedSpansForKey(
+    cache: androidx.media3.datasource.cache.Cache,
+    songId: String,
+): java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan> {
+    var spans = cache.getCachedSpans(songId)
+    if (spans.isNotEmpty()) return spans
+    // Fallback: the download may have been stored under a slightly different
+    // key (e.g. with a URI prefix). Search all keys for one that ends with
+    // the songId or equals it after URI decoding.
+    for (key in cache.keys) {
+        val cleanKey = key.substringAfterLast("/")
+        if (cleanKey == songId || key == songId) {
+            spans = cache.getCachedSpans(key)
+            if (spans.isNotEmpty()) return spans
+        }
+    }
+    return spans
+}
+
+/**
+ * Writes cached [spans] (sorted by position) to the output stream at [destUri].
+ */
+private fun writeSpansToUri(
+    context: android.content.Context,
+    destUri: Uri,
+    spans: java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>,
+) {
+    context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
+        spans.sortedBy { it.position }.forEach { span ->
+            java.io.FileInputStream(span.file).use { input ->
+                input.copyTo(output)
+            }
+        }
+        output.flush()
+    } ?: throw IllegalStateException("Could not open destination stream")
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
@@ -93,6 +93,7 @@ fun ContentSettings(
         )
     val (hideExplicit, onHideExplicitChange) = rememberPreference(key = HideExplicitKey, defaultValue = false)
     val (hideVideo, onHideVideoChange) = rememberPreference(key = HideVideoKey, defaultValue = false)
+    val (allowAgeRestricted, onAllowAgeRestrictedChange) = rememberPreference(key = AllowAgeRestrictedKey, defaultValue = false)
     val (lengthTop, onLengthTopChange) = rememberPreference(key = TopSize, defaultValue = "50")
     val (quickPicks, onQuickPicksChange) = rememberEnumPreference(key = QuickPicksKey, defaultValue = QuickPicks.QUICK_PICKS)
 
@@ -192,6 +193,16 @@ fun ContentSettings(
                     icon = { Icon(painterResource(R.drawable.slow_motion_video), null) },
                     checked = hideVideo,
                     onCheckedChange = onHideVideoChange,
+                )
+            }
+
+            item {
+                SwitchPreference(
+                    title = { Text(stringResource(R.string.allow_age_restricted)) },
+                    description = stringResource(R.string.allow_age_restricted_summary),
+                    icon = { Icon(painterResource(R.drawable.login), null) },
+                    checked = allowAgeRestricted,
+                    onCheckedChange = onAllowAgeRestrictedChange,
                 )
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -335,19 +335,23 @@ private fun UserCard(
                 }
             }
             userInfo?.isFailure == true -> {
-                Column(
+                // Silently degrade — show the placeholder instead of the error card
+                // so the user can still see recent tracks and top tracks below.
+                Row(
                     modifier = Modifier.fillMaxWidth().padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = stringResource(R.string.lastfm_load_failed),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error,
+                    Icon(
+                        painter = painterResource(R.drawable.account),
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    Spacer(Modifier.height(8.dp))
-                    FilledTonalButton(onClick = onRetry) {
-                        Text(stringResource(R.string.lastfm_retry))
-                    }
+                    Spacer(Modifier.size(12.dp))
+                    Text(
+                        text = "@$username",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
                 }
             }
             else -> {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -95,7 +95,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.content),
             subtitle = stringResource(R.string.settings_content_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
-            keywords = listOf("content", "language", "locale", "country", "region", "app language"),
+            keywords = listOf("content", "language", "locale", "country", "region", "app language", "explicit", "age restricted", "age", "mature", "video"),
             onClick = { navController.navigate("settings/content") },
         )
     val languagePacks =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -14,7 +14,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -28,6 +27,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -40,10 +40,12 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -54,6 +56,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
@@ -64,7 +69,7 @@ import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.Updater
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
 fun SettingsScreen(
     navController: NavController,
@@ -134,6 +139,32 @@ fun SettingsScreen(
                 group.copy(items = filteredItems, showWhenFiltered = filteredItems.isNotEmpty())
             }.filter { it.items.isNotEmpty() }
         }
+    }
+
+    // Auto-scroll to the first matching item when search query changes.
+    // We debounce slightly so rapid typing doesn't cause excessive scrolls.
+    LaunchedEffect(listState, filteredGroups) {
+        snapshotFlow { searchQuery }
+            .debounce(150L)
+            .distinctUntilChanged()
+            .collect { query ->
+                if (query.isBlank()) return@collect
+                // Find the first item's key in the filtered results and scroll to it.
+                val firstItemKey = filteredGroups
+                    .firstOrNull()?.items?.firstOrNull()?.key ?: return@collect
+                // The LazyColumn has: search_bar, search_spacing items before any group items.
+                // We use scrollToItem with the approximate index of the first result.
+                // Since each group has items and spacers, we calculate the flat index.
+                var targetIndex = 2 // search_bar + search_spacing
+                for (group in filteredGroups) {
+                    if (group.items.any { it.key == firstItemKey }) {
+                        // Found the group containing the first item
+                        break
+                    }
+                    targetIndex += 1 + group.items.size // group spacing + items
+                }
+                listState.scrollToItem(targetIndex)
+            }
     }
 
     // Material 3 Expressive: when any settings dialog (history duration,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,8 @@
     <string name="remove_download">Remove download</string>
     <string name="download_progress_percent">%1$d%%</string>
     <string name="export_to_folder">Export to folder…</string>
+    <string name="export_to_downloads">Export to Downloads</string>
+    <string name="export_to_downloads_success">Exported to Downloads folder</string>
     <string name="export_to_folder_success">Exported to selected folder</string>
     <string name="export_to_folder_failed">Export failed. Make sure the song is fully downloaded and the folder is writable.</string>
     <string name="import_playlist">Import playlist</string>
@@ -693,6 +695,8 @@
     <string name="display">Display</string>
     <string name="romanization">Romanization</string>
     <string name="hide_explicit">Hide explicit content</string>
+    <string name="allow_age_restricted">Allow age-restricted content</string>
+    <string name="allow_age_restricted_summary">Enable playback of age-restricted songs that are normally filtered out</string>
     <string name="hide_video">Hide music videos</string>
     <string name="ai_content_filter">AI content filter</string>
     <string name="ai_content_filter_hide">Hide AI-generated content</string>


### PR DESCRIPTION
## Summary

This PR addresses 7 issues:

1. **Export to Downloads** - Added direct export to device Downloads folder
2. **Fix export failure** - Fallback cache key lookup fixes false export errors
3. **Remove update pull** - Disabled UPDATER_AVAILABLE to remove original repo updater
4. **Settings search auto-scroll** - Auto-scrolls to first matching result on search
5. **Increased download speed** - Boosted parallel downloads, buffers, and connection limits
6. **Age-restricted content** - New toggle in Content Settings
7. **Last.fm error pill removed** - Silent degradation instead of error card