### PR TITLE
fix: downloads failing at 0% + settings search not finding / not auto-scrolling to non-switch settings

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -143,6 +143,30 @@ class DownloadUtil
                 .setUpstreamDataSourceFactory(OkHttpDataSource.Factory(mediaOkHttpClient))
                 .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
 
+        /**
+         * Read-only view of [playerCache] used as an inner upstream of the download chain.
+         *
+         * The download [CacheDataSource] is bound to [downloadCache]; without this inner layer,
+         * any byte range present in [playerCache] (e.g. a song that was just streamed from Qobuz
+         * or YouTube) but absent from [downloadCache] would fall through to [OkHttpDataSource]
+         * holding the *bare media id* the [DownloadRequest] carried (e.g. "dJth8oW7CAQ"), which
+         * is not a valid URL — producing `HttpDataSourceException: Malformed URL` and failing
+         * the download at 0%.
+         *
+         * Chaining [playerCache] as the next upstream means: downloadCache miss → playerCache hit
+         * → serve bytes (and write them through to downloadCache so subsequent chunks persist).
+         * Only when *both* caches miss do we reach [OkHttpDataSource], by which point the
+         * [ResolvingDataSource] resolver below has already swapped the URI for a real YouTube
+         * stream URL.
+         */
+        private val playerCacheDownloadUpstreamFactory =
+            CacheDataSource
+                .Factory()
+                .setCache(playerCache)
+                .setCacheReadDataSourceFactory(FileDataSource.Factory())
+                .setUpstreamDataSourceFactory(OkHttpDataSource.Factory(mediaOkHttpClient))
+                .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+
         private val youtubeDataSourceFactory =
             ResolvingDataSource.Factory(
                 CacheDataSource
@@ -150,11 +174,8 @@ class DownloadUtil
                     .setCache(downloadCache)
                     .setCacheKeyFactory(DownloadRequestCacheKeyFactory)
                     .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
-                    .setUpstreamDataSourceFactory(
-                        OkHttpDataSource.Factory(
-                            mediaOkHttpClient,
-                        ),
-                    ).setCacheWriteDataSinkFactory(
+                    .setUpstreamDataSourceFactory(playerCacheDownloadUpstreamFactory)
+                    .setCacheWriteDataSinkFactory(
                         CacheDataSink.Factory().setCache(downloadCache).setBufferSize(DOWNLOAD_WRITE_BUFFER_SIZE),
                     ),
             ) { dataSpec ->
@@ -167,6 +188,9 @@ class DownloadUtil
                 // downloading a song that was streamed from an external lossless
                 // source saves the actual lossless data instead of re-downloading
                 // from YouTube Music. The keys match MusicService.sourceCacheKey().
+                // The chained [playerCacheDownloadUpstreamFactory] reads these source-specific
+                // keys directly from playerCache — no YouTube URL resolution is needed when the
+                // lossless bytes are already cached.
                 for (sourcePrefix in listOf("qobuz:", "tidal:")) {
                     val sourceKey = "$sourcePrefix$mediaId"
                     if (playerCache.isCached(sourceKey, dataSpec.position, length)) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -517,8 +517,11 @@ fun NavGraphBuilder.navigationBuilder(
     composable("settings/music_together") {
         MusicTogetherScreen(navController)
     }
-    composable("settings/lastfm") {
-        LastFMSettings(navController)
+    composable(
+        route = "settings/lastfm?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        LastFMSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable("lastfm_dashboard") {
         LastFmDashboardScreen(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -485,46 +485,54 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item(visible = !dynamicTheme || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.color_palette)) },
-                        description = stringResource(R.string.customize_theme_colors),
-                        icon = { Icon(painterResource(R.drawable.format_paint), null) },
-                        onClick = { navController.navigate("settings/appearance/palette_picker") },
-                    )
+                    Column(modifier = positions.modifierFor("color_palette")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.color_palette)) },
+                            description = stringResource(R.string.customize_theme_colors),
+                            icon = { Icon(painterResource(R.drawable.format_paint), null) },
+                            onClick = { navController.navigate("settings/appearance/palette_picker") },
+                        )
+                    }
                 }
 
                 item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.app_icon)) },
-                        description = stringResource(R.string.app_icon_description),
-                        icon = { Icon(painterResource(R.drawable.app_icon_small), null) },
-                        onClick = { navController.navigate("settings/appearance/icon") },
-                    )
+                    Column(modifier = positions.modifierFor("app_icon")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.app_icon)) },
+                            description = stringResource(R.string.app_icon_description),
+                            icon = { Icon(painterResource(R.drawable.app_icon_small), null) },
+                            onClick = { navController.navigate("settings/appearance/icon") },
+                        )
+                    }
                 }
 
                 item {
-                    EnumListPreference(
-                        title = { Text(stringResource(R.string.dark_theme)) },
-                        icon = { Icon(painterResource(R.drawable.dark_mode), null) },
-                        selectedValue = darkMode,
-                        onValueSelected = onDarkModeChange,
-                        valueText = {
-                            when (it) {
-                                DarkMode.ON -> stringResource(R.string.dark_theme_on)
-                                DarkMode.OFF -> stringResource(R.string.dark_theme_off)
-                                DarkMode.AUTO -> stringResource(R.string.dark_theme_follow_system)
-                            }
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("dark_theme")) {
+                        EnumListPreference(
+                            title = { Text(stringResource(R.string.dark_theme)) },
+                            icon = { Icon(painterResource(R.drawable.dark_mode), null) },
+                            selectedValue = darkMode,
+                            onValueSelected = onDarkModeChange,
+                            valueText = {
+                                when (it) {
+                                    DarkMode.ON -> stringResource(R.string.dark_theme_on)
+                                    DarkMode.OFF -> stringResource(R.string.dark_theme_off)
+                                    DarkMode.AUTO -> stringResource(R.string.dark_theme_follow_system)
+                                }
+                            },
+                        )
+                    }
                 }
 
                 item(visible = useDarkTheme) {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.pure_black)) },
-                        icon = { Icon(painterResource(R.drawable.contrast), null) },
-                        checked = pureBlack,
-                        onCheckedChange = onPureBlackChange,
-                    )
+                    Column(modifier = positions.modifierFor("pure_black")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.pure_black)) },
+                            icon = { Icon(painterResource(R.drawable.contrast), null) },
+                            checked = pureBlack,
+                            onCheckedChange = onPureBlackChange,
+                        )
+                    }
                 }
 
                 item {
@@ -563,23 +571,25 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.blur_intensity)) },
-                        description = stringResource(R.string.blur_intensity_value, blurRadius.roundToInt()),
-                        icon = { Icon(painterResource(R.drawable.blur_on), null) },
-                        isEnabled = !disableBlur,
-                        content = {
-                            Spacer(modifier = Modifier.height(10.dp))
-                            Slider(
-                                value = blurRadius,
-                                onValueChange = onBlurRadiusChange,
-                                valueRange = 0f..64f,
-                                steps = 63,
-                                enabled = !disableBlur,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("blur_intensity")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.blur_intensity)) },
+                            description = stringResource(R.string.blur_intensity_value, blurRadius.roundToInt()),
+                            icon = { Icon(painterResource(R.drawable.blur_on), null) },
+                            isEnabled = !disableBlur,
+                            content = {
+                                Spacer(modifier = Modifier.height(10.dp))
+                                Slider(
+                                    value = blurRadius,
+                                    onValueChange = onBlurRadiusChange,
+                                    valueRange = 0f..64f,
+                                    steps = 63,
+                                    enabled = !disableBlur,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            },
+                        )
+                    }
                 }
 
                 item {
@@ -613,20 +623,22 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    EnumListPreference(
-                        title = { Text(stringResource(R.string.font_preference)) },
-                        description = stringResource(R.string.font_preference_desc),
-                        icon = { Icon(painterResource(R.drawable.text_fields), null) },
-                        selectedValue = fontPreference,
-                        onValueSelected = onFontPreferenceSelected,
-                        valueText = {
-                            when (it) {
-                                AppFontPreference.DEFAULT -> stringResource(R.string.font_preference_default)
-                                AppFontPreference.SYSTEM -> stringResource(R.string.font_preference_system)
-                                AppFontPreference.CUSTOM -> stringResource(R.string.font_preference_custom)
-                            }
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("font_preference")) {
+                        EnumListPreference(
+                            title = { Text(stringResource(R.string.font_preference)) },
+                            description = stringResource(R.string.font_preference_desc),
+                            icon = { Icon(painterResource(R.drawable.text_fields), null) },
+                            selectedValue = fontPreference,
+                            onValueSelected = onFontPreferenceSelected,
+                            valueText = {
+                                when (it) {
+                                    AppFontPreference.DEFAULT -> stringResource(R.string.font_preference_default)
+                                    AppFontPreference.SYSTEM -> stringResource(R.string.font_preference_system)
+                                    AppFontPreference.CUSTOM -> stringResource(R.string.font_preference_custom)
+                                }
+                            },
+                        )
+                    }
                 }
 
                 item(visible = fontPreference == AppFontPreference.CUSTOM) {
@@ -652,27 +664,29 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 title = stringResource(R.string.player),
             ) {
                 item {
-                    EnumListPreference(
-                        title = { Text(stringResource(R.string.player_design_style)) },
-                        icon = { Icon(painterResource(R.drawable.palette), null) },
-                        selectedValue = playerDesignStyle,
-                        onValueSelected = onPlayerDesignStyleChange,
-                        valueText = {
-                            when (it) {
-                                PlayerDesignStyle.V1 -> stringResource(R.string.player_design_v1)
-                                PlayerDesignStyle.V2 -> stringResource(R.string.player_design_v2)
-                                PlayerDesignStyle.V3 -> stringResource(R.string.player_design_v3)
-                                PlayerDesignStyle.V4 -> stringResource(R.string.player_design_v4)
-                                PlayerDesignStyle.V5 -> stringResource(R.string.player_design_v5)
-                                PlayerDesignStyle.V6 -> stringResource(R.string.player_design_v6)
-                                PlayerDesignStyle.V7 -> stringResource(R.string.player_design_v7)
-                                PlayerDesignStyle.V8 -> stringResource(R.string.player_design_v8)
-                                PlayerDesignStyle.V9 -> stringResource(R.string.player_design_v9)
-                                PlayerDesignStyle.APPLE_MUSIC ->
-                                    stringResource(R.string.player_design_apple_music)
-                            }
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("player_design_style")) {
+                        EnumListPreference(
+                            title = { Text(stringResource(R.string.player_design_style)) },
+                            icon = { Icon(painterResource(R.drawable.palette), null) },
+                            selectedValue = playerDesignStyle,
+                            onValueSelected = onPlayerDesignStyleChange,
+                            valueText = {
+                                when (it) {
+                                    PlayerDesignStyle.V1 -> stringResource(R.string.player_design_v1)
+                                    PlayerDesignStyle.V2 -> stringResource(R.string.player_design_v2)
+                                    PlayerDesignStyle.V3 -> stringResource(R.string.player_design_v3)
+                                    PlayerDesignStyle.V4 -> stringResource(R.string.player_design_v4)
+                                    PlayerDesignStyle.V5 -> stringResource(R.string.player_design_v5)
+                                    PlayerDesignStyle.V6 -> stringResource(R.string.player_design_v6)
+                                    PlayerDesignStyle.V7 -> stringResource(R.string.player_design_v7)
+                                    PlayerDesignStyle.V8 -> stringResource(R.string.player_design_v8)
+                                    PlayerDesignStyle.V9 -> stringResource(R.string.player_design_v9)
+                                    PlayerDesignStyle.APPLE_MUSIC ->
+                                        stringResource(R.string.player_design_apple_music)
+                                }
+                            },
+                        )
+                    }
                 }
 
                 item {
@@ -692,61 +706,65 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    EnumListPreference(
-                        title = { Text(stringResource(R.string.player_background_style)) },
-                        description =
-                            if (isPlayerStyleCustomizationEnabled) {
-                                null
-                            } else {
-                                stringResource(R.string.player_background_style_v8_v9_desc)
-                            },
-                        icon = { Icon(painterResource(R.drawable.gradient), null) },
-                        selectedValue = playerBackground,
-                        onValueSelected = { selectedBackground ->
-                            onPlayerBackgroundChange(selectedBackground)
-                            when {
-                                selectedBackground == PlayerBackgroundStyle.CUSTOM -> {
-                                    onLyricsBackgroundChange(LyricsBackgroundStyle.CUSTOM)
-                                }
+                    Column(modifier = positions.modifierFor("player_background_style")) {
+                        EnumListPreference(
+                            title = { Text(stringResource(R.string.player_background_style)) },
+                            description =
+                                if (isPlayerStyleCustomizationEnabled) {
+                                    null
+                                } else {
+                                    stringResource(R.string.player_background_style_v8_v9_desc)
+                                },
+                            icon = { Icon(painterResource(R.drawable.gradient), null) },
+                            selectedValue = playerBackground,
+                            onValueSelected = { selectedBackground ->
+                                onPlayerBackgroundChange(selectedBackground)
+                                when {
+                                    selectedBackground == PlayerBackgroundStyle.CUSTOM -> {
+                                        onLyricsBackgroundChange(LyricsBackgroundStyle.CUSTOM)
+                                    }
 
-                                configuredLyricsBackground == LyricsBackgroundStyle.CUSTOM -> {
-                                    onLyricsBackgroundChange(LyricsBackgroundStyle.DEFAULT)
+                                    configuredLyricsBackground == LyricsBackgroundStyle.CUSTOM -> {
+                                        onLyricsBackgroundChange(LyricsBackgroundStyle.DEFAULT)
+                                    }
                                 }
-                            }
-                        },
-                        isEnabled = isPlayerStyleCustomizationEnabled,
-                        valueText = {
-                            when (it) {
-                                PlayerBackgroundStyle.DEFAULT -> stringResource(R.string.follow_theme)
-                                PlayerBackgroundStyle.GRADIENT -> stringResource(R.string.gradient)
-                                PlayerBackgroundStyle.CUSTOM -> stringResource(R.string.custom)
-                                PlayerBackgroundStyle.BLUR -> stringResource(R.string.player_background_blur)
-                                PlayerBackgroundStyle.COLORING -> stringResource(R.string.coloring)
-                                PlayerBackgroundStyle.BLUR_GRADIENT -> stringResource(R.string.blur_gradient)
-                                PlayerBackgroundStyle.GLOW -> stringResource(R.string.glow)
-                                PlayerBackgroundStyle.GLOW_ANIMATED -> "Glow Animated"
-                            }
-                        },
-                    )
+                            },
+                            isEnabled = isPlayerStyleCustomizationEnabled,
+                            valueText = {
+                                when (it) {
+                                    PlayerBackgroundStyle.DEFAULT -> stringResource(R.string.follow_theme)
+                                    PlayerBackgroundStyle.GRADIENT -> stringResource(R.string.gradient)
+                                    PlayerBackgroundStyle.CUSTOM -> stringResource(R.string.custom)
+                                    PlayerBackgroundStyle.BLUR -> stringResource(R.string.player_background_blur)
+                                    PlayerBackgroundStyle.COLORING -> stringResource(R.string.coloring)
+                                    PlayerBackgroundStyle.BLUR_GRADIENT -> stringResource(R.string.blur_gradient)
+                                    PlayerBackgroundStyle.GLOW -> stringResource(R.string.glow)
+                                    PlayerBackgroundStyle.GLOW_ANIMATED -> "Glow Animated"
+                                }
+                            },
+                        )
+                    }
                 }
 
                 item {
-                    ListPreference(
-                        title = { Text(stringResource(R.string.lyrics_background_style)) },
-                        icon = { Icon(painterResource(R.drawable.lyrics), null) },
-                        selectedValue = lyricsBackground,
-                        values = availableLyricsBackgroundStyles,
-                        onValueSelected = onLyricsBackgroundChange,
-                        isEnabled = playerBackground != PlayerBackgroundStyle.CUSTOM,
-                        valueText = {
-                            when (it) {
-                                LyricsBackgroundStyle.DEFAULT -> stringResource(R.string.lyrics_background_default)
-                                LyricsBackgroundStyle.FOLLOW_THEME -> stringResource(R.string.follow_theme)
-                                LyricsBackgroundStyle.COLORING -> stringResource(R.string.coloring)
-                                LyricsBackgroundStyle.CUSTOM -> stringResource(R.string.custom)
-                            }
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("lyrics_background_style")) {
+                        ListPreference(
+                            title = { Text(stringResource(R.string.lyrics_background_style)) },
+                            icon = { Icon(painterResource(R.drawable.lyrics), null) },
+                            selectedValue = lyricsBackground,
+                            values = availableLyricsBackgroundStyles,
+                            onValueSelected = onLyricsBackgroundChange,
+                            isEnabled = playerBackground != PlayerBackgroundStyle.CUSTOM,
+                            valueText = {
+                                when (it) {
+                                    LyricsBackgroundStyle.DEFAULT -> stringResource(R.string.lyrics_background_default)
+                                    LyricsBackgroundStyle.FOLLOW_THEME -> stringResource(R.string.follow_theme)
+                                    LyricsBackgroundStyle.COLORING -> stringResource(R.string.coloring)
+                                    LyricsBackgroundStyle.CUSTOM -> stringResource(R.string.custom)
+                                }
+                            },
+                        )
+                    }
                 }
 
                 item(visible = playerBackground == PlayerBackgroundStyle.CUSTOM) {
@@ -758,20 +776,22 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    EnumListPreference(
-                        title = { Text(stringResource(R.string.mini_player_background_style)) },
-                        icon = { Icon(painterResource(R.drawable.gradient), null) },
-                        selectedValue = miniPlayerBackground,
-                        onValueSelected = onMiniPlayerBackgroundChange,
-                        valueText = {
-                            when (it) {
-                                MiniPlayerBackgroundStyle.THEME -> stringResource(R.string.follow_theme)
-                                MiniPlayerBackgroundStyle.GRADIENT -> stringResource(R.string.gradient)
-                                MiniPlayerBackgroundStyle.GLOW -> stringResource(R.string.glow)
-                                MiniPlayerBackgroundStyle.FROSTED -> stringResource(R.string.frosted_blur)
-                            }
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("mini_player_background_style")) {
+                        EnumListPreference(
+                            title = { Text(stringResource(R.string.mini_player_background_style)) },
+                            icon = { Icon(painterResource(R.drawable.gradient), null) },
+                            selectedValue = miniPlayerBackground,
+                            onValueSelected = onMiniPlayerBackgroundChange,
+                            valueText = {
+                                when (it) {
+                                    MiniPlayerBackgroundStyle.THEME -> stringResource(R.string.follow_theme)
+                                    MiniPlayerBackgroundStyle.GRADIENT -> stringResource(R.string.gradient)
+                                    MiniPlayerBackgroundStyle.GLOW -> stringResource(R.string.glow)
+                                    MiniPlayerBackgroundStyle.FROSTED -> stringResource(R.string.frosted_blur)
+                                }
+                            },
+                        )
+                    }
                 }
 
                 item {
@@ -810,37 +830,41 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    EnumListPreference(
-                        title = { Text(stringResource(R.string.player_buttons_style)) },
-                        description =
-                            if (isPlayerStyleCustomizationEnabled) {
-                                null
-                            } else {
-                                stringResource(R.string.player_background_style_v8_v9_desc)
+                    Column(modifier = positions.modifierFor("player_buttons_style")) {
+                        EnumListPreference(
+                            title = { Text(stringResource(R.string.player_buttons_style)) },
+                            description =
+                                if (isPlayerStyleCustomizationEnabled) {
+                                    null
+                                } else {
+                                    stringResource(R.string.player_background_style_v8_v9_desc)
+                                },
+                            icon = { Icon(painterResource(R.drawable.palette), null) },
+                            selectedValue = playerButtonsStyle,
+                            onValueSelected = onPlayerButtonsStyleChange,
+                            isEnabled = isPlayerStyleCustomizationEnabled,
+                            valueText = {
+                                when (it) {
+                                    PlayerButtonsStyle.DEFAULT -> stringResource(R.string.default_style)
+                                    PlayerButtonsStyle.SECONDARY -> stringResource(R.string.secondary_color_style)
+                                }
                             },
-                        icon = { Icon(painterResource(R.drawable.palette), null) },
-                        selectedValue = playerButtonsStyle,
-                        onValueSelected = onPlayerButtonsStyleChange,
-                        isEnabled = isPlayerStyleCustomizationEnabled,
-                        valueText = {
-                            when (it) {
-                                PlayerButtonsStyle.DEFAULT -> stringResource(R.string.default_style)
-                                PlayerButtonsStyle.SECONDARY -> stringResource(R.string.secondary_color_style)
-                            }
-                        },
-                    )
+                        )
+                    }
                 }
 
                 item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.player_slider_style)) },
-                        description = sliderStyleLabel(sliderStyle),
-                        icon = { Icon(painterResource(R.drawable.sliders), null) },
-                        onClick = {
-                            showSliderOptionDialog = true
-                        },
-                        isEnabled = isPlayerStyleCustomizationEnabled,
-                    )
+                    Column(modifier = positions.modifierFor("player_slider_style")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.player_slider_style)) },
+                            description = sliderStyleLabel(sliderStyle),
+                            icon = { Icon(painterResource(R.drawable.sliders), null) },
+                            onClick = {
+                                showSliderOptionDialog = true
+                            },
+                            isEnabled = isPlayerStyleCustomizationEnabled,
+                        )
+                    }
                 }
 
                 item {
@@ -921,12 +945,14 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         }
                     }
 
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.swipe_sensitivity)) },
-                        description = stringResource(R.string.sensitivity_percentage, (swipeSensitivity * 100).roundToInt()),
-                        icon = { Icon(painterResource(R.drawable.tune), null) },
-                        onClick = { showSensitivityDialog = true },
-                    )
+                    Column(modifier = positions.modifierFor("swipe_sensitivity")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.swipe_sensitivity)) },
+                            description = stringResource(R.string.sensitivity_percentage, (swipeSensitivity * 100).roundToInt()),
+                            icon = { Icon(painterResource(R.drawable.tune), null) },
+                            onClick = { showSensitivityDialog = true },
+                        )
+                    }
                 }
             }
 
@@ -950,20 +976,22 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    EnumListPreference(
-                        title = { Text(stringResource(R.string.navigation_bar_style)) },
-                        icon = { Icon(painterResource(R.drawable.nav_bar), null) },
-                        selectedValue = navigationBarStyle,
-                        onValueSelected = onNavigationBarStyleChange,
-                        valueText = {
-                            when (it) {
-                                NavigationBarStyle.DEFAULT ->
-                                    stringResource(R.string.navigation_bar_style_default)
-                                NavigationBarStyle.FLOATING ->
-                                    stringResource(R.string.navigation_bar_style_floating)
-                            }
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("navigation_bar_style")) {
+                        EnumListPreference(
+                            title = { Text(stringResource(R.string.navigation_bar_style)) },
+                            icon = { Icon(painterResource(R.drawable.nav_bar), null) },
+                            selectedValue = navigationBarStyle,
+                            onValueSelected = onNavigationBarStyleChange,
+                            valueText = {
+                                when (it) {
+                                    NavigationBarStyle.DEFAULT ->
+                                        stringResource(R.string.navigation_bar_style_default)
+                                    NavigationBarStyle.FLOATING ->
+                                        stringResource(R.string.navigation_bar_style_floating)
+                                }
+                            },
+                        )
+                    }
                 }
 
                 item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -270,12 +270,16 @@ fun BackupAndRestore(
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
             val scheduledBackupData =
@@ -307,9 +311,13 @@ fun BackupAndRestore(
                 onFrequencySelected = viewModel::onScheduledBackupFrequencySelected,
                 onDirectoryClick = { backupDirectoryLauncher.launch(null) },
                 onOverwriteChanged = viewModel::onScheduledBackupOverwriteChanged,
+                positions = positions,
             )
 
-            PreferenceGroup(title = stringResource(R.string.internal_service)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("backup"),
+                title = stringResource(R.string.internal_service),
+            ) {
                 item {
                     PreferenceEntry(
                         title = { Text(stringResource(R.string.action_backup)) },
@@ -347,7 +355,10 @@ fun BackupAndRestore(
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.external_service)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("restore"),
+                title = stringResource(R.string.external_service),
+            ) {
                 spotifyAccountPreferences(
                     state = spotifyState,
                     showPlaylists = showSpotifyPlaylists,
@@ -482,8 +493,12 @@ private fun ScheduledBackupSection(
     onFrequencySelected: (ScheduledBackupFrequency) -> Unit,
     onDirectoryClick: () -> Unit,
     onOverwriteChanged: (Boolean) -> Unit,
+    positions: PreferencePositions,
 ) {
-    PreferenceGroup(title = stringResource(R.string.scheduled_backup)) {
+    PreferenceGroup(
+        modifier = positions.modifierFor("scheduled_backup"),
+        title = stringResource(R.string.scheduled_backup),
+    ) {
         item {
             SwitchPreference(
                 title = { Text(stringResource(R.string.scheduled_backup_enabled)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
@@ -98,13 +98,21 @@ fun ContentSettings(
     val (lengthTop, onLengthTopChange) = rememberPreference(key = TopSize, defaultValue = "50")
     val (quickPicks, onQuickPicksChange) = rememberEnumPreference(key = QuickPicksKey, defaultValue = QuickPicks.QUICK_PICKS)
 
+    val scrollState = rememberScrollState()
+    val positions = rememberPreferencePositions()
+
+    LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
+
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
-        PreferenceGroup(title = stringResource(R.string.general)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("content_language"),
+            title = stringResource(R.string.general),
+        ) {
             item {
                 ListPreference(
                     title = { Text(stringResource(R.string.content_language)) },
@@ -216,7 +224,10 @@ fun ContentSettings(
             onOpenSource = viewModel::openAiContentFilterSource,
         )
 
-        PreferenceGroup(title = stringResource(R.string.app_language)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("app_language"),
+            title = stringResource(R.string.app_language),
+        ) {
             item {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     PreferenceEntry(
@@ -255,7 +266,10 @@ fun ContentSettings(
             }
         }
 
-        PreferenceGroup(title = stringResource(R.string.misc)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("quick_picks"),
+            title = stringResource(R.string.misc),
+        ) {
             item {
                 EditTextPreference(
                     title = { Text(stringResource(R.string.top_length)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
@@ -17,9 +17,10 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -439,7 +440,12 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
             )
         },
     ) { innerPadding ->
-        LazyColumn(
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
+
+        Column(
             modifier =
                 Modifier
                     .fillMaxSize()
@@ -447,255 +453,258 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
                         LocalPlayerAwareWindowInsets.current.only(
                             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                         ),
+                    )
+                    .verticalScroll(scrollState)
+                    .padding(
+                        top = innerPadding.calculateTopPadding() + 16.dp,
+                        bottom = 32.dp,
                     ),
-            contentPadding =
-                PaddingValues(
-                    top = innerPadding.calculateTopPadding() + 16.dp,
-                    bottom = 32.dp,
-                ),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            item {
-                PreferenceGroup(title = stringResource(R.string.account)) {
-                    item {
-                        DiscordAccountGroupCard(
-                            displayName = accountDisplayName,
-                            username = activeDiscordUsername,
-                            avatarUrl = activeDiscordAvatarUrl.takeIf { it.isNotBlank() },
-                            isLoggedIn = isLoggedIn,
-                            authorizationUiMode = authorizationUiMode,
-                            authorizationMessage = authorizationMessage,
-                            isAccessTokenExpired = isAccessTokenExpired,
-                            discordRpcEnabled = discordRPC,
-                            onDiscordRpcEnabledChange = onDiscordRPCChange,
-                            onReauthorize = launchAuthorization,
-                            onPrimaryAction = {
-                                if (isLoggedIn) {
-                                    showLogoutConfirm = true
-                                } else {
-                                    launchAuthorization()
+            PreferenceGroup(
+                modifier = positions.modifierFor("discord_account"),
+                title = stringResource(R.string.account),
+            ) {
+                item {
+                    DiscordAccountGroupCard(
+                        displayName = accountDisplayName,
+                        username = activeDiscordUsername,
+                        avatarUrl = activeDiscordAvatarUrl.takeIf { it.isNotBlank() },
+                        isLoggedIn = isLoggedIn,
+                        authorizationUiMode = authorizationUiMode,
+                        authorizationMessage = authorizationMessage,
+                        isAccessTokenExpired = isAccessTokenExpired,
+                        discordRpcEnabled = discordRPC,
+                        onDiscordRpcEnabledChange = onDiscordRPCChange,
+                        onReauthorize = launchAuthorization,
+                        onPrimaryAction = {
+                            if (isLoggedIn) {
+                                showLogoutConfirm = true
+                            } else {
+                                launchAuthorization()
+                            }
+                        },
+                        primaryActionEnabled = authorizationUiMode != DiscordAuthorizationUiMode.Waiting,
+                    )
+                }
+            }
+
+            PreferenceGroup(
+                modifier = positions.modifierFor("discord_options"),
+                title = stringResource(R.string.options),
+            ) {
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.refresh)) },
+                        description = stringResource(R.string.description_refresh),
+                        icon = { Icon(painterResource(R.drawable.update), null) },
+                        isEnabled = discordRPC && isLoggedIn,
+                        trailingContent = {
+                            if (isRefreshing) {
+                                CircularWavyProgressIndicator(
+                                    modifier = Modifier.size(28.dp),
+                                )
+                            } else {
+                                OutlinedButton(
+                                    enabled = discordRPC && isLoggedIn,
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            isRefreshing = true
+                                            val success =
+                                                playerConnection.service.refreshDiscordNow()
+                                            isRefreshing = false
+                                            snackbarHostState.showSnackbar(
+                                                message =
+                                                    if (success) {
+                                                        context.getString(R.string.discord_refresh_success)
+                                                    } else {
+                                                        context.getString(R.string.discord_refresh_failed)
+                                                    },
+                                            )
+                                        }
+                                    },
+                                    shapes = ButtonDefaults.shapes(),
+                                ) {
+                                    Text(stringResource(R.string.refresh))
                                 }
-                            },
-                            primaryActionEnabled = authorizationUiMode != DiscordAuthorizationUiMode.Waiting,
-                        )
-                    }
+                            }
+                        },
+                    )
                 }
             }
 
-            item {
-                PreferenceGroup(title = stringResource(R.string.options)) {
-                    item {
-                        PreferenceEntry(
-                            title = { Text(stringResource(R.string.refresh)) },
-                            description = stringResource(R.string.description_refresh),
-                            icon = { Icon(painterResource(R.drawable.update), null) },
-                            isEnabled = discordRPC && isLoggedIn,
-                            trailingContent = {
-                                if (isRefreshing) {
-                                    CircularWavyProgressIndicator(
-                                        modifier = Modifier.size(28.dp),
-                                    )
-                                } else {
-                                    OutlinedButton(
-                                        enabled = discordRPC && isLoggedIn,
-                                        onClick = {
-                                            coroutineScope.launch {
-                                                isRefreshing = true
-                                                val success =
-                                                    playerConnection.service.refreshDiscordNow()
-                                                isRefreshing = false
-                                                snackbarHostState.showSnackbar(
-                                                    message =
-                                                        if (success) {
-                                                            context.getString(R.string.discord_refresh_success)
-                                                        } else {
-                                                            context.getString(R.string.discord_refresh_failed)
-                                                        },
-                                                )
-                                            }
-                                        },
-                                        shapes = ButtonDefaults.shapes(),
-                                    ) {
-                                        Text(stringResource(R.string.refresh))
-                                    }
-                                }
-                            },
-                        )
-                    }
+            PreferenceGroup(
+                modifier = positions.modifierFor("discord_connection"),
+                title = stringResource(R.string.discord_connection_settings),
+            ) {
+                item {
+                    ListPreference(
+                        title = { Text(stringResource(R.string.activity_status)) },
+                        icon = { Icon(painterResource(R.drawable.status), null) },
+                        selectedValue = activityStatusSelection,
+                        values = DiscordActivityStatusOptions,
+                        valueText = { discordPresenceStatusLabel(it) },
+                        onValueSelected = onActivityStatusSelectionChange,
+                    )
+                }
+
+                item {
+                    ListPreference(
+                        title = { Text(stringResource(R.string.platform_status)) },
+                        icon = { Icon(painterResource(R.drawable.desktop_windows), null) },
+                        selectedValue = platformSelection,
+                        values = DiscordPlatformOptions,
+                        valueText = { discordPlatformLabel(it) },
+                        onValueSelected = onPlatformSelectionChange,
+                    )
                 }
             }
 
-            item {
-                PreferenceGroup(title = stringResource(R.string.discord_connection_settings)) {
-                    item {
-                        ListPreference(
-                            title = { Text(stringResource(R.string.activity_status)) },
-                            icon = { Icon(painterResource(R.drawable.status), null) },
-                            selectedValue = activityStatusSelection,
-                            values = DiscordActivityStatusOptions,
-                            valueText = { discordPresenceStatusLabel(it) },
-                            onValueSelected = onActivityStatusSelectionChange,
-                        )
-                    }
+            PreferenceGroup(
+                modifier = positions.modifierFor("discord_activity"),
+                title = stringResource(R.string.discord_activity_content),
+            ) {
+                item {
+                    EnumListPreference(
+                        title = { Text(stringResource(R.string.discord_activity_name)) },
+                        selectedValue = nameSource,
+                        onValueSelected = onNameSourceChange,
+                        valueText = { activitySourceLabel(it) },
+                        icon = { Icon(painterResource(R.drawable.text_fields), null) },
+                    )
+                }
+                item {
+                    EnumListPreference(
+                        title = { Text(stringResource(R.string.discord_activity_details)) },
+                        selectedValue = detailsSource,
+                        onValueSelected = onDetailsSourceChange,
+                        valueText = { activitySourceLabel(it) },
+                        icon = { Icon(painterResource(R.drawable.text_fields), null) },
+                    )
+                }
+                item {
+                    EnumListPreference(
+                        title = { Text(stringResource(R.string.discord_activity_state)) },
+                        selectedValue = stateSource,
+                        onValueSelected = onStateSourceChange,
+                        valueText = { activitySourceLabel(it) },
+                        icon = { Icon(painterResource(R.drawable.text_fields), null) },
+                    )
+                }
 
-                    item {
-                        ListPreference(
-                            title = { Text(stringResource(R.string.platform_status)) },
-                            icon = { Icon(painterResource(R.drawable.desktop_windows), null) },
-                            selectedValue = platformSelection,
-                            values = DiscordPlatformOptions,
-                            valueText = { discordPlatformLabel(it) },
-                            onValueSelected = onPlatformSelectionChange,
-                        )
-                    }
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.discord_show_when_paused)) },
+                        description = stringResource(R.string.discord_show_when_paused_desc),
+                        icon = { Icon(painterResource(R.drawable.ic_pause_white), null) },
+                        checked = showWhenPaused,
+                        onCheckedChange = { showWhenPaused = it },
+                    )
+                }
+
+                item {
+                    ListPreference(
+                        title = { Text(stringResource(R.string.discord_activity_type)) },
+                        icon = { Icon(painterResource(R.drawable.discord), null) },
+                        selectedValue = activityType,
+                        values = DiscordActivityTypeOptions,
+                        valueText = { discordActivityTypeLabel(it) },
+                        onValueSelected = onActivityTypeChange,
+                    )
                 }
             }
 
-            item {
-                PreferenceGroup(title = stringResource(R.string.discord_activity_content)) {
-                    item {
-                        EnumListPreference(
-                            title = { Text(stringResource(R.string.discord_activity_name)) },
-                            selectedValue = nameSource,
-                            onValueSelected = onNameSourceChange,
-                            valueText = { activitySourceLabel(it) },
-                            icon = { Icon(painterResource(R.drawable.text_fields), null) },
-                        )
-                    }
-                    item {
-                        EnumListPreference(
-                            title = { Text(stringResource(R.string.discord_activity_details)) },
-                            selectedValue = detailsSource,
-                            onValueSelected = onDetailsSourceChange,
-                            valueText = { activitySourceLabel(it) },
-                            icon = { Icon(painterResource(R.drawable.text_fields), null) },
-                        )
-                    }
-                    item {
-                        EnumListPreference(
-                            title = { Text(stringResource(R.string.discord_activity_state)) },
-                            selectedValue = stateSource,
-                            onValueSelected = onStateSourceChange,
-                            valueText = { activitySourceLabel(it) },
-                            icon = { Icon(painterResource(R.drawable.text_fields), null) },
-                        )
-                    }
+            PreferenceGroup(
+                modifier = positions.modifierFor("discord_images"),
+                title = stringResource(R.string.discord_image_options),
+            ) {
+                item {
+                    ListPreference(
+                        title = { Text(stringResource(R.string.large_image)) },
+                        icon = { Icon(painterResource(R.drawable.image), null) },
+                        selectedValue = largeImageType,
+                        values = DiscordImageOptions,
+                        valueText = { discordImageTypeLabel(it) },
+                        onValueSelected = onLargeImageTypeChange,
+                    )
+                }
 
-                    item {
-                        SwitchPreference(
-                            title = { Text(stringResource(R.string.discord_show_when_paused)) },
-                            description = stringResource(R.string.discord_show_when_paused_desc),
-                            icon = { Icon(painterResource(R.drawable.ic_pause_white), null) },
-                            checked = showWhenPaused,
-                            onCheckedChange = { showWhenPaused = it },
-                        )
-                    }
+                item(visible = largeImageType == "custom") {
+                    EditTextPreference(
+                        title = { Text(stringResource(R.string.large_image_custom_url)) },
+                        icon = { Icon(painterResource(R.drawable.link), null) },
+                        value = largeImageCustomUrl,
+                        onValueChange = onLargeImageCustomUrlChange,
+                        isInputValid = { true },
+                    )
+                }
 
-                    item {
-                        ListPreference(
-                            title = { Text(stringResource(R.string.discord_activity_type)) },
-                            icon = { Icon(painterResource(R.drawable.discord), null) },
-                            selectedValue = activityType,
-                            values = DiscordActivityTypeOptions,
-                            valueText = { discordActivityTypeLabel(it) },
-                            onValueSelected = onActivityTypeChange,
-                        )
-                    }
+                item {
+                    ListPreference(
+                        title = { Text(stringResource(R.string.large_text)) },
+                        icon = { Icon(painterResource(R.drawable.text_fields), null) },
+                        selectedValue = largeTextSource,
+                        values = DiscordLargeTextOptions,
+                        valueText = { discordLargeTextSourceLabel(it) },
+                        onValueSelected = onLargeTextSourceChange,
+                    )
+                }
+
+                item(visible = largeTextSource == "custom") {
+                    EditTextPreference(
+                        title = { Text(stringResource(R.string.custom_large_text)) },
+                        icon = { Icon(painterResource(R.drawable.text_fields), null) },
+                        value = largeTextCustom,
+                        onValueChange = onLargeTextCustomChange,
+                        isInputValid = { true },
+                    )
+                }
+
+                item {
+                    ListPreference(
+                        title = { Text(stringResource(R.string.small_image)) },
+                        icon = { Icon(painterResource(R.drawable.image), null) },
+                        selectedValue = smallImageType,
+                        values = DiscordSmallImageOptions,
+                        valueText = { discordImageTypeLabel(it) },
+                        onValueSelected = onSmallImageTypeChange,
+                    )
+                }
+
+                item(visible = smallImageType == "custom") {
+                    EditTextPreference(
+                        title = { Text(stringResource(R.string.small_image_custom_url)) },
+                        icon = { Icon(painterResource(R.drawable.link), null) },
+                        value = smallImageCustomUrl,
+                        onValueChange = onSmallImageCustomUrlChange,
+                        isInputValid = { true },
+                    )
                 }
             }
 
-            item {
-                PreferenceGroup(title = stringResource(R.string.discord_image_options)) {
-                    item {
-                        ListPreference(
-                            title = { Text(stringResource(R.string.large_image)) },
-                            icon = { Icon(painterResource(R.drawable.image), null) },
-                            selectedValue = largeImageType,
-                            values = DiscordImageOptions,
-                            valueText = { discordImageTypeLabel(it) },
-                            onValueSelected = onLargeImageTypeChange,
-                        )
-                    }
-
-                    item(visible = largeImageType == "custom") {
-                        EditTextPreference(
-                            title = { Text(stringResource(R.string.large_image_custom_url)) },
-                            icon = { Icon(painterResource(R.drawable.link), null) },
-                            value = largeImageCustomUrl,
-                            onValueChange = onLargeImageCustomUrlChange,
-                            isInputValid = { true },
-                        )
-                    }
-
-                    item {
-                        ListPreference(
-                            title = { Text(stringResource(R.string.large_text)) },
-                            icon = { Icon(painterResource(R.drawable.text_fields), null) },
-                            selectedValue = largeTextSource,
-                            values = DiscordLargeTextOptions,
-                            valueText = { discordLargeTextSourceLabel(it) },
-                            onValueSelected = onLargeTextSourceChange,
-                        )
-                    }
-
-                    item(visible = largeTextSource == "custom") {
-                        EditTextPreference(
-                            title = { Text(stringResource(R.string.custom_large_text)) },
-                            icon = { Icon(painterResource(R.drawable.text_fields), null) },
-                            value = largeTextCustom,
-                            onValueChange = onLargeTextCustomChange,
-                            isInputValid = { true },
-                        )
-                    }
-
-                    item {
-                        ListPreference(
-                            title = { Text(stringResource(R.string.small_image)) },
-                            icon = { Icon(painterResource(R.drawable.image), null) },
-                            selectedValue = smallImageType,
-                            values = DiscordSmallImageOptions,
-                            valueText = { discordImageTypeLabel(it) },
-                            onValueSelected = onSmallImageTypeChange,
-                        )
-                    }
-
-                    item(visible = smallImageType == "custom") {
-                        EditTextPreference(
-                            title = { Text(stringResource(R.string.small_image_custom_url)) },
-                            icon = { Icon(painterResource(R.drawable.link), null) },
-                            value = smallImageCustomUrl,
-                            onValueChange = onSmallImageCustomUrlChange,
-                            isInputValid = { true },
-                        )
-                    }
-                }
-            }
-
-            item {
-                RichPresence(
-                    song = song,
-                    currentPlaybackTimeMillis = playerConnection.player.currentPosition,
-                    nameSource = nameSource,
-                    detailsSource = detailsSource,
-                    stateSource = stateSource,
-                    activityType = activityType,
-                    largeImageType = largeImageType,
-                    largeImageCustomUrl = largeImageCustomUrl,
-                    largeTextSource = largeTextSource,
-                    largeTextCustom = largeTextCustom,
-                    smallImageType = smallImageType,
-                    smallImageCustomUrl = smallImageCustomUrl,
-                    button1Label = button1Label,
-                    button1Enabled = button1Enabled,
-                    button1UrlSource = button1UrlSource,
-                    button1CustomUrl = button1CustomUrl,
-                    button2Label = button2Label,
-                    button2Enabled = button2Enabled,
-                    button2UrlSource = button2UrlSource,
-                    button2CustomUrl = button2CustomUrl,
-                    isPlaying = playerConnection.player.isPlaying,
-                )
-            }
+            RichPresence(
+                song = song,
+                currentPlaybackTimeMillis = playerConnection.player.currentPosition,
+                nameSource = nameSource,
+                detailsSource = detailsSource,
+                stateSource = stateSource,
+                activityType = activityType,
+                largeImageType = largeImageType,
+                largeImageCustomUrl = largeImageCustomUrl,
+                largeTextSource = largeTextSource,
+                largeTextCustom = largeTextCustom,
+                smallImageType = smallImageType,
+                smallImageCustomUrl = smallImageCustomUrl,
+                button1Label = button1Label,
+                button1Enabled = button1Enabled,
+                button1UrlSource = button1UrlSource,
+                button1CustomUrl = button1CustomUrl,
+                button2Label = button2Label,
+                button2Enabled = button2Enabled,
+                button2UrlSource = button2UrlSource,
+                button2CustomUrl = button2CustomUrl,
+                isPlaying = playerConnection.player.isPlaying,
+            )
         }
 
         if (showLogoutConfirm) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -71,21 +72,31 @@ fun IntegrationScreen(navController: NavController, scrollTo: String? = null) {
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
-            PreferenceGroup(title = stringResource(R.string.integration_accounts)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("lastfm_scrobbling"),
+                title = stringResource(R.string.integration_accounts),
+            ) {
                 item {
                     IntegrationAccountCards(navController = navController)
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.general)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("discord_presence"),
+                title = stringResource(R.string.general),
+            ) {
                 item {
                     PreferenceEntry(
                         title = { Text(stringResource(R.string.discord_integration)) },
@@ -98,7 +109,10 @@ fun IntegrationScreen(navController: NavController, scrollTo: String? = null) {
             }
 
             if (manualSourceLogin) {
-                PreferenceGroup(title = stringResource(R.string.music_sources)) {
+                PreferenceGroup(
+                    modifier = positions.modifierFor("music_sources"),
+                    title = stringResource(R.string.music_sources),
+                ) {
                     item {
                         PreferenceEntry(
                             title = { Text(stringResource(R.string.tidal_integration)) },
@@ -123,7 +137,10 @@ fun IntegrationScreen(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.scrobbling)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("listenbrainz"),
+                title = stringResource(R.string.scrobbling),
+            ) {
                 item {
                     PreferenceEntry(
                         title = { Text(stringResource(R.string.lastfm_integration)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -192,17 +193,24 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
             InternetWarningBox()
 
-            PreferenceGroup(title = stringResource(R.string.dns_over_https)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("enable_tor"),
+                title = stringResource(R.string.dns_over_https),
+            ) {
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.dns_over_https)) },
@@ -233,7 +241,10 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.proxy)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("proxy_settings"),
+                title = stringResource(R.string.proxy),
+            ) {
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.enable_proxy)) },
@@ -385,7 +396,10 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.ip_rotation)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("download_speed_limit"),
+                title = stringResource(R.string.ip_rotation),
+            ) {
                 item {
                     IpRotationPreference(
                         title = { Text(stringResource(R.string.ip_rotation)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -76,6 +77,7 @@ import kotlin.math.roundToInt
 @Composable
 fun LastFMSettings(
     navController: NavController,
+    scrollTo: String? = null,
     viewModel: LastFmSettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -103,6 +105,7 @@ fun LastFMSettings(
         LastFmSettingsContent(
             state = state,
             topPadding = topPadding,
+            scrollTo = scrollTo,
             onOpenServiceEditor = viewModel::openServiceEditor,
             onDismissServiceEditor = viewModel::dismissServiceEditor,
             onServiceProviderChange = viewModel::updateServiceProvider,
@@ -132,6 +135,7 @@ fun LastFMSettings(
 private fun LastFmSettingsContent(
     state: LastFmSettingsScreenState,
     topPadding: Dp,
+    scrollTo: String? = null,
     onOpenServiceEditor: () -> Unit,
     onDismissServiceEditor: () -> Unit,
     onServiceProviderChange: (LastFmProvider) -> Unit,
@@ -154,11 +158,16 @@ private fun LastFmSettingsContent(
     onTimingDelaySecondsChange: (Int) -> Unit,
     onSaveTimingEditor: () -> Unit,
 ) {
+    val scrollState = rememberScrollState()
+    val positions = rememberPreferencePositions()
+
+    LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
+
     Column(
         Modifier
             .padding(top = topPadding)
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         when (state) {
@@ -177,6 +186,7 @@ private fun LastFmSettingsContent(
             is LastFmSettingsScreenState.Success -> {
                 LastFmSettingsSuccess(
                     model = state.model,
+                    positions = positions,
                     onOpenServiceEditor = onOpenServiceEditor,
                     onOpenLoginDialog = onOpenLoginDialog,
                     onLogout = onLogout,
@@ -252,6 +262,7 @@ private fun LastFmSettingsError(
 @Composable
 private fun LastFmSettingsSuccess(
     model: LastFmSettingsUiModel,
+    positions: PreferencePositions,
     onOpenServiceEditor: () -> Unit,
     onOpenLoginDialog: () -> Unit,
     onLogout: () -> Unit,
@@ -267,7 +278,10 @@ private fun LastFmSettingsSuccess(
             stringResource(R.string.lastfm_endpoint_invalid)
         }
 
-    PreferenceGroup(title = stringResource(R.string.lastfm_service)) {
+    PreferenceGroup(
+        modifier = positions.modifierFor("lastfm_service"),
+        title = stringResource(R.string.lastfm_service),
+    ) {
         item {
             PreferenceEntry(
                 title = { Text(stringResource(R.string.lastfm_service_provider)) },
@@ -292,7 +306,10 @@ private fun LastFmSettingsSuccess(
         }
     }
 
-    PreferenceGroup(title = stringResource(R.string.account)) {
+    PreferenceGroup(
+        modifier = positions.modifierFor("lastfm_account"),
+        title = stringResource(R.string.account),
+    ) {
         item {
             PreferenceEntry(
                 title = {
@@ -322,7 +339,10 @@ private fun LastFmSettingsSuccess(
         }
     }
 
-    PreferenceGroup(title = stringResource(R.string.options)) {
+    PreferenceGroup(
+        modifier = positions.modifierFor("lastfm_options"),
+        title = stringResource(R.string.options),
+    ) {
         item {
             SwitchPreference(
                 title = { Text(stringResource(R.string.enable_scrobbling)) },
@@ -342,7 +362,10 @@ private fun LastFmSettingsSuccess(
         }
     }
 
-    PreferenceGroup(title = stringResource(R.string.scrobbling_configuration)) {
+    PreferenceGroup(
+        modifier = positions.modifierFor("lastfm_scrobbling_config"),
+        title = stringResource(R.string.scrobbling_configuration),
+    ) {
         item {
             PreferenceEntry(
                 title = { Text(stringResource(R.string.scrobble_min_track_duration)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -235,10 +235,15 @@ fun LyricsSettings(
         )
     }
 
+    val scrollState = rememberScrollState()
+    val positions = rememberPreferencePositions()
+
+    LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
+
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         var showLyricsTextSizeDialog by rememberSaveable { mutableStateOf(false) }
@@ -375,7 +380,10 @@ fun LyricsSettings(
             }
         }
 
-        PreferenceGroup(title = stringResource(R.string.display)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("lyrics_font_size"),
+            title = stringResource(R.string.display),
+        ) {
             item {
                 EnumListPreference(
                     title = { Text(stringResource(R.string.lyrics_mode)) },
@@ -449,7 +457,10 @@ fun LyricsSettings(
             }
         }
 
-        PreferenceGroup(title = stringResource(R.string.providers)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("lyrics_provider"),
+            title = stringResource(R.string.providers),
+        ) {
             item {
                 SwitchPreference(
                     title = { Text(stringResource(R.string.enable_betterlyrics)) },
@@ -594,7 +605,10 @@ fun LyricsSettings(
             }
         }
 
-        PreferenceGroup(title = stringResource(R.string.romanization)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("lyrics_romanize"),
+            title = stringResource(R.string.romanization),
+        ) {
             item {
                 SwitchPreference(
                     title = { Text(stringResource(R.string.lyrics_romanize_japanese)) },
@@ -648,7 +662,10 @@ fun LyricsSettings(
             }
         }
 
-        PreferenceGroup(title = stringResource(R.string.queue)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("lyrics_preload"),
+            title = stringResource(R.string.queue),
+        ) {
             item {
                 SwitchPreference(
                     title = { Text(stringResource(R.string.preload_queue_lyrics)) },
@@ -671,7 +688,10 @@ fun LyricsSettings(
             }
         }
 
-        PreferenceGroup(title = stringResource(R.string.cache)) {
+        PreferenceGroup(
+            modifier = positions.modifierFor("lyrics_cache_size"),
+            title = stringResource(R.string.cache),
+        ) {
             item {
                 PreferenceEntry(
                     title = { Text(stringResource(R.string.clear_lyrics_cache)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -296,27 +296,31 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    SliderPreference(
-                        title = { Text(stringResource(R.string.history_duration)) },
-                        icon = { Icon(painterResource(R.drawable.history), null) },
-                        value = historyDuration,
-                        onValueChange = onHistoryDurationChange,
-                    )
+                    Column(modifier = positions.modifierFor("history_duration")) {
+                        SliderPreference(
+                            title = { Text(stringResource(R.string.history_duration)) },
+                            icon = { Icon(painterResource(R.drawable.history), null) },
+                            value = historyDuration,
+                            onValueChange = onHistoryDurationChange,
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.audio_crossfade_title)) },
-                        description = stringResource(R.string.audio_crossfade_description),
-                        icon = { Icon(painterResource(R.drawable.animation), null) },
-                        checked = crossfadeEnabled,
-                        onCheckedChange = { enabled ->
-                            if (enabled) {
-                                onAudioOffloadChange(false)
-                            }
-                            onCrossfadeEnabledChange(enabled)
-                        },
-                    )
+                    Column(modifier = positions.modifierFor("crossfade")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.audio_crossfade_title)) },
+                            description = stringResource(R.string.audio_crossfade_description),
+                            icon = { Icon(painterResource(R.drawable.animation), null) },
+                            checked = crossfadeEnabled,
+                            onCheckedChange = { enabled ->
+                                if (enabled) {
+                                    onAudioOffloadChange(false)
+                                }
+                                onCrossfadeEnabledChange(enabled)
+                            },
+                        )
+                    }
                 }
 
                 item {
@@ -328,33 +332,39 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.crossfade_gapless_title)) },
-                        description = stringResource(R.string.crossfade_gapless_description),
-                        icon = { Icon(painterResource(R.drawable.fast_forward), null) },
-                        checked = crossfadeGapless,
-                        onCheckedChange = onCrossfadeGaplessChange,
-                        isEnabled = crossfadeEnabled,
-                    )
+                    Column(modifier = positions.modifierFor("crossfade_gapless")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.crossfade_gapless_title)) },
+                            description = stringResource(R.string.crossfade_gapless_description),
+                            icon = { Icon(painterResource(R.drawable.fast_forward), null) },
+                            checked = crossfadeGapless,
+                            onCheckedChange = onCrossfadeGaplessChange,
+                            isEnabled = crossfadeEnabled,
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.skip_silence)) },
-                        icon = { Icon(painterResource(R.drawable.fast_forward), null) },
-                        checked = skipSilence,
-                        onCheckedChange = onSkipSilenceChange,
-                        isEnabled = !audioOffload,
-                    )
+                    Column(modifier = positions.modifierFor("skip_silence")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.skip_silence)) },
+                            icon = { Icon(painterResource(R.drawable.fast_forward), null) },
+                            checked = skipSilence,
+                            onCheckedChange = onSkipSilenceChange,
+                            isEnabled = !audioOffload,
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.audio_normalization)) },
-                        icon = { Icon(painterResource(R.drawable.volume_up), null) },
-                        checked = audioNormalization,
-                        onCheckedChange = onAudioNormalizationChange,
-                    )
+                    Column(modifier = positions.modifierFor("audio_normalization")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.audio_normalization)) },
+                            icon = { Icon(painterResource(R.drawable.volume_up), null) },
+                            checked = audioNormalization,
+                            onCheckedChange = onAudioNormalizationChange,
+                        )
+                    }
                 }
 
                 item {
@@ -374,23 +384,27 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.seek_seconds_addup)) },
-                        description = stringResource(R.string.seek_seconds_addup_description),
-                        icon = { Icon(painterResource(R.drawable.arrow_forward), null) },
-                        checked = seekExtraSeconds,
-                        onCheckedChange = onSeekExtraSeconds,
-                    )
+                    Column(modifier = positions.modifierFor("seek_seconds")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.seek_seconds_addup)) },
+                            description = stringResource(R.string.seek_seconds_addup_description),
+                            icon = { Icon(painterResource(R.drawable.arrow_forward), null) },
+                            checked = seekExtraSeconds,
+                            onCheckedChange = onSeekExtraSeconds,
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.pause_on_device_mute)) },
-                        description = stringResource(R.string.pause_on_device_mute_desc),
-                        icon = { Icon(painterResource(R.drawable.volume_off), null) },
-                        checked = pauseOnDeviceMute,
-                        onCheckedChange = onPauseOnDeviceMuteChange,
-                    )
+                    Column(modifier = positions.modifierFor("pause_mute")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.pause_on_device_mute)) },
+                            description = stringResource(R.string.pause_on_device_mute_desc),
+                            icon = { Icon(painterResource(R.drawable.volume_off), null) },
+                            checked = pauseOnDeviceMute,
+                            onCheckedChange = onPauseOnDeviceMuteChange,
+                        )
+                    }
                 }
 
                 item(visible = pauseOnDeviceMute) {
@@ -406,26 +420,30 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                                 }
                             }
                         }
-                    NumberPickerPreference(
-                        title = { Text(stringResource(R.string.device_mute_recovery_volume)) },
-                        icon = { Icon(painterResource(R.drawable.volume_up), null) },
-                        value = deviceMutePlaybackRecoveryVolume,
-                        onValueChange = onDeviceMutePlaybackRecoveryVolumeChange,
-                        minValue = 0,
-                        maxValue = 100,
-                        valueText = recoveryVolumeText,
-                        isEnabled = pauseOnDeviceMute,
-                    )
+                    Column(modifier = positions.modifierFor("device_mute_recovery_volume")) {
+                        NumberPickerPreference(
+                            title = { Text(stringResource(R.string.device_mute_recovery_volume)) },
+                            icon = { Icon(painterResource(R.drawable.volume_up), null) },
+                            value = deviceMutePlaybackRecoveryVolume,
+                            onValueChange = onDeviceMutePlaybackRecoveryVolumeChange,
+                            minValue = 0,
+                            maxValue = 100,
+                            valueText = recoveryVolumeText,
+                            isEnabled = pauseOnDeviceMute,
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.auto_start_on_bluetooth)) },
-                        description = stringResource(R.string.auto_start_on_bluetooth_desc),
-                        icon = { Icon(painterResource(R.drawable.bluetooth), null) },
-                        checked = autoStartOnBluetooth,
-                        onCheckedChange = onAutoStartOnBluetoothChange,
-                    )
+                    Column(modifier = positions.modifierFor("bluetooth_auto_start")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.auto_start_on_bluetooth)) },
+                            description = stringResource(R.string.auto_start_on_bluetooth_desc),
+                            icon = { Icon(painterResource(R.drawable.bluetooth), null) },
+                            checked = autoStartOnBluetooth,
+                            onCheckedChange = onAutoStartOnBluetoothChange,
+                        )
+                    }
                 }
             }
 
@@ -444,21 +462,23 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.tidal_artwork_fallback)) },
-                        description =
-                            stringResource(
-                                if (tidalEnabled) {
-                                    R.string.tidal_artwork_fallback_description
-                                } else {
-                                    R.string.tidal_artwork_fallback_unavailable
-                                },
-                            ),
-                        icon = { Icon(painterResource(R.drawable.image), null) },
-                        checked = tidalArtworkEnabled,
-                        onCheckedChange = onTidalArtworkEnabledChange,
-                        isEnabled = tidalEnabled,
-                    )
+                    Column(modifier = positions.modifierFor("tidal_artwork_fallback")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.tidal_artwork_fallback)) },
+                            description =
+                                stringResource(
+                                    if (tidalEnabled) {
+                                        R.string.tidal_artwork_fallback_description
+                                    } else {
+                                        R.string.tidal_artwork_fallback_unavailable
+                                    },
+                                ),
+                            icon = { Icon(painterResource(R.drawable.image), null) },
+                            checked = tidalArtworkEnabled,
+                            onCheckedChange = onTidalArtworkEnabledChange,
+                            isEnabled = tidalEnabled,
+                        )
+                    }
                 }
             }
 
@@ -477,23 +497,27 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.permanent_shuffle)) },
-                        description = stringResource(R.string.permanent_shuffle_desc),
-                        icon = { Icon(painterResource(R.drawable.shuffle), null) },
-                        checked = permanentShuffle,
-                        onCheckedChange = onPermanentShuffleChange,
-                    )
+                    Column(modifier = positions.modifierFor("permanent_shuffle")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.permanent_shuffle)) },
+                            description = stringResource(R.string.permanent_shuffle_desc),
+                            icon = { Icon(painterResource(R.drawable.shuffle), null) },
+                            checked = permanentShuffle,
+                            onCheckedChange = onPermanentShuffleChange,
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.auto_download_on_like)) },
-                        description = stringResource(R.string.auto_download_on_like_desc),
-                        icon = { Icon(painterResource(R.drawable.download), null) },
-                        checked = autoDownloadOnLike,
-                        onCheckedChange = onAutoDownloadOnLikeChange,
-                    )
+                    Column(modifier = positions.modifierFor("auto_download_like")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.auto_download_on_like)) },
+                            description = stringResource(R.string.auto_download_on_like_desc),
+                            icon = { Icon(painterResource(R.drawable.download), null) },
+                            checked = autoDownloadOnLike,
+                            onCheckedChange = onAutoDownloadOnLikeChange,
+                        )
+                    }
                 }
 
                 item {
@@ -514,13 +538,15 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.auto_skip_next_on_error)) },
-                        description = stringResource(R.string.auto_skip_next_on_error_desc),
-                        icon = { Icon(painterResource(R.drawable.skip_next), null) },
-                        checked = autoSkipNextOnError,
-                        onCheckedChange = onAutoSkipNextOnErrorChange,
-                    )
+                    Column(modifier = positions.modifierFor("auto_skip_error")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.auto_skip_next_on_error)) },
+                            description = stringResource(R.string.auto_skip_next_on_error_desc),
+                            icon = { Icon(painterResource(R.drawable.skip_next), null) },
+                            checked = autoSkipNextOnError,
+                            onCheckedChange = onAutoSkipNextOnErrorChange,
+                        )
+                    }
                 }
             }
 
@@ -529,60 +555,72 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 title = stringResource(R.string.misc),
             ) {
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.stop_music_on_task_clear)) },
-                        icon = { Icon(painterResource(R.drawable.clear_all), null) },
-                        checked = stopMusicOnTaskClear,
-                        onCheckedChange = onStopMusicOnTaskClearChange,
-                    )
+                    Column(modifier = positions.modifierFor("stop_task_clear")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.stop_music_on_task_clear)) },
+                            icon = { Icon(painterResource(R.drawable.clear_all), null) },
+                            checked = stopMusicOnTaskClear,
+                            onCheckedChange = onStopMusicOnTaskClearChange,
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.wakelock)) },
-                        description = stringResource(R.string.wakelock_desc),
-                        icon = { Icon(painterResource(R.drawable.bolt), null) },
-                        checked = wakelockEnabled,
-                        onCheckedChange = onWakelockChange,
-                    )
+                    Column(modifier = positions.modifierFor("wakelock")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.wakelock)) },
+                            description = stringResource(R.string.wakelock_desc),
+                            icon = { Icon(painterResource(R.drawable.bolt), null) },
+                            checked = wakelockEnabled,
+                            onCheckedChange = onWakelockChange,
+                        )
+                    }
                 }
 
                 item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.artist_separators)) },
-                        description = artistSeparators.map { "\"$it\"" }.joinToString("  "),
-                        icon = { Icon(painterResource(R.drawable.artist), null) },
-                        onClick = { showArtistSeparatorsDialog = true },
-                    )
+                    Column(modifier = positions.modifierFor("artist_separators")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.artist_separators)) },
+                            description = artistSeparators.map { "\"$it\"" }.joinToString("  "),
+                            icon = { Icon(painterResource(R.drawable.artist), null) },
+                            onClick = { showArtistSeparatorsDialog = true },
+                        )
+                    }
                 }
 
                 item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.manage_playlist_tags)) },
-                        description = stringResource(R.string.manage_playlist_tags_desc),
-                        icon = { Icon(painterResource(R.drawable.style), null) },
-                        onClick = { showTagsManagementDialog = true },
-                    )
+                    Column(modifier = positions.modifierFor("manage_playlist_tags")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.manage_playlist_tags)) },
+                            description = stringResource(R.string.manage_playlist_tags_desc),
+                            icon = { Icon(painterResource(R.drawable.style), null) },
+                            onClick = { showTagsManagementDialog = true },
+                        )
+                    }
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.external_downloader)) },
-                        description = stringResource(R.string.external_downloader_desc),
-                        icon = { Icon(painterResource(R.drawable.download), null) },
-                        checked = externalDownloaderEnabled,
-                        onCheckedChange = onExternalDownloaderEnabledChange,
-                    )
+                    Column(modifier = positions.modifierFor("external_downloader")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.external_downloader)) },
+                            description = stringResource(R.string.external_downloader_desc),
+                            icon = { Icon(painterResource(R.drawable.download), null) },
+                            checked = externalDownloaderEnabled,
+                            onCheckedChange = onExternalDownloaderEnabledChange,
+                        )
+                    }
                 }
 
                 item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.external_downloader_package)) },
-                        description = externalDownloaderPackage.ifEmpty { stringResource(R.string.external_downloader_package_desc) },
-                        icon = { Icon(painterResource(R.drawable.integration), null) },
-                        onClick = { showExternalDownloaderPackageDialog = true },
-                        isEnabled = externalDownloaderEnabled,
-                    )
+                    Column(modifier = positions.modifierFor("external_downloader_package")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.external_downloader_package)) },
+                            description = externalDownloaderPackage.ifEmpty { stringResource(R.string.external_downloader_package_desc) },
+                            icon = { Icon(painterResource(R.drawable.integration), null) },
+                            onClick = { showExternalDownloaderPackageDialog = true },
+                            isEnabled = externalDownloaderEnabled,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -168,15 +169,22 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
-            PreferenceGroup(title = stringResource(R.string.listen_history)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("pause_listen_history"),
+                title = stringResource(R.string.listen_history),
+            ) {
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.pause_listen_history)) },
@@ -195,7 +203,10 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.search_history)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("pause_search_history"),
+                title = stringResource(R.string.search_history),
+            ) {
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.pause_search_history)) },
@@ -214,7 +225,10 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.misc)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("haptics"),
+                title = stringResource(R.string.misc),
+            ) {
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.haptics)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -552,6 +553,10 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
@@ -561,10 +566,13 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                         WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                     ),
                 )
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
-            PreferenceGroup(title = stringResource(R.string.qobuz_integration)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("qobuz_account"),
+                title = stringResource(R.string.qobuz_integration),
+            ) {
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.qobuz_enable)) },
@@ -593,7 +601,10 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.qobuz_tokens)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("qobuz_tokens"),
+                title = stringResource(R.string.qobuz_tokens),
+            ) {
                 item {
                     PreferenceEntry(
                         title = { Text(stringResource(R.string.qobuz_login_web)) },
@@ -739,7 +750,10 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.qobuz_instances)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("qobuz_instances"),
+                title = stringResource(R.string.qobuz_instances),
+            ) {
                 item {
                     PreferenceEntry(
                         title = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -138,7 +138,7 @@ fun buildSettingsGroups(
                 SettingsChild("Pause on device mute", "pause_mute", listOf("mute", "pause mute", "headphone", "silence detect")) { SearchResultSwitch(PauseOnDeviceMuteKey, false) },
                 SettingsChild("Device mute recovery volume", "device_mute_recovery_volume", listOf("recovery volume", "mute recovery", "volume restore")),
                 SettingsChild("Auto start on Bluetooth", "bluetooth_auto_start", listOf("bluetooth", "auto start", "auto play", "connect")) { SearchResultSwitch(AutoStartOnBluetoothKey, false) },
-                SettingsChild("ArchiveTune Canvas", "archivetune_canvas", listOf("canvas", "animated artwork", "motion artwork", "live artwork")) { SearchResultSwitch(ArchiveTuneCanvasKey, true) },
+                SettingsChild("ArchiveTune Canvas", "archive_tune_canvas", listOf("canvas", "animated artwork", "motion artwork", "live artwork")) { SearchResultSwitch(ArchiveTuneCanvasKey, true) },
                 SettingsChild("Tidal artwork fallback", "tidal_artwork_fallback", listOf("tidal artwork", "artwork fallback", "tidal cover", "hi-res artwork")) { SearchResultSwitch(TidalArtworkFallbackEnabledKey, true) },
                 SettingsChild("Persistent queue", "persistent_queue", listOf("queue", "persistent", "save queue", "resume")) { SearchResultSwitch(PersistentQueueKey, true) },
                 SettingsChild("Permanent shuffle", "permanent_shuffle", listOf("shuffle", "random", "permanent")) { SearchResultSwitch(PermanentShuffleKey, false) },
@@ -242,6 +242,78 @@ fun buildSettingsGroups(
                 SettingsChild("Discord rich presence", "discord_presence", listOf("discord", "rich presence", "status", "now playing")),
                 SettingsChild("ListenBrainz", "listenbrainz", listOf("listenbrainz", "listen brainz", "scrobble")),
             ),
+        )
+    val discord =
+        SettingsItem(
+            key = "discord",
+            icon = painterResource(R.drawable.discord),
+            title = stringResource(R.string.discord_integration),
+            subtitle = stringResource(R.string.settings_integration_subtitle),
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("discord", "rich presence", "rpc", "status", "activity", "now playing"),
+            onClick = { navController.navigate("settings/discord") },
+            children = listOf(
+                SettingsChild("Discord account", "discord_account", listOf("discord account", "discord login", "discord token", "discord authorization")),
+                SettingsChild("Discord options", "discord_options", listOf("discord options", "discord refresh", "refresh discord")),
+                SettingsChild("Discord connection settings", "discord_connection", listOf("discord connection", "activity status", "platform status", "discord platform")),
+                SettingsChild("Discord activity content", "discord_activity", listOf("discord activity", "activity name", "activity details", "activity state", "activity type", "discord show when paused")),
+                SettingsChild("Discord image options", "discord_images", listOf("discord image", "large image", "large text", "discord artwork", "discord cover")),
+            ),
+        )
+    val lastfm =
+        SettingsItem(
+            key = "lastfm",
+            icon = painterResource(R.drawable.discord),
+            title = stringResource(R.string.lastfm_integration),
+            subtitle = stringResource(R.string.settings_integration_subtitle),
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("lastfm", "last.fm", "scrobble", "scrobbling", "listens", "session"),
+            onClick = { navController.navigate("settings/lastfm") },
+            children = listOf(
+                SettingsChild("Last.fm service", "lastfm_service", listOf("lastfm service", "lastfm provider", "lastfm instance")),
+                SettingsChild("Last.fm account", "lastfm_account", listOf("lastfm account", "lastfm login", "lastfm session", "lastfm username")),
+                SettingsChild("Last.fm options", "lastfm_options", listOf("lastfm options", "lastfm settings", "scrobble toggle", "now playing")),
+                SettingsChild("Last.fm scrobbling configuration", "lastfm_scrobbling_config", listOf("scrobble config", "scrobble configuration", "scrobble threshold", "scrobble percentage")),
+            ),
+        )
+    val tidal =
+        SettingsItem(
+            key = "tidal",
+            icon = painterResource(R.drawable.provider_tidal),
+            title = stringResource(R.string.source_tidal),
+            subtitle = stringResource(R.string.settings_integration_subtitle),
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("tidal", "hifi", "master", "mqa", "lossless", "flac"),
+            onClick = { navController.navigate("settings/tidal") },
+            children = listOf(
+                SettingsChild("Tidal account", "tidal_account", listOf("tidal account", "tidal login", "tidal token", "tidal session")),
+                SettingsChild("Tidal instances", "tidal_instances", listOf("tidal instance", "tidal server", "tidal url", "tidal endpoint")),
+            ),
+        )
+    val qobuz =
+        SettingsItem(
+            key = "qobuz",
+            icon = painterResource(R.drawable.provider_qobuz),
+            title = stringResource(R.string.source_qobuz),
+            subtitle = stringResource(R.string.settings_integration_subtitle),
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("qobuz", "hires", "hi-res", "flac", "lossless", "cd quality"),
+            onClick = { navController.navigate("settings/qobuz") },
+            children = listOf(
+                SettingsChild("Qobuz account", "qobuz_account", listOf("qobuz account", "qobuz login", "qobuz email", "qobuz session")),
+                SettingsChild("Qobuz tokens", "qobuz_tokens", listOf("qobuz token", "qobuz app secret", "qobuz credential")),
+                SettingsChild("Qobuz instances", "qobuz_instances", listOf("qobuz instance", "qobuz server", "qobuz url", "qobuz endpoint")),
+            ),
+        )
+    val telegram =
+        SettingsItem(
+            key = "telegram",
+            icon = painterResource(R.drawable.telegram),
+            title = stringResource(R.string.telegram_integration),
+            subtitle = stringResource(R.string.settings_integration_subtitle),
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("telegram", "telegram channel", "channel sync", "telegram music", "telegram bot"),
+            onClick = { navController.navigate("settings/telegram") },
         )
     val aiIntegration =
         SettingsItem(
@@ -425,7 +497,7 @@ fun buildSettingsGroups(
         ),
         SettingsGroup(
             title = stringResource(R.string.integration),
-            items = listOf(integration, aiIntegration, internet, poToken),
+            items = listOf(integration, discord, lastfm, tidal, qobuz, telegram, aiIntegration, internet, poToken),
         ),
         SettingsGroup(
             title = stringResource(R.string.storage),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -81,9 +81,19 @@ private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): Stri
             "backup_restore" -> "settings/backup_restore"
             "developer_options" -> "settings/misc"
             "about" -> "settings/about"
+            "discord" -> "settings/discord"
+            "tidal" -> "settings/tidal"
+            "qobuz" -> "settings/qobuz"
+            "telegram" -> "settings/telegram"
+            "lastfm" -> "settings/lastfm"
+            "ai_integration" -> "settings/ai_integration"
+            "language_packs" -> "settings/language_packs"
+            "po_token" -> PO_TOKEN_ROUTE
             else -> return null
         }
-    val supportsScroll = parentKey !in setOf("developer_options", "about")
+    // About / developer-options screens intentionally don't participate in auto-scroll
+    // (their contents are mostly static links). All other screens honor ?scrollTo=.
+    val supportsScroll = parentKey !in setOf("developer_options", "about", "po_token")
     return if (!supportsScroll || scrollKey.isNullOrBlank()) route else "$route?scrollTo=$scrollKey"
 }
 
@@ -145,53 +155,63 @@ fun SettingsScreen(
     val allSettingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
     // When searching, flatten all individual SettingsChildren across every
     // category so each matching setting is shown as a separate row.
+    //
+    // Per product decision: settings that ship with an inline switch control
+    // (boolean toggles like Dynamic theme, Pure black, Low data mode, Crossfade,
+    // Skip silence, Audio normalization, Audio offload, Persistent queue, etc.)
+    // are EXCLUDED from search results — they already expose their toggle in the
+    // parent screen, and showing them as search rows that don't auto-scroll was
+    // confusing. Every non-switch setting must be both searchable AND auto-scroll
+    // to its position when tapped.
     val filteredChildResults = remember(searchQuery, allSettingsGroups) {
         if (searchQuery.isBlank()) emptyList()
         else {
             val query = searchQuery.trim().lowercase()
             allSettingsGroups.flatMap { group ->
                 group.items.flatMap { item ->
-                    item.children.mapNotNull { child ->
-                        val matchesTitle = child.title.lowercase().contains(query)
-                        val matchesKeywords = child.keywords.any { it.lowercase().contains(query) }
-                        val matchesParent =
-                            item.title.lowercase().contains(query) ||
-                                item.subtitle?.lowercase()?.contains(query) == true ||
-                                item.keywords.any { it.lowercase().contains(query) }
-                        if (matchesTitle || matchesKeywords || matchesParent) {
-                            SearchResultItem(
-                                title = child.title,
-                                parentTitle = item.title,
-                                parentIcon = item.icon,
-                                parentKey = item.key,
-                                parentAccentColor = item.accentColor,
-                                parentRoute = searchableSettingsRoute(item.key, child.scrollKey),
-                                scrollKey = child.scrollKey,
-                                onClick = item.onClick,
-                                switchControl = child.switchControl,
-                            )
-                        } else null
-                    }.ifEmpty {
-                        // If the parent matches but has no children,
-                        // show the parent itself as a single result.
-                        if (item.title.lowercase().contains(query) ||
-                            item.subtitle?.lowercase()?.contains(query) == true ||
-                            item.keywords.any { it.lowercase().contains(query) }
-                        ) {
-                            listOf(
+                    item.children
+                        .filter { child -> child.switchControl == null }
+                        .mapNotNull { child ->
+                            val matchesTitle = child.title.lowercase().contains(query)
+                            val matchesKeywords = child.keywords.any { it.lowercase().contains(query) }
+                            val matchesParent =
+                                item.title.lowercase().contains(query) ||
+                                    item.subtitle?.lowercase()?.contains(query) == true ||
+                                    item.keywords.any { it.lowercase().contains(query) }
+                            if (matchesTitle || matchesKeywords || matchesParent) {
                                 SearchResultItem(
-                                    title = item.title,
-                                    parentTitle = item.subtitle ?: "",
+                                    title = child.title,
+                                    parentTitle = item.title,
                                     parentIcon = item.icon,
                                     parentKey = item.key,
                                     parentAccentColor = item.accentColor,
-                                    parentRoute = null,
-                                    scrollKey = null,
+                                    parentRoute = searchableSettingsRoute(item.key, child.scrollKey),
+                                    scrollKey = child.scrollKey,
                                     onClick = item.onClick,
-                                ),
-                            )
-                        } else emptyList()
-                    }
+                                    switchControl = null,
+                                )
+                            } else null
+                        }.ifEmpty {
+                            // If the parent matches but has no non-switch children,
+                            // show the parent itself as a single result.
+                            if (item.title.lowercase().contains(query) ||
+                                item.subtitle?.lowercase()?.contains(query) == true ||
+                                item.keywords.any { it.lowercase().contains(query) }
+                            ) {
+                                listOf(
+                                    SearchResultItem(
+                                        title = item.title,
+                                        parentTitle = item.subtitle ?: "",
+                                        parentIcon = item.icon,
+                                        parentKey = item.key,
+                                        parentAccentColor = item.accentColor,
+                                        parentRoute = null,
+                                        scrollKey = null,
+                                        onClick = item.onClick,
+                                    ),
+                                )
+                            } else emptyList()
+                        }
                 }
             }
         }
@@ -211,11 +231,6 @@ fun SettingsScreen(
             }.filter { it.items.isNotEmpty() }
         }
     }
-
-    // Note: Search results show individual settings items. Clicking a result
-    // navigates directly to the parent settings page. The previous auto-scroll
-    // approach was removed because it only scrolled to section headers, not
-    // the specific setting items.
 
     // Material 3 Expressive: when any settings dialog (history duration,
     // lyrics preload count, etc.) is showing, apply a backdrop blur to

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -73,6 +74,10 @@ fun SourceSettings(navController: NavController, scrollTo: String? = null) {
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
@@ -82,13 +87,13 @@ fun SourceSettings(navController: NavController, scrollTo: String? = null) {
                         WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                     ),
                 )
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
             // Manual "refresh from pool" — pulls the latest shared accounts and instances on demand
             // (the app also does this automatically on startup). Only shown when a source pool is
             // configured at build time.
-            PoolRefreshSection()
+            PoolRefreshSection(positions)
 
             // Preferred-source picker, per-source enable toggles and quality. Account/instance
             // management remains in Integration (behind the manual-source-login toggle).
@@ -104,14 +109,16 @@ fun SourceSettings(navController: NavController, scrollTo: String? = null) {
  * pool URL is baked in, since there is nothing to refresh.
  */
 @Composable
-private fun PoolRefreshSection() {
+private fun PoolRefreshSection(positions: PreferencePositions) {
     if (!PoolAccountManager.isEnabled) return
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var refreshing by remember { mutableStateOf(false) }
 
-    PreferenceGroup {
+    PreferenceGroup(
+        modifier = positions.modifierFor("youtube_music"),
+    ) {
         item {
             PreferenceEntry(
                 title = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -396,12 +396,16 @@ fun StorageSettings(
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(
                     start = 12.dp,
                     top = 12.dp,
@@ -415,9 +419,13 @@ fun StorageSettings(
                 isSmartTrimmerAvailable = isSmartTrimmerAvailable,
                 onSmartTrimmerChange = onSmartTrimmerChange,
                 onSelectFolder = viewModel::openStorageLocationPicker,
+                positions = positions,
             )
 
-            PreferenceGroup(title = stringResource(R.string.downloaded_songs)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("downloaded_songs"),
+                title = stringResource(R.string.downloaded_songs),
+            ) {
                 item {
                     PreferenceEntry(
                         title = { Text(stringResource(R.string.clear_all_downloads)) },
@@ -482,7 +490,10 @@ fun StorageSettings(
                 )
             }
 
-            PreferenceGroup(title = stringResource(R.string.song_cache)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("song_cache_size"),
+                title = stringResource(R.string.song_cache),
+            ) {
                 item {
                     ListPreference(
                         title = { Text(stringResource(R.string.max_song_cache_size)) },
@@ -540,7 +551,10 @@ fun StorageSettings(
                 )
             }
 
-            PreferenceGroup(title = stringResource(R.string.image_cache)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("image_cache_size"),
+                title = stringResource(R.string.image_cache),
+            ) {
                 item {
                     ListPreference(
                         title = { Text(stringResource(R.string.max_image_cache_size)) },
@@ -606,7 +620,10 @@ fun StorageSettings(
                 )
             }
 
-            PreferenceGroup(title = stringResource(R.string.canvas_cache)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("canvas_cache"),
+                title = stringResource(R.string.canvas_cache),
+            ) {
                 item {
                     ListPreference(
                         title = { Text(stringResource(R.string.max_cache_size)) },
@@ -700,8 +717,12 @@ private fun StorageFolderSection(
     isSmartTrimmerAvailable: Boolean,
     onSmartTrimmerChange: (Boolean) -> Unit,
     onSelectFolder: () -> Unit,
+    positions: PreferencePositions,
 ) {
-    PreferenceGroup(title = stringResource(R.string.storage_folder)) {
+    PreferenceGroup(
+        modifier = positions.modifierFor("storage_folder"),
+        title = stringResource(R.string.storage_folder),
+    ) {
         when (state) {
             StorageSettingsScreenState.Loading -> {
                 item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -418,6 +419,10 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
         },
     ) { innerPadding ->
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
@@ -427,10 +432,13 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
                         WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                     ),
                 )
-                .verticalScroll(rememberScrollState())
+                .verticalScroll(scrollState)
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
-            PreferenceGroup(title = stringResource(R.string.tidal_account)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("tidal_account"),
+                title = stringResource(R.string.tidal_account),
+            ) {
                 if (accountConfigured) {
                     item {
                         PreferenceEntry(
@@ -504,7 +512,10 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
                 }
             }
 
-            PreferenceGroup(title = stringResource(R.string.tidal_instances)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("tidal_instances"),
+                title = stringResource(R.string.tidal_instances),
+            ) {
                 item {
                     val onlineCount = effectiveInstances.count {
                         healthStatus[it] == TidalAudioProvider.InstanceHealth.HEALTHY


### PR DESCRIPTION
## Summary

Fixes two issues reported in this session:

### 1. Downloads fail at 0% with `HttpDataSourceException: Malformed URL`

**Root cause** (from the attached logcat):
```
E/DownloadManager: Task failed: null:dJth8oW7CAQ, false
E/DownloadManager: androidx.media3.datasource.HttpDataSource$HttpDataSourceException: Malformed URL
    at androidx.media3.datasource.okhttp.OkHttpDataSource.makeRequest(...)
    at androidx.media3.datasource.cache.CacheDataSource.openNextSource(...)
    at androidx.media3.datasource.ResolvingDataSource.open(...)
```

When a song was previously streamed (cached in `playerCache`) and the user then requested a download, `DownloadUtil`'s resolver returned the `dataSpec` **unchanged** on cache hit — keeping the **bare media id** (e.g. `"dJth8oW7CAQ"`) as the URI. Because the download's `CacheDataSource` is bound to `downloadCache` (a separate cache from `playerCache`), it would miss and fall through to `OkHttpDataSource`, which then failed with `Malformed URL` — leaving the download stuck at 0%. This affected **every download source** (YouTube, Qobuz, Tidal) because they all share the same `youtubeDataSourceFactory`.

**Fix** (`DownloadUtil.kt`):
Insert `playerCache` as an **inner `CacheDataSource` upstream** so the chain becomes:

```
downloadCache (writes here for persistence)
   ↓ (on miss)
playerCache (reads bytes streamed earlier — Qobuz/Tidal/YouTube)
   ↓ (on miss)
OkHttpDataSource (uses the resolved YouTube stream URL)
```

Now: cache hits in `playerCache` serve bytes directly (and propagate to `downloadCache` for persistence), and `OkHttpDataSource` is only reached when both caches miss — at which point the resolver has already swapped the URI for a real YouTube stream URL. The source-specific `qobuz:`/`tidal:` cache-key path also works correctly because the inner `playerCache` honours the rewritten key.

### 2. Settings search: missing entries + broken auto-scroll

User reported:
> any setting in settings page should be searchable except the ones that have a switch besides them. there's a lot of settings that I don't see in the search results and even if I see it doesn't auto scroll to its specific position except a few ones.

Three-part fix:

**(a) Filter switch-bearing children out of search results** (`SettingsScreen.kt`):
Settings that ship with an inline switch control (Dynamic theme, Pure black, Low data mode, Crossfade, Skip silence, Audio normalization, Audio offload, Persistent queue, etc.) are no longer shown as search result rows — they already expose their toggle in the parent screen, and showing them as search rows that don't auto-scroll was confusing. Every **non-switch** setting is now searchable.

**(b) Wire auto-scroll into 11 screens that previously accepted `scrollTo` but silently dropped it**:

| Screen | Action |
|---|---|
| `ContentSettings.kt` | Added `scrollState` + `positions` + `LaunchedEffect` + `modifierFor` on 3 PreferenceGroups |
| `LyricsSettings.kt` | Same pattern, 5 PreferenceGroups |
| `PrivacySettings.kt` | Same pattern, 3 PreferenceGroups |
| `SourceSettings.kt` | Same pattern, 1 PreferenceGroup (via `PoolRefreshSection(positions)`) |
| `StorageSettings.kt` | Same pattern, 5 PreferenceGroups (via `StorageFolderSection(positions)`) |
| `InternetSettings.kt` | Same pattern, 3 PreferenceGroups |
| `BackupAndRestore.kt` | Same pattern, 3 PreferenceGroups (via `ScheduledBackupSection(positions)`) |
| `IntegrationScreen.kt` | Same pattern, 4 PreferenceGroups |
| `TidalSettings.kt` | Same pattern, 2 PreferenceGroups |
| `QobuzSettings.kt` | Same pattern, 3 PreferenceGroups |
| `LastFMSettings.kt` | Added `scrollTo` param (was missing) + threaded through `NavigationBuilder.kt` route + same pattern, 4 PreferenceGroups (via `LastFmSettingsSuccess(positions)`) |
| `DiscordSettings.kt` | Converted `LazyColumn` → `Column + verticalScroll` (the auto-scroll helper only works with `ScrollState`, not `LazyListState`), then wired the same pattern, 5 PreferenceGroups |
| `AppearanceSettings.kt` | Added `modifierFor` to all 14 remaining PreferenceGroups / items (previously only 4 of ~18 had anchors) |
| `PlayerSettings.kt` | Added `modifierFor` to all 19 remaining PreferenceGroups / items (previously only 4 of ~23 had anchors) |

Each screen now captures `rememberScrollState()`, registers a `PreferencePositions` instance, drives a `LaunchedEffect(scrollTo)` that calls `scrollToKey(...)`, and tags every relevant `PreferenceGroup` (or individual `item` for fine-grained settings) with `modifier = positions.modifierFor("<scrollKey>")`.

**(c) Register `SettingsChild` entries for previously-unindexed screens** (`SettingsDataBuilders.kt`):
- DiscordSettings: 5 children (account, options, connection, activity, images)
- TidalSettings: 2 children (account, instances)
- QobuzSettings: 3 children (account, tokens, instances)
- LastFMSettings: 4 children (service, account, options, scrobbling config)
- TelegramSettings: top-level item (no children — single screen)

Updated `searchableSettingsRoute()` to support the new parentKeys: `discord`, `tidal`, `qobuz`, `telegram`, `lastfm`, `ai_integration`, `language_packs`, `po_token`.

### Additional fixes

- **Key mismatch**: `archivetune_canvas` (no underscore) in `SettingsDataBuilders.kt` vs `archive_tune_canvas` (with underscore) in `PlayerSettings.kt` — unified to `archive_tune_canvas` so the "ArchiveTune Canvas" search result actually scrolls.
- **Removed misleading comment** in `SettingsScreen.kt` that claimed auto-scroll was removed (it wasn't — it was just unfinished).
- **Added `scrollTo` parameter** to `LastFMSettings` (was missing) and threaded it through `NavigationBuilder.kt`'s `settings/lastfm` route (now `settings/lastfm?scrollTo={scrollTo}`).

## Files changed

- `app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt`

## Verification

- No Android SDK available in the dev environment, so `./gradlew :app:compileDebugKotlin` was not run locally. **GitHub CI will validate the build.**
- Each modified file was re-read after editing to confirm syntactic correctness (brace matching, named-argument form, import presence).
- Pattern used matches the existing `AppearanceSettings.kt` precedent (lines 447-462) — same `rememberPreferencePositions()` + `LaunchedEffect(scrollTo)` + `modifierFor(...)` triplet.
- For `DiscordSettings.kt` (LazyColumn → Column conversion), all `item { }` wrappers were unwrapped and `PreferenceGroup` content lambdas were preserved verbatim.

## Test plan

1. **Downloads**: play a Qobuz/Tidal/YouTube track (so it caches in `playerCache`), then immediately tap "Download" from the song menu. Confirm the download progresses past 0% and completes.
2. **Downloads (cold)**: clear `playerCache`, then tap "Download" on a fresh track. Confirm the download still works (YouTube URL resolution path).
3. **Settings search — switch exclusion**: search "dynamic theme" / "low data mode" / "crossfade" — confirm NO results appear (these are switch-bearing and should be excluded).
4. **Settings search — non-switch appearance**: search "color palette" / "player design" / "blur intensity" / "font" / "navigation bar" — confirm results appear AND tapping scrolls to the exact item in `AppearanceSettings`.
5. **Settings search — non-switch playback**: search "history duration" / "device mute recovery volume" / "artist separators" / "external downloader package" — confirm results appear AND tapping scrolls to the exact item in `PlayerSettings`.
6. **Settings search — newly indexed screens**: search "discord account" / "discord activity" / "tidal instances" / "qobuz tokens" / "lastfm scrobbling configuration" — confirm results appear AND tapping scrolls to the right group on the right screen.
7. **Settings search — previously broken screens**: search "content language" / "lyrics provider" / "pause listen history" / "proxy" / "download speed limit" / "song cache size" / "scheduled backup" — confirm auto-scroll works on all of them.

## Notes / out-of-scope

- Switch-bearing settings (Dynamic theme, Pure black, Low data mode, Crossfade, etc.) are intentionally excluded from search per the user's explicit request. If the maintainers prefer them included with auto-scroll instead, the filter at `SettingsScreen.kt:172` (`.filter { child -> child.switchControl == null }`) can be removed and the `switchControl` field can be preserved on `SearchResultItem` so the inline toggle still works — but then each switch-bearing item would also need a `modifierFor(...)` anchor on its host screen for auto-scroll to work.
- The `archive_tune_canvas` scrollKey is anchored to the `R.string.tidal_artwork` PreferenceGroup in `PlayerSettings.kt` (pre-existing oddity — the `ArchiveTune Canvas` switch actually lives in that group, so the anchor is correct, just the group title is misleading). Left as-is to avoid scope creep.
- `grid_layout` and `color_source` scrollKeys are registered in `SettingsDataBuilders.kt` but have no matching preference UI in `AppearanceSettings.kt` (the `gridItemSize` state is declared but never rendered). A follow-up PR could either implement the missing UI or remove the orphaned children from the registry.