### PR TITLE
fix: lastfm top tracks crash, download 416, settings search

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -897,6 +897,11 @@ fun SongMenu(
                                                         false,
                                                     )
                                                 }
+                                                // Also clear any partial cached data from the
+                                                // download cache. Stale bytes can cause HTTP 416
+                                                // (Range Not Satisfiable) when the stream URL or
+                                                // content-length changes between attempts.
+                                                downloadUtil.downloadCache.removeResource(song.id)
                                                 val downloadRequest =
                                                     DownloadRequest
                                                         .Builder(song.id, song.id.toUri())

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -262,7 +262,7 @@ fun LastFmDashboardScreen(
                             DashboardTrackCard(
                                 track = track,
                                 rank = index + 1,
-                                playCount = track.playcount?.toString(),
+                                playCount = track.playcount,
                             )
                         }
                     }
@@ -537,7 +537,7 @@ private fun bestArtwork(images: List<moe.rukamori.archivetune.lastfm.models.User
 private fun DashboardTrackCard(
     track: RecentTrack,
     rank: Int? = null,
-    playCount: String? = null,
+    playCount: Int? = null,
 ) {
     val artworkUrl = bestArtwork(track.image)
 
@@ -648,7 +648,7 @@ private fun DashboardTrackCard(
 private fun DashboardTrackCard(
     track: TopTrack,
     rank: Int? = null,
-    playCount: String? = null,
+    playCount: Int? = null,
 ) {
     val artworkUrl = bestArtwork(track.image)
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -40,12 +40,10 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -57,8 +55,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
@@ -193,25 +189,10 @@ fun SettingsScreen(
         }
     }
 
-    // Auto-scroll to the first matching search result when the query changes.
-    // We debounce slightly so rapid typing doesn't cause excessive scrolls.
-    // Note: filteredChildResults is NOT a LaunchedEffect key — if it were, every
-    // keystroke would cancel the debounce timer before it fires.
-    LaunchedEffect(listState) {
-        snapshotFlow { searchQuery }
-            .debounce(200L)
-            .distinctUntilChanged()
-            .collect { query ->
-                if (query.isBlank()) return@collect
-                // Snapshot the current search results inside the flow so
-                // we always scroll to the latest match.
-                val results = filteredChildResults
-                if (results.isEmpty()) return@collect
-                // When searching, the LazyColumn layout is:
-                //   0 = search_bar, 1 = search_spacing, 2+ = search results.
-                listState.animateScrollToItem(2)
-            }
-    }
+    // Note: Search results show individual settings items. Clicking a result
+    // navigates directly to the parent settings page. The previous auto-scroll
+    // approach was removed because it only scrolled to section headers, not
+    // the specific setting items.
 
     // Material 3 Expressive: when any settings dialog (history duration,
     // lyrics preload count, etc.) is showing, apply a backdrop blur to
@@ -364,36 +345,8 @@ fun SettingsScreen(
                     SettingsSearchResultItem(
                         result = result,
                         onClick = {
-                            // If we have a scrollKey, navigate to the parent route with a
-                            // scrollTo query parameter so the sub-page auto-scrolls to the item.
-                            if (result.scrollKey != null && result.parentRoute != null) {
-                                val route = when (result.parentRoute) {
-                                    "appearance" -> "settings/appearance"
-                                    "player" -> "settings/player"
-                                    "content" -> "settings/content"
-                                    "lyrics" -> "settings/lyrics"
-                                    "language_packs" -> "settings/language_packs"
-                                    "internet" -> "settings/internet"
-                                    "sources" -> "settings/sources"
-                                    "storage" -> "settings/storage"
-                                    "privacy" -> "settings/privacy"
-                                    "backup_restore" -> "settings/backup_restore"
-                                    "discord" -> "settings/discord"
-                                    "integration" -> "settings/integration"
-                                    "tidal" -> "settings/tidal"
-                                    "qobuz" -> "settings/qobuz"
-                                    "telegram" -> "settings/telegram"
-                                    "about" -> "settings/about"
-                                    else -> null
-                                }
-                                if (route != null) {
-                                    navController.navigate("$route?scrollTo=${result.scrollKey}")
-                                } else {
-                                    result.onClick()
-                                }
-                            } else {
-                                result.onClick()
-                            }
+                            // Navigate to the parent settings page directly.
+                            result.onClick()
                         },
                         modifier = Modifier.padding(
                             horizontal = SettingsDimensions.SegmentedGroupHorizontalPadding,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -897,7 +897,7 @@
     <string name="lastfm_sign_in_required_desc">Connect your Last.fm account to view your listening dashboard, recent tracks, and top tracks.</string>
     <string name="lastfm_sign_in_button">Sign in to Last.fm</string>
     <string name="lastfm_recent_tracks">Recent tracks</string>
-    <string name="lastfm_top_tracks">Top tracks (all time)</string>
+    <string name="lastfm_top_tracks">Top tracks</string>
     <string name="lastfm_no_recent_tracks">No recent tracks to show.</string>
     <string name="lastfm_no_top_tracks">No top tracks to show.</string>
     <string name="lastfm_load_failed">Could not load your Last.fm dashboard.</string>


### PR DESCRIPTION
Three fixes:

**1. Last.fm Dashboard crash when clicking Top Played tab**
- `IllegalFormatConversionException: d != java.lang.String` — `lastfm_playcount_short` uses `%1$d` (int format) but was receiving a `String?` (`track.playcount?.toString()`). Changed `playCount` parameter type from `String?` to `Int?` in both `DashboardTrackCard` overloads and pass `track.playcount` (which is already `Int?`) directly.
- Removed "(all time)" from the "Top tracks" tab label per request.

**2. Download keeps failing with HTTP 416 (Range Not Satisfiable)**
- `sendRemoveDownload` only removes the download request from the DownloadManager index but does NOT clear the cached byte data from the download cache. When a new download starts, Media3 finds stale partial data and tries to resume with a byte range that no longer matches the server's content-length or the URL has expired, causing 416.
- Added `downloadUtil.downloadCache.removeResource(song.id)` before `sendAddDownload` to clear any stale cached data, ensuring a clean download from scratch.

**3. Settings search auto-scroll removed**
- The auto-scroll mechanism (`scrollTo` query parameter + `LaunchedEffect`) only scrolled to the section header, not the specific setting item. Removed it entirely.
- Search results now navigate directly to the parent settings page when clicked.
- Removed the broken `LaunchedEffect` with `snapshotFlow`/`debounce` and the route mapping with `scrollTo` parameter.