### PR TITLE
fix: search key crash, remove download source setting, serve cached stream on download

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -139,6 +139,16 @@ class DownloadUtil
                 if (playerCache.isCached(mediaId, dataSpec.position, length)) {
                     return@Factory dataSpec
                 }
+                // Check source-specific player-cache keys (Qobuz, Tidal) so that
+                // downloading a song that was streamed from an external lossless
+                // source saves the actual lossless data instead of re-downloading
+                // from YouTube Music. The keys match MusicService.sourceCacheKey().
+                for (sourcePrefix in listOf("qobuz:", "tidal:")) {
+                    val sourceKey = "$sourcePrefix$mediaId"
+                    if (playerCache.isCached(sourceKey, dataSpec.position, length)) {
+                        return@Factory dataSpec.buildUpon().setKey(sourceKey).build()
+                    }
+                }
                 val lowDataModeActive = context.isLowDataModeActive()
                 val requestedAudioQuality = resolveDownloadAudioQuality(lowDataModeActive)
                 val streamCacheKey = buildSongUrlCacheKey(mediaId, requestedAudioQuality)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -43,7 +43,6 @@ import moe.rukamori.archivetune.constants.CrossfadeDurationKey
 import moe.rukamori.archivetune.constants.CrossfadeEnabledKey
 import moe.rukamori.archivetune.constants.CrossfadeGaplessKey
 import moe.rukamori.archivetune.constants.DeviceMutePlaybackRecoveryVolumeKey
-import moe.rukamori.archivetune.constants.DownloadSourceKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderEnabledKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderPackageKey
 import moe.rukamori.archivetune.constants.HISTORY_DURATION_DEFAULT
@@ -52,7 +51,6 @@ import moe.rukamori.archivetune.constants.LowDataModeKey
 import moe.rukamori.archivetune.constants.PauseOnDeviceMuteKey
 import moe.rukamori.archivetune.constants.PermanentShuffleKey
 import moe.rukamori.archivetune.constants.PersistentQueueKey
-import moe.rukamori.archivetune.constants.QobuzEnabledKey
 import moe.rukamori.archivetune.constants.SeekExtraSeconds
 import moe.rukamori.archivetune.constants.SkipSilenceKey
 import moe.rukamori.archivetune.constants.StopMusicOnTaskClearKey
@@ -206,19 +204,6 @@ fun PlayerSettings(navController: NavController) {
     val (wakelockEnabled, onWakelockChange) =
         rememberPreference(
             WakelockKey,
-            defaultValue = false,
-        )
-    val (downloadSource, onDownloadSourceChange) =
-        rememberPreference(
-            DownloadSourceKey,
-            defaultValue = "youtube_music",
-        )
-    // When the user selects Qobuz or Tidal as download source, ensure the
-    // corresponding source provider is enabled so the resolution chain
-    // actually tries that provider during playback/download.
-    val (qobuzEnabled, onQobuzEnabledChange) =
-        rememberPreference(
-            QobuzEnabledKey,
             defaultValue = false,
         )
     var showArtistSeparatorsDialog by remember { mutableStateOf(false) }
@@ -460,38 +445,6 @@ fun PlayerSettings(navController: NavController) {
             }
 
             PreferenceGroup(title = stringResource(R.string.queue)) {
-                item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.download_source_title)) },
-                        description = when (downloadSource) {
-                            "youtube_music" -> stringResource(R.string.download_source_youtube_music)
-                            "tidal" -> stringResource(R.string.download_source_tidal)
-                            "qobuz" -> stringResource(R.string.download_source_qobuz)
-                            else -> downloadSource
-                        },
-                        icon = { Icon(painterResource(R.drawable.download), null) },
-                        onClick = { onDownloadSourceChange(
-                            when (downloadSource) {
-                                "youtube_music" -> "tidal"
-                                "tidal" -> "qobuz"
-                                else -> "youtube_music"
-                            }
-                        )
-                            // Enable the newly selected source so the resolution chain
-                            // actually tries it. Qobuz is disabled by default.
-                            when (downloadSource) {
-                                "youtube_music" -> {
-                                    // Next is tidal (already enabled by default)
-                                }
-                                "tidal" -> onQobuzEnabledChange(true)
-                                else -> {
-                                    // Back to youtube_music, no enable needed
-                                }
-                            }
-                        },
-                    )
-                }
-
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.persistent_queue)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -91,7 +91,6 @@ fun buildSettingsGroups(
                 SettingsChild("Seek seconds add-up", "seek_seconds", listOf("seek", "skip", "forward", "rewind", "seconds")),
                 SettingsChild("Pause on device mute", "pause_mute", listOf("mute", "pause mute", "headphone", "silence detect")),
                 SettingsChild("Auto start on Bluetooth", "bluetooth_auto_start", listOf("bluetooth", "auto start", "auto play", "connect")),
-                SettingsChild("Download source", "download_source", listOf("download source", "youtube music", "tidal", "qobuz", "provider")),
                 SettingsChild("Persistent queue", "persistent_queue", listOf("queue", "persistent", "save queue", "resume")),
                 SettingsChild("Permanent shuffle", "permanent_shuffle", listOf("shuffle", "random", "permanent")),
                 SettingsChild("Auto download on like", "auto_download_like", listOf("auto download", "like", "download liked")),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -358,7 +358,7 @@ fun SettingsScreen(
             if (searchQuery.isNotBlank() && filteredChildResults.isNotEmpty()) {
                 itemsIndexed(
                     items = filteredChildResults,
-                    key = { _, result -> result.parentKey + ":" + result.scrollKey },
+                    key = { index, result -> result.parentKey + ":" + result.title + ":" + index },
                     contentType = { _, _ -> "search_result" },
                 ) { _, result ->
                     SettingsSearchResultItem(


### PR DESCRIPTION
## Fixes

### 1. Settings search crash on typing
Key "appearance:null" duplicate. Fixed by using parentKey:title:index.

### 2. Remove Download Source setting from Playback
Dead code removed - DownloadSourceKey was never read.

### 3. Downloads save cached stream (lossless when applicable)
Download resolver checks source-specific cache keys (qobuz:, tidal:) before YouTube fallback.