### PR TITLE
fix: resolve compile errors in PR #31

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
@@ -185,12 +185,13 @@ object TelegramClient {
         // Check for invite link first — private channels require a different TDLib API.
         extractInviteHash(trimmed)?.let { inviteHash ->
             runCatching {
-                val inviteInfo = send(TdApi.CheckChatInviteLink(inviteHash))
+                val inviteInfo = send<TdApi.ChatInviteLinkInfo>(TdApi.CheckChatInviteLink(inviteHash))
                 // If the invite link is valid, try to join the chat.
                 // If already a member, JoinChatByInviteLink returns the chat id anyway.
-                val chatId = runCatching {
-                    send(TdApi.JoinChatByInviteLink(inviteHash)).chatId
-                }.getOrNull() ?: inviteInfo.chatId
+                val joinedChatId = runCatching {
+                    send<TdApi.Chat>(TdApi.JoinChatByInviteLink(inviteHash)).id
+                }.getOrNull()
+                val chatId = joinedChatId ?: inviteInfo.chatId
                 if (chatId != 0L) {
                     chatIds += chatId
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -140,7 +140,7 @@ fun SettingsScreen(
         else {
             val query = searchQuery.trim().lowercase()
             allSettingsGroups.flatMap { group ->
-                group.items.mapNotNull { item ->
+                group.items.flatMap { item ->
                     item.children.mapNotNull { child ->
                         val matchesTitle = child.title.lowercase().contains(query)
                         val matchesKeywords = child.keywords.any { it.lowercase().contains(query) }


### PR DESCRIPTION
## Summary

Fixes 2 compile errors from PR #31:

### TelegramClient.kt — Type inference failure
- `send(TdApi.CheckChatInviteLink(...))` and `send(TdApi.JoinChatByInviteLink(...))` could not infer return types
- Fixed by adding explicit type parameters: `send<TdApi.ChatInviteLinkInfo>(...)` and `send<TdApi.Chat>(...)`
- Fixed `.chatId` → `.id` for `TdApi.Chat` (Chat uses `id`, not `chatId`)

### SettingsScreen.kt — Nested list type mismatch
- `group.items.mapNotNull { item -> item.children.mapNotNull { ... }.ifEmpty { ... } }` produced `List<List<SearchResultItem>>` because each item mapped to a list
- Fixed by changing `mapNotNull` to `flatMap` for `group.items`, properly flattening to `List<SearchResultItem>`