### PR TITLE
fix: add missing positionInRoot import and use function call syntax

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
@@ -8,6 +8,7 @@
 package moe.rukamori.archivetune.ui.screens.settings
 
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -42,7 +43,7 @@ internal class PreferencePositions(private val positions: MutableMap<String, Int
     /** Returns a [Modifier] that records the composable's y-position under [key]. */
     fun modifierFor(key: String): Modifier =
         Modifier.onGloballyPositioned { coordinates ->
-            positions[key] = coordinates.positionInRoot.y.toInt()
+            positions[key] = coordinates.positionInRoot().y.toInt()
         }
 
     /** Scrolls the [scrollState] to the position registered for [key]. */


### PR DESCRIPTION
## Summary

Fixes the `Unresolved reference 'positionInRoot'` compilation error in `SettingsAutoScroll.kt:45`.

### Root cause
`positionInRoot` is an **extension function** defined in `androidx.compose.ui.layout`, not a member property of `LayoutCoordinates`. It requires:
1. An explicit import: `import androidx.compose.ui.layout.positionInRoot`
2. Function call syntax with parentheses: `coordinates.positionInRoot()`

This matches how every other file in the codebase uses it (FloatingNavigationToolbar, MiniPlayer, MainActivity).

### Changes
```diff
+import androidx.compose.ui.layout.positionInRoot
- positions[key] = coordinates.positionInRoot.y.toInt()
+ positions[key] = coordinates.positionInRoot().y.toInt()
```
