### PR TITLE
fix: settings search crash, export format detection, Telegram invite links

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
@@ -117,6 +117,57 @@ fun FormatEntity.formattedFileSize(): String =
         }
     } ?: ""
 
+/**
+ * Detects the actual audio container format by reading magic bytes from the first
+ * cached span file. This is used when exporting downloaded songs to ensure the
+ * file extension matches the real data (e.g. a FormatEntity may claim FLAC while the
+ * cached bytes are actually Opus from YouTube Music).
+ *
+ * @return a file extension string: "flac", "opus", "m4a", "wav", "ogg", or "mp3"
+ */
+fun detectAudioExtensionFromSpans(
+    spans: java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>,
+): String {
+    val firstSpan = spans.firstOrNull() ?: return "mp3"
+    val file = firstSpan.file
+    if (!file.exists() || file.length() < 12) return "mp3"
+    val header = ByteArray(12)
+    file.inputStream().use { if (it.read(header) < 4) return "mp3" }
+    return when {
+        // FLAC: "fLaC" marker
+        header[0] == 0x66.toByte() && header[1] == 0x4C.toByte() &&
+            header[2] == 0x61.toByte() && header[3] == 0x43.toByte() -> "flac"
+        // OGG/Opus: "OggS" marker
+        header[0] == 0x4F.toByte() && header[1] == 0x67.toByte() &&
+            header[2] == 0x67.toByte() && header[3] == 0x53.toByte() -> "opus"
+        // M4A/AAC: "ftyp" at offset 4
+        header.size >= 8 && header[4] == 0x66.toByte() && header[5] == 0x74.toByte() &&
+            header[6] == 0x79.toByte() && header[7] == 0x70.toByte() -> "m4a"
+        // WAV: "RIFF" marker
+        header[0] == 0x52.toByte() && header[1] == 0x49.toByte() &&
+            header[2] == 0x46.toByte() && header[3] == 0x46.toByte() -> "wav"
+        // MP3: ID3 tag header or MPEG sync word
+        header[0] == 0x49.toByte() && header[1] == 0x44.toByte() &&
+            header[2] == 0x33.toByte() -> "mp3"
+        (header[0].toInt() and 0xFF) == 0xFF &&
+            (header[1].toInt() and 0xE0) == 0xE0 -> "mp3"
+        else -> "mp3"
+    }
+}
+
+/**
+ * Returns the MIME type corresponding to the given audio file extension.
+ */
+fun extensionToMimeType(ext: String): String = when (ext) {
+    "flac" -> "audio/flac"
+    "opus" -> "audio/opus"
+    "m4a" -> "audio/mp4"
+    "ogg" -> "audio/ogg"
+    "wav" -> "audio/wav"
+    "mp3" -> "audio/mpeg"
+    else -> "application/octet-stream"
+}
+
 enum class RatePriority {
     BITRATE_FIRST,
     SAMPLE_RATE_FIRST,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
@@ -183,13 +183,13 @@ object TelegramClient {
         val chatIds = linkedSetOf<Long>()
 
         // Check for invite link first — private channels require a different TDLib API.
-        extractInviteHash(trimmed)?.let { inviteHash ->
+        extractInviteLink(trimmed)?.let { inviteLink ->
             runCatching {
-                val inviteInfo = send<TdApi.ChatInviteLinkInfo>(TdApi.CheckChatInviteLink(inviteHash))
+                val inviteInfo = send<TdApi.ChatInviteLinkInfo>(TdApi.CheckChatInviteLink(inviteLink))
                 // If the invite link is valid, try to join the chat.
                 // If already a member, JoinChatByInviteLink returns the chat id anyway.
                 val joinedChatId = runCatching {
-                    send<TdApi.Chat>(TdApi.JoinChatByInviteLink(inviteHash)).id
+                    send<TdApi.Chat>(TdApi.JoinChatByInviteLink(inviteLink)).id
                 }.getOrNull()
                 val chatId = joinedChatId ?: inviteInfo.chatId
                 if (chatId != 0L) {
@@ -542,16 +542,21 @@ object TelegramClient {
     }
 
     /**
-     * Extracts the invite hash from a Telegram invite link.
-     * Supports formats: t.me/+hash, t.me/joinchat/hash, t.me/add/1234hash
+     * Extracts the full invite link from a Telegram invite URL.
+     * Supports formats: t.me/+hash, t.me/joinchat/hash, t.me/add/1234hash.
+     * Returns the full URL including the https:// scheme, which TDLib requires
+     * for CheckChatInviteLink and JoinChatByInviteLink.
      */
-    private fun extractInviteHash(query: String): String? {
+    private fun extractInviteLink(query: String): String? {
         val trimmed = query.trim()
         val inviteRegex =
             Regex(
-                "(?:https?://)?t(?:elegram)?\\.me/(?:\\+|joinchat/|add/)([A-Za-z0-9_-]+)",
+                "((?:https?://)?t(?:elegram)?\\.me/(?:\\+|joinchat/|add/)[A-Za-z0-9_-]+)",
                 RegexOption.IGNORE_CASE,
             )
-        return inviteRegex.find(trimmed)?.groupValues?.get(1)
+        val match = inviteRegex.find(trimmed) ?: return null
+        val link = match.groupValues[1]
+        // Ensure the link has a scheme so TDLib can parse it correctly.
+        return if (link.startsWith("http")) link else "https://$link"
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -92,6 +92,7 @@ import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.Event
 import moe.rukamori.archivetune.db.entities.exportMimeType
 import moe.rukamori.archivetune.db.entities.fileExtension
+import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
 import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.extensions.toMediaItem
@@ -146,10 +147,25 @@ fun SongMenu(
     val downloadUtil = LocalDownloadUtil.current
 
     // Direct export to the device's Downloads folder (via SAF CreateDocument).
-    // The MIME type and file extension are resolved from the cached FormatEntity
-    // so that lossless FLAC tracks export as .flac (not .mp3).
+    // The MIME type hint is resolved from the cached FormatEntity, but the actual
+    // file extension is detected from the cached audio data's magic bytes to
+    // avoid exporting lossy data with a .flac extension.
     val songFormat by database.format(song.id).collectAsState(initial = null)
     val exportMimeType = songFormat?.exportMimeType() ?: "audio/mpeg"
+    // Detect the real audio format from the download cache so the exported
+    // file always gets the correct extension (e.g. .opus instead of .flac).
+    val detectedExt by produceState(
+        initialValue = songFormat?.fileExtension() ?: "mp3",
+        song.id,
+    ) {
+        withContext(Dispatchers.IO) {
+            val cache = downloadUtil.downloadCache
+            val spans = getCachedSpansForKey(cache, song.id)
+            if (spans.isNotEmpty()) {
+                value = detectAudioExtensionFromSpans(spans)
+            }
+        }
+    }
     val exportToDownloadsLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportMimeType)) { destUri ->
             if (destUri == null) return@rememberLauncherForActivityResult
@@ -887,7 +903,7 @@ fun SongMenu(
                             if (download?.state == Download.STATE_COMPLETED) {
                                 val safeTitle = song.song.title.trim()
                                     .replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
-                                val ext = songFormat?.fileExtension() ?: "mp3"
+                                val ext = detectedExt
                                 ListItem(
                                     headlineContent = {
                                         Text(text = stringResource(R.string.export))

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -78,8 +78,8 @@ import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.HideExplicitKey
-import moe.rukamori.archivetune.db.entities.exportMimeType
-import moe.rukamori.archivetune.db.entities.fileExtension
+import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
+import moe.rukamori.archivetune.db.entities.extensionToMimeType
 import moe.rukamori.archivetune.constants.SongSortDescendingKey
 import moe.rukamori.archivetune.constants.SongSortType
 import moe.rukamori.archivetune.constants.SongSortTypeKey
@@ -142,11 +142,11 @@ fun CachePlaylistScreen(
                             }
                             val safeTitle = song.title.trim()
                                 .replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
-                            // Resolve the correct file extension and MIME type from
-                            // the FormatEntity so lossless FLAC tracks export as .flac.
-                            val formatInfo = database.format(song.id).first()
-                            val ext = formatInfo?.fileExtension() ?: "mp3"
-                            val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
+                            // Detect the actual audio format from cached data's
+                            // magic bytes so the exported file gets the correct
+                            // extension (e.g. .opus instead of wrongly .flac).
+                            val detectedExt = detectAudioExtensionFromSpans(spans)
+                            val mime = extensionToMimeType(detectedExt)
                             // createDocument() requires a document URI (representing the
                             // parent directory as a document), NOT the tree URI returned by
                             // OpenDocumentTree. Convert via getTreeDocumentId + buildDocumentUriUsingTree.
@@ -158,7 +158,7 @@ fun CachePlaylistScreen(
                                 context.contentResolver,
                                 parentDocUri,
                                 mime,
-                                "$safeTitle.$ext",
+                                "$safeTitle.$detectedExt",
                             ) ?: throw IllegalStateException("Could not create file")
                             context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
                                 spans.sortedBy { it.position }.forEach { span ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -124,14 +124,6 @@ fun SettingsScreen(
         BuildConfig.UPDATER_AVAILABLE &&
             Updater.isUpdateAvailable(latestVersionName, BuildConfig.VERSION_NAME)
     var isUpdateDismissed by remember { mutableStateOf(false) }
-    /** Navigate to a settings sub-screen, optionally scrolling to a child setting. */
-    fun navigateToSetting(route: String, scrollToKey: String? = null) {
-        if (scrollToKey != null) {
-            navController.navigate("$route?scrollTo=$scrollToKey")
-        } else {
-            navController.navigate(route)
-        }
-    }
     val allSettingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
     // When searching, flatten all individual SettingsChildren across every
     // category so each matching setting is shown as a separate row.
@@ -155,8 +147,8 @@ fun SettingsScreen(
                                 parentIcon = item.icon,
                                 parentKey = item.key,
                                 parentAccentColor = item.accentColor,
-                                parentRoute = "settings/${item.key}",
-                                scrollKey = child.scrollKey,
+                                parentRoute = null,
+                                scrollKey = null,
                                 onClick = item.onClick,
                             )
                         } else null
@@ -372,11 +364,7 @@ fun SettingsScreen(
                     SettingsSearchResultItem(
                         result = result,
                         onClick = {
-                            if (result.parentRoute != null && result.scrollKey != null) {
-                                navigateToSetting(result.parentRoute, result.scrollKey)
-                            } else {
-                                result.onClick()
-                            }
+                            result.onClick()
                         },
                         modifier = Modifier.padding(
                             horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -85,8 +85,8 @@ import moe.rukamori.archivetune.constants.MaxCanvasCacheSizeKey
 import moe.rukamori.archivetune.constants.MaxImageCacheSizeKey
 import moe.rukamori.archivetune.constants.MaxSongCacheSizeKey
 import moe.rukamori.archivetune.constants.SmartTrimmerKey
-import moe.rukamori.archivetune.db.entities.exportMimeType
-import moe.rukamori.archivetune.db.entities.fileExtension
+import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
+import moe.rukamori.archivetune.db.entities.extensionToMimeType
 import moe.rukamori.archivetune.extensions.directorySizeBytes
 import moe.rukamori.archivetune.extensions.tryOrNull
 import moe.rukamori.archivetune.storage.StorageFolderKind
@@ -216,9 +216,11 @@ fun StorageSettings(
                         for (songId in keys) {
                             val spans = cache.getCachedSpans(songId)
                             if (spans.isEmpty()) continue
-                            val formatInfo = database.format(songId).first()
-                            val ext = formatInfo?.fileExtension() ?: "mp3"
-                            val mime = formatInfo?.exportMimeType() ?: "audio/mpeg"
+                            // Detect the actual audio format from cached data's
+                            // magic bytes so the exported file gets the correct
+                            // extension (e.g. .opus instead of wrongly .flac).
+                            val detectedExt = detectAudioExtensionFromSpans(spans)
+                            val mime = extensionToMimeType(detectedExt)
                             // Try to get song title from the database for a meaningful filename
                             val songEntity = database.getSongByIdBlocking(songId)
                             val safeTitle = songEntity?.title?.trim()
@@ -235,7 +237,7 @@ fun StorageSettings(
                                 context.contentResolver,
                                 parentDocUri,
                                 mime,
-                                "$safeTitle.$ext",
+                                "$safeTitle.$detectedExt",
                             ) ?: run { failed++; continue }
                             runCatching {
                                 context.contentResolver.openOutputStream(destUri, "w")?.use { output ->


### PR DESCRIPTION
## Fixes

### 1. Settings search crash on click (IllegalArgumentException)
**Problem:** Clicking a search result (e.g. "Cache songs" under Behavior) crashed with:
```
Navigation destination that matches route settings/behavior?scrollTo=cache_songs cannot be found
```
**Root cause:** `parentRoute` was derived as `settings/${item.key}`, but several categories have keys that don't match their navigation route (e.g. `behavior` → `settings/privacy`, `developer_options` → `settings/misc`). The `?scrollTo=` query parameter was also appended, but no route in the nav graph declares it.

**Fix:** Search results now use the parent item's original `onClick` handler directly, which navigates to the correct pre-defined route without any query parameter.

### 2. Exported songs are lossy data with .flac extension
**Problem:** Songs exported from the download cache were getting the wrong file extension. A song whose FormatEntity claimed FLAC (1411 kbps) was exported as a 2.79MB .flac file — far too small for actual lossless audio. The cached data was actually lossy Opus from YouTube Music.

**Fix:** Added `detectAudioExtensionFromSpans()` that reads magic bytes from the first cached span file to determine the actual audio container format:
- `fLaC` → .flac
- `OggS` → .opus  
- `ftyp` at offset 4 → .m4a
- `RIFF` → .wav
- ID3/MPEG sync → .mp3

Applied to all three export paths: SongMenu, StorageSettings, and CachePlaylistScreen.

### 3. Private Telegram channel search returns no results
**Problem:** Pasting a private invite link like `https://t.me/+J3u7ZseEVIllZmQ1` into the Telegram channel search returned no results.

**Root cause:** `extractInviteHash()` extracted only the bare hash (`J3u7ZseEVIllZmQ1`), but TDLib's `CheckChatInviteLink` and `JoinChatByInviteLink` expect the full invite link URL.

**Fix:** Renamed to `extractInviteLink()` which returns the full URL with `https://` scheme (e.g. `https://t.me/+J3u7ZseEVIllZmQ1`), ensuring TDLib can parse and resolve the invite correctly.

## Files changed (6)
- `FormatEntity.kt` — added `detectAudioExtensionFromSpans()` and `extensionToMimeType()`
- `TelegramClient.kt` — `extractInviteLink` returns full URL instead of bare hash
- `SongMenu.kt` — detect actual format from cache for export extension
- `StorageSettings.kt` — detect actual format for bulk export
- `CachePlaylistScreen.kt` — detect actual format for playlist export
- `SettingsScreen.kt` — use onClick handler instead of route construction