### PR TITLE
fix: resolve Kotlin compilation errors in LastFmDashboardScreen and CachePlaylistScreen

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -116,6 +116,7 @@ fun CachePlaylistScreen(
     val haptic = LocalHapticFeedback.current
     val focusManager = LocalFocusManager.current
     val coroutineScope = rememberCoroutineScope()
+    val cachedSongs by viewModel.cachedSongs.collectAsState()
 
     // SAF folder picker for "Export all"
     val exportAllLauncher =
@@ -162,7 +163,6 @@ fun CachePlaylistScreen(
 
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
-    val cachedSongs by viewModel.cachedSongs.collectAsState()
 
     val (sortType, onSortTypeChange) =
         rememberEnumPreference(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Int
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel


### PR DESCRIPTION
## Summary

Fixes two Kotlin compilation errors that were causing CI to fail on the previous PR:

### 1. `LastFmDashboardScreen.kt` — Unresolved reference `Int`
- **Cause**: Invalid import `androidx.compose.ui.unit.Int` was added. `Int` is a Kotlin built-in type, not a Compose UI class.
- **Fix**: Removed the erroneous import. `Int.MAX_VALUE` used in `RepeatableSpec` resolves to `kotlin.Int` automatically.

### 2. `CachePlaylistScreen.kt` — Unresolved reference `cachedSongs`
- **Cause**: `cachedSongs` (declared via `collectAsState` at line 165) was referenced inside the `exportAllLauncher` lambda callback at line 127 — before its declaration. Kotlin lambdas capture variables from enclosing scope, but the variable must be declared before the lambda definition.
- **Fix**: Moved `val cachedSongs by viewModel.cachedSongs.collectAsState()` to before the `exportAllLauncher` declaration.

## Test Plan
- [ ] CI build passes (`:app:compileGmsMobileArmeabiReleaseKotlin`)
- [ ] Last.fm dashboard refresh button still works with spinning animation
- [ ] Song thumbnails still load from Last.fm API image data
- [ ] Cache playlist export all feature still works

Supersedes #23