### PR TITLE
feat: lossless export, storage export, download speed, settings search improvements

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
@@ -27,6 +27,42 @@ data class FormatEntity(
 
 fun FormatEntity.containerLabel(): String = mimeType.substringAfter("/").substringBefore(";").uppercase()
 
+/**
+ * Returns the appropriate file extension for this format's audio codec.
+ * Used when exporting cached songs so lossless FLAC files get a .flac
+ * extension instead of the generic .mp3 that was previously hardcoded.
+ */
+fun FormatEntity.fileExtension(): String {
+    val rawCodec = codecs.ifBlank { mimeType.substringAfter("/") }.lowercase()
+    val rawMime = mimeType.substringAfter("/").substringBefore(";").lowercase()
+    return when {
+        rawCodec.contains("flac") || rawCodec.contains("alac") -> "flac"
+        rawCodec.contains("opus") || rawMime.contains("opus") -> "opus"
+        rawCodec.contains("aac") || rawCodec.contains("mp4a") || rawMime.contains("mp4") -> "m4a"
+        rawCodec.contains("vorbis") -> "ogg"
+        rawCodec.contains("mp3") || rawMime.contains("mpeg") -> "mp3"
+        rawMime.contains("wav") || rawCodec.contains("pcm") -> "wav"
+        else -> "bin"
+    }
+}
+
+/**
+ * Returns the MIME type corresponding to this format's audio codec,
+ * suitable for use with SAF DocumentsContract.createDocument().
+ */
+fun FormatEntity.exportMimeType(): String {
+    val ext = fileExtension()
+    return when (ext) {
+        "flac" -> "audio/flac"
+        "opus" -> "audio/opus"
+        "m4a" -> "audio/mp4"
+        "ogg" -> "audio/ogg"
+        "wav" -> "audio/wav"
+        "mp3" -> "audio/mpeg"
+        else -> "application/octet-stream"
+    }
+}
+
 fun FormatEntity.codecLabel(): String {
     val rawCodec = codecs.ifBlank { mimeType.substringAfter("/") }.uppercase()
     val rawMime = mimeType.substringAfter("/").substringBefore(";").uppercase()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -82,8 +82,9 @@ class DownloadUtil
                 .followRedirects(true)
                 .followSslRedirects(true)
                 .retryOnConnectionFailure(true)
-                .connectTimeout(10, TimeUnit.SECONDS)
-                .readTimeout(20, TimeUnit.SECONDS)
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
                 .dispatcher(
                     okhttp3.Dispatcher().apply {
                         maxRequests = MAX_DOWNLOAD_HTTP_REQUESTS
@@ -364,6 +365,6 @@ class DownloadUtil
             private const val MAX_IDLE_DOWNLOAD_CONNECTIONS = 32
             private const val MAX_DOWNLOAD_HTTP_REQUESTS = 64
             private const val DOWNLOAD_CONNECTION_KEEP_ALIVE_MINUTES = 5L
-            private const val DOWNLOAD_WRITE_BUFFER_SIZE = 1024 * 1024
+            private const val DOWNLOAD_WRITE_BUFFER_SIZE = 4 * 1024 * 1024  // 4MB — larger buffer reduces I/O syscalls for faster downloads
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -92,6 +92,8 @@ import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.Event
 import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
+import moe.rukamori.archivetune.db.entities.exportMimeType
+import moe.rukamori.archivetune.db.entities.fileExtension
 import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.models.toMediaMetadata
@@ -143,9 +145,16 @@ fun SongMenu(
 
     val downloadUtil = LocalDownloadUtil.current
 
-    // Direct export to the device's Downloads folder (via SAF CreateDocument)
+    // Direct export to the device's Downloads folder (via SAF CreateDocument).
+    // The MIME type and file extension are resolved from the cached FormatEntity
+    // so that lossless FLAC tracks export as .flac (not .mp3).
+    val database = LocalDatabase.current
+    val songFormat by produceState<moe.rukamori.archivetune.db.entities.FormatEntity?>(null, song.id) {
+        database.query { format(song.id)?.let { value = it } }
+    }
+    val exportMimeType = songFormat?.exportMimeType() ?: "audio/mpeg"
     val exportToDownloadsLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("audio/mpeg")) { destUri ->
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportMimeType)) { destUri ->
             if (destUri == null) return@rememberLauncherForActivityResult
             val songId = song.id
             val songTitle = song.song.title
@@ -876,9 +885,12 @@ fun SongMenu(
                                 }
                             }
                             // Export — only shown when the download has actually completed.
+                            // Uses the correct file extension based on the audio codec
+                            // (FLAC for lossless, OPUS/M4A for lossy, etc.).
                             if (download?.state == Download.STATE_COMPLETED) {
                                 val safeTitle = song.song.title.trim()
                                     .replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
+                                val ext = songFormat?.fileExtension() ?: "mp3"
                                 ListItem(
                                     headlineContent = {
                                         Text(text = stringResource(R.string.export))
@@ -891,7 +903,7 @@ fun SongMenu(
                                     },
                                     modifier =
                                         Modifier.clickable {
-                                            exportToDownloadsLauncher.launch("$safeTitle.mp3")
+                                            exportToDownloadsLauncher.launch("$safeTitle.$ext")
                                         },
                                     colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                                 )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -74,9 +74,12 @@ import moe.rukamori.archivetune.R
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.HideExplicitKey
+import moe.rukamori.archivetune.db.entities.exportMimeType
+import moe.rukamori.archivetune.db.entities.fileExtension
 import moe.rukamori.archivetune.constants.SongSortDescendingKey
 import moe.rukamori.archivetune.constants.SongSortType
 import moe.rukamori.archivetune.constants.SongSortTypeKey
@@ -117,14 +120,17 @@ fun CachePlaylistScreen(
     val focusManager = LocalFocusManager.current
     val coroutineScope = rememberCoroutineScope()
 
-    // SAF folder picker for "Export all"
+    // SAF folder picker for "Export all".
+    // Exports songs in their original audio format (FLAC, OPUS, M4A, etc.)
+    // based on the FormatEntity codec metadata, instead of hardcoded .mp3.
+    val database = LocalDatabase.current
     val exportAllLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri ->
             if (treeUri == null) return@rememberLauncherForActivityResult
             coroutineScope.launch {
                 var exported = 0
                 var failed = 0
-                for (song in cachedSongs) {
+                for ((index, song) in cachedSongs.withIndex()) {
                     val result = runCatching {
                         withContext(Dispatchers.IO) {
                             val cache = downloadUtil.downloadCache
@@ -134,11 +140,18 @@ fun CachePlaylistScreen(
                             }
                             val safeTitle = song.title.trim()
                                 .replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
+                            // Resolve the correct file extension and MIME type from
+                            // the FormatEntity so lossless FLAC tracks export as .flac.
+                            val formatInfo = database.query {
+                                format(song.id)
+                            }
+                            val ext = formatInfo?.fileExtension() ?: "mp3"
+                            val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
                             val destUri = android.provider.DocumentsContract.createDocument(
                                 context.contentResolver,
                                 treeUri,
-                                "audio/mpeg",
-                                "$safeTitle.mp3",
+                                mime,
+                                "$safeTitle.$ext",
                             ) ?: throw IllegalStateException("Could not create file")
                             context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
                                 spans.sortedBy { it.position }.forEach { span ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -65,7 +65,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_playback_title),
             subtitle = stringResource(R.string.settings_playback_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
-            keywords = listOf("playback", "player", "audio", "quality", "equalizer", "eq", "volume", "crossfade", "gapless"),
+            keywords = listOf("playback", "player", "audio", "quality", "equalizer", "eq", "volume", "crossfade", "gapless", "flac", "lossless", "hi-res", "sample rate", "bitrate"),
             onClick = { navController.navigate("settings/player") },
         )
     val sources =
@@ -75,7 +75,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.source_settings),
             subtitle = stringResource(R.string.source_settings_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
-            keywords = listOf("source", "music source", "youtube music", "tidal", "qobuz", "provider", "streaming"),
+            keywords = listOf("source", "music source", "youtube music", "tidal", "qobuz", "provider", "streaming", "telegram", "telegram channel", "flac", "lossless", "private channel"),
             onClick = { navController.navigate("settings/sources") },
         )
     val lyrics =
@@ -165,7 +165,7 @@ fun buildSettingsGroups(
             title = stringResource(R.string.storage),
             subtitle = stringResource(R.string.settings_storage_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
-            keywords = listOf("storage", "download", "cache", "disk", "space", "memory", "path", "location"),
+            keywords = listOf("storage", "download", "cache", "disk", "space", "memory", "path", "location", "export", "export songs", "local storage", "save songs"),
             onClick = { navController.navigate("settings/storage") },
         )
     val backupRestore =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -30,9 +30,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -60,15 +62,21 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalDatabase
+import moe.rukamori.archivetune.LocalDownloadUtil
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import coil3.annotation.ExperimentalCoilApi
 import coil3.imageLoader
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
@@ -76,6 +84,8 @@ import moe.rukamori.archivetune.constants.MaxCanvasCacheSizeKey
 import moe.rukamori.archivetune.constants.MaxImageCacheSizeKey
 import moe.rukamori.archivetune.constants.MaxSongCacheSizeKey
 import moe.rukamori.archivetune.constants.SmartTrimmerKey
+import moe.rukamori.archivetune.db.entities.exportMimeType
+import moe.rukamori.archivetune.db.entities.fileExtension
 import moe.rukamori.archivetune.extensions.directorySizeBytes
 import moe.rukamori.archivetune.extensions.tryOrNull
 import moe.rukamori.archivetune.storage.StorageFolderKind
@@ -182,6 +192,66 @@ fun StorageSettings(
         (screenState as? StorageSettingsScreenState.Success)
             ?.model
             ?.cacheClear != null
+
+    val downloadUtil = LocalDownloadUtil.current
+    val database = LocalDatabase.current
+    val coroutineScope = rememberCoroutineScope()
+    var isExporting by remember { mutableStateOf(false) }
+
+    // SAF folder picker for exporting all downloaded songs to local storage.
+    val exportDownloadedSongsLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri ->
+            if (treeUri == null) return@rememberLauncherForActivityResult
+            isExporting = true
+            coroutineScope.launch {
+                var exported = 0
+                var failed = 0
+                try {
+                    withContext(Dispatchers.IO) {
+                        // Iterate all keys in the download cache and export each song
+                        // in its original audio format.
+                        val cache = downloadUtil.downloadCache
+                        val keys = cache.keys.toList()
+                        for (songId in keys) {
+                            val spans = cache.getCachedSpans(songId)
+                            if (spans.isEmpty()) continue
+                            val formatInfo = database.query { format(songId) }
+                            val ext = formatInfo?.fileExtension() ?: "mp3"
+                            val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
+                            // Try to get song title from the database for a meaningful filename
+                            val songEntity = database.query { getSongByIdBlocking(songId)?.song }
+                            val safeTitle = songEntity?.title?.trim()
+                                ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+                                ?.ifBlank { "audio" } ?: "audio_$songId"
+                            val destUri = android.provider.DocumentsContract.createDocument(
+                                context.contentResolver,
+                                treeUri,
+                                mime,
+                                "$safeTitle.$ext",
+                            ) ?: run { failed++; continue }
+                            runCatching {
+                                context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
+                                    spans.sortedBy { it.position }.forEach { span ->
+                                        java.io.FileInputStream(span.file).use { input ->
+                                            input.copyTo(output)
+                                        }
+                                    }
+                                    output.flush()
+                                }
+                            }.onSuccess { exported++ }.onFailure { failed++ }
+                        }
+                    }
+                } finally {
+                    isExporting = false
+                }
+                val failedMsg = if (failed > 0) ", $failed failed" else ""
+                android.widget.Toast.makeText(
+                    context,
+                    context.getString(R.string.export_all_songs_complete, exported, failedMsg),
+                    android.widget.Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
 
     val maxImageCacheSizeBytes =
         if (maxImageCacheSize > 0) {
@@ -349,6 +419,40 @@ fun StorageSettings(
                         },
                         onClick = { clearDownloads = true },
                     )
+                }
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.export_downloaded_songs)) },
+                        description = stringResource(R.string.export_downloaded_songs_description),
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.send),
+                                contentDescription = null,
+                            )
+                        },
+                        onClick = { exportDownloadedSongsLauncher.launch(null) },
+                    )
+                }
+                if (isExporting) {
+                    item {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                            horizontalArrangement = Arrangement.Center,
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp,
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Text(
+                                text = stringResource(R.string.export_songs_to_local_description),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,11 @@
     <string name="export_to_downloads_success">Exported to Downloads folder</string>
     <string name="export_to_folder_success">Exported to selected folder</string>
     <string name="export_to_folder_failed">Export failed. Make sure the song is fully downloaded and the folder is writable.</string>
+    <string name="export_songs_to_local">Export songs to local storage</string>
+    <string name="export_songs_to_local_description">Export all downloaded songs to a folder on your device. Files are saved in their original format (FLAC, OPUS, M4A, etc.).</string>
+    <string name="export_all_songs_progress">Exporting songs… (%1$d of %2$d)</string>
+    <string name="export_all_songs_complete">Exported %1$d song(s) successfully%2$s</string>
+    <string name="export_all_songs_no_downloads">No downloaded songs to export</string>
     <string name="import_playlist">Import playlist</string>
     <string name="import_failed">Import failed</string>
     <string name="update_button">Update</string>
@@ -663,6 +668,8 @@
     <string name="max_cache_size">Max cache size</string>
     <string name="unlimited">Unlimited</string>
     <string name="clear_all_downloads">Clear all downloads</string>
+    <string name="export_downloaded_songs">Export downloaded songs</string>
+    <string name="export_downloaded_songs_description">Save a copy of all downloaded songs to a chosen folder in their original audio format</string>
     <string name="max_image_cache_size">Max image cache size</string>
     <string name="clear_image_cache">Clear image cache</string>
     <string name="max_song_cache_size">Max song cache size</string>


### PR DESCRIPTION
Fixes 5 issues:

1. Lossless format-aware export (FLAC exports as .flac, not .mp3)
2. Telegram private channel support (already exists, added search keywords)
3. Export downloaded songs from Storage Settings
4. Download speed improvements (4MB buffer, longer timeouts)
5. Enhanced settings search keywords

See commit message for full details.