### PR TITLE
fix(compile): AudioTagger — use explicit jaudiotagger Java getter

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioTagger.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioTagger.kt
@@ -86,7 +86,14 @@ object AudioTagger {
         if (!file.exists() || file.length() == 0L) return false
         return runCatching {
             val audioFile = AudioFileIO.read(file)
-            val tag = audioFile.tagOrCreateAndSetDefault()
+            // Use the explicit Java getter call instead of the synthetic
+            // `tagOrCreateAndSetDefault` property access — Kotlin 2.4
+            // misinterprets `audioFile.tagOrCreateAndSetDefault()` as
+            // property-access + invoke(), which yields an unresolved type
+            // for `tag` and cascades into "Unresolved reference 'setField'"
+            // on every field-write below. Calling the Java getter directly
+            // avoids the property-access synthesis and returns Tag cleanly.
+            val tag = audioFile.getTagOrCreateAndSetDefault()
             metadata.title?.takeIf(String::isNotBlank)?.let { tag.setField(FieldKey.TITLE, it) }
             metadata.artist?.takeIf(String::isNotBlank)?.let { tag.setField(FieldKey.ARTIST, it) }
             metadata.albumArtist?.takeIf(String::isNotBlank)?.let { tag.setField(FieldKey.ALBUM_ARTIST, it) }


### PR DESCRIPTION
## Root cause

The previous PR (#57, commit `85725c0d8`) introduced `AudioTagger.kt` to write ID3 / Vorbis / MP4 / FLAC tags onto downloaded songs via the [jaudiotagger](https://github.com/RouHim/jaudiotagger) library (v1.4.31).

CI failed with:

```
e: …/AudioTagger.kt:102:69 Unresolved reference 'setField'.
> Task :app:compileGmsMobileUniversalDebugKotlin FAILED
```

The reported column (69) points at `setField`, but the actual fault is on **line 89**:

```kotlin
val tag = audioFile.tagOrCreateAndSetDefault()
```

Kotlin **2.4.0** synthesises a property `tagOrCreateAndSetDefault` from the Java getter `AudioFile#getTagOrCreateAndSetDefault()`. When Kotlin sees `audioFile.tagOrCreateAndSetDefault()` (property access **+** `()`), it tries to resolve `Tag.invoke()` — which doesn't exist — so the type of `tag` cannot be inferred. Every subsequent `tag.setField(FieldKey.X, value)` call then fails with `Unresolved reference 'setField'` because the receiver type is unknown.

## Fix

Call the Java getter explicitly — this bypasses the synthetic-property path entirely:

```diff
-val tag = audioFile.tagOrCreateAndSetDefault()
+val tag = audioFile.getTagOrCreateAndSetDefault()
```

With `tag` now correctly typed as `Tag`, all 13 `tag.setField(FieldKey.X, value)` calls resolve to `Tag.setField(FieldKey, String...)` (Java varargs — Kotlin accepts the single-string call natively).

## Local verification

Installed `kotlinc 2.4.0` locally, downloaded the exact JitPack artifact `com.github.RouHim:jaudiotagger:1.4.31`, and compiled the full `AudioTagger.kt` source against it:

```bash
$ kotlinc -cp jaudiotagger-1.4.31.jar AudioTagger.kt -d out
# exit 0 — no errors
```

Before the fix, the same command produced 6 errors (all cascading from the unresolved `tag` type on line 89).

## Scope

Single-file, single-line behavioural change. No API surface change — `AudioTagger.tag(file, metadata)` still has the same signature and behaviour. No other call sites in the repo use the problematic pattern (grep confirmed only one occurrence).

## Follow-up

Once this compiles cleanly, the larger feature work from #57 (Ketch downloader + jaudiotagger metadata tagging + restored flat gradient hero) becomes usable end-to-end.