### PR TITLE
fix: export crash, individual settings search, private channels, download source

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
@@ -173,14 +173,31 @@ object TelegramClient {
     // ------------------------------------------------------------------
 
     /**
-     * Searches public chats and keeps only channels/supergroups. Accepts plain queries, @usernames
-     * and t.me links.
+     * Searches public chats and keeps only channels/supergroups. Accepts plain queries, @usernames,
+     * t.me links, and Telegram invite links (t.me/+hash or t.me/joinchat/hash).
      */
     suspend fun searchChannels(query: String): List<TelegramChannel> {
         val trimmed = query.trim()
         if (trimmed.isEmpty()) return emptyList()
 
         val chatIds = linkedSetOf<Long>()
+
+        // Check for invite link first — private channels require a different TDLib API.
+        extractInviteHash(trimmed)?.let { inviteHash ->
+            runCatching {
+                val inviteInfo = send(TdApi.CheckChatInviteLink(inviteHash))
+                // If the invite link is valid, try to join the chat.
+                // If already a member, JoinChatByInviteLink returns the chat id anyway.
+                val chatId = runCatching {
+                    send(TdApi.JoinChatByInviteLink(inviteHash)).chatId
+                }.getOrNull() ?: inviteInfo.chatId
+                if (chatId != 0L) {
+                    chatIds += chatId
+                }
+            }.onFailure { e ->
+                Timber.w(e, "Failed to resolve Telegram invite link")
+            }
+        }
 
         // Exact username / t.me link lookup first so pasting a link always works.
         extractUsername(trimmed)?.let { username ->
@@ -521,5 +538,19 @@ object TelegramClient {
             return trimmed.removePrefix("@").takeIf { it.matches(Regex("[A-Za-z0-9_]{3,}")) }
         }
         return null
+    }
+
+    /**
+     * Extracts the invite hash from a Telegram invite link.
+     * Supports formats: t.me/+hash, t.me/joinchat/hash, t.me/add/1234hash
+     */
+    private fun extractInviteHash(query: String): String? {
+        val trimmed = query.trim()
+        val inviteRegex =
+            Regex(
+                "(?:https?://)?t(?:elegram)?\\.me/(?:\\+|joinchat/|add/)([A-Za-z0-9_-]+)",
+                RegexOption.IGNORE_CASE,
+            )
+        return inviteRegex.find(trimmed)?.groupValues?.get(1)
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -147,9 +147,16 @@ fun CachePlaylistScreen(
                             val formatInfo = database.format(song.id).first()
                             val ext = formatInfo?.fileExtension() ?: "mp3"
                             val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
+                            // createDocument() requires a document URI (representing the
+                            // parent directory as a document), NOT the tree URI returned by
+                            // OpenDocumentTree. Convert via getTreeDocumentId + buildDocumentUriUsingTree.
+                            val parentDocUri = android.provider.DocumentsContract.buildDocumentUriUsingTree(
+                                treeUri,
+                                android.provider.DocumentsContract.getTreeDocumentId(treeUri),
+                            )
                             val destUri = android.provider.DocumentsContract.createDocument(
                                 context.contentResolver,
-                                treeUri,
+                                parentDocUri,
                                 mime,
                                 "$safeTitle.$ext",
                             ) ?: throw IllegalStateException("Could not create file")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -52,6 +52,7 @@ import moe.rukamori.archivetune.constants.LowDataModeKey
 import moe.rukamori.archivetune.constants.PauseOnDeviceMuteKey
 import moe.rukamori.archivetune.constants.PermanentShuffleKey
 import moe.rukamori.archivetune.constants.PersistentQueueKey
+import moe.rukamori.archivetune.constants.QobuzEnabledKey
 import moe.rukamori.archivetune.constants.SeekExtraSeconds
 import moe.rukamori.archivetune.constants.SkipSilenceKey
 import moe.rukamori.archivetune.constants.StopMusicOnTaskClearKey
@@ -211,6 +212,14 @@ fun PlayerSettings(navController: NavController) {
         rememberPreference(
             DownloadSourceKey,
             defaultValue = "youtube_music",
+        )
+    // When the user selects Qobuz or Tidal as download source, ensure the
+    // corresponding source provider is enabled so the resolution chain
+    // actually tries that provider during playback/download.
+    val (qobuzEnabled, onQobuzEnabledChange) =
+        rememberPreference(
+            QobuzEnabledKey,
+            defaultValue = false,
         )
     var showArtistSeparatorsDialog by remember { mutableStateOf(false) }
     var showTagsManagementDialog by remember { mutableStateOf(false) }
@@ -467,7 +476,19 @@ fun PlayerSettings(navController: NavController) {
                                 "tidal" -> "qobuz"
                                 else -> "youtube_music"
                             }
-                        ) },
+                        )
+                            // Enable the newly selected source so the resolution chain
+                            // actually tries it. Qobuz is disabled by default.
+                            when (downloadSource) {
+                                "youtube_music" -> {
+                                    // Next is tidal (already enabled by default)
+                                }
+                                "tidal" -> onQobuzEnabledChange(true)
+                                else -> {
+                                    // Back to youtube_music, no enable needed
+                                }
+                            }
+                        },
                     )
                 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsComponents.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.R
-
 @Composable
 fun SettingsProfileHeader(
     state: SettingsProfileState,
@@ -795,6 +794,77 @@ fun SettingsFlatItem(
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsSearchResultItem(
+    result: SearchResultItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val effectiveAccent =
+        if (result.parentAccentColor.isSpecified) {
+            result.parentAccentColor
+        } else {
+            MaterialTheme.colorScheme.primary
+        }
+
+    Card(
+        onClick = onClick,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 64.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(effectiveAccent.copy(alpha = 0.12f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = result.parentIcon,
+                    contentDescription = null,
+                    tint = effectiveAccent,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+            Spacer(Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = result.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (result.parentTitle.isNotBlank()) {
+                    Text(
+                        text = result.parentTitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -57,6 +57,19 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.secondary,
             keywords = listOf("appearance", "theme", "dark", "light", "color", "palette", "style", "design"),
             onClick = { navController.navigate("settings/appearance") },
+            children = listOf(
+                SettingsChild("Dark theme", "dark_theme", listOf("dark", "dark theme", "night", "amoled")),
+                SettingsChild("Pure black", "pure_black", listOf("pure black", "amoled", "oled", "black background")),
+                SettingsChild("Grid layout", "grid_layout", listOf("grid", "layout", "list view", "artist grid")),
+                SettingsChild("Toggle fullscreen", "toggle_fullscreen", listOf("fullscreen", "immersive", "hide status bar")),
+                SettingsChild("Player background blur", "player_blur", listOf("background blur", "blur", "player background")),
+                SettingsChild("Lyrics background blur", "lyrics_blur", listOf("lyrics blur", "lyrics background")),
+                SettingsChild("Thumbnail corner radius", "thumbnail_corner", listOf("thumbnail", "corner radius", "rounded", "round")),
+                SettingsChild("Canvas blur level", "canvas_blur_level", listOf("canvas", "blur level", "blur amount")),
+                SettingsChild("Icon pack", "icon_pack", listOf("icon", "icon pack", "app icon")),
+                SettingsChild("Language", "app_language", listOf("language", "app language", "locale")),
+                SettingsChild("Color source", "color_source", listOf("color", "color source", "dynamic color", "material you")),
+            ),
         )
     val playback =
         SettingsItem(
@@ -67,6 +80,26 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.tertiary,
             keywords = listOf("playback", "player", "audio", "quality", "equalizer", "eq", "volume", "crossfade", "gapless", "flac", "lossless", "hi-res", "sample rate", "bitrate"),
             onClick = { navController.navigate("settings/player") },
+            children = listOf(
+                SettingsChild("Low data mode", "low_data_mode", listOf("data", "data saver", "low quality", "data mode")),
+                SettingsChild("History duration", "history_duration", listOf("history", "duration", "recent", "queue length")),
+                SettingsChild("Crossfade", "crossfade", listOf("crossfade", "fade", "transition", "mix", "blend")),
+                SettingsChild("Gapless playback", "gapless", listOf("gapless", "gap", "seamless", "no gap")),
+                SettingsChild("Skip silence", "skip_silence", listOf("silence", "skip silence", "blank", "quiet")),
+                SettingsChild("Audio normalization", "audio_normalization", listOf("normalization", "loudness", "normalize", "volume level")),
+                SettingsChild("Audio offload", "audio_offload", listOf("offload", "audio offload", "hardware decoder")),
+                SettingsChild("Seek seconds add-up", "seek_seconds", listOf("seek", "skip", "forward", "rewind", "seconds")),
+                SettingsChild("Pause on device mute", "pause_mute", listOf("mute", "pause mute", "headphone", "silence detect")),
+                SettingsChild("Auto start on Bluetooth", "bluetooth_auto_start", listOf("bluetooth", "auto start", "auto play", "connect")),
+                SettingsChild("Download source", "download_source", listOf("download source", "youtube music", "tidal", "qobuz", "provider")),
+                SettingsChild("Persistent queue", "persistent_queue", listOf("queue", "persistent", "save queue", "resume")),
+                SettingsChild("Permanent shuffle", "permanent_shuffle", listOf("shuffle", "random", "permanent")),
+                SettingsChild("Auto download on like", "auto_download_like", listOf("auto download", "like", "download liked")),
+                SettingsChild("Auto skip on error", "auto_skip_error", listOf("skip", "error", "auto skip", "failed")),
+                SettingsChild("Stop music on task clear", "stop_task_clear", listOf("stop", "task clear", "background", "close app")),
+                SettingsChild("Wakelock", "wakelock", listOf("wakelock", "wake lock", "keep awake", "cpu")),
+                SettingsChild("Artist separators", "artist_separators", listOf("artist", "separator", "split", "featuring")),
+            ),
         )
     val sources =
         SettingsItem(
@@ -77,6 +110,11 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.tertiary,
             keywords = listOf("source", "music source", "youtube music", "tidal", "qobuz", "provider", "streaming", "telegram", "telegram channel", "flac", "lossless", "private channel"),
             onClick = { navController.navigate("settings/sources") },
+            children = listOf(
+                SettingsChild("YouTube Music", "youtube_music", listOf("youtube", "youtube music", "yt music")),
+                SettingsChild("Qobuz", "qobuz", listOf("qobuz", "hires", "hi-res", "flac", "lossless", "cd quality")),
+                SettingsChild("Tidal", "tidal", listOf("tidal", "lossless", "hifi", "master", "mq")),
+            ),
         )
     val lyrics =
         SettingsItem(
@@ -87,6 +125,12 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.secondary,
             keywords = listOf("lyrics", "lyric", "subtitle", "text", "sing along", "lrc"),
             onClick = { navController.navigate("settings/lyrics") },
+            children = listOf(
+                SettingsChild("Lyrics provider", "lyrics_provider", listOf("lyrics provider", "source", "lrclib")),
+                SettingsChild("Show lyrics", "show_lyrics", listOf("show lyrics", "display lyrics", "lyrics toggle")),
+                SettingsChild("Lyrics font size", "lyrics_font_size", listOf("font size", "lyrics size", "text size")),
+                SettingsChild("Lyrics animations", "lyrics_animations", listOf("animation", "animated lyrics", "lyrics effect")),
+            ),
         )
     val content =
         SettingsItem(
@@ -97,6 +141,12 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.primary,
             keywords = listOf("content", "language", "locale", "country", "region", "app language", "explicit", "age restricted", "age", "mature", "video"),
             onClick = { navController.navigate("settings/content") },
+            children = listOf(
+                SettingsChild("Content language", "content_language", listOf("language", "content language", "locale", "country")),
+                SettingsChild("Content country", "content_country", listOf("country", "region", "content country")),
+                SettingsChild("Hide explicit", "hide_explicit", listOf("explicit", "age", "mature", "age restricted", "clean")),
+                SettingsChild("Enable video", "enable_video", listOf("video", "music video", "mv")),
+            ),
         )
     val languagePacks =
         SettingsItem(
@@ -117,6 +167,13 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.primary,
             keywords = listOf("behavior", "privacy", "swipe", "gesture", "history", "cache", "data"),
             onClick = { navController.navigate("settings/privacy") },
+            children = listOf(
+                SettingsChild("Swipe sensitivity", "swipe_sensitivity", listOf("swipe", "gesture", "sensitivity")),
+                SettingsChild("Cache songs", "cache_songs", listOf("cache", "offline", "download cache")),
+                SettingsChild("Listen history", "listen_history", listOf("history", "listen history", "recent")),
+                SettingsChild("Search history", "search_history", listOf("search history", "clear search")),
+                SettingsChild("Analytics", "analytics", listOf("analytics", "tracking", "crash")),
+            ),
         )
     val integration =
         SettingsItem(
@@ -127,6 +184,11 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.secondary,
             keywords = listOf("integration", "lastfm", "last.fm", "scrobble", "scrobbling", "discord"),
             onClick = { navController.navigate("settings/integration") },
+            children = listOf(
+                SettingsChild("Last.fm scrobbling", "lastfm_scrobbling", listOf("lastfm", "last.fm", "scrobble", "scrobbling", "listens")),
+                SettingsChild("Discord rich presence", "discord_presence", listOf("discord", "rich presence", "status", "now playing")),
+                SettingsChild("ListenBrainz", "listenbrainz", listOf("listenbrainz", "listen brainz", "scrobble")),
+            ),
         )
     val aiIntegration =
         SettingsItem(
@@ -147,6 +209,11 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.tertiary,
             keywords = listOf("internet", "proxy", "vpn", "network", "wifi", "connection", "traffic"),
             onClick = { navController.navigate("settings/internet") },
+            children = listOf(
+                SettingsChild("Proxy", "proxy_settings", listOf("proxy", "http proxy", "socks", "vpn")),
+                SettingsChild("Enable tor", "enable_tor", listOf("tor", "onion", "anonymous")),
+                SettingsChild("Download speed limit", "download_speed_limit", listOf("speed", "limit", "throttle", "bandwidth", "download speed")),
+            ),
         )
     val poToken =
         SettingsItem(
@@ -167,6 +234,12 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.primary,
             keywords = listOf("storage", "download", "cache", "disk", "space", "memory", "path", "location", "export", "export songs", "local storage", "save songs"),
             onClick = { navController.navigate("settings/storage") },
+            children = listOf(
+                SettingsChild("Song cache size", "song_cache_size", listOf("cache size", "song cache", "memory", "download cache")),
+                SettingsChild("Image cache size", "image_cache_size", listOf("image cache", "thumbnail cache", "artwork cache")),
+                SettingsChild("Download location", "download_location", listOf("download path", "location", "folder", "directory", "save to")),
+                SettingsChild("Export downloaded songs", "export_downloaded_songs", listOf("export", "export songs", "save songs", "local storage", "file")),
+            ),
         )
     val backupRestore =
         SettingsItem(
@@ -177,6 +250,10 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.primary,
             keywords = listOf("backup", "restore", "export", "import", "data", "save"),
             onClick = { navController.navigate("settings/backup_restore") },
+            children = listOf(
+                SettingsChild("Backup", "backup", listOf("backup", "save data", "export backup")),
+                SettingsChild("Restore", "restore", listOf("restore", "import", "recover")),
+            ),
         )
     val developerOptions =
         SettingsItem(
@@ -187,6 +264,10 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.tertiary,
             keywords = listOf("developer", "debug", "experimental", "advanced", "logcat", "dev"),
             onClick = { navController.navigate("settings/misc") },
+            children = listOf(
+                SettingsChild("Logcat", "logcat", listOf("logcat", "log", "debug log")),
+                SettingsChild("Update channel", "update_channel", listOf("update channel", "canary", "stable", "beta")),
+            ),
         )
     val defaultLinks =
         if (isAndroid12OrLater) {
@@ -270,6 +351,11 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.secondary,
             keywords = listOf("about", "info", "version", "license", "credits", "contributors", "changelog"),
             onClick = { navController.navigate("settings/about") },
+            children = listOf(
+                SettingsChild("Version", "about_version", listOf("version", "build")),
+                SettingsChild("Changelog", "about_changelog", listOf("changelog", "changes", "release notes", "what's new")),
+                SettingsChild("License", "about_license", listOf("license", "gpl", "open source")),
+            ),
         )
 
     return listOf(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsModels.kt
@@ -37,5 +37,35 @@ data class SettingsItem(
     val showUpdateIndicator: Boolean = false,
     val accentColor: Color = Color.Unspecified,
     val keywords: List<String> = emptyList(),
+    val children: List<SettingsChild> = emptyList(),
+    val onClick: () -> Unit,
+)
+
+/**
+ * Represents a single searchable setting inside a settings category.
+ * When the user searches settings, each [SettingsChild] that matches is
+ * shown as a separate result row. Clicking it navigates to the parent
+ * category screen with [scrollKey] so it auto-scrolls to the item.
+ */
+@Immutable
+data class SettingsChild(
+    val title: String,
+    val scrollKey: String,
+    val keywords: List<String> = emptyList(),
+)
+
+/**
+ * A flattened search result derived from a [SettingsChild].
+ * Shown as an individual row in the search results list.
+ */
+@Immutable
+data class SearchResultItem(
+    val title: String,
+    val parentTitle: String,
+    val parentIcon: Painter,
+    val parentKey: String,
+    val parentAccentColor: Color = Color.Unspecified,
+    val parentRoute: String?,
+    val scrollKey: String?,
     val onClick: () -> Unit,
 )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -124,7 +124,67 @@ fun SettingsScreen(
         BuildConfig.UPDATER_AVAILABLE &&
             Updater.isUpdateAvailable(latestVersionName, BuildConfig.VERSION_NAME)
     var isUpdateDismissed by remember { mutableStateOf(false) }
+    /** Navigate to a settings sub-screen, optionally scrolling to a child setting. */
+    fun navigateToSetting(route: String, scrollToKey: String? = null) {
+        if (scrollToKey != null) {
+            navController.navigate("$route?scrollTo=$scrollToKey")
+        } else {
+            navController.navigate(route)
+        }
+    }
     val allSettingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
+    // When searching, flatten all individual SettingsChildren across every
+    // category so each matching setting is shown as a separate row.
+    val filteredChildResults = remember(searchQuery, allSettingsGroups) {
+        if (searchQuery.isBlank()) emptyList()
+        else {
+            val query = searchQuery.trim().lowercase()
+            allSettingsGroups.flatMap { group ->
+                group.items.mapNotNull { item ->
+                    item.children.mapNotNull { child ->
+                        val matchesTitle = child.title.lowercase().contains(query)
+                        val matchesKeywords = child.keywords.any { it.lowercase().contains(query) }
+                        val matchesParent =
+                            item.title.lowercase().contains(query) ||
+                                item.subtitle?.lowercase()?.contains(query) == true ||
+                                item.keywords.any { it.lowercase().contains(query) }
+                        if (matchesTitle || matchesKeywords || matchesParent) {
+                            SearchResultItem(
+                                title = child.title,
+                                parentTitle = item.title,
+                                parentIcon = item.icon,
+                                parentKey = item.key,
+                                parentAccentColor = item.accentColor,
+                                parentRoute = "settings/${item.key}",
+                                scrollKey = child.scrollKey,
+                                onClick = item.onClick,
+                            )
+                        } else null
+                    }.ifEmpty {
+                        // If the parent matches but has no children,
+                        // show the parent itself as a single result.
+                        if (item.title.lowercase().contains(query) ||
+                            item.subtitle?.lowercase()?.contains(query) == true ||
+                            item.keywords.any { it.lowercase().contains(query) }
+                        ) {
+                            listOf(
+                                SearchResultItem(
+                                    title = item.title,
+                                    parentTitle = item.subtitle ?: "",
+                                    parentIcon = item.icon,
+                                    parentKey = item.key,
+                                    parentAccentColor = item.accentColor,
+                                    parentRoute = null,
+                                    scrollKey = null,
+                                    onClick = item.onClick,
+                                ),
+                            )
+                        } else emptyList()
+                    }
+                }
+            }
+        }
+    }
     val filteredGroups = remember(searchQuery, allSettingsGroups) {
         if (searchQuery.isBlank()) {
             allSettingsGroups
@@ -141,9 +201,9 @@ fun SettingsScreen(
         }
     }
 
-    // Auto-scroll to the first matching item when search query changes.
+    // Auto-scroll to the first matching search result when the query changes.
     // We debounce slightly so rapid typing doesn't cause excessive scrolls.
-    // Note: filteredGroups is NOT a LaunchedEffect key — if it were, every
+    // Note: filteredChildResults is NOT a LaunchedEffect key — if it were, every
     // keystroke would cancel the debounce timer before it fires.
     LaunchedEffect(listState) {
         snapshotFlow { searchQuery }
@@ -151,26 +211,13 @@ fun SettingsScreen(
             .distinctUntilChanged()
             .collect { query ->
                 if (query.isBlank()) return@collect
-                // Snapshot the current filtered groups inside the flow so
+                // Snapshot the current search results inside the flow so
                 // we always scroll to the latest match.
-                val groups = filteredGroups
-                val firstItemKey = groups
-                    .firstOrNull()?.items?.firstOrNull()?.key ?: return@collect
-                // When searching, the banners are hidden, so the LazyColumn layout is:
-                //   0 = search_bar, 1 = search_spacing, then group items.
-                var targetIndex = 2
-                var found = false
-                for (group in groups) {
-                    if (group.items.any { it.key == firstItemKey }) {
-                        found = true
-                        break
-                    }
-                    // Each non-first group has a spacer item before its items.
-                    targetIndex += 1 + group.items.size
-                }
-                if (found) {
-                    listState.animateScrollToItem(targetIndex)
-                }
+                val results = filteredChildResults
+                if (results.isEmpty()) return@collect
+                // When searching, the LazyColumn layout is:
+                //   0 = search_bar, 1 = search_spacing, 2+ = search results.
+                listState.animateScrollToItem(2)
             }
     }
 
@@ -316,37 +363,71 @@ fun SettingsScreen(
                 Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
             }
 
-            filteredGroups.forEachIndexed { groupIndex, group ->
-                if (groupIndex > 0) {
-                    item(
-                        key = "settings_group_spacing_$groupIndex",
-                        contentType = "settings_group_spacing",
-                    ) {
-                        Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
-                    }
-                }
-
+            if (searchQuery.isNotBlank() && filteredChildResults.isNotEmpty()) {
                 itemsIndexed(
-                    items = group.items,
-                    key = { _, item -> item.key },
-                    contentType = { _, _ -> "settings_segment" },
-                ) { index, settingsItem ->
-                    SettingsSegmentedItem(
-                        item = settingsItem,
-                        index = index,
-                        count = group.items.size,
-                        modifier =
-                            Modifier
-                                .padding(horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding)
-                                .padding(
-                                    bottom =
-                                        if (index < group.items.lastIndex) {
-                                            SettingsDimensions.SegmentedItemGap
-                                        } else {
-                                            0.dp
-                                        },
-                                ),
+                    items = filteredChildResults,
+                    key = { _, result -> result.parentKey + ":" + result.scrollKey },
+                    contentType = { _, _ -> "search_result" },
+                ) { _, result ->
+                    SettingsSearchResultItem(
+                        result = result,
+                        onClick = {
+                            if (result.parentRoute != null && result.scrollKey != null) {
+                                navigateToSetting(result.parentRoute, result.scrollKey)
+                            } else {
+                                result.onClick()
+                            }
+                        },
+                        modifier = Modifier.padding(
+                            horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding,
+                            vertical = 4.dp,
+                        ),
                     )
+                }
+            } else if (searchQuery.isNotBlank()) {
+                item(key = "no_results") {
+                    Text(
+                        text = stringResource(R.string.no_results_found),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(
+                            horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding,
+                            vertical = 16.dp,
+                        ),
+                    )
+                }
+            } else {
+                filteredGroups.forEachIndexed { groupIndex, group ->
+                    if (groupIndex > 0) {
+                        item(
+                            key = "settings_group_spacing_$groupIndex",
+                            contentType = "settings_group_spacing",
+                        ) {
+                            Spacer(modifier = Modifier.height(SettingsDimensions.SectionSpacing))
+                        }
+                    }
+
+                    itemsIndexed(
+                        items = group.items,
+                        key = { _, item -> item.key },
+                        contentType = { _, _ -> "settings_segment" },
+                    ) { index, settingsItem ->
+                        SettingsSegmentedItem(
+                            item = settingsItem,
+                            index = index,
+                            count = group.items.size,
+                            modifier =
+                                Modifier
+                                    .padding(horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding)
+                                    .padding(
+                                        bottom =
+                                            if (index < group.items.lastIndex) {
+                                                SettingsDimensions.SegmentedItemGap
+                                            } else {
+                                                0.dp
+                                            },
+                                    ),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -224,9 +224,16 @@ fun StorageSettings(
                             val safeTitle = songEntity?.title?.trim()
                                 ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
                                 ?.ifBlank { "audio" } ?: "audio_$songId"
+                            // createDocument() requires a document URI (representing the
+                            // parent directory as a document), NOT the tree URI returned by
+                            // OpenDocumentTree. Convert via getTreeDocumentId + buildDocumentUriUsingTree.
+                            val parentDocUri = android.provider.DocumentsContract.buildDocumentUriUsingTree(
+                                treeUri,
+                                android.provider.DocumentsContract.getTreeDocumentId(treeUri),
+                            )
                             val destUri = android.provider.DocumentsContract.createDocument(
                                 context.contentResolver,
-                                treeUri,
+                                parentDocUri,
                                 mime,
                                 "$safeTitle.$ext",
                             ) ?: run { failed++; continue }


### PR DESCRIPTION
## Summary

Fixes multiple issues reported in the app:

### 1. Export crash (`IllegalArgumentException: Invalid URI`)
**Files:** `StorageSettings.kt`, `CachePlaylistScreen.kt`

`OpenDocumentTree` returns a tree URI but `DocumentsContract.createDocument()` requires a document URI. Fixed by converting via `getTreeDocumentId()` + `buildDocumentUriUsingTree()` before `createDocument()`. `ScheduledBackupWorker.kt` already did this correctly.

### 2. Settings search shows only categories, not individual settings
**Files:** `SettingsModels.kt`, `SettingsDataBuilders.kt`, `SettingsComponents.kt`, `SettingsScreen.kt`

- Added `SettingsChild` and `SearchResultItem` data classes to model individual settings
- Added `children` lists with searchable keywords to all category settings items
- Added `SettingsSearchResultItem` composable showing each matching setting as a separate card
- Clicking a result navigates to the parent category with `?scrollTo=childKey` for auto-scroll

### 3. Private Telegram channels not found when pasting invite links
**Files:** `TelegramClient.kt`

- Added `extractInviteHash()` to detect `t.me/+hash`, `t.me/joinchat/hash`, `t.me/add/hash` formats
- Uses `CheckChatInviteLink` + `JoinChatByInviteLink` TDLib APIs for private channel resolution

### 4. Download source not respected / wrong format on export
**Files:** `PlayerSettings.kt`

- `QobuzEnabledKey` defaults to `false`, so `MusicService.sourceResolutionChain()` never tries Qobuz
- Auto-enables Qobuz when user cycles download source preference to "qobuz"
- Ensures songs actually come from Qobuz/Tidal when selected, producing correct FLAC files for export