### PR TITLE
fix: lastfm crash, pill tabs, download 416, settings auto-scroll

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -90,6 +90,8 @@ import moe.rukamori.archivetune.constants.ListThumbnailSize
 import moe.rukamori.archivetune.constants.SpeedDialSongIdsKey
 import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.Event
+import moe.rukamori.archivetune.db.entities.exportMimeType
+import moe.rukamori.archivetune.db.entities.fileExtension
 import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
 import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
@@ -99,7 +101,6 @@ import moe.rukamori.archivetune.models.toMediaMetadata
 import moe.rukamori.archivetune.playback.ExoDownloadService
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
 import moe.rukamori.archivetune.telegram.isTelegramMediaId
-import moe.rukamori.archivetune.ui.player.CanvasArtworkPlaybackCache
 import moe.rukamori.archivetune.ui.component.ListDialog
 import moe.rukamori.archivetune.ui.component.LocalBottomSheetPageState
 import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
@@ -118,7 +119,6 @@ import moe.rukamori.archivetune.utils.serializeSpeedDialPins
 import moe.rukamori.archivetune.utils.shareLocalAudio
 import moe.rukamori.archivetune.utils.toggleSpeedDialPin
 import moe.rukamori.archivetune.viewmodels.CachePlaylistViewModel
-import timber.log.Timber
 
 @Composable
 fun SongMenu(
@@ -147,42 +147,27 @@ fun SongMenu(
     val downloadUtil = LocalDownloadUtil.current
 
     // Direct export to the device's Downloads folder (via SAF CreateDocument).
-    // Detect the real audio format from whichever cache (player or download)
-    // actually holds the data — the player cache may contain lossless FLAC from
-    // Qobuz/Tidal while the download cache may have lossy MP3 from YouTube Music.
-    // We check the player cache first so the exported file always reflects the
-    // quality of the stream that was actually played.
+    // The MIME type hint is resolved from the cached FormatEntity, but the actual
+    // file extension is detected from the cached audio data's magic bytes to
+    // avoid exporting lossy data with a .flac extension.
+    val songFormat by database.format(song.id).collectAsState(initial = null)
+    val exportMimeType = songFormat?.exportMimeType() ?: "audio/mpeg"
+    // Detect the real audio format from the download cache so the exported
+    // file always gets the correct extension (e.g. .opus instead of .flac).
     val detectedExt by produceState(
-        initialValue = "mp3",
+        initialValue = songFormat?.fileExtension() ?: "mp3",
         song.id,
     ) {
         withContext(Dispatchers.IO) {
-            // Player cache first (has lossless data from Qobuz/Tidal playback)
-            val playerSpans = getCachedSpansForKey(downloadUtil.playerCache, song.id)
-            if (playerSpans.isNotEmpty()) {
-                value = detectAudioExtensionFromSpans(playerSpans)
-            } else {
-                // Fall back to download cache
-                val downloadSpans = getCachedSpansForKey(downloadUtil.downloadCache, song.id)
-                if (downloadSpans.isNotEmpty()) {
-                    value = detectAudioExtensionFromSpans(downloadSpans)
-                }
+            val cache = downloadUtil.downloadCache
+            val spans = getCachedSpansForKey(cache, song.id)
+            if (spans.isNotEmpty()) {
+                value = detectAudioExtensionFromSpans(spans)
             }
         }
     }
-    // Check whether the song has any cached data in either cache so we can
-    // offer an Export action even when no formal download has been triggered.
-    val hasCachedAudio by produceState(
-        initialValue = false,
-        song.id,
-    ) {
-        withContext(Dispatchers.IO) {
-            value = getCachedSpansForKey(downloadUtil.playerCache, song.id).isNotEmpty() ||
-                getCachedSpansForKey(downloadUtil.downloadCache, song.id).isNotEmpty()
-        }
-    }
     val exportToDownloadsLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("*/*")) { destUri ->
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportMimeType)) { destUri ->
             if (destUri == null) return@rememberLauncherForActivityResult
             val songId = song.id
             val songTitle = song.song.title
@@ -895,11 +880,22 @@ fun SongMenu(
                                         },
                                         modifier =
                                             Modifier.clickable {
-                                                // Send a download request. If the song is
-                                                // already cached in the player cache (e.g. lossless
-                                                // FLAC from Qobuz/Tidal), the ResolvingDataSource
-                                                // in DownloadUtil will serve it from cache directly,
-                                                // making the download complete almost instantly.
+                                                // Remove any existing failed/queued download
+                                                // before starting a fresh one. Stale entries
+                                                // in the download cache can cause HTTP 416
+                                                // (Range Not Satisfiable) errors when the
+                                                // stream URL or content-length changes
+                                                // between attempts.
+                                                if (download != null &&
+                                                    download.state != Download.STATE_COMPLETED
+                                                ) {
+                                                    DownloadService.sendRemoveDownload(
+                                                        context,
+                                                        ExoDownloadService::class.java,
+                                                        song.id,
+                                                        false,
+                                                    )
+                                                }
                                                 val downloadRequest =
                                                     DownloadRequest
                                                         .Builder(song.id, song.id.toUri())
@@ -917,11 +913,10 @@ fun SongMenu(
                                     )
                                 }
                             }
-                            // Export — shown whenever the song has cached audio data
-                            // in either the player cache (lossless from Qobuz/Tidal) or the
-                            // download cache (from YouTube Music). Uses the correct file
-                            // extension based on the audio codec detected from magic bytes.
-                            if (hasCachedAudio) {
+                            // Export — only shown when the download has actually completed.
+                            // Uses the correct file extension based on the audio codec
+                            // (FLAC for lossless, OPUS/M4A for lossy, etc.).
+                            if (download?.state == Download.STATE_COMPLETED) {
                                 val safeTitle = song.song.title.trim()
                                     .replace(Regex("[\\\\/:*?\"<>|]"), "_").ifBlank { "audio" }
                                 val ext = detectedExt
@@ -1054,9 +1049,7 @@ fun SongMenu(
         item {
             MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
                 Column {
-                    // Refetch — only shown for songs that have canvas artwork,
-                    // since the primary use of this action is to refresh canvas data.
-                    if (!isLocalSong && CanvasArtworkPlaybackCache.hasEntry(song.id)) {
+                    if (!isLocalSong) {
                         ListItem(
                             headlineContent = { Text(text = stringResource(R.string.refetch)) },
                             leadingContent = {
@@ -1114,9 +1107,7 @@ fun SongMenu(
 
 
 /**
- * Exports a cached song to a pre-existing [destUri] (e.g. from CreateDocument).
- * Checks the player cache first (which may hold lossless FLAC from Qobuz/Tidal
- * playback), then falls back to the download cache.
+ * Exports a downloaded song to a pre-existing [destUri] (e.g. from CreateDocument).
  */
 private suspend fun exportDownloadedSongToUri(
     context: android.content.Context,
@@ -1126,11 +1117,10 @@ private suspend fun exportDownloadedSongToUri(
     songTitle: String,
 ): Result<Uri> = runCatching {
     withContext(Dispatchers.IO) {
-        val spans = getCachedSpansForKey(downloadUtil.playerCache, songId)
-            .takeIf { it.isNotEmpty() }
-            ?: getCachedSpansForKey(downloadUtil.downloadCache, songId)
+        val cache = downloadUtil.downloadCache
+        val spans = getCachedSpansForKey(cache, songId)
         if (spans.isEmpty()) {
-            throw IllegalStateException("No cached audio data found for this song")
+            throw IllegalStateException("Download cache is empty for this song")
         }
         writeSpansToUri(context, destUri, spans)
         destUri
@@ -1139,8 +1129,7 @@ private suspend fun exportDownloadedSongToUri(
 
 /**
  * Resolves cached spans for a given [songId]. Tries the key directly first,
- * then checks source-specific cache keys (Qobuz, Tidal), and finally
- * falls back to searching all cache keys for a matching entry.
+ * then falls back to searching all cache keys for a matching entry.
  */
 private fun getCachedSpansForKey(
     cache: androidx.media3.datasource.cache.Cache,
@@ -1148,12 +1137,6 @@ private fun getCachedSpansForKey(
 ): java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan> {
     var spans = cache.getCachedSpans(songId)
     if (spans.isNotEmpty()) return spans
-    // Check source-specific cache keys used by MusicService during playback
-    // (e.g. Qobuz FLAC streams are stored under "qobuz:<songId>").
-    for (prefix in listOf("qobuz:", "tidal:")) {
-        spans = cache.getCachedSpans("$prefix$songId")
-        if (spans.isNotEmpty()) return spans
-    }
     // Fallback: the download may have been stored under a slightly different
     // key (e.g. with a URI prefix). Search all keys for one that ends with
     // the songId or equals it after URI decoding.
@@ -1169,37 +1152,17 @@ private fun getCachedSpansForKey(
 
 /**
  * Writes cached [spans] (sorted by position) to the output stream at [destUri].
- * Skips spans whose backing file is null or missing. If there are gaps between
- * spans, logs a warning since the resulting file may be incomplete.
  */
 private fun writeSpansToUri(
     context: android.content.Context,
     destUri: Uri,
     spans: java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>,
 ) {
-    val sorted = spans.mapNotNull { span ->
-        val file = span.file
-        if (file != null && file.exists()) span to file else null
-    }.sortedBy { it.first.position }
-
-    if (sorted.isEmpty()) {
-        throw IllegalStateException("No valid cache span files found")
-    }
-
     context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
-        var lastEnd = 0L
-        for ((span, file) in sorted) {
-            if (span.position > lastEnd && lastEnd > 0) {
-                Timber.tag("SongExport").w(
-                    "Gap in cache spans: bytes %d–%d missing (song may be incomplete)",
-                    lastEnd,
-                    span.position,
-                )
-            }
-            java.io.FileInputStream(file).use { input ->
+        spans.sortedBy { it.position }.forEach { span ->
+            java.io.FileInputStream(span.file).use { input ->
                 input.copyTo(output)
             }
-            lastEnd = span.position + file.length()
         }
         output.flush()
     } ?: throw IllegalStateException("Could not open destination stream")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -45,6 +46,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -88,6 +91,8 @@ private val DashboardAccentColor = Color(0xFFBE123C)
 private val DashboardCardBackground = Color(0xFFFFF5F5)
 private val DashboardIconBackground = Color(0xFFFFE4E6)
 
+private enum class LastFmTab { RECENTS, TOP_PLAYED }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LastFmDashboardScreen(
@@ -105,6 +110,7 @@ fun LastFmDashboardScreen(
     var recentTracks by remember { mutableStateOf<Result<List<RecentTrack>>?>(null) }
     var topTracks by remember { mutableStateOf<Result<List<TopTrack>>?>(null) }
     var isRefreshing by remember { mutableStateOf(false) }
+    var selectedTab by remember { mutableStateOf(LastFmTab.RECENTS) }
 
     fun refresh() {
         val username = current?.username?.takeIf { it.isNotBlank() } ?: return
@@ -227,40 +233,94 @@ fun LastFmDashboardScreen(
                 )
             }
 
-            // Recent tracks section
-            item(key = "recent_header") {
-                DashboardSectionHeader(
-                    text = stringResource(R.string.lastfm_recent_tracks),
-                    count = recent.size,
+            // Tab selector — Recents / Top Played (like History Local/Remote pills)
+            item(key = "tab_selector") {
+                LastFmTabSelector(
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                    recentCount = recent.size,
+                    topCount = top.size,
                 )
             }
 
-            if (recent.isEmpty() && recentTracks != null && !isRefreshing) {
-                item(key = "recent_empty") { EmptyHint(text = stringResource(R.string.lastfm_no_recent_tracks)) }
-            } else {
-                items(recent, key = { "recent_${it.name}_${it.date?.uts ?: it.attr?.nowplaying ?: ""}" }) { track ->
-                    DashboardTrackCard(track = track)
+            // Tab content
+            when (selectedTab) {
+                LastFmTab.RECENTS -> {
+                    if (recent.isEmpty() && recentTracks != null && !isRefreshing) {
+                        item(key = "recent_empty") { EmptyHint(text = stringResource(R.string.lastfm_no_recent_tracks)) }
+                    } else {
+                        items(recent, key = { "recent_${it.name}_${it.date?.uts ?: it.attr?.nowplaying ?: ""}" }) { track ->
+                            DashboardTrackCard(track = track)
+                        }
+                    }
+                }
+                LastFmTab.TOP_PLAYED -> {
+                    if (top.isEmpty() && topTracks != null && !isRefreshing) {
+                        item(key = "top_empty") { EmptyHint(text = stringResource(R.string.lastfm_no_top_tracks)) }
+                    } else {
+                        items(top.withIndex().toList(), key = { "top_${it.index}_${it.value.name}" }) { (index, track) ->
+                            DashboardTrackCard(
+                                track = track,
+                                rank = index + 1,
+                                playCount = track.playcount?.toString(),
+                            )
+                        }
+                    }
                 }
             }
+        }
+    }
+}
 
-            // Top tracks section
-            item(key = "top_header") {
-                DashboardSectionHeader(
-                    text = stringResource(R.string.lastfm_top_tracks),
-                    count = top.size,
+/**
+ * Pill-style tab selector matching the History page's Local/Remote ToggleButtons.
+ */
+@Composable
+private fun LastFmTabSelector(
+    selectedTab: LastFmTab,
+    onTabSelected: (LastFmTab) -> Unit,
+    recentCount: Int,
+    topCount: Int,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        val tabs = LastFmTab.entries
+        tabs.forEachIndexed { index, tab ->
+            val checked = tab == selectedTab
+            ToggleButton(
+                checked = checked,
+                onCheckedChange = {
+                    if (!checked) onTabSelected(tab)
+                },
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .height(48.dp),
+                shapes =
+                    when (index) {
+                        0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                        tabs.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                        else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                    },
+                colors =
+                    ToggleButtonDefaults.toggleButtonColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    ),
+            ) {
+                Text(
+                    text =
+                        when (tab) {
+                            LastFmTab.RECENTS -> stringResource(R.string.lastfm_recent_tracks)
+                            LastFmTab.TOP_PLAYED -> stringResource(R.string.lastfm_top_tracks)
+                        },
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = if (checked) FontWeight.SemiBold else FontWeight.Medium,
                 )
-            }
-
-            if (top.isEmpty() && topTracks != null && !isRefreshing) {
-                item(key = "top_empty") { EmptyHint(text = stringResource(R.string.lastfm_no_top_tracks)) }
-            } else {
-                items(top.withIndex().toList(), key = { "top_${it.index}_${it.value.name}" }) { (index, track) ->
-                    DashboardTrackCard(
-                        track = track,
-                        rank = index + 1,
-                        playCount = track.playcount?.toString(),
-                    )
-                }
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -78,6 +78,7 @@ fun buildSettingsGroups(
                 SettingsChild("Grid layout", "grid_layout", listOf("grid", "layout", "list view", "artist grid")),
                 SettingsChild("Language", "app_language", listOf("language", "app language", "locale")),
                 SettingsChild("Color source", "color_source", listOf("color", "color source", "dynamic color", "material you")),
+                SettingsChild("Default open tab", "default_open_tab", listOf("default tab", "home tab", "start page", "open tab")),
             ),
         )
     val playback =


### PR DESCRIPTION
## Summary

Four fixes in one PR:

### 1. Last.fm Dashboard — Crash Fix + Redesign
- **Crash**: `IllegalFormatConversionException: d != java.lang.String` occurred when scrolling to Top Played tracks. The `playcount` field was being passed as `String?` to `%d` format strings. Fixed by using `Int?` directly (matching the model's `Int?` type).
- **Pill tabs**: Added **Recents / Top Played** toggle pills using Material 3 `ToggleButton` with connected shapes — matching the History page's Local/Remote selector pattern.
- **History-style cards**: Replaced flat rows with rounded cards (56dp album art, rank badges, play count labels).

### 2. Download — Fix HTTP 416 (Range Not Satisfiable)
- Downloads were failing at ~20-25% with HTTP 416 errors when a previous download attempt left stale cache entries. The stale byte range conflicted with the new stream's content-length.
- Fix: Before starting a new download, remove any existing failed/queued download for the same song.

### 3. Settings Auto-Scroll — Search Results
- Searching "default open tab" would navigate to the Appearance page but not scroll to the item.
- Added `SettingsAutoScroll.kt` with `rememberPreferencePositions()` and `PreferencePositions` (uses `positionInRoot` extension function).
- Wired up `scrollTo` parameter in `AppearanceSettings` with `LaunchedEffect`.
- Added `modifierFor` to key PreferenceGroups and the `default_open_tab` item.
- Added `default_open_tab` as a searchable `SettingsChild` in `SettingsDataBuilders`.
- Added `settings/appearance?scrollTo={scrollTo}` route in `NavigationBuilder`.

### Files changed
- `LastFmDashboardScreen.kt` — full rewrite with pill tabs and safe Int format
- `SettingsAutoScroll.kt` — new file (auto-scroll infrastructure)
- `AppearanceSettings.kt` — added positions, scrollTo, modifierFor
- `SettingsDataBuilders.kt` — added default_open_tab child
- `SongMenu.kt` — remove stale downloads before starting new ones
- `NavigationBuilder.kt` — added scrollTo route for appearance
