### PR TITLE
fix: compile errors + 6 features (FLAC export, settings search, lastfm thumbs, canvas gate, export picker, AM fav color)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -60,6 +60,7 @@ import moe.rukamori.archivetune.ui.screens.settings.ContentSettings
 import moe.rukamori.archivetune.ui.screens.settings.CustomizeBackground
 import moe.rukamori.archivetune.ui.screens.settings.DebugSettings
 import moe.rukamori.archivetune.ui.screens.settings.DiscordSettings
+import moe.rukamori.archivetune.ui.screens.settings.ExportDownloadedSongsScreen
 import moe.rukamori.archivetune.ui.screens.settings.HiddenPlaylistsScreen
 import moe.rukamori.archivetune.ui.screens.settings.IconScreen
 import moe.rukamori.archivetune.ui.screens.settings.IntegrationScreen

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
@@ -243,6 +243,7 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
                                     selectedIds.addAll(songs.map { it.songId })
                                 }
                             },
+                            onLongClick = {},
                         ) {
                             Icon(
                                 painter =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -573,10 +573,12 @@ private fun List<RecentTrack>.associateArtworkByTrack(): Map<String, String> =
 private suspend fun resolveYtThumbnail(title: String, artist: String?): String? {
     if (title.isBlank()) return null
     val term = listOfNotNull(artist?.takeIf(String::isNotBlank), title).joinToString(" ")
-    val result =
-        runCatching { YouTube.search(term, YouTube.SearchFilter.FILTER_SONG) }.getOrNull()
+    // YouTube.search already returns Result<SearchResult>; don't wrap in runCatching
+    // (that would produce Result<Result<SearchResult>> and break type inference).
+    val searchResult =
+        YouTube.search(term, YouTube.SearchFilter.FILTER_SONG).getOrNull()
             ?: return null
-    val first = result.items.firstOrNull { it is SongItem } as? SongItem ?: return null
+    val first = searchResult.items.firstOrNull { it is SongItem } as? SongItem ?: return null
     return first.thumbnail.takeIf(String::isNotBlank)
 }
 


### PR DESCRIPTION
## Summary

Six user-reported fixes shipped in a single PR, plus compile fixes for the GitHub Actions failures that blocked PR #50.

> Supersedes #50. Same feature set, plus 4 compile errors fixed so CI can run.

### Compile fixes (new in this PR)
1. **`LastFmDashboardScreen.kt:579`** — `None of the following candidates is applicable` on `result.items.firstOrNull`.
   - Root cause: `YouTube.search()` already returns `Result<SearchResult>`, so wrapping it in `runCatching { ... }` produced `Result<Result<SearchResult>>`, and `.getOrNull()` returned `Result<SearchResult>?` — which has no `.items` property. The compiler then resolved `items` to the unrelated `LazyListScope.items()` extension imported from `androidx.compose.foundation.lazy`, causing the receiver-type-mismatch error and the downstream `Unresolved reference 'it'` on the lambda.
   - Fix: drop the redundant `runCatching` wrapper; call `YouTube.search(...).getOrNull()` directly.
2. **`ExportDownloadedSongsScreen.kt:239`** — `No value passed for parameter 'onLongClick'`. The custom `moe.rukamori.archivetune.ui.component.IconButton` requires both `onClick` and `onLongClick` (no default). The select-all `IconButton` in the `TopAppBar` actions slot was missing `onLongClick`.
   - Fix: add `onLongClick = {}`.
3. **`NavigationBuilder.kt:464`** — `Unresolved reference 'ExportDownloadedSongsScreen'`. The new screen's composable lives in package `moe.rukamori.archivetune.ui.screens.settings`, but `NavigationBuilder.kt` (in package `...ui.screens`) was missing the import.
   - Fix: add `import moe.rukamori.archivetune.ui.screens.settings.ExportDownloadedSongsScreen`.

### Feature fixes (carried over from #50)

#### 1. Export uncached songs in FLAC when Qobuz FLAC stream is available
Previously, downloading / exporting a song that wasn't already cached produced an MP3 (lossy) file even when a FLAC stream was available via Qobuz.

- `DownloadUtil.resolvePreferredDownloadDataSpec()` now resolves the Qobuz / Tidal lossless stream **at download time** (when not in low-data mode and the configured download source is Qobuz/Tidal) and persists a `FormatEntity` carrying the correct MIME type / codecs (`audio/flac`) so future exports don't default to MP3.
- `SongMenu`'s SAF `CreateDocument` MIME type is now derived from `detectAudioExtensionFromSpans(spans)` via `extensionToMimeType(detectedExt)` — the export picker advertises `audio/flac` when the cached bytes are FLAC.
- `getCachedSpansForKey` now also checks the source-prefixed cache keys (`qobuz:<songId>` / `tidal:<songId>`) so lossless bytes are found when present.

#### 2. Settings search overhaul
- **Two-word queries now work**: the query is split on whitespace; every word must appear in (title | keywords | parent tokens). `low data` matches `Low data mode`, `persistent queue` matches `Persistent queue`, etc.
- **Popup / bottom-sheet settings are indexed**: hidden playlists, tap to show tokens (account), account switcher, save current account, logout, discord / lastfm / tidal / qobuz / telegram sub-pages, AI integration sub-pages, low data mode, crossfade, crossfade gapless, persistent queue, wakelock, audio normalization, skip silence, audio offload, seek seconds, pause on device mute, auto start on bluetooth, archive-tune canvas, tidal artwork fallback, permanent shuffle, auto download on like, auto skip on error, stop music on task clear, download source, and more.
- **Switch settings are now included** (reverses the earlier exclude-switches instruction) and render the `Switch` inline in the search result row, so the user can toggle directly from search. Tapping anywhere else on the row still navigates to the parent screen with `?scrollTo=` and auto-scrolls to the precise preference item via the `PreferencePositions` anchors wired earlier.

#### 3. Last.fm top tracks thumbnails
The "Top tracks" category previously showed a generic star icon as the thumbnail. A `LaunchedEffect(top)` now resolves the artwork for each `TopTrack` via the chain: **Last.fm image → TelegramCoverProvider → YouTube.search(FILTER_SONG) first song thumbnail**. Falls through to the existing placeholder when all resolvers come up empty.

#### 4. Refetch canvas button — only show when animated artwork exists
The "Refetch canvas" overflow action in `PlayerMenu` was always visible when canvas was enabled. It now additionally checks `CanvasArtworkPlaybackCache.hasEntry(mediaMetadata.id)` and is only rendered when the current song actually has a cached animated-artwork entry.

#### 5. Export downloaded songs — new picker page
Clicking "Export downloaded songs" used to immediately launch a SAF folder picker that silently exported every cached song. It now navigates to a new **ExportDownloadedSongsScreen** at `settings/storage/export_songs` that:
- lists every downloaded song (deduped by `songId` across `qobuz:` / `tidal:` / bare cache keys),
- shows each song's thumbnail, title and artist,
- supports per-row tap-to-select,
- has a top-bar **select-all / deselect-all** toggle,
- has a bottom bar with the live selection count and a **Pick export folder** button that triggers the SAF export for the selected songs with progress reporting and a completion toast.

#### 6. Apple Music favorite button — white instead of gold
The favorite button in the Apple Music player style was gold (`Color(0xFFFFD700)`) when liked. It is now `Color.White` regardless of like state, matching the rest of the Apple Music chip row.

## Test plan
- [ ] CI build job is green.
- [ ] Download an uncached song from a Qobuz source with Qobuz audio quality = FLAC; export it via song overflow menu → verify the exported file has a `.flac` extension and is a valid FLAC stream.
- [ ] In settings search, type `low data`, `persistent queue`, `hidden playlists`, `tap to show tokens` → verify each returns the expected setting.
- [ ] In settings search, find a switch setting (e.g. `Low data mode`) → verify the switch renders inline and toggles the underlying preference when tapped.
- [ ] Open Last.fm stats → Top tracks → verify real song thumbnails appear instead of the star icon.
- [ ] Open the song overflow menu for a song that has animated artwork → verify "Refetch canvas" is visible. Open it for a song without animated artwork → verify it is hidden.
- [ ] Settings → Storage → "Export downloaded songs" → verify the new picker page opens, select some songs, tap "Pick export folder", choose a folder → verify the songs are exported with a progress indicator and a completion toast.
- [ ] Play a song in Apple Music player style → like it → verify the favorite chip is white, not gold.

## Notes
- Cannot compile locally (no Android SDK in the dev sandbox). Relying on GitHub Actions CI for the final compile gate.
- Closes #50 (superseded).