### PR TITLE
fix: restore missing FormatEntity imports and qualify getSongByIdBlocking

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -90,6 +90,8 @@ import moe.rukamori.archivetune.constants.ListThumbnailSize
 import moe.rukamori.archivetune.constants.SpeedDialSongIdsKey
 import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.Event
+import moe.rukamori.archivetune.db.entities.exportMimeType
+import moe.rukamori.archivetune.db.entities.fileExtension
 import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.extensions.toMediaItem

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -220,7 +220,7 @@ fun StorageSettings(
                             val ext = formatInfo?.fileExtension() ?: "mp3"
                             val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
                             // Try to get song title from the database for a meaningful filename
-                            val songEntity = getSongByIdBlocking(songId)
+                            val songEntity = database.getSongByIdBlocking(songId)
                             val safeTitle = songEntity?.title?.trim()
                                 ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
                                 ?.ifBlank { "audio" } ?: "audio_$songId"


### PR DESCRIPTION
Fixes 3 compile errors introduced by previous PR merges:

1. **SongMenu.kt:150 — Unresolved reference 'exportMimeType'**
2. **SongMenu.kt:888 — Unresolved reference 'fileExtension'**

Root cause: PR #27's fix commit (c62de7542) accidentally removed the imports
for `FormatEntity.exportMimeType()` and `FormatEntity.fileExtension()` while
cleaning up other issues in SongMenu.kt. These are package-level extension
functions defined in `moe.rukamori.archivetune.db.entities`, so they require
explicit imports in any file that calls them.

Fix: Restored the two missing import statements.

3. **StorageSettings.kt:223 — Unresolved reference 'getSongByIdBlocking'**

Root cause: `getSongByIdBlocking()` is a member function of `DatabaseDao`,
inherited by `MusicDatabase` via interface delegation. It is not a standalone
function in scope. The previous fix (PR #28) called it without a receiver.

Fix: Qualified the call as `database.getSongByIdBlocking(songId)`.