### PR TITLE
feat(playlist): add Spotify and Qobuz playlist import

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServiceImportCredentials.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServiceImportCredentials.kt
@@ -1,0 +1,62 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playlist
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.constants.QobuzTokensKey
+import moe.rukamori.archivetune.constants.TidalAccessTokenKey
+import moe.rukamori.archivetune.constants.TidalCountryCodeKey
+import moe.rukamori.archivetune.qobuz.QobuzToken
+import moe.rukamori.archivetune.utils.PoolAccountManager
+import moe.rukamori.archivetune.utils.dataStore
+
+/**
+ * Collects the credentials [CrossServicePlaylistImporter] needs for the
+ * services whose playlist APIs reject anonymous reads (Tidal and Qobuz).
+ *
+ * Mirrors the precedence used by the playback resolvers: the user's own
+ * linked account first, then a shared community Source Pool account. Nothing
+ * here throws — a missing credential simply comes back null and the importer
+ * turns it into a "sign in first" message.
+ */
+object CrossServiceImportCredentials {
+
+    suspend fun load(context: Context): CrossServicePlaylistImporter.Credentials =
+        withContext(Dispatchers.IO) {
+            // Warm the pool cache from disk so a cold start still has accounts.
+            runCatching { PoolAccountManager.loadCached(context) }
+
+            val prefs = runCatching { context.dataStore.data.first() }.getOrNull()
+
+            val userTidalToken = prefs?.get(TidalAccessTokenKey)?.takeIf { it.isNotBlank() }
+            val poolTidal = PoolAccountManager.tidalAccounts().firstOrNull()
+            val tidalToken = userTidalToken ?: poolTidal?.token?.takeIf { it.isNotBlank() }
+            val tidalCountry = prefs?.get(TidalCountryCodeKey)?.takeIf { it.isNotBlank() }
+                ?: poolTidal?.countryCode?.takeIf { it.isNotBlank() }
+                ?: "US"
+
+            // Qobuz needs the app_id alongside the auth token; a token without
+            // one can't sign requests, so only complete pairs are used.
+            val qobuz = QobuzToken.listFromJson(prefs?.get(QobuzTokensKey))
+                .firstOrNull { it.token.isNotBlank() && it.appId.isNotBlank() }
+                ?.let { it.appId to it.token }
+                ?: PoolAccountManager.qobuzAccounts()
+                    .firstOrNull { it.token.isNotBlank() && it.appId.isNotBlank() }
+                    ?.let { it.appId to it.token }
+
+            CrossServicePlaylistImporter.Credentials(
+                tidalAccessToken = tidalToken,
+                tidalCountryCode = tidalCountry,
+                qobuzAppId = qobuz?.first,
+                qobuzAuthToken = qobuz?.second,
+            )
+        }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt
@@ -14,9 +14,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.SongItem
+import moe.rukamori.archivetune.spotify.Spotify
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.json.JSONArray
 import org.json.JSONObject
+import org.json.JSONTokener
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
@@ -65,12 +68,31 @@ object CrossServicePlaylistImporter {
 
     enum class ImportSource(val displayName: String) {
         YOUTUBE_MUSIC("YouTube Music"),
+        SPOTIFY("Spotify"),
         APPLE_MUSIC("Apple Music"),
         AMAZON_MUSIC("Amazon Music"),
         TIDAL("Tidal"),
+        QOBUZ("Qobuz"),
         DEEZER("Deezer"),
         UNKNOWN("Unknown"),
     }
+
+    /**
+     * Credentials for the services whose playlist APIs are not publicly
+     * readable. Tidal and Qobuz both reject anonymous playlist reads, so the
+     * caller supplies whatever the user already has configured (own account
+     * or a community Source Pool account) — see
+     * `CrossServiceImportCredentials.load`.
+     *
+     * Both fields are optional: an import from a service with no credentials
+     * fails with a friendly "sign in first" message rather than a 401.
+     */
+    data class Credentials(
+        val tidalAccessToken: String? = null,
+        val tidalCountryCode: String = "US",
+        val qobuzAppId: String? = null,
+        val qobuzAuthToken: String? = null,
+    )
 
     private val client: OkHttpClient by lazy {
         OkHttpClient.Builder()
@@ -86,9 +108,11 @@ object CrossServicePlaylistImporter {
      */
     fun detectSource(url: String): ImportSource = when {
         url.contains("music.youtube.com") || url.contains("youtube.com/playlist") -> ImportSource.YOUTUBE_MUSIC
+        url.contains("spotify.com") || url.startsWith("spotify:") -> ImportSource.SPOTIFY
         url.contains("music.apple.com") -> ImportSource.APPLE_MUSIC
         url.contains("music.amazon.com") -> ImportSource.AMAZON_MUSIC
         url.contains("tidal.com") -> ImportSource.TIDAL
+        url.contains("qobuz.com") -> ImportSource.QOBUZ
         url.contains("deezer.com") -> ImportSource.DEEZER
         else -> ImportSource.UNKNOWN
     }
@@ -100,7 +124,10 @@ object CrossServicePlaylistImporter {
      * skip the [resolveToYouTubeMusic] step). For all other services the
      * tracks are `(title, artist)` tuples that need to be looked up.
      */
-    suspend fun fetchPlaylist(url: String): Result<ResolvedImport> = withContext(Dispatchers.IO) {
+    suspend fun fetchPlaylist(
+        url: String,
+        credentials: Credentials = Credentials(),
+    ): Result<ResolvedImport> = withContext(Dispatchers.IO) {
         runCatching {
             val source = detectSource(url)
             when (source) {
@@ -124,11 +151,16 @@ object CrossServicePlaylistImporter {
                         },
                     )
                 }
+                ImportSource.SPOTIFY -> fetchSpotifyPlaylist(url)
                 ImportSource.APPLE_MUSIC -> fetchAppleMusicPlaylist(url)
                 ImportSource.AMAZON_MUSIC -> fetchAmazonMusicPlaylist(url)
-                ImportSource.TIDAL -> fetchTidalPlaylist(url)
+                ImportSource.TIDAL -> fetchTidalPlaylist(url, credentials)
+                ImportSource.QOBUZ -> fetchQobuzPlaylist(url, credentials)
                 ImportSource.DEEZER -> fetchDeezerPlaylist(url)
-                ImportSource.UNKNOWN -> error("Unrecognized URL — supported: YouTube Music, Apple Music, Amazon Music, Tidal, Deezer")
+                ImportSource.UNKNOWN -> error(
+                    "Unrecognized URL — supported: YouTube Music, Spotify, Apple Music, " +
+                        "Amazon Music, Tidal, Qobuz, Deezer",
+                )
             }
         }
     }
@@ -168,6 +200,115 @@ object CrossServicePlaylistImporter {
             onProgress?.invoke(completed, total)
         }
         results
+    }
+
+    // ─── Spotify ──────────────────────────────────────────────────────────
+    // URL pattern: https://open.spotify.com/playlist/{base62-id}
+    //
+    // Two paths, in order of preference:
+    //
+    //  1. **Authenticated GQL** — when the user has linked their Spotify
+    //     account (`Spotify.accessToken` set by `SpotifyLibraryRepository`),
+    //     we page through `Spotify.playlistTracks` and get the *whole*
+    //     playlist plus private/collaborative ones.
+    //  2. **Anonymous embed** — otherwise we read the public embed page's
+    //     `__NEXT_DATA__` blob, which carries up to 100 tracks with no
+    //     credentials at all. Good enough for public playlists and keeps the
+    //     feature usable for users who never sign in.
+    private suspend fun fetchSpotifyPlaylist(url: String): ResolvedImport {
+        val id = extractSpotifyPlaylistId(url)
+            ?: error("Couldn't extract Spotify playlist id from URL")
+
+        if (Spotify.isAuthenticated()) {
+            val viaApi = runCatching { fetchSpotifyPlaylistViaApi(id) }.getOrNull()
+            if (viaApi != null && viaApi.tracks.isNotEmpty()) return viaApi
+        }
+        return fetchSpotifyPlaylistViaEmbed(id)
+    }
+
+    /** Pages through the authenticated GQL endpoint until every track is collected. */
+    private suspend fun fetchSpotifyPlaylistViaApi(id: String): ResolvedImport {
+        val meta = Spotify.playlist(id).getOrNull()
+        val tracks = mutableListOf<ForeignTrack>()
+        var offset = 0
+        while (true) {
+            val page = Spotify.playlistTracks(id, limit = SPOTIFY_PAGE_SIZE, offset = offset)
+                .getOrNull() ?: break
+            val items = page.items.mapNotNull { item ->
+                val track = item.track ?: return@mapNotNull null
+                val title = track.name.ifBlank { return@mapNotNull null }
+                ForeignTrack(
+                    title = title,
+                    artist = track.artists.firstOrNull()?.name,
+                    album = track.album?.name,
+                    durationMs = track.durationMs.toLong().takeIf { it > 0 },
+                )
+            }
+            tracks.addAll(items)
+            offset += SPOTIFY_PAGE_SIZE
+            // Stop when we've drained the playlist or the API stopped
+            // returning rows (guards against an off-by-one `total`).
+            if (page.items.isEmpty() || offset >= page.total || tracks.size >= SPOTIFY_MAX_TRACKS) break
+        }
+        return ResolvedImport(
+            source = ImportSource.SPOTIFY,
+            sourcePlaylistId = id,
+            title = meta?.name?.takeIf { it.isNotBlank() } ?: "Spotify Playlist",
+            thumbnailUrl = meta?.images?.firstOrNull()?.url?.takeIf { it.isNotBlank() },
+            tracks = tracks,
+        )
+    }
+
+    /**
+     * Reads the public `open.spotify.com/embed/playlist/{id}` page. The page
+     * embeds a `__NEXT_DATA__` script whose
+     * `props.pageProps.state.data.entity` holds `name`, `coverArt.sources`
+     * and a `trackList` of `{title, subtitle, duration}` — `subtitle` is the
+     * artist name.
+     */
+    private suspend fun fetchSpotifyPlaylistViaEmbed(id: String): ResolvedImport {
+        val html = fetchText("https://open.spotify.com/embed/playlist/$id")
+        val nextData = extractNextData(html)
+            ?: error("Spotify playlist is private or unavailable")
+        val entity = JSONObject(nextData)
+            .optJSONObject("props")
+            ?.optJSONObject("pageProps")
+            ?.optJSONObject("state")
+            ?.optJSONObject("data")
+            ?.optJSONObject("entity")
+            ?: error("Spotify playlist is private or unavailable")
+
+        val trackList = entity.optJSONArray("trackList")
+        val tracks = (0 until (trackList?.length() ?: 0)).mapNotNull { i ->
+            val obj = trackList?.optJSONObject(i) ?: return@mapNotNull null
+            val title = obj.optString("title").ifBlank { return@mapNotNull null }
+            ForeignTrack(
+                title = title,
+                artist = obj.optString("subtitle").ifBlank { null },
+                durationMs = obj.optLong("duration").takeIf { it > 0 },
+            )
+        }
+        val cover = entity.optJSONObject("coverArt")
+            ?.optJSONArray("sources")
+            ?.optJSONObject(0)
+            ?.optString("url")
+            ?.ifBlank { null }
+
+        return ResolvedImport(
+            source = ImportSource.SPOTIFY,
+            sourcePlaylistId = id,
+            title = entity.optString("name").ifBlank { "Spotify Playlist" },
+            thumbnailUrl = cover,
+            tracks = tracks,
+        )
+    }
+
+    /** Accepts web URLs, `spotify:playlist:` URIs, and embed links. */
+    internal fun extractSpotifyPlaylistId(url: String): String? {
+        val uri = Pattern.compile("spotify:playlist:([A-Za-z0-9]+)").matcher(url)
+        if (uri.find()) return uri.group(1)
+        val web = Pattern.compile("playlist[/:]([A-Za-z0-9]{16,})").matcher(url)
+        return if (web.find()) web.group(1) else null
     }
 
     // ─── Apple Music ──────────────────────────────────────────────────────
@@ -211,8 +352,22 @@ object CrossServicePlaylistImporter {
     private fun parseAppleMusicTracks(html: String): List<ForeignTrack> {
         val tracks = mutableListOf<ForeignTrack>()
 
-        // Strategy 1: the schema:music-playlist JSON blob — most reliable.
-        // Each track looks like {"name":"...","artistName":"..."}.
+        // Strategy 1: the `serialized-server-data` script block — this is what
+        // current Apple Music pages server-render. Track rows appear nested
+        // several levels deep (data[].data.sections[].items[]) and each carries
+        // a `title` + `artistName`, so we walk the whole tree rather than
+        // hardcoding indices that Apple reshuffles between redesigns.
+        extractScriptJson(html, "serialized-server-data")?.let { raw ->
+            runCatching {
+                collectAppleMusicTracks(JSONTokener(raw).nextValue(), tracks)
+            }
+        }
+        if (tracks.isNotEmpty()) {
+            return tracks.distinctBy { it.title to it.artist }
+        }
+
+        // Strategy 2: the older schema:music-playlist JSON blob, where each
+        // track looks like {"name":"...","artistName":"..."}.
         val schemaRegex = Pattern.compile("\\{\"name\":\"([^\"]{2,200})\",\"artistName\":\"([^\"]{2,200})\"")
         val sm = schemaRegex.matcher(html)
         while (sm.find()) {
@@ -225,7 +380,7 @@ object CrossServicePlaylistImporter {
             return tracks.distinctBy { it.title to it.artist }
         }
 
-        // Strategy 2: JSON-LD MusicRecording entries.
+        // Strategy 3: JSON-LD MusicRecording entries.
         val itemRegex = Pattern.compile("\\{\"@type\":\"MusicRecording\",\"name\":\"([^\"]+)\"[^}]*?(?:\"byArtist\":\\{\"@type\":\"MusicGroup\",\"name\":\"([^\"]+)\"\\})?")
         val m = itemRegex.matcher(html)
         while (m.find()) {
@@ -246,6 +401,33 @@ object CrossServicePlaylistImporter {
             }
         }
         return tracks.distinctBy { it.title to it.artist }
+    }
+
+    /**
+     * Depth-first walk over the Apple Music server-data tree, collecting any
+     * object that carries both a `title` and an `artistName`. Order is
+     * preserved because Apple serialises the track rows in playlist order.
+     */
+    private fun collectAppleMusicTracks(node: Any?, into: MutableList<ForeignTrack>) {
+        when (node) {
+            is JSONObject -> {
+                val title = node.optString("title").takeIf { it.isNotBlank() }
+                val artist = node.optString("artistName").takeIf { it.isNotBlank() }
+                if (title != null && artist != null) {
+                    into.add(
+                        ForeignTrack(
+                            title = title,
+                            artist = artist,
+                            durationMs = node.optLong("durationInMillis").takeIf { it > 0 },
+                        ),
+                    )
+                }
+                node.keys().forEach { key -> collectAppleMusicTracks(node.opt(key), into) }
+            }
+            is JSONArray -> {
+                for (i in 0 until node.length()) collectAppleMusicTracks(node.opt(i), into)
+            }
+        }
     }
 
     // ─── Amazon Music ─────────────────────────────────────────────────────
@@ -313,63 +495,143 @@ object CrossServicePlaylistImporter {
 
     // ─── Tidal ────────────────────────────────────────────────────────────
     // URL pattern: https://tidal.com/browse/playlist/{uuid}
-    // Tidal's public page embeds a Next.js __NEXT_DATA__ JSON blob that
-    // includes the track list. We extract from there.
-    private suspend fun fetchTidalPlaylist(url: String): ResolvedImport {
-        val html = fetchText(url)
-        val id = extractTidalPlaylistId(url) ?: url
-        val title = extractTidalTitle(html)
-        val tracks = parseTidalTracks(html)
+    //
+    // tidal.com is a client-rendered SPA — the served HTML contains no track
+    // data at all, so scraping it can't work. Instead we call the same
+    // `api.tidal.com/v1` endpoints the app's playback path already uses, with
+    // the user's own OAuth token or a community Source Pool account. Playlist
+    // reads are paginated 100 items at a time.
+    private suspend fun fetchTidalPlaylist(url: String, credentials: Credentials): ResolvedImport {
+        val id = extractTidalPlaylistId(url) ?: error("Couldn't extract Tidal playlist id from URL")
+        val accessToken = credentials.tidalAccessToken?.takeIf { it.isNotBlank() }
+            ?: error("Tidal import needs a signed-in Tidal account (Settings → Integration → Tidal)")
+        val country = credentials.tidalCountryCode.ifBlank { "US" }
+
+        val meta = runCatching {
+            JSONObject(
+                fetchText(
+                    url = "$TIDAL_API_BASE/playlists/$id?countryCode=$country",
+                    headers = mapOf("Authorization" to "Bearer $accessToken"),
+                ),
+            )
+        }.getOrNull()
+
+        val tracks = mutableListOf<ForeignTrack>()
+        var offset = 0
+        while (tracks.size < TIDAL_MAX_TRACKS) {
+            val body = fetchText(
+                url = "$TIDAL_API_BASE/playlists/$id/items" +
+                    "?countryCode=$country&limit=$TIDAL_PAGE_SIZE&offset=$offset",
+                headers = mapOf("Authorization" to "Bearer $accessToken"),
+            )
+            val root = JSONObject(body)
+            val items = root.optJSONArray("items") ?: break
+            if (items.length() == 0) break
+            for (i in 0 until items.length()) {
+                // Each row wraps the payload as {"item": {...}, "type": "track"}.
+                val wrapper = items.optJSONObject(i) ?: continue
+                if (wrapper.optString("type").let { it.isNotBlank() && it != "track" }) continue
+                val item = wrapper.optJSONObject("item") ?: wrapper
+                val title = item.optString("title")
+                if (title.isBlank()) continue
+                tracks.add(
+                    ForeignTrack(
+                        title = title,
+                        artist = item.optJSONObject("artist")?.optString("name")?.ifBlank { null }
+                            ?: item.optJSONArray("artists")?.optJSONObject(0)?.optString("name")?.ifBlank { null },
+                        album = item.optJSONObject("album")?.optString("title")?.ifBlank { null },
+                        durationMs = item.optLong("duration").takeIf { it > 0 }?.times(1000L),
+                    ),
+                )
+            }
+            offset += TIDAL_PAGE_SIZE
+            if (offset >= root.optInt("totalNumberOfItems", offset)) break
+        }
+
         return ResolvedImport(
             source = ImportSource.TIDAL,
             sourcePlaylistId = id,
-            title = title,
-            thumbnailUrl = null,
+            title = meta?.optString("title")?.ifBlank { null } ?: "Tidal Playlist",
+            thumbnailUrl = meta?.optString("squareImage")?.ifBlank { null }
+                ?.let { "https://resources.tidal.com/images/${it.replace('-', '/')}/640x640.jpg" },
             tracks = tracks,
         )
+    }
+
+    // ─── Qobuz ────────────────────────────────────────────────────────────
+    // URL patterns: https://open.qobuz.com/playlist/{id}
+    //               https://www.qobuz.com/{cc}/playlists/{slug}/{id}
+    //
+    // Qobuz rejects anonymous playlist reads (401), so we sign the request
+    // with an app_id + user auth token — the user's own pasted Qobuz token or
+    // a community Source Pool account, exactly like the playback path does.
+    private suspend fun fetchQobuzPlaylist(url: String, credentials: Credentials): ResolvedImport {
+        val id = extractQobuzPlaylistId(url) ?: error("Couldn't extract Qobuz playlist id from URL")
+        val appId = credentials.qobuzAppId?.takeIf { it.isNotBlank() }
+        val authToken = credentials.qobuzAuthToken?.takeIf { it.isNotBlank() }
+        if (appId == null || authToken == null) {
+            error("Qobuz import needs a Qobuz token (Settings → Integration → Qobuz)")
+        }
+
+        val tracks = mutableListOf<ForeignTrack>()
+        var title = "Qobuz Playlist"
+        var thumbnail: String? = null
+        var offset = 0
+        while (tracks.size < QOBUZ_MAX_TRACKS) {
+            val body = fetchText(
+                url = "$QOBUZ_API_BASE/playlist/get?playlist_id=$id&extra=tracks" +
+                    "&limit=$QOBUZ_PAGE_SIZE&offset=$offset&app_id=$appId",
+                headers = mapOf(
+                    "X-App-Id" to appId,
+                    "X-User-Auth-Token" to authToken,
+                ),
+            )
+            val root = JSONObject(body)
+            if (offset == 0) {
+                title = root.optString("name").ifBlank { title }
+                thumbnail = root.optJSONObject("image")?.optString("large")?.ifBlank { null }
+            }
+            val trackObj = root.optJSONObject("tracks")
+            val items = trackObj?.optJSONArray("items") ?: break
+            if (items.length() == 0) break
+            for (i in 0 until items.length()) {
+                val item = items.optJSONObject(i) ?: continue
+                val trackTitle = item.optString("title")
+                if (trackTitle.isBlank()) continue
+                tracks.add(
+                    ForeignTrack(
+                        title = trackTitle,
+                        artist = item.optJSONObject("performer")?.optString("name")?.ifBlank { null }
+                            ?: item.optJSONObject("album")?.optJSONObject("artist")
+                                ?.optString("name")?.ifBlank { null },
+                        album = item.optJSONObject("album")?.optString("title")?.ifBlank { null },
+                        durationMs = item.optLong("duration").takeIf { it > 0 }?.times(1000L),
+                    ),
+                )
+            }
+            offset += QOBUZ_PAGE_SIZE
+            if (offset >= trackObj.optInt("total", offset)) break
+        }
+
+        return ResolvedImport(
+            source = ImportSource.QOBUZ,
+            sourcePlaylistId = id,
+            title = title,
+            thumbnailUrl = thumbnail,
+            tracks = tracks,
+        )
+    }
+
+    /** Qobuz playlist ids are numeric and always the last path segment. */
+    internal fun extractQobuzPlaylistId(url: String): String? {
+        val m = Pattern.compile("playlists?/(?:[^/?#]+/)*?(\\d{3,})").matcher(url)
+        return if (m.find()) m.group(1) else null
     }
 
     private fun extractTidalPlaylistId(url: String): String? {
         // Tidal ids are UUIDs.
         val m = Pattern.compile("playlist/([a-f0-9\\-]{20,40})").matcher(url)
         return if (m.find()) m.group(1) else null
-    }
-
-    private fun extractTidalTitle(html: String): String {
-        val og = Pattern.compile("<meta[^>]+property=\"og:title\"[^>]+content=\"([^\"]+)\"").matcher(html)
-        if (og.find()) return unescapeJson(og.group(1))
-        val title = Pattern.compile("<title>([^<]+)</title>").matcher(html)
-        if (title.find()) {
-            val raw = title.group(1).trim()
-            return raw.substringBefore(" |").ifBlank { raw }
-        }
-        return "Tidal Playlist"
-    }
-
-    private fun parseTidalTracks(html: String): List<ForeignTrack> {
-        val tracks = mutableListOf<ForeignTrack>()
-        // Tidal embeds tracks as `{"title":"...","artists":[{"name":"..."}]}`
-        val regex = Pattern.compile("\\{\"title\":\"([^\"]{2,120})\",\"artists\":\\[\\{\"name\":\"([^\"]+)\"")
-        val m = regex.matcher(html)
-        while (m.find()) {
-            tracks.add(ForeignTrack(
-                title = unescapeJson(m.group(1)),
-                artist = unescapeJson(m.group(2)),
-            ))
-        }
-        // Fallback: search for `{"name":"...","artist":"..."}` pairs (older
-        // Tidal serializations).
-        if (tracks.isEmpty()) {
-            val alt = Pattern.compile("\\{\"name\":\"([^\"]{2,120})\",\"artist\":\"([^\"]+)\"")
-            val am = alt.matcher(html)
-            while (am.find()) {
-                tracks.add(ForeignTrack(
-                    title = unescapeJson(am.group(1)),
-                    artist = unescapeJson(am.group(2)),
-                ))
-            }
-        }
-        return tracks.distinctBy { it.title to it.artist }
     }
 
     // ─── Deezer ───────────────────────────────────────────────────────────
@@ -410,29 +672,48 @@ object CrossServicePlaylistImporter {
     }
 
     // ─── Shared helpers ───────────────────────────────────────────────────
-    private suspend fun fetchText(url: String): String = withContext(Dispatchers.IO) {
+    private suspend fun fetchText(
+        url: String,
+        headers: Map<String, String> = emptyMap(),
+    ): String = withContext(Dispatchers.IO) {
         val req = Request.Builder()
             .url(url)
-            .header("User-Agent", "Mozilla/5.0 (Linux; Android 14; ArchiveTune) AppleWebKit/537.36")
+            // Spotify's embed page varies its markup by client; a desktop UA
+            // reliably returns the __NEXT_DATA__ payload we parse.
+            .header("User-Agent", BROWSER_USER_AGENT)
             .header("Accept", "text/html,application/json,application/xhtml+xml")
             .header("Accept-Language", "en-US,en;q=0.9")
+            .apply { headers.forEach { (name, value) -> header(name, value) } }
             .build()
         client.newCall(req).execute().use { res ->
-            if (!res.isSuccessful) error("HTTP ${res.code} fetching $url")
+            if (!res.isSuccessful) {
+                // Surface auth problems in words the user can act on — a bare
+                // "HTTP 401" in a toast tells them nothing.
+                when (res.code) {
+                    401, 403 -> error("Not authorised (HTTP ${res.code}) — the account or token may have expired")
+                    404 -> error("Playlist not found (HTTP 404) — it may be private or the URL is wrong")
+                    429 -> error("Rate limited by the service (HTTP 429) — try again in a minute")
+                    else -> error("HTTP ${res.code} fetching $url")
+                }
+            }
             res.body?.string() ?: error("Empty response from $url")
         }
     }
 
+    /** Pulls the raw JSON body out of a `<script id="...">…</script>` block. */
+    internal fun extractScriptJson(html: String, scriptId: String): String? {
+        val m = Pattern
+            .compile("<script[^>]*id=\"$scriptId\"[^>]*>(.*?)</script>", Pattern.DOTALL)
+            .matcher(html)
+        return if (m.find()) m.group(1)?.trim()?.takeIf { it.isNotEmpty() } else null
+    }
+
+    /** Convenience for Next.js pages (Spotify's embed). */
+    private fun extractNextData(html: String): String? = extractScriptJson(html, "__NEXT_DATA__")
+
     private fun extractQuery(url: String, key: String): String? {
         val m = Pattern.compile("[?&]$key=([^&]+)").matcher(url)
         return if (m.find()) java.net.URLDecoder.decode(m.group(1), "UTF-8") else null
-    }
-
-    private fun extractFromTag(html: String, tag: String): String? {
-        val idx = html.indexOf(tag)
-        if (idx < 0) return null
-        val after = html.substring(idx + tag.length)
-        return after
     }
 
     private fun unescapeJson(s: String): String =
@@ -447,4 +728,21 @@ object CrossServicePlaylistImporter {
             .replace("&#x2F;", "/")
 
     private const val MAX_PARALLEL_SEARCHES = 6
+
+    private const val BROWSER_USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+            "(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+
+    private const val TIDAL_API_BASE = "https://api.tidal.com/v1"
+    private const val QOBUZ_API_BASE = "https://www.qobuz.com/api.json/0.2"
+
+    private const val SPOTIFY_PAGE_SIZE = 100
+    private const val TIDAL_PAGE_SIZE = 100
+    private const val QOBUZ_PAGE_SIZE = 500
+
+    // Hard ceilings so a pathological playlist can't spin the importer forever
+    // (each track also costs one YouTube Music search downstream).
+    private const val SPOTIFY_MAX_TRACKS = 2000
+    private const val TIDAL_MAX_TRACKS = 2000
+    private const val QOBUZ_MAX_TRACKS = 2000
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.db.entities.PlaylistEntity
+import moe.rukamori.archivetune.playlist.CrossServiceImportCredentials
 import moe.rukamori.archivetune.playlist.CrossServicePlaylistImporter
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import java.time.LocalDateTime
@@ -164,7 +165,10 @@ fun CrossServiceImportPlaylistDialog(
                     statusMessage = context.getString(R.string.cross_service_import_resolving_playlist)
                     coroutineScope.launch(Dispatchers.IO) {
                         try {
-                            val resolved = CrossServicePlaylistImporter.fetchPlaylist(url)
+                            // Tidal/Qobuz playlist reads need an account token;
+                            // the other services resolve anonymously.
+                            val credentials = CrossServiceImportCredentials.load(context)
+                            val resolved = CrossServicePlaylistImporter.fetchPlaylist(url, credentials)
                                 .getOrElse { e ->
                                     withContext(Dispatchers.Main) {
                                         statusMessage = null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,8 +193,8 @@
     <string name="update_button">Update</string>
     <string name="cross_service_import_playlist_title">Import playlist from URL</string>
     <string name="cross_service_import_playlist_url_label">Playlist URL</string>
-    <string name="cross_service_import_playlist_url_placeholder">Paste a YouTube Music, Apple Music, Amazon Music, Tidal or Deezer playlist URL</string>
-    <string name="cross_service_import_playlist_supported">Supports YouTube Music, Apple Music, Amazon Music, Tidal and Deezer playlists. Each track is matched on YouTube Music and added to a new local playlist.</string>
+    <string name="cross_service_import_playlist_url_placeholder">Paste a YouTube Music, Spotify, Apple Music, Amazon Music, Tidal, Qobuz or Deezer playlist URL</string>
+    <string name="cross_service_import_playlist_supported">Supports YouTube Music, Spotify, Apple Music, Amazon Music, Tidal, Qobuz and Deezer playlists. Each track is matched on YouTube Music and added to a new local playlist.\n\nTidal and Qobuz imports need a linked account or Source Pool.</string>
     <string name="cross_service_import_action">Import</string>
     <string name="cross_service_import_resolving_playlist">Resolving playlist…</string>
     <string name="cross_service_import_searching_yt">Matching %1$d tracks on YouTube Music…</string>
@@ -204,7 +204,7 @@
     <string name="cross_service_import_success">Imported %1$d of %2$d tracks into "%3$s"</string>
     <string name="cross_service_import_failed">Import failed: %1$s</string>
     <string name="cross_service_import_entry_title">Import playlist from another service</string>
-    <string name="cross_service_import_entry_desc">Pull a playlist from YouTube Music, Apple Music, Amazon Music, Tidal or Deezer</string>
+    <string name="cross_service_import_entry_desc">Pull a playlist from YouTube Music, Spotify, Apple Music, Amazon Music, Tidal, Qobuz or Deezer</string>
     <string name="add">Add</string>
     <string name="add_to_playlist">Add to playlist</string>
     <string name="add_to_n_playlists">Add to %1$d</string>

--- a/app/src/test/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporterTest.kt
+++ b/app/src/test/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporterTest.kt
@@ -1,0 +1,166 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playlist
+
+import moe.rukamori.archivetune.playlist.CrossServicePlaylistImporter.ImportSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * URL-parsing contract for the cross-service playlist importer. These are the
+ * pure parts of the importer — no network — so they pin the routing and id
+ * extraction that every import depends on.
+ */
+class CrossServicePlaylistImporterTest {
+
+    // ─── Source detection ─────────────────────────────────────────────────
+
+    @Test
+    fun detectsSpotifyWebAndUriForms() {
+        assertEquals(
+            ImportSource.SPOTIFY,
+            CrossServicePlaylistImporter.detectSource(
+                "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+            ),
+        )
+        assertEquals(
+            ImportSource.SPOTIFY,
+            CrossServicePlaylistImporter.detectSource("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
+        )
+    }
+
+    @Test
+    fun detectsQobuzAndOtherServices() {
+        assertEquals(
+            ImportSource.QOBUZ,
+            CrossServicePlaylistImporter.detectSource("https://open.qobuz.com/playlist/5966313"),
+        )
+        assertEquals(
+            ImportSource.TIDAL,
+            CrossServicePlaylistImporter.detectSource(
+                "https://tidal.com/browse/playlist/1c5d01ed-4f05-40c4-bd28-0f73099e8186",
+            ),
+        )
+        assertEquals(
+            ImportSource.DEEZER,
+            CrossServicePlaylistImporter.detectSource("https://www.deezer.com/us/playlist/908622995"),
+        )
+        assertEquals(
+            ImportSource.APPLE_MUSIC,
+            CrossServicePlaylistImporter.detectSource(
+                "https://music.apple.com/us/playlist/todays-hits/pl.f4d106fed2bd41149aaacabb233eb5eb",
+            ),
+        )
+        assertEquals(
+            ImportSource.YOUTUBE_MUSIC,
+            CrossServicePlaylistImporter.detectSource("https://music.youtube.com/playlist?list=RDCLAK5uy_l"),
+        )
+    }
+
+    @Test
+    fun unknownUrlIsRejectedRatherThanGuessed() {
+        assertEquals(
+            ImportSource.UNKNOWN,
+            CrossServicePlaylistImporter.detectSource("https://example.com/playlist/123"),
+        )
+    }
+
+    /**
+     * Spotify is checked before the generic hosts, but YouTube must still win
+     * for its own URLs — a regression here would send YT playlists down the
+     * scraping path.
+     */
+    @Test
+    fun youtubeTakesPrecedenceOverGenericMatching() {
+        assertEquals(
+            ImportSource.YOUTUBE_MUSIC,
+            CrossServicePlaylistImporter.detectSource("https://www.youtube.com/playlist?list=PLabc123"),
+        )
+    }
+
+    // ─── Spotify id extraction ────────────────────────────────────────────
+
+    @Test
+    fun extractsSpotifyIdFromWebUrlWithQueryParams() {
+        assertEquals(
+            "37i9dQZF1DXcBWIGoYBM5M",
+            CrossServicePlaylistImporter.extractSpotifyPlaylistId(
+                "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M?si=abc123&pt=xyz",
+            ),
+        )
+    }
+
+    @Test
+    fun extractsSpotifyIdFromUriAndEmbedForms() {
+        assertEquals(
+            "37i9dQZF1DXcBWIGoYBM5M",
+            CrossServicePlaylistImporter.extractSpotifyPlaylistId("spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"),
+        )
+        assertEquals(
+            "37i9dQZF1DXcBWIGoYBM5M",
+            CrossServicePlaylistImporter.extractSpotifyPlaylistId(
+                "https://open.spotify.com/embed/playlist/37i9dQZF1DXcBWIGoYBM5M",
+            ),
+        )
+    }
+
+    @Test
+    fun rejectsSpotifyUrlWithoutPlaylistId() {
+        assertNull(CrossServicePlaylistImporter.extractSpotifyPlaylistId("https://open.spotify.com/browse"))
+    }
+
+    // ─── Qobuz id extraction ──────────────────────────────────────────────
+
+    @Test
+    fun extractsQobuzIdFromShortAndSluggedUrls() {
+        assertEquals(
+            "5966313",
+            CrossServicePlaylistImporter.extractQobuzPlaylistId("https://open.qobuz.com/playlist/5966313"),
+        )
+        assertEquals(
+            "5966313",
+            CrossServicePlaylistImporter.extractQobuzPlaylistId(
+                "https://www.qobuz.com/us-en/playlists/gems-of-the-week/5966313",
+            ),
+        )
+    }
+
+    @Test
+    fun rejectsQobuzUrlWithoutNumericId() {
+        assertNull(CrossServicePlaylistImporter.extractQobuzPlaylistId("https://www.qobuz.com/us-en/playlists"))
+    }
+
+    // ─── Script-block extraction ──────────────────────────────────────────
+
+    @Test
+    fun extractsJsonFromScriptBlockAcrossNewlines() {
+        val html =
+            """
+            <html><body>
+            <script id="__NEXT_DATA__" type="application/json">
+            {"props":{"pageProps":{"state":{"data":{"entity":{"name":"Mix"}}}}}}
+            </script>
+            </body></html>
+            """.trimIndent()
+
+        val json = CrossServicePlaylistImporter.extractScriptJson(html, "__NEXT_DATA__")
+
+        assertEquals(
+            "{\"props\":{\"pageProps\":{\"state\":{\"data\":{\"entity\":{\"name\":\"Mix\"}}}}}}",
+            json,
+        )
+    }
+
+    @Test
+    fun missingScriptBlockReturnsNull() {
+        assertNull(
+            CrossServicePlaylistImporter.extractScriptJson("<html><body>no data</body></html>", "__NEXT_DATA__"),
+        )
+    }
+}


### PR DESCRIPTION
Extends the cross-service playlist importer in Settings → Integration with two new sources and repairs two that had stopped working.

Added:
  - Spotify. Uses the authenticated GQL client from :spotifycore when the user has linked their account (full pagination, private/collaborative playlists); otherwise falls back to the public embed page, which needs no credentials and carries up to 100 tracks.
  - Qobuz. Qobuz rejects anonymous playlist reads, so requests are signed with an app_id + user auth token taken from the user's own pasted token or a community Source Pool account, mirroring the playback path.

Fixed:
  - Tidal. tidal.com is a client-rendered SPA with no track data in the served HTML, so the previous regex scrape matched nothing. Replaced with the api.tidal.com/v1 endpoints the playback path already uses.
  - Apple Music. Current pages server-render tracks into a serialized-server-data script block; the old patterns matched zero tracks. Now walks that JSON tree for title/artistName pairs.

Credentials are gathered by the new CrossServiceImportCredentials, which follows the same precedence as the playback resolvers (own account, then Source Pool). Services needing an account that isn't linked fail with a "sign in first" message instead of a bare 401, and HTTP errors are now translated into actionable text.

Parsing was verified against live Spotify and Apple Music pages; URL routing and id extraction are covered by unit tests.

# Pull Request

## Summary

<!-- Describe the change in 2-5 concise sentences. Include the user-facing behavior, architectural change, or maintenance outcome. -->

## Linked Work

<!-- Link related issues, discussions, releases, or design notes. Use "Closes #123" only when the PR fully resolves the issue. -->

- Closes:
- Related:

## Change Type

<!-- Check every category that applies. -->

- [ ] Feature
- [ ] Bug fix
- [ ] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

<!-- Be explicit so reviewers can focus on the correct runtime paths. -->

- [ ] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

<!-- Required for UI, widget, notification, player, lyrics, settings, and visual changes. Include before/after when possible. -->

| Before | After |
| --- | --- |
|  |  |

## Behavior Notes

<!-- Describe the exact behavior reviewers should verify. Include edge cases, fallback behavior, and migration behavior. -->

## Architecture Checklist

- [ ] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [ ] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [ ] Business work is not triggered directly from composition.
- [ ] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [ ] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [ ] UI state is hoisted out of composable layout code.
- [ ] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [ ] New UI models are annotated with `@Immutable` or `@Stable`.
- [ ] Lazy layouts use stable `key` values and explicit `contentType`.
- [ ] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered.
- [ ] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [ ] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided.
- [ ] Interactive elements keep a minimum 48dp touch target.
- [ ] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [ ] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [ ] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [ ] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [ ] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [ ] The change avoids blocking the main thread.
- [ ] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [ ] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [ ] DataStore or preference-key changes are backward compatible.
- [ ] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

- [ ] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [ ] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [ ] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [ ] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

## Privacy / Security Checklist

- [ ] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [ ] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [ ] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [ ] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

<!-- Do not leave this blank. If a check is not applicable, state why. -->

- [ ] Android Studio sync:
- [ ] Manual device/emulator verification:
- [ ] UI screenshot/recording attached:
- [ ] Accessibility or touch-target review:
- [ ] Regression areas checked:
- [ ] CI expectation:

## Reviewer Focus

<!-- Call out the exact files, architecture decisions, performance-sensitive paths, or risky behavior that need close review. -->

## Release Notes

<!-- Write one concise user-facing sentence, or "None" for internal-only changes. -->

