### PR TITLE
fix: resolve remaining compile errors in export code

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -220,7 +220,7 @@ fun StorageSettings(
                             val ext = formatInfo?.fileExtension() ?: "mp3"
                             val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
                             // Try to get song title from the database for a meaningful filename
-                            val songEntity = database.query { getSongByIdBlocking(songId) }
+                            val songEntity = getSongByIdBlocking(songId)
                             val safeTitle = songEntity?.title?.trim()
                                 ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
                                 ?.ifBlank { "audio" } ?: "audio_$songId"


### PR DESCRIPTION
Fixes 2 remaining compile errors from PR #27:

1. **StorageSettings.kt: `database.query` returns Unit, not Song?**
   - `database.query { getSongByIdBlocking(songId) }` returns `Unit` because `MusicDatabase.query()` is a fire-and-forget executor wrapper.
   - Changed to direct `getSongByIdBlocking(songId)` call, which returns `Song?`.
   - Fixes: `Unresolved reference 'title'` at line 224.

2. **CachePlaylistScreen.kt: `cachedSongs` forward reference** (already fixed in main)
   - `cachedSongs` was declared after the `exportAllLauncher` lambda that used it, causing the Kotlin compiler to fail type inference for `song.id` and `song.title`.
   - Moved declaration before the lambda.

Both fixes are minimal and target only the compilation errors without changing logic.