### PR TITLE
fix: resolve compile error in PR #33

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
@@ -129,7 +129,7 @@ fun detectAudioExtensionFromSpans(
     spans: java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>,
 ): String {
     val firstSpan = spans.firstOrNull() ?: return "mp3"
-    val file = firstSpan.file
+    val file = firstSpan.file ?: return "mp3"
     if (!file.exists() || file.length() < 12) return "mp3"
     val header = ByteArray(12)
     file.inputStream().use { if (it.read(header) < 4) return "mp3" }


### PR DESCRIPTION
## Fix

`CacheSpan.file` is `@Nullable File` in Media3's Java API. The `detectAudioExtensionFromSpans()` function was missing a null guard, causing 3 compile errors:

```
Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type 'File?'
```

Added `?: return "mp3"` to safely handle the null case.