### PR TITLE
fix(compile): DataSpec.Builder.subrange + RenderEffect type mismatch

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -8823,9 +8823,14 @@ class MusicService :
             ) >= requestedLength
         } ?: return null
 
+        // DataSpec.Builder has no subrange() method (subrange() is defined
+        // on the DataSpec data class, not on its Builder). Use the Builder
+        // equivalents setPosition() / setLength() to scope the cached
+        // request to the bytes that are actually present.
         return dataSpec.buildUpon()
             .setKey(matchingKey)
-            .subrange(0L, requestedLength)
+            .setPosition(0L)
+            .setLength(requestedLength)
             .build()
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/MediaDetailHero.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/MediaDetailHero.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.Layout
@@ -709,29 +708,21 @@ private val MediaDetailSecondaryActionSize = 52.dp
 private val MediaDetailActionSize = 48.dp
 
 /**
- * Blur modifier used by the hero's backdrop. Uses a hardware-accelerated
- * [android.graphics.RenderEffect] on API 31+ (Android 12) for a real
- * Gaussian blur, and falls back to [Modifier.blur] on older API levels
- * (which itself uses a software fallback in Compose 1.6+).
+ * Blur modifier used by the hero's backdrop. Compose's [Modifier.blur]
+ * already dispatches to a hardware-accelerated
+ * `android.graphics.RenderEffect` on API 31+ (Android 12) and falls back
+ * to a software-rendered blur on older API levels — so calling
+ * `RenderEffect.createBlurEffect` directly is unnecessary and produces a
+ * type mismatch (`android.graphics.RenderEffect` vs the Compose
+ * `androidx.compose.ui.graphics.RenderEffect` expected by
+ * `GraphicsLayerScope.renderEffect`).
  *
  * The radius (24dp) is tuned to be obviously blurred while still
  * preserving enough color information that the artwork is recognisable —
  * a frosted-glass tint is layered on top in the hero to guarantee
  * legibility regardless of the thumbnail's average color.
  */
-private val MediaDetailHeroBlurModifier: Modifier =
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-        Modifier.graphicsLayer {
-            renderEffect =
-                android.graphics.RenderEffect.createBlurEffect(
-                    24f,
-                    24f,
-                    android.graphics.Shader.TileMode.CLAMP,
-                )
-        }
-    } else {
-        Modifier.blur(24.dp)
-    }
+private val MediaDetailHeroBlurModifier: Modifier = Modifier.blur(24.dp)
 
 private enum class MediaDetailActionLayoutId {
     Shuffle,


### PR DESCRIPTION
## Summary

Fixes the two `:app:compileGmsMobileUniversalDebugKotlin` errors from the most recent CI run on this branch (see screenshots in chat):

| # | File:Line | Error | Fix |
|---|-----------|-------|-----|
| 1 | `MusicService.kt:8828:14` | `Unresolved reference 'subrange'` | `DataSpec.Builder` does not expose `subrange()` — that method lives on the `DataSpec` data class itself. Replaced `.subrange(0L, requestedLength)` on the Builder with `.setPosition(0L).setLength(requestedLength)`, which is the Builder API equivalent. The two other `.subrange()` call sites in this file operate on `DataSpec` instances (`resolvedDataSpec`), not on a Builder, so they are unchanged and still valid. |
| 2 | `MediaDetailHero.kt:725:26` | `Assignment type mismatch: actual type is 'android.graphics.RenderEffect', but 'androidx.compose.ui.graphics.RenderEffect?' was expected.` | `GraphicsLayerScope.renderEffect` expects the Compose `androidx.compose.ui.graphics.RenderEffect` wrapper, not the platform `android.graphics.RenderEffect` returned by `RenderEffect.createBlurEffect`. Compose's `Modifier.blur(24.dp)` already dispatches to a hardware-accelerated platform `RenderEffect` on API 31+ and falls back to a software-rendered blur on older API levels — which is exactly what the deleted `if (SDK_INT >= S) { graphicsLayer { renderEffect = ... } } else { Modifier.blur(...) }` branch was trying to do manually. Delegating to `Modifier.blur(24.dp)` directly removes the type mismatch, simplifies the code, and keeps the same visual behaviour. The now-unused `androidx.compose.ui.graphics.graphicsLayer` import is also removed. |

## Why these broke

- The previous commit on this branch (`29b754385`) introduced a source-prefixed cache-key lookup in `resolveCachedDataSpec`. The Builder chain ended with `.subrange(0L, requestedLength)`, but `subrange()` is **not** a method on `androidx.media3.datasource.DataSpec.Builder` — it is an instance method on `DataSpec`. kotlinc only reports the first error per identifier, so a single `Unresolved reference 'subrange'` was emitted.
- The blur modifier in `MediaDetailHero.kt` was written against the platform `RenderEffect` API directly, which Compose's `GraphicsLayerScope` does not accept — it requires the `androidx.compose.ui.graphics.RenderEffect` wrapper.

## Validation

- No Android SDK is available locally; this PR is intended to be validated by GitHub Actions `Build and Lint Mobile Universal Debug APK` workflow on push.
- Both fixes are minimal and only touch the two error sites (plus one unused-import removal).

## Test plan

- [ ] CI `:app:compileGmsMobileUniversalDebugKotlin` task succeeds.
- [ ] Playlist detail hero still renders with a visibly blurred backdrop (24dp Gaussian blur).
- [ ] Downloaded Qobuz/Tidal/Deezer tracks play back from cache (no Code 3003, no YouTube-MP3 fallback) — exercises the modified `resolveCachedDataSpec` path.
