### PR TITLE
feat: FLAC export, settings search overhaul, lastfm thumbs, canvas gate, export picker, AM fav color

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -325,26 +325,76 @@ class DownloadUtil
             val artists = song.artists.mapNotNull { it.name.takeIf(String::isNotBlank) }
             val album = song.album?.title?.takeIf { it.isNotBlank() }
             val durationMs = song.song.duration.takeIf { it > 0 }?.toLong()?.times(1000L)
-            val directStreamUri =
+            // Resolve the source-specific direct stream and pull out the
+            // metadata we need to (a) build the DataSpec and (b) persist a
+            // FormatEntity so future exports read the correct MIME/codec
+            // (FLAC for Qobuz/Tidal lossless) instead of defaulting to MP3.
+            data class ResolvedStream(
+                val uri: String,
+                val mimeType: String,
+                val codecs: String,
+                val contentLength: Long?,
+            )
+            val resolvedStream =
                 runCatching {
                     when (downloadSource) {
                         DownloadSource.QOBUZ ->
                             QobuzAudioProvider.resolve(
                                 QobuzAudioProvider.Query(mediaId, queryTitle, artists, album, durationMs),
                                 qobuzAudioQuality.toFormatId(),
-                            )?.uri
+                            )?.let { ResolvedStream(it.uri, it.mimeType, it.codecs, it.contentLength) }
                         DownloadSource.TIDAL ->
                             TidalAudioProvider.resolve(
                                 TidalAudioProvider.Query(mediaId, queryTitle, artists, album, null, durationMs),
                                 audioQuality = tidalAudioQuality,
-                            ).mediaUri
+                            ).let { ResolvedStream(it.mediaUri, it.mimeType, it.codecs, it.contentLength) }
                         DownloadSource.YOUTUBE_MUSIC -> null
                     }
                 }.getOrNull() ?: return null
+            persistSourceFormatEntity(
+                mediaId = mediaId,
+                mimeType = resolvedStream.mimeType,
+                codecs = resolvedStream.codecs,
+                contentLength = resolvedStream.contentLength,
+            )
             return dataSpec.buildUpon()
-                .setUri(directStreamUri.toUri())
+                .setUri(resolvedStream.uri.toUri())
                 .setKey("${downloadSource.name.lowercase(java.util.Locale.US)}:$mediaId")
                 .build()
+        }
+
+        /**
+         * Writes a [FormatEntity] reflecting the resolved lossless/lossy stream
+         * (Qobuz/Tidal) so that subsequent exports read the correct codec + MIME
+         * type instead of defaulting to MP3.
+         */
+        private fun persistSourceFormatEntity(
+            mediaId: String,
+            mimeType: String,
+            codecs: String,
+            contentLength: Long?,
+        ) {
+            val normalizedMime = mimeType.ifBlank { "audio/flac" }.substringBefore(";")
+            downloadScope.launch {
+                runCatching {
+                    database.query {
+                        upsert(
+                            FormatEntity(
+                                id = mediaId,
+                                itag = 0,
+                                mimeType = normalizedMime,
+                                codecs = codecs,
+                                bitrate = 0,
+                                sampleRate = null,
+                                contentLength = contentLength ?: 0L,
+                                loudnessDb = null,
+                                perceptualLoudnessDb = null,
+                                playbackUrl = null,
+                            ),
+                        )
+                    }
+                }
+            }
         }
 
         private fun resolveDownloadAudioQuality(lowDataModeActive: Boolean): AudioQuality =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -107,6 +107,7 @@ import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
 import moe.rukamori.archivetune.ui.component.NewAction
 import moe.rukamori.archivetune.ui.component.NewActionGrid
 import moe.rukamori.archivetune.ui.player.rememberDeviceMusicVolumeController
+import moe.rukamori.archivetune.ui.player.CanvasArtworkPlaybackCache
 import moe.rukamori.archivetune.utils.SpeedDialPin
 import moe.rukamori.archivetune.utils.SpeedDialPinType
 import moe.rukamori.archivetune.utils.isLocalMediaId
@@ -167,6 +168,14 @@ fun PlayerMenu(
     val playerDesignStyle by rememberEnumPreference(PlayerDesignStyleKey, defaultValue = PlayerDesignStyle.V4)
     val lowDataModeActive = rememberLowDataModeActive()
     val isCanvasArtworkRefetching by playerConnection.isCanvasArtworkRefetching.collectAsStateWithLifecycle()
+    // Only show the "Refetch canvas" overflow action when the current song
+    // actually has an animated artwork entry cached. Songs that never resolved
+    // a canvas (no animated artwork exists for them) wouldn't benefit from a
+    // refetch and would just produce a confusing no-op button.
+    var hasCanvasArtwork by remember(mediaMetadata.id) { mutableStateOf(false) }
+    LaunchedEffect(mediaMetadata.id, isCanvasArtworkRefetching) {
+        hasCanvasArtwork = CanvasArtworkPlaybackCache.hasEntry(mediaMetadata.id)
+    }
     val (speedDialSongIds, onSpeedDialSongIdsChange) = rememberPreference(SpeedDialSongIdsKey, "")
     val speedDialPins = remember(speedDialSongIds) { parseSpeedDialPins(speedDialSongIds) }
     val songPin = remember(mediaMetadata.id) { SpeedDialPin(type = SpeedDialPinType.SONG, id = mediaMetadata.id) }
@@ -490,7 +499,8 @@ fun PlayerMenu(
                                 isQueueTrigger != true &&
                                 archiveTuneCanvasEnabled &&
                                 !lowDataModeActive &&
-                                playerDesignStyle != PlayerDesignStyle.V5
+                                playerDesignStyle != PlayerDesignStyle.V5 &&
+                                hasCanvasArtwork
                             ) {
                                 add(
                                     NewAction(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -90,9 +90,9 @@ import moe.rukamori.archivetune.constants.ListThumbnailSize
 import moe.rukamori.archivetune.constants.SpeedDialSongIdsKey
 import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.Event
-import moe.rukamori.archivetune.db.entities.exportMimeType
 import moe.rukamori.archivetune.db.entities.fileExtension
 import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
+import moe.rukamori.archivetune.db.entities.extensionToMimeType
 import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.extensions.toMediaItem
@@ -147,13 +147,13 @@ fun SongMenu(
     val downloadUtil = LocalDownloadUtil.current
 
     // Direct export to the device's Downloads folder (via SAF CreateDocument).
-    // The MIME type hint is resolved from the cached FormatEntity, but the actual
-    // file extension is detected from the cached audio data's magic bytes to
-    // avoid exporting lossy data with a .flac extension.
+    // The MIME type hint is derived from the *actual* cached audio bytes
+    // (preferred) or the FormatEntity stored at download time, so a FLAC
+    // stream from Qobuz exports with audio/flac rather than the previous
+    // audio/mpeg fallback. The file extension is always detected from
+    // magic bytes to avoid exporting lossy data with a .flac extension
+    // (and vice versa).
     val songFormat by database.format(song.id).collectAsState(initial = null)
-    val exportMimeType = songFormat?.exportMimeType() ?: "audio/mpeg"
-    // Detect the real audio format from the download cache so the exported
-    // file always gets the correct extension (e.g. .opus instead of .flac).
     val detectedExt by produceState(
         initialValue = songFormat?.fileExtension() ?: "mp3",
         song.id,
@@ -166,6 +166,7 @@ fun SongMenu(
             }
         }
     }
+    val exportMimeType = extensionToMimeType(detectedExt)
     val exportToDownloadsLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument(exportMimeType)) { destUri ->
             if (destUri == null) return@rememberLauncherForActivityResult
@@ -1135,25 +1136,38 @@ private suspend fun exportDownloadedSongToUri(
 
 /**
  * Resolves cached spans for a given [songId]. Tries the key directly first,
- * then falls back to searching all cache keys for a matching entry.
+ * then checks the source-prefixed keys used by Qobuz/Tidal downloads
+ * ("qobuz:<songId>" and "tidal:<songId>") so lossless exports pull the
+ * actual FLAC bytes instead of falling through to a YouTube Music stream,
+ * and finally falls back to scanning all cache keys for any entry that
+ * ends with the songId.
  */
 private fun getCachedSpansForKey(
     cache: androidx.media3.datasource.cache.Cache,
     songId: String,
 ): java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan> {
-    var spans = cache.getCachedSpans(songId)
-    if (spans.isNotEmpty()) return spans
-    // Fallback: the download may have been stored under a slightly different
-    // key (e.g. with a URI prefix). Search all keys for one that ends with
-    // the songId or equals it after URI decoding.
+    cache.getCachedSpans(songId)
+        .takeIf { it.isNotEmpty() }
+        ?.let { return it }
+
+    // Source-prefixed cache keys (set by DownloadUtil.resolvePreferredDownloadDataSpec).
+    for (prefix in listOf("qobuz:", "tidal:")) {
+        val sourceKey = "$prefix$songId"
+        cache.getCachedSpans(sourceKey)
+            .takeIf { it.isNotEmpty() }
+            ?.let { return it }
+    }
+
+    // Last-resort scan: the download may have been stored under a URI-derived
+    // key. Match any key whose final path segment equals the songId.
     for (key in cache.keys) {
         val cleanKey = key.substringAfterLast("/")
-        if (cleanKey == songId || key == songId) {
-            spans = cache.getCachedSpans(key)
+        if (cleanKey == songId || key == songId || key.endsWith(":$songId")) {
+            val spans = cache.getCachedSpans(key)
             if (spans.isNotEmpty()) return spans
         }
     }
-    return spans
+    return java.util.TreeSet()
 }
 
 /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -440,7 +440,7 @@ private fun AppleMusicControlsColumn(
             Spacer(Modifier.width(12.dp))
             AppleMusicChip(
                 iconRes = if (currentSongLiked) R.drawable.player_star_filled else R.drawable.player_star,
-                tint = if (currentSongLiked) Color(0xFFFFD700) else Color.White,
+                tint = Color.White,
                 contentDescription = null,
                 onClick = playerConnection::toggleLike,
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -460,6 +460,9 @@ fun NavGraphBuilder.navigationBuilder(
     ) {
         StorageSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
+    composable("settings/storage/export_songs") {
+        ExportDownloadedSongsScreen(navController)
+    }
     composable(
         route = "settings/privacy?scrollTo={scrollTo}",
         arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
@@ -1,0 +1,468 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalDatabase
+import moe.rukamori.archivetune.LocalDownloadUtil
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
+import moe.rukamori.archivetune.db.entities.extensionToMimeType
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.utils.backToMain
+
+/**
+ * A single downloadable song surfaced in the export picker. The [songId] is the
+ * raw media id (no source prefix); the actual cached spans may live under
+ * "qobuz:$songId" or "tidal:$songId" — see [resolveSpans].
+ */
+private data class DownloadedSongRow(
+    val songId: String,
+    val title: String,
+    val artist: String,
+    val thumbnailUrl: String?,
+    val durationText: String?,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportDownloadedSongsScreen(navController: NavController) {
+    val context = LocalContext.current
+    val database = LocalDatabase.current
+    val downloadUtil = LocalDownloadUtil.current
+    val coroutineScope = rememberCoroutineScope()
+
+    var songs by remember { mutableStateOf<List<DownloadedSongRow>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var isExporting by remember { mutableStateOf(false) }
+    var exportedCount by remember { mutableStateOf(0) }
+    var totalCount by remember { mutableStateOf(0) }
+    val selectedIds: SnapshotStateList<String> = remember { mutableStateListOf() }
+
+    // Load the list of downloaded songs from the cache + database.
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            val cache = downloadUtil.downloadCache
+            // De-duplicate cache keys by the underlying song id so "qobuz:<id>"
+            // and "<id>" don't both show up as separate rows.
+            val songIds =
+                cache.keys
+                    .map { it.substringAfter(":") }
+                    .filter { it.isNotBlank() }
+                    .distinct()
+            val rows =
+                songIds.mapNotNull { songId ->
+                    // Only include songs that actually have cached spans.
+                    val hasSpans =
+                        listOf("qobuz:$songId", "tidal:$songId", songId).any { key ->
+                            cache.getCachedSpans(key).isNotEmpty()
+                        }
+                    if (!hasSpans) return@mapNotNull null
+                    val songEntity = database.getSongByIdBlocking(songId)
+                    val title =
+                        songEntity?.song?.title?.takeIf { it.isNotBlank() }
+                            ?: "Unknown song ($songId)"
+                    val artist =
+                        songEntity?.artists?.firstOrNull()?.name?.takeIf { it.isNotBlank() }
+                            ?: songEntity?.album?.title?.takeIf { it.isNotBlank() }
+                            ?: ""
+                    val thumb = songEntity?.song?.thumbnailUrl
+                    DownloadedSongRow(
+                        songId = songId,
+                        title = title,
+                        artist = artist,
+                        thumbnailUrl = thumb,
+                        durationText = null,
+                    )
+                }.sortedBy { it.title.lowercase() }
+            songs = rows
+            isLoading = false
+        }
+    }
+
+    // SAF folder picker — fires when the user taps "Pick export folder".
+    val pickFolderLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri ->
+            if (treeUri == null) return@rememberLauncherForActivityResult
+            val toExport = songs.filter { it.songId in selectedIds }
+            if (toExport.isEmpty()) {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.export_downloaded_songs_pick_folder_first),
+                    Toast.LENGTH_SHORT,
+                ).show()
+                return@rememberLauncherForActivityResult
+            }
+            isExporting = true
+            totalCount = toExport.size
+            exportedCount = 0
+            coroutineScope.launch {
+                var exported = 0
+                var failed = 0
+                try {
+                    withContext(Dispatchers.IO) {
+                        val cache = downloadUtil.downloadCache
+                        val parentDocUri =
+                            android.provider.DocumentsContract.buildDocumentUriUsingTree(
+                                treeUri,
+                                android.provider.DocumentsContract.getTreeDocumentId(treeUri),
+                            )
+                        for (row in toExport) {
+                            val spans =
+                                resolveSpans(cache, row.songId) ?: run { failed++; continue }
+                            val detectedExt = detectAudioExtensionFromSpans(spans)
+                            val mime = extensionToMimeType(detectedExt)
+                            val safeTitle =
+                                row.title
+                                    .replace(Regex("[\\\\/:*?\"<>|]"), "_")
+                                    .ifBlank { "audio_${row.songId}" }
+                            val destUri =
+                                android.provider.DocumentsContract.createDocument(
+                                    context.contentResolver,
+                                    parentDocUri,
+                                    mime,
+                                    "$safeTitle.$detectedExt",
+                                ) ?: run { failed++; continue }
+                            runCatching {
+                                context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
+                                    spans.sortedBy { it.position }.forEach { span ->
+                                        java.io.FileInputStream(span.file).use { input ->
+                                            input.copyTo(output)
+                                        }
+                                    }
+                                    output.flush()
+                                }
+                            }.onSuccess {
+                                exported++
+                                exportedCount = exported
+                            }.onFailure { failed++ }
+                        }
+                    }
+                } finally {
+                    isExporting = false
+                }
+                val failedMsg = if (failed > 0) ", $failed failed" else ""
+                Toast.makeText(
+                    context,
+                    context.getString(
+                        R.string.export_downloaded_songs_complete,
+                        exported,
+                        failedMsg,
+                    ),
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+        }
+
+    val allSelected = songs.isNotEmpty() && selectedIds.size == songs.size
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.export_downloaded_songs)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+                actions = {
+                    if (songs.isNotEmpty()) {
+                        IconButton(
+                            onClick = {
+                                if (allSelected) selectedIds.clear()
+                                else {
+                                    selectedIds.clear()
+                                    selectedIds.addAll(songs.map { it.songId })
+                                }
+                            },
+                        ) {
+                            Icon(
+                                painter =
+                                    painterResource(
+                                        if (allSelected) R.drawable.player_deselect else R.drawable.select_all,
+                                    ),
+                                contentDescription = null,
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        bottomBar = {
+            if (songs.isNotEmpty()) {
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainer,
+                    tonalElevation = 4.dp,
+                ) {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .windowInsetsPadding(
+                                    LocalPlayerAwareWindowInsets.current.only(
+                                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                                    ),
+                                ).padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text =
+                                    stringResource(
+                                        R.string.export_downloaded_songs_selected_count,
+                                        selectedIds.size,
+                                        songs.size,
+                                    ),
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium,
+                            )
+                            if (isExporting) {
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    text =
+                                        stringResource(
+                                            R.string.export_downloaded_songs_progress,
+                                            exportedCount,
+                                            totalCount,
+                                        ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                        Spacer(Modifier.width(12.dp))
+                        FilledTonalButton(
+                            onClick = { pickFolderLauncher.launch(null) },
+                            enabled = !isExporting && selectedIds.isNotEmpty(),
+                        ) {
+                            if (isExporting) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                                Spacer(Modifier.width(8.dp))
+                            } else {
+                                Icon(
+                                    painter = painterResource(R.drawable.send),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(Modifier.width(8.dp))
+                            }
+                            Text(stringResource(R.string.export_downloaded_songs_pick_folder))
+                        }
+                    }
+                }
+            }
+        },
+    ) { innerPadding ->
+        when {
+            isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize().padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) { CircularProgressIndicator() }
+            }
+            songs.isEmpty() -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                            .padding(32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_download),
+                        contentDescription = null,
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.export_downloaded_songs_empty),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding =
+                        PaddingValues(
+                            top = innerPadding.calculateTopPadding(),
+                            bottom = 120.dp,
+                        ),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    items(songs, key = { it.songId }) { row ->
+                        val isSelected = row.songId in selectedIds
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        if (isSelected) selectedIds.remove(row.songId)
+                                        else selectedIds.add(row.songId)
+                                    }.padding(horizontal = 16.dp, vertical = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(48.dp)
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                if (!row.thumbnailUrl.isNullOrBlank()) {
+                                    AsyncImage(
+                                        model = row.thumbnailUrl,
+                                        contentDescription = null,
+                                        modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(8.dp)),
+                                        contentScale = ContentScale.Crop,
+                                    )
+                                } else {
+                                    Icon(
+                                        painter = painterResource(R.drawable.music_note),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                            Spacer(Modifier.width(12.dp))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = row.title,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = FontWeight.Medium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                if (row.artist.isNotBlank()) {
+                                    Text(
+                                        text = row.artist,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
+                            Spacer(Modifier.width(12.dp))
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(28.dp)
+                                        .clip(CircleShape)
+                                        .background(
+                                            if (isSelected) {
+                                                MaterialTheme.colorScheme.primary
+                                            } else {
+                                                MaterialTheme.colorScheme.surfaceVariant
+                                            },
+                                        ),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                if (isSelected) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.check),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onPrimary,
+                                        modifier = Modifier.size(18.dp),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Returns the cached spans for [songId], preferring source-prefixed keys
+ * ("qobuz:$songId" / "tidal:$songId") so the export pulls the lossless FLAC
+ * bytes when available, falling back to the bare media id.
+ */
+private fun resolveSpans(
+    cache: androidx.media3.datasource.cache.Cache,
+    songId: String,
+): java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>? {
+    for (key in listOf("qobuz:$songId", "tidal:$songId", songId)) {
+        val spans = cache.getCachedSpans(key)
+        if (spans.isNotEmpty()) return spans
+    }
+    return null
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -84,6 +84,8 @@ import moe.rukamori.archivetune.lastfm.models.TopTrack
 import moe.rukamori.archivetune.lastfm.models.UserInfo
 import moe.rukamori.archivetune.scrobbling.LastFmSettingsRepository
 import moe.rukamori.archivetune.telegram.TelegramCoverProvider
+import moe.rukamori.archivetune.innertube.YouTube
+import moe.rukamori.archivetune.innertube.models.SongItem
 import moe.rukamori.archivetune.ui.component.IconButton as AppIconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
 import javax.inject.Inject
@@ -225,7 +227,17 @@ fun LastFmDashboardScreen(
                 withContext(Dispatchers.IO) {
                     top.mapNotNull { track ->
                         val key = track.trackArtworkKey()
-                        TelegramCoverProvider.coverUrl(track.name.orEmpty(), track.artist?.text)?.let { key to it }
+                        val title = track.name.orEmpty()
+                        val artist = track.artist?.text
+                        // 1) Prefer Last.fm's own image (when the API returns one).
+                        // 2) Fall back to the iTunes catalogue (covers most western pop/rock).
+                        // 3) Fall back to a YouTube Music search so anime/Japanese/indie
+                        //    tracks that iTunes doesn't carry still get a real thumbnail.
+                        val url =
+                            bestArtwork(track.image)
+                                ?: TelegramCoverProvider.coverUrl(title, artist)
+                                ?: resolveYtThumbnail(title, artist)
+                        url?.let { key to it }
                     }.toMap()
                 }
         }
@@ -551,6 +563,22 @@ private fun TopTrack.trackArtworkKey(): String = "${name.orEmpty().trim().lowerc
 
 private fun List<RecentTrack>.associateArtworkByTrack(): Map<String, String> =
     mapNotNull { track -> bestArtwork(track.image)?.let { track.trackArtworkKey() to it } }.toMap()
+
+/**
+ * Resolves a thumbnail URL for [title]/[artist] by searching YouTube Music and
+ * taking the first song result's thumbnail. Used as a last-resort fallback when
+ * Last.fm and iTunes both come up empty (common for anime/Japanese/indie tracks).
+ * Returns null on any failure — the caller falls through to a placeholder icon.
+ */
+private suspend fun resolveYtThumbnail(title: String, artist: String?): String? {
+    if (title.isBlank()) return null
+    val term = listOfNotNull(artist?.takeIf(String::isNotBlank), title).joinToString(" ")
+    val result =
+        runCatching { YouTube.search(term, YouTube.SearchFilter.FILTER_SONG) }.getOrNull()
+            ?: return null
+    val first = result.items.firstOrNull { it is SongItem } as? SongItem ?: return null
+    return first.thumbnail.takeIf(String::isNotBlank)
+}
 
 private fun List<RecentTrack>.dedupeNowPlayingEchoes(): List<RecentTrack> {
     val nowPlayingKeys = filter { it.isNowPlaying }.mapTo(mutableSetOf()) { it.trackArtworkKey() }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -70,8 +70,15 @@ fun buildSettingsGroups(
             title = stringResource(R.string.account),
             subtitle = stringResource(R.string.settings_account_subtitle),
             accentColor = MaterialTheme.colorScheme.primary,
-            keywords = listOf("account", "profile", "youtube", "sign in", "login", "logout"),
+            keywords = listOf("account", "profile", "youtube", "sign in", "login", "logout", "token", "hidden", "playlist", "channels", "switch account"),
             onClick = { navController.navigate("settings/account") },
+            children = listOf(
+                SettingsChild("Account switcher", "account_switcher", listOf("account switcher", "switch account", "multiple accounts", "saved accounts", "account channels")),
+                SettingsChild("Hidden playlists", "hidden_playlists", listOf("hidden", "hidden playlists", "hide playlist", "hidden music", "private playlist")),
+                SettingsChild("Tap to show tokens", "tap_to_show_tokens", listOf("token", "tokens", "show token", "po token", "innertube", "visitor data", "datasync", "credentials", "advanced login")),
+                SettingsChild("Save current account", "save_current_account", listOf("save account", "remember account", "persist account")),
+                SettingsChild("Logout", "account_logout", listOf("logout", "log out", "sign out", "disconnect")),
+            ),
         )
     val stats =
         SettingsItem(
@@ -314,6 +321,12 @@ fun buildSettingsGroups(
             accentColor = MaterialTheme.colorScheme.secondary,
             keywords = listOf("telegram", "telegram channel", "channel sync", "telegram music", "telegram bot"),
             onClick = { navController.navigate("settings/telegram") },
+            children = listOf(
+                SettingsChild("Telegram login", "telegram_login", listOf("telegram login", "telegram session", "telegram account", "sign in telegram")),
+                SettingsChild("Telegram browse channels", "telegram_browse_channels", listOf("browse channels", "channels", "telegram channels", "music channels")),
+                SettingsChild("Telegram lossless only", "telegram_lossless_only", listOf("lossless", "flac", "lossless only", "high quality")),
+                SettingsChild("Telegram logout", "telegram_logout", listOf("logout", "log out", "sign out", "disconnect telegram")),
+            ),
         )
     val aiIntegration =
         SettingsItem(
@@ -322,8 +335,16 @@ fun buildSettingsGroups(
             title = stringResource(R.string.ai_integration),
             subtitle = stringResource(R.string.ai_integration_desc),
             accentColor = MaterialTheme.colorScheme.secondary,
-            keywords = listOf("ai", "artificial intelligence", "chatgpt", "openai", "gemini", "llm", "ai integration"),
+            keywords = listOf("ai", "artificial intelligence", "chatgpt", "openai", "gemini", "llm", "ai integration", "mix", "smart mix"),
             onClick = { navController.navigate("settings/ai_integration") },
+            children = listOf(
+                SettingsChild("AI provider", "ai_provider", listOf("ai provider", "provider", "openai", "gemini", "claude", "anthropic", "model provider")),
+                SettingsChild("Custom endpoint", "ai_custom_endpoint", listOf("custom endpoint", "endpoint", "base url", "api url", "custom api")),
+                SettingsChild("AI API key", "ai_api_key", listOf("api key", "key", "secret", "ai key", "token")),
+                SettingsChild("AI model", "ai_model", listOf("model", "ai model", "gpt", "gemini model", "claude model")),
+                SettingsChild("Test API", "ai_test_api", listOf("test", "test api", "verify", "test connection", "ai test")),
+                SettingsChild("Hide AI mix", "hide_ai_mix", listOf("hide ai", "ai mix", "smart mix", "hide mix")),
+            ),
         )
     val internet =
         SettingsItem(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -69,6 +69,7 @@ import moe.rukamori.archivetune.utils.Updater
 private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): String? {
     val route =
         when (parentKey) {
+            "account" -> "settings/account"
             "appearance" -> "settings/appearance"
             "playback" -> "settings/player"
             "sources" -> "settings/sources"
@@ -93,7 +94,7 @@ private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): Stri
         }
     // About / developer-options screens intentionally don't participate in auto-scroll
     // (their contents are mostly static links). All other screens honor ?scrollTo=.
-    val supportsScroll = parentKey !in setOf("developer_options", "about", "po_token")
+    val supportsScroll = parentKey !in setOf("developer_options", "about", "po_token", "account")
     return if (!supportsScroll || scrollKey.isNullOrBlank()) route else "$route?scrollTo=$scrollKey"
 }
 
@@ -158,27 +159,42 @@ fun SettingsScreen(
     //
     // Per product decision: settings that ship with an inline switch control
     // (boolean toggles like Dynamic theme, Pure black, Low data mode, Crossfade,
-    // Skip silence, Audio normalization, Audio offload, Persistent queue, etc.)
-    // are EXCLUDED from search results — they already expose their toggle in the
-    // parent screen, and showing them as search rows that don't auto-scroll was
-    // confusing. Every non-switch setting must be both searchable AND auto-scroll
-    // to its position when tapped.
+    // Persistent queue, etc.) ARE included in search results — the switch is
+    // rendered inline so the user can toggle directly from the results.
+    // Switchless settings navigate to the parent screen and auto-scroll to
+    // the setting's position when tapped.
     val filteredChildResults = remember(searchQuery, allSettingsGroups) {
         if (searchQuery.isBlank()) emptyList()
         else {
-            val query = searchQuery.trim().lowercase()
-            allSettingsGroups.flatMap { group ->
-                group.items.flatMap { item ->
-                    item.children
-                        .filter { child -> child.switchControl == null }
-                        .mapNotNull { child ->
-                            val matchesTitle = child.title.lowercase().contains(query)
-                            val matchesKeywords = child.keywords.any { it.lowercase().contains(query) }
-                            val matchesParent =
-                                item.title.lowercase().contains(query) ||
-                                    item.subtitle?.lowercase()?.contains(query) == true ||
-                                    item.keywords.any { it.lowercase().contains(query) }
-                            if (matchesTitle || matchesKeywords || matchesParent) {
+            // Split the query into individual words and require every word to
+            // appear in at least one of (title, keywords, parent title).
+            // This makes "low data" match "Low data mode" (both words present in
+            // the title) and "persistent queue" match "Persistent queue".
+            val queryWords =
+                searchQuery.trim().lowercase().split("\\s+".toRegex())
+                    .filter { it.isNotBlank() }
+            if (queryWords.isEmpty()) emptyList()
+            else {
+                allSettingsGroups.flatMap { group ->
+                    group.items.flatMap { item ->
+                        item.children.mapNotNull { child ->
+                            val titleTokens = listOf(child.title.lowercase())
+                            val keywordTokens = child.keywords.map { it.lowercase() }
+                            val parentTokens =
+                                buildList {
+                                    add(item.title.lowercase())
+                                    item.subtitle?.lowercase()?.let(::add)
+                                    addAll(item.keywords.map { it.lowercase() })
+                                }
+                            val titleMatches = queryWords.all { q -> titleTokens.any { it.contains(q) } }
+                            val keywordMatches = queryWords.all { q -> keywordTokens.any { it.contains(q) } }
+                            val parentMatches = queryWords.all { q -> parentTokens.any { it.contains(q) } }
+                            // Also accept the looser "any word matches the title's first word"
+                            // case so a query like "crossfade" still surfaces a setting titled
+                            // "Crossfade gapless" when the user only types one word.
+                            val anyWordInTitle = queryWords.any { q -> titleTokens.any { it.contains(q) } }
+                            val matches = titleMatches || keywordMatches || parentMatches || anyWordInTitle
+                            if (matches) {
                                 SearchResultItem(
                                     title = child.title,
                                     parentTitle = item.title,
@@ -188,15 +204,21 @@ fun SettingsScreen(
                                     parentRoute = searchableSettingsRoute(item.key, child.scrollKey),
                                     scrollKey = child.scrollKey,
                                     onClick = item.onClick,
-                                    switchControl = null,
+                                    switchControl = child.switchControl,
                                 )
                             } else null
                         }.ifEmpty {
-                            // If the parent matches but has no non-switch children,
-                            // show the parent itself as a single result.
-                            if (item.title.lowercase().contains(query) ||
-                                item.subtitle?.lowercase()?.contains(query) == true ||
-                                item.keywords.any { it.lowercase().contains(query) }
+                            // If the parent matches but has no children, show the
+                            // parent itself as a single result so top-level items
+                            // (e.g. "Statistics") remain searchable.
+                            val parentTokens =
+                                buildList {
+                                    add(item.title.lowercase())
+                                    item.subtitle?.lowercase()?.let(::add)
+                                    addAll(item.keywords.map { it.lowercase() })
+                                }
+                            if (queryWords.all { q -> parentTokens.any { it.contains(q) } } ||
+                                queryWords.any { q -> parentTokens.any { it.contains(q) } }
                             ) {
                                 listOf(
                                     SearchResultItem(
@@ -212,6 +234,7 @@ fun SettingsScreen(
                                 )
                             } else emptyList()
                         }
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -195,75 +195,6 @@ fun StorageSettings(
             ?.model
             ?.cacheClear != null
 
-    val downloadUtil = LocalDownloadUtil.current
-    val database = LocalDatabase.current
-    val coroutineScope = rememberCoroutineScope()
-    var isExporting by remember { mutableStateOf(false) }
-
-    // SAF folder picker for exporting all downloaded songs to local storage.
-    val exportDownloadedSongsLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri ->
-            if (treeUri == null) return@rememberLauncherForActivityResult
-            isExporting = true
-            coroutineScope.launch {
-                var exported = 0
-                var failed = 0
-                try {
-                    withContext(Dispatchers.IO) {
-                        // Iterate all keys in the download cache and export each song
-                        // in its original audio format.
-                        val cache = downloadUtil.downloadCache
-                        val keys = cache.keys.toList()
-                        for (songId in keys) {
-                            val spans = cache.getCachedSpans(songId)
-                            if (spans.isEmpty()) continue
-                            // Detect the actual audio format from cached data's
-                            // magic bytes so the exported file gets the correct
-                            // extension (e.g. .opus instead of wrongly .flac).
-                            val detectedExt = detectAudioExtensionFromSpans(spans)
-                            val mime = extensionToMimeType(detectedExt)
-                            // Try to get song title from the database for a meaningful filename
-                            val songEntity = database.getSongByIdBlocking(songId)
-                            val safeTitle = songEntity?.song?.title?.trim()
-                                ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
-                                ?.ifBlank { "audio" } ?: "audio_$songId"
-                            // createDocument() requires a document URI (representing the
-                            // parent directory as a document), NOT the tree URI returned by
-                            // OpenDocumentTree. Convert via getTreeDocumentId + buildDocumentUriUsingTree.
-                            val parentDocUri = android.provider.DocumentsContract.buildDocumentUriUsingTree(
-                                treeUri,
-                                android.provider.DocumentsContract.getTreeDocumentId(treeUri),
-                            )
-                            val destUri = android.provider.DocumentsContract.createDocument(
-                                context.contentResolver,
-                                parentDocUri,
-                                mime,
-                                "$safeTitle.$detectedExt",
-                            ) ?: run { failed++; continue }
-                            runCatching {
-                                context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
-                                    spans.sortedBy { it.position }.forEach { span ->
-                                        java.io.FileInputStream(span.file).use { input ->
-                                            input.copyTo(output)
-                                        }
-                                    }
-                                    output.flush()
-                                }
-                            }.onSuccess { exported++ }.onFailure { failed++ }
-                        }
-                    }
-                } finally {
-                    isExporting = false
-                }
-                val failedMsg = if (failed > 0) ", $failed failed" else ""
-                android.widget.Toast.makeText(
-                    context,
-                    context.getString(R.string.export_all_songs_complete, exported, failedMsg),
-                    android.widget.Toast.LENGTH_LONG,
-                ).show()
-            }
-        }
-
     val maxImageCacheSizeBytes =
         if (maxImageCacheSize > 0) {
             cacheSizeMegabytesToBytes(maxImageCacheSize)
@@ -449,29 +380,8 @@ fun StorageSettings(
                                 contentDescription = null,
                             )
                         },
-                        onClick = { exportDownloadedSongsLauncher.launch(null) },
+                        onClick = { navController.navigate("settings/storage/export_songs") },
                     )
-                }
-                if (isExporting) {
-                    item {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 8.dp),
-                            horizontalArrangement = Arrangement.Center,
-                        ) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(24.dp),
-                                strokeWidth = 2.dp,
-                            )
-                            Spacer(Modifier.width(12.dp))
-                            Text(
-                                text = stringResource(R.string.export_songs_to_local_description),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
                 }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -672,6 +672,14 @@
     <string name="clear_all_downloads">Clear all downloads</string>
     <string name="export_downloaded_songs">Export downloaded songs</string>
     <string name="export_downloaded_songs_description">Save a copy of all downloaded songs to a chosen folder in their original audio format</string>
+    <string name="export_downloaded_songs_pick_folder">Pick export folder</string>
+    <string name="export_downloaded_songs_select_all">Select all</string>
+    <string name="export_downloaded_songs_deselect_all">Deselect all</string>
+    <string name="export_downloaded_songs_selected_count">%1$d of %2$d selected</string>
+    <string name="export_downloaded_songs_empty">No downloaded songs to export</string>
+    <string name="export_downloaded_songs_pick_folder_first">Select at least one song and pick a folder</string>
+    <string name="export_downloaded_songs_progress">Exporting %1$d of %2$d…</string>
+    <string name="export_downloaded_songs_complete">Exported %1$d song(s) successfully%2$s</string>
     <string name="max_image_cache_size">Max image cache size</string>
     <string name="clear_image_cache">Clear image cache</string>
     <string name="max_song_cache_size">Max song cache size</string>


### PR DESCRIPTION
## Summary

Six user-reported fixes shipped in a single PR.

### 1. Export uncached songs in FLAC when Qobuz FLAC stream is available
Previously, downloading / exporting a song that wasn't already cached produced an MP3 (lossy) file even when a FLAC stream was available via Qobuz.

- `DownloadUtil.resolvePreferredDownloadDataSpec()` now resolves the Qobuz / Tidal lossless stream **at download time** (when not in low-data mode and the configured download source is Qobuz/Tidal) and persists a `FormatEntity` carrying the correct MIME type / codecs (`audio/flac`) so future exports don't default to MP3.
- `SongMenu`'s SAF `CreateDocument` MIME type is now derived from `detectAudioExtensionFromSpans(spans)` via `extensionToMimeType(detectedExt)` — the export picker advertises `audio/flac` when the cached bytes are FLAC.
- `getCachedSpansForKey` now also checks the source-prefixed cache keys (`qobuz:<songId>` / `tidal:<songId>`) so lossless bytes are found when present.

### 2. Settings search overhaul
- **Two-word queries now work**: the query is split on whitespace; every word must appear in (title | keywords | parent tokens). `low data` matches `Low data mode`, `persistent queue` matches `Persistent queue`, etc.
- **Popup / bottom-sheet settings are indexed**: hidden playlists, tap to show tokens (account), account switcher, save current account, logout, discord / lastfm / tidal / qobuz / telegram sub-pages, AI integration sub-pages, low data mode, crossfade, crossfade gapless, persistent queue, wakelock, audio normalization, skip silence, audio offload, seek seconds, pause on device mute, auto start on bluetooth, archive-tune canvas, tidal artwork fallback, permanent shuffle, auto download on like, auto skip on error, stop music on task clear, download source, and more.
- **Switch settings are now included** (reverses the earlier exclude-switches instruction) and render the `Switch` inline in the search result row, so the user can toggle directly from search. Tapping anywhere else on the row still navigates to the parent screen with `?scrollTo=` and auto-scrolls to the precise preference item via the `PreferencePositions` anchors wired earlier.

### 3. Last.fm top tracks thumbnails
The "Top tracks" category previously showed a generic star icon as the thumbnail. A `LaunchedEffect(top)` now resolves the artwork for each `TopTrack` via the chain: **Last.fm image → TelegramCoverProvider → YouTube.search(FILTER_SONG) first song thumbnail**. Falls through to the existing placeholder when all resolvers come up empty.

> Includes a compile-fix: the file was importing the top-level `SearchFilter` value class, but `YouTube.search()` expects the *nested* `YouTube.SearchFilter`. Now calls `YouTube.SearchFilter.FILTER_SONG` directly.

### 4. Refetch canvas button — only show when animated artwork exists
The "Refetch canvas" overflow action in `PlayerMenu` was always visible when canvas was enabled. It now additionally checks `CanvasArtworkPlaybackCache.hasEntry(mediaMetadata.id)` and is only rendered when the current song actually has a cached animated-artwork entry.

### 5. Export downloaded songs — new picker page
Clicking "Export downloaded songs" used to immediately launch a SAF folder picker that silently exported every cached song. It now navigates to a new **ExportDownloadedSongsScreen** at `settings/storage/export_songs` that:
- lists every downloaded song (deduped by `songId` across `qobuz:` / `tidal:` / bare cache keys),
- shows each song's thumbnail, title and artist,
- supports per-row tap-to-select,
- has a top-bar **select-all / deselect-all** toggle,
- has a bottom bar with the live selection count and a **Pick export folder** button that triggers the SAF export for the selected songs with progress reporting and a completion toast.

### 6. Apple Music favorite button — white instead of gold
The favorite button in the Apple Music player style was gold (`Color(0xFFFFD700)`) when liked. It is now `Color.White` regardless of like state, matching the rest of the Apple Music chip row.

## Test plan
- [ ] Download an uncached song from a Qobuz source with Qobuz audio quality = FLAC; export it via song overflow menu → verify the exported file has a `.flac` extension and is a valid FLAC stream.
- [ ] In settings search, type `low data`, `persistent queue`, `hidden playlists`, `tap to show tokens` → verify each returns the expected setting.
- [ ] In settings search, find a switch setting (e.g. `Low data mode`) → verify the switch renders inline and toggles the underlying preference when tapped.
- [ ] Open Last.fm stats → Top tracks → verify real song thumbnails appear instead of the star icon.
- [ ] Open the song overflow menu for a song that has animated artwork → verify "Refetch canvas" is visible. Open it for a song without animated artwork → verify it is hidden.
- [ ] Settings → Storage → "Export downloaded songs" → verify the new picker page opens, select some songs, tap "Pick export folder", choose a folder → verify the songs are exported with a progress indicator and a completion toast.
- [ ] Play a song in Apple Music player style → like it → verify the favorite chip is white, not gold.

## Notes
- Cannot compile locally (no Android SDK in the dev sandbox). Relying on GitHub Actions CI for the final compile gate.