### PR TITLE
fix: resolve compile errors in format-aware export code

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -92,8 +92,6 @@ import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.Event
 import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
-import moe.rukamori.archivetune.db.entities.exportMimeType
-import moe.rukamori.archivetune.db.entities.fileExtension
 import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.models.toMediaMetadata
@@ -148,10 +146,7 @@ fun SongMenu(
     // Direct export to the device's Downloads folder (via SAF CreateDocument).
     // The MIME type and file extension are resolved from the cached FormatEntity
     // so that lossless FLAC tracks export as .flac (not .mp3).
-    val database = LocalDatabase.current
-    val songFormat by produceState<moe.rukamori.archivetune.db.entities.FormatEntity?>(null, song.id) {
-        database.query { format(song.id)?.let { value = it } }
-    }
+    val songFormat by database.format(song.id).collectAsState(initial = null)
     val exportMimeType = songFormat?.exportMimeType() ?: "audio/mpeg"
     val exportToDownloadsLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportMimeType)) { destUri ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -101,6 +101,7 @@ import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.viewmodels.CachePlaylistViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
@@ -142,9 +143,7 @@ fun CachePlaylistScreen(
                                 .replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
                             // Resolve the correct file extension and MIME type from
                             // the FormatEntity so lossless FLAC tracks export as .flac.
-                            val formatInfo = database.query {
-                                format(song.id)
-                            }
+                            val formatInfo = database.format(song.id).first()
                             val ext = formatInfo?.fileExtension() ?: "mp3"
                             val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
                             val destUri = android.provider.DocumentsContract.createDocument(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -66,6 +66,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalDatabase
@@ -215,11 +216,11 @@ fun StorageSettings(
                         for (songId in keys) {
                             val spans = cache.getCachedSpans(songId)
                             if (spans.isEmpty()) continue
-                            val formatInfo = database.query { format(songId) }
+                            val formatInfo = database.format(songId).first()
                             val ext = formatInfo?.fileExtension() ?: "mp3"
                             val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
                             // Try to get song title from the database for a meaningful filename
-                            val songEntity = database.query { getSongByIdBlocking(songId)?.song }
+                            val songEntity = database.query { getSongByIdBlocking(songId) }
                             val safeTitle = songEntity?.title?.trim()
                                 ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
                                 ?.ifBlank { "audio" } ?: "audio_$songId"


### PR DESCRIPTION
Fixes 3 compile errors from PR #26:

1. **SongMenu.kt: Conflicting declarations + type mismatch**
   - Removed duplicate `val database = LocalDatabase.current` (was declared twice)
   - Changed from `produceState + database.query { format() }` to `database.format(song.id).collectAsState()` because `format()` returns `Flow<FormatEntity?>` not a direct value

2. **CachePlaylistScreen.kt: Unresolved reference on Flow receiver**
   - Changed `database.query { format(songId) }` to `database.format(songId).first()` because `format()` returns a Room `Flow` that must be collected, not used as a direct value
   - Added `import kotlinx.coroutines.flow.first`

3. **StorageSettings.kt: Same Flow issue + unresolved title**
   - Same Flow fix with `.first()`
   - Fixed `getSongByIdBlocking(songId)?.song` to `getSongByIdBlocking(songId)` because `getSongByIdBlocking` returns `Song?` directly, not wrapped

All features from PR #26 (lossless export, storage export, download speed, settings search) are preserved.