### PR TITLE
fix: lastfm crash, pill tabs, download 416, settings auto-scroll (compile fixes)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -886,8 +886,9 @@ fun SongMenu(
                                                 // (Range Not Satisfiable) errors when the
                                                 // stream URL or content-length changes
                                                 // between attempts.
-                                                if (download != null &&
-                                                    download.state != Download.STATE_COMPLETED
+                                                val dl = download
+                                                if (dl != null &&
+                                                    dl.state != Download.STATE_COMPLETED
                                                 ) {
                                                     DownloadService.sendRemoveDownload(
                                                         context,


### PR DESCRIPTION
Cherry-picks the fixes from PR #41 (lastfm crash, pill tabs, download 416, settings auto-scroll) with two additional compile error fixes:

1. **SongMenu.kt** — Smart cast to  impossible because  is a delegated property. Fixed by assigning to a local  before the null check.
2. **SettingsAutoScroll.kt** —  is an extension function in  that requires an explicit import and function call syntax . Added the missing import and used  syntax.