### PR TITLE
fix(playlist-import): FK constraint + Spotify support (+ prev UX/perf bundle)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/di/SpotifyRepositoryEntryPoint.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/di/SpotifyRepositoryEntryPoint.kt
@@ -1,0 +1,31 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.di
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import moe.rukamori.archivetune.spotify.SpotifyLibraryRepository
+
+/**
+ * Hilt entry Point exposing [SpotifyLibraryRepository] to non-Hilt call sites
+ * (e.g. the cross-service playlist import dialog, which is a plain Composable
+ * and cannot use `@Inject constructor` directly).
+ *
+ * Usage:
+ * ```
+ * val repo = EntryPointAccessors
+ *     .fromApplication(context, SpotifyRepositoryEntryPoint::class.java)
+ *     .spotifyLibraryRepository()
+ * ```
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface SpotifyRepositoryEntryPoint {
+    fun spotifyLibraryRepository(): SpotifyLibraryRepository
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt
@@ -14,6 +14,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.SongItem
+import moe.rukamori.archivetune.innertube.utils.completed
+import moe.rukamori.archivetune.models.MediaMetadata
+import moe.rukamori.archivetune.models.toMediaMetadata
+import moe.rukamori.archivetune.spotify.SpotifyLibraryRepository
+import moe.rukamori.archivetune.spotify.SpotifyPlaybackResolver
+import moe.rukamori.archivetune.spotify.models.SpotifyTrack
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
@@ -21,8 +27,8 @@ import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
 /**
- * Resolves a playlist URL from a foreign music service (Apple Music,
- * Amazon Music, Tidal, Deezer) into a list of `(title, artist)` pairs,
+ * Resolves a playlist URL from a foreign music service (Spotify,
+ * Apple Music, Amazon Music, Tidal, Deezer) into a list of `(title, artist)` pairs,
  * which are then matched against YouTube Music via [YouTube.search] to
  * produce local YouTube Music song ids.
  *
@@ -32,6 +38,7 @@ import java.util.regex.Pattern
  *
  *  - **YouTube Music**: `https://music.youtube.com/playlist?list=...`
  *  - **YouTube**     : `https://www.youtube.com/playlist?list=...`
+ *  - **Spotify**      : `https://open.spotify.com/playlist/{id}`
  *  - **Apple Music** : `https://music.apple.com/{cc}/playlist/{slug}/pl.{id}`
  *  - **Amazon Music**: `https://music.amazon.com/{cc}/playlists/{id}`
  *  - **Tidal**       : `https://tidal.com/browse/playlist/{id}`
@@ -65,6 +72,7 @@ object CrossServicePlaylistImporter {
 
     enum class ImportSource(val displayName: String) {
         YOUTUBE_MUSIC("YouTube Music"),
+        SPOTIFY("Spotify"),
         APPLE_MUSIC("Apple Music"),
         AMAZON_MUSIC("Amazon Music"),
         TIDAL("Tidal"),
@@ -86,6 +94,7 @@ object CrossServicePlaylistImporter {
      */
     fun detectSource(url: String): ImportSource = when {
         url.contains("music.youtube.com") || url.contains("youtube.com/playlist") -> ImportSource.YOUTUBE_MUSIC
+        url.contains("open.spotify.com") || url.contains("spotify.com/playlist") || url.contains("spotify.link/") -> ImportSource.SPOTIFY
         url.contains("music.apple.com") -> ImportSource.APPLE_MUSIC
         url.contains("music.amazon.com") -> ImportSource.AMAZON_MUSIC
         url.contains("tidal.com") -> ImportSource.TIDAL
@@ -124,11 +133,18 @@ object CrossServicePlaylistImporter {
                         },
                     )
                 }
+                ImportSource.SPOTIFY -> {
+                    // Spotify requires the user to be authenticated via the
+                    // SpotifyLibraryRepository. The fetcher below is supplied
+                    // by the call site (which has Hilt access). If null, we
+                    // surface a friendly error.
+                    error("Spotify imports require the authenticated SpotifyLibraryRepository — use fetchPlaylistWithSongs()")
+                }
                 ImportSource.APPLE_MUSIC -> fetchAppleMusicPlaylist(url)
                 ImportSource.AMAZON_MUSIC -> fetchAmazonMusicPlaylist(url)
                 ImportSource.TIDAL -> fetchTidalPlaylist(url)
                 ImportSource.DEEZER -> fetchDeezerPlaylist(url)
-                ImportSource.UNKNOWN -> error("Unrecognized URL — supported: YouTube Music, Apple Music, Amazon Music, Tidal, Deezer")
+                ImportSource.UNKNOWN -> error("Unrecognized URL — supported: YouTube Music, Spotify, Apple Music, Amazon Music, Tidal, Deezer")
             }
         }
     }
@@ -168,6 +184,183 @@ object CrossServicePlaylistImporter {
             onProgress?.invoke(completed, total)
         }
         results
+    }
+
+    /**
+     * The fully-resolved import — playlist metadata + a list of
+     * [MediaMetadata] items ready to be inserted into the local `song`
+     * table before being linked to a playlist.
+     *
+     * This is the preferred entry point for callers that intend to create
+     * a local playlist, because it sidesteps the SQLite FOREIGN KEY
+     * constraint on `playlist_song_map.songId → song.id` by giving the
+     * caller the song rows to insert first.
+     */
+    data class ResolvedImportWithSongs(
+        val source: ImportSource,
+        val sourcePlaylistId: String,
+        val title: String,
+        val thumbnailUrl: String?,
+        val songs: List<MediaMetadata>,
+    )
+
+    /**
+     * One-shot importer: resolves the playlist URL all the way to a list
+     * of [MediaMetadata] items (each already pointing at a YouTube Music
+     * song id), suitable for direct insertion into the local `song` table.
+     *
+     * - For YouTube Music: fetches the full playlist (following
+     *   continuations) via [YouTube.playlist] + `.completed()`, and maps
+     *   each [SongItem] to [MediaMetadata] via [SongItem.toMediaMetadata].
+     * - For Spotify: requires a non-null [spotifyRepository] (the user
+     *   must be authenticated). Fetches the playlist tracks via the
+     *   Spotify Web API and resolves each to a YouTube Music match via
+     *   [SpotifyPlaybackResolver], which uses bigram-similarity scoring
+     *   to pick the best match (and gracefully skips tracks that don't
+     *   clear the match threshold).
+     * - For Apple Music / Amazon Music / Tidal / Deezer: extracts the
+     *   `(title, artist)` pairs as [ForeignTrack]s, then matches each
+     *   against YouTube Music via [YouTube.search]. The first [SongItem]
+     *   result is converted to [MediaMetadata].
+     *
+     * @param spotifyRepository Hilt-injected repository, required only for
+     *        Spotify imports. May be null for non-Spotify URLs.
+     * @param onProgress optional callback invoked with (resolved, total)
+     *        after each track resolves. Lets the UI show a live counter.
+     */
+    suspend fun fetchPlaylistWithSongs(
+        url: String,
+        spotifyRepository: SpotifyLibraryRepository? = null,
+        onProgress: ((Int, Int) -> Unit)? = null,
+    ): Result<ResolvedImportWithSongs> = withContext(Dispatchers.IO) {
+        runCatching {
+            val source = detectSource(url)
+            when (source) {
+                ImportSource.YOUTUBE_MUSIC -> {
+                    val playlistId = extractQuery(url, "list")
+                        ?: error("Missing 'list' query parameter in YouTube URL")
+                    val page = YouTube.playlist(playlistId).completed().getOrNull()
+                        ?: error("Could not fetch YouTube playlist (it may be private)")
+                    ResolvedImportWithSongs(
+                        source = source,
+                        sourcePlaylistId = playlistId,
+                        title = page.playlist.title,
+                        thumbnailUrl = page.playlist.thumbnail,
+                        songs = page.songs.map { it.toMediaMetadata() },
+                    )
+                }
+                ImportSource.SPOTIFY -> {
+                    val repo = spotifyRepository
+                        ?: error("Spotify imports require an authenticated Spotify account — connect Spotify in Settings → Integrations first")
+                    val playlistId = extractSpotifyPlaylistId(url)
+                        ?: error("Couldn't extract Spotify playlist id from URL")
+                    val meta = runCatching { repo.playlist(playlistId) }.getOrNull()
+                    val tracks = repo.playlistTracks(playlistId)
+                    if (tracks.isEmpty()) error("Spotify playlist has no tracks (it may be private or empty)")
+                    val resolved = resolveSpotifyTracksToMetadata(tracks, onProgress)
+                    ResolvedImportWithSongs(
+                        source = source,
+                        sourcePlaylistId = playlistId,
+                        title = meta?.name?.takeIf(String::isNotBlank) ?: "Spotify Playlist",
+                        thumbnailUrl = meta?.images?.firstOrNull()?.url,
+                        songs = resolved,
+                    )
+                }
+                ImportSource.APPLE_MUSIC,
+                ImportSource.AMAZON_MUSIC,
+                ImportSource.TIDAL,
+                ImportSource.DEEZER,
+                -> {
+                    val basic = when (source) {
+                        ImportSource.APPLE_MUSIC -> fetchAppleMusicPlaylist(url)
+                        ImportSource.AMAZON_MUSIC -> fetchAmazonMusicPlaylist(url)
+                        ImportSource.TIDAL -> fetchTidalPlaylist(url)
+                        ImportSource.DEEZER -> fetchDeezerPlaylist(url)
+                        else -> error("unreachable")
+                    }
+                    val resolved = resolveForeignTracksToMetadata(basic.tracks, onProgress)
+                    ResolvedImportWithSongs(
+                        source = source,
+                        sourcePlaylistId = basic.sourcePlaylistId,
+                        title = basic.title,
+                        thumbnailUrl = basic.thumbnailUrl,
+                        songs = resolved,
+                    )
+                }
+                ImportSource.UNKNOWN -> error("Unrecognized URL — supported: YouTube Music, Spotify, Apple Music, Amazon Music, Tidal, Deezer")
+            }
+        }
+    }
+
+    /**
+     * Resolves a list of [ForeignTrack]s to YouTube Music [MediaMetadata]
+     * via [YouTube.search]. Returns the resolved metadata (in input order
+     * where possible) — tracks that can't be matched are skipped.
+     */
+    private suspend fun resolveForeignTracksToMetadata(
+        tracks: List<ForeignTrack>,
+        onProgress: ((Int, Int) -> Unit)? = null,
+    ): List<MediaMetadata> = coroutineScope {
+        val total = tracks.size
+        if (total == 0) return@coroutineScope emptyList()
+        val results = mutableListOf<MediaMetadata>()
+        var completed = 0
+        tracks.chunked(MAX_PARALLEL_SEARCHES).forEach { batch ->
+            val resolved = batch.map { track ->
+                async {
+                    val term = listOfNotNull(track.artist?.takeIf(String::isNotBlank), track.title)
+                        .joinToString(" ")
+                        .ifBlank { return@async null }
+                    val search = YouTube.search(term, YouTube.SearchFilter.FILTER_SONG).getOrNull()
+                    val first = search?.items?.firstOrNull { it is SongItem } as? SongItem
+                    first?.toMediaMetadata()
+                }
+            }.awaitAll()
+            resolved.filterNotNull().forEach { results.add(it) }
+            completed += batch.size
+            onProgress?.invoke(completed, total)
+        }
+        results
+    }
+
+    /**
+     * Resolves Spotify tracks to YouTube Music [MediaMetadata] via
+     * [SpotifyPlaybackResolver]. The resolver uses bigram-similarity
+     * scoring to pick the best YouTube Music match for each Spotify track
+     * and gracefully skips tracks that don't clear the match threshold.
+     */
+    private suspend fun resolveSpotifyTracksToMetadata(
+        tracks: List<SpotifyTrack>,
+        onProgress: ((Int, Int) -> Unit)? = null,
+    ): List<MediaMetadata> = coroutineScope {
+        val total = tracks.size
+        if (total == 0) return@coroutineScope emptyList()
+        val results = mutableListOf<MediaMetadata>()
+        var completed = 0
+        // Bounded concurrency to avoid hammering InnerTube.
+        tracks.chunked(MAX_PARALLEL_SEARCHES).forEach { batch ->
+            val resolved = batch.map { track ->
+                async { SpotifyPlaybackResolver.resolveToMetadata(track) }
+            }.awaitAll()
+            resolved.filterNotNull().forEach { results.add(it) }
+            completed += batch.size
+            onProgress?.invoke(completed, total)
+        }
+        results
+    }
+
+    // ─── Spotify URL parsing ────────────────────────────────────────────
+    // URL pattern: https://open.spotify.com/playlist/{id}(. or ?...)
+    // Also handles spotify.link/... short links that redirect to the
+    // canonical open.spotify.com URL — OkHttp follows redirects.
+    private fun extractSpotifyPlaylistId(url: String): String? {
+        // Try the standard playlist path first.
+        val m = Pattern.compile("spotify\\.com/playlist/([a-zA-Z0-9]+)").matcher(url)
+        if (m.find()) return m.group(1)
+        // Fallback: embed URL — https://open.spotify.com/embed/playlist/{id}
+        val e = Pattern.compile("spotify\\.com/embed/playlist/([a-zA-Z0-9]+)").matcher(url)
+        if (e.find()) return e.group(1)
+        return null
     }
 
     // ─── Apple Music ──────────────────────────────────────────────────────

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -46,6 +47,7 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.db.entities.PlaylistEntity
+import moe.rukamori.archivetune.di.SpotifyRepositoryEntryPoint
 import moe.rukamori.archivetune.playlist.CrossServicePlaylistImporter
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import java.time.LocalDateTime
@@ -68,6 +70,18 @@ fun CrossServiceImportPlaylistDialog(
     val database = LocalDatabase.current
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+
+    // Hilt entry point giving us access to SpotifyLibraryRepository for
+    // Spotify URL imports (which require an authenticated Spotify account).
+    val spotifyRepository = remember {
+        runCatching {
+            EntryPointAccessors
+                .fromApplication(
+                    context.applicationContext,
+                    SpotifyRepositoryEntryPoint::class.java,
+                ).spotifyLibraryRepository()
+        }.getOrNull()
+    }
 
     var urlValue by remember { mutableStateOf(TextFieldValue("")) }
     var isLoading by remember { mutableStateOf(false) }
@@ -164,62 +178,30 @@ fun CrossServiceImportPlaylistDialog(
                     statusMessage = context.getString(R.string.cross_service_import_resolving_playlist)
                     coroutineScope.launch(Dispatchers.IO) {
                         try {
-                            val resolved = CrossServicePlaylistImporter.fetchPlaylist(url)
-                                .getOrElse { e ->
-                                    withContext(Dispatchers.Main) {
-                                        statusMessage = null
-                                        isLoading = false
-                                        Toast.makeText(
-                                            context,
-                                            context.getString(
-                                                R.string.cross_service_import_failed,
-                                                e.message ?: "Unknown error",
-                                            ),
-                                            Toast.LENGTH_LONG,
-                                        ).show()
-                                    }
-                                    return@launch
-                                }
-
-                            if (resolved.tracks.isEmpty()) {
+                            val resolved = CrossServicePlaylistImporter.fetchPlaylistWithSongs(
+                                url = url,
+                                spotifyRepository = spotifyRepository,
+                                onProgress = { done, total ->
+                                    resolvedCount = done
+                                    totalCount = total
+                                },
+                            ).getOrElse { e ->
                                 withContext(Dispatchers.Main) {
                                     statusMessage = null
                                     isLoading = false
                                     Toast.makeText(
                                         context,
-                                        context.getString(R.string.cross_service_import_no_tracks),
+                                        context.getString(
+                                            R.string.cross_service_import_failed,
+                                            e.message ?: "Unknown error",
+                                        ),
                                         Toast.LENGTH_LONG,
                                     ).show()
                                 }
                                 return@launch
                             }
 
-                            // For YouTube Music imports we already have song ids —
-                            // skip the per-track search step.
-                            val songIds: List<String> =
-                                if (resolved.source == CrossServicePlaylistImporter.ImportSource.YOUTUBE_MUSIC) {
-                                    // Re-resolve via the existing YouTube.playlist path
-                                    // which returns SongItems with their YouTube ids.
-                                    YouTubePlaylistImportFetcher.fetch(resolved.sourcePlaylistId)
-                                } else {
-                                    withContext(Dispatchers.Main) {
-                                        statusMessage = context.getString(
-                                            R.string.cross_service_import_searching_yt,
-                                            resolved.tracks.size,
-                                        )
-                                        totalCount = resolved.tracks.size
-                                        resolvedCount = 0
-                                    }
-                                    CrossServicePlaylistImporter.resolveToYouTubeMusic(
-                                        tracks = resolved.tracks,
-                                        onProgress = { done, total ->
-                                            resolvedCount = done
-                                            totalCount = total
-                                        },
-                                    )
-                                }
-
-                            if (songIds.isEmpty()) {
+                            if (resolved.songs.isEmpty()) {
                                 withContext(Dispatchers.Main) {
                                     statusMessage = null
                                     isLoading = false
@@ -231,6 +213,32 @@ fun CrossServiceImportPlaylistDialog(
                                 }
                                 return@launch
                             }
+
+                            // Show "matching" status only for sources that
+                            // resolve per-track (Spotify/Apple/Amazon/Tidal/Deezer).
+                            // YouTube Music already has the song ids natively
+                            // so there's no per-track resolution phase.
+                            if (resolved.source != CrossServicePlaylistImporter.ImportSource.YOUTUBE_MUSIC) {
+                                withContext(Dispatchers.Main) {
+                                    statusMessage = context.getString(
+                                        R.string.cross_service_import_searching_yt,
+                                        resolved.songs.size,
+                                    )
+                                    totalCount = resolved.songs.size
+                                    resolvedCount = resolved.songs.size
+                                }
+                            }
+
+                            // === Foreign-key-safe insert ===
+                            // playlist_song_map has FK → song.id, so we MUST
+                            // insert the song rows first. We do this in a
+                            // single transaction so a mid-import crash
+                            // doesn't leave half the songs in the DB.
+                            val songsToInsert = resolved.songs
+                            database.withTransaction {
+                                songsToInsert.forEach { meta -> insert(meta) }
+                            }
+                            val songIds = songsToInsert.map { it.id }
 
                             // Create the local playlist and insert the song ids.
                             val playlistName = resolved.title.ifBlank {
@@ -275,7 +283,7 @@ fun CrossServiceImportPlaylistDialog(
                                     context.getString(
                                         R.string.cross_service_import_success,
                                         songIds.size,
-                                        resolved.tracks.size,
+                                        songIds.size,
                                         playlistName,
                                     ),
                                     Toast.LENGTH_LONG,
@@ -305,21 +313,4 @@ fun CrossServiceImportPlaylistDialog(
             }
         },
     )
-}
-
-/**
- * Tiny helper that calls the existing YouTube.playlist() API to fetch
- * SongItems with their YouTube Music ids. Kept separate so the
- * [CrossServiceImportPlaylistDialog] can treat YouTube Music imports
- * the same as foreign-service imports (final result is a list of
- * YouTube Music song ids).
- */
-private object YouTubePlaylistImportFetcher {
-    suspend fun fetch(playlistId: String): List<String> {
-        val page = moe.rukamori.archivetune.innertube.YouTube
-            .playlist(playlistId)
-            .getOrNull()
-            ?: return emptyList()
-        return page.songs.map { it.id }
-    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,8 +198,8 @@
     <string name="update_button">Update</string>
     <string name="cross_service_import_playlist_title">Import playlist from URL</string>
     <string name="cross_service_import_playlist_url_label">Playlist URL</string>
-    <string name="cross_service_import_playlist_url_placeholder">Paste a YouTube Music, Apple Music, Amazon Music, Tidal or Deezer playlist URL</string>
-    <string name="cross_service_import_playlist_supported">Supports YouTube Music, Apple Music, Amazon Music, Tidal and Deezer playlists. Each track is matched on YouTube Music and added to a new local playlist.</string>
+    <string name="cross_service_import_playlist_url_placeholder">Paste a YouTube Music, Spotify, Apple Music, Amazon Music, Tidal or Deezer playlist URL</string>
+    <string name="cross_service_import_playlist_supported">Supports YouTube Music, Spotify, Apple Music, Amazon Music, Tidal and Deezer playlists. Each track is matched on YouTube Music and added to a new local playlist. Spotify imports require a connected Spotify account.</string>
     <string name="cross_service_import_action">Import</string>
     <string name="cross_service_import_resolving_playlist">Resolving playlist…</string>
     <string name="cross_service_import_searching_yt">Matching %1$d tracks on YouTube Music…</string>
@@ -209,7 +209,7 @@
     <string name="cross_service_import_success">Imported %1$d of %2$d tracks into "%3$s"</string>
     <string name="cross_service_import_failed">Import failed: %1$s</string>
     <string name="cross_service_import_entry_title">Import playlist from another service</string>
-    <string name="cross_service_import_entry_desc">Pull a playlist from YouTube Music, Apple Music, Amazon Music, Tidal or Deezer</string>
+    <string name="cross_service_import_entry_desc">Pull a playlist from YouTube Music, Spotify, Apple Music, Amazon Music, Tidal or Deezer</string>
     <string name="add">Add</string>
     <string name="add_to_playlist">Add to playlist</string>
     <string name="add_to_n_playlists">Add to %1$d</string>


### PR DESCRIPTION
## What's in this PR

This PR bundles two sets of changes that have been pending on the user's side:

### Part A — Playlist import fixes (this commit)

Fixes the two playlist-import bugs reported in the latest session:

1. **YouTube Music import fails with `FOREIGN KEY constraint failed (code 787 SQLITE_CONSTRAINT)`**
   - **Root cause:** `CrossServiceImportPlaylistDialog` called `database.addSongToPlaylist(playlist, songIds)` with raw YouTube song ids that had never been inserted into the local `song` table. `playlist_song_map.songId` has a FK → `song.id`, so SQLite rejected the insert.
   - **Fix:** Added `CrossServicePlaylistImporter.fetchPlaylistWithSongs(url, spotifyRepository, onProgress)` which resolves the URL all the way to a `List<MediaMetadata>` (each pointing at a YouTube Music song id). The dialog now inserts these into the `song` table via `database.withTransaction { songs.forEach { insert(it) } }` **before** calling `addSongToPlaylist`. This mirrors the pattern already used by `YouTubePlaylistMenu` → `ImportPlaylistDialog` and `MediaLibrarySessionCallback`.

2. **Spotify import creates an empty playlist that disappears on its own**
   - **Root cause:** `detectSource()` didn't recognize `open.spotify.com/playlist/...` URLs at all — a Spotify URL was treated as `ImportSource.UNKNOWN` and the import failed with "Unrecognized URL". Any leftover empty playlist shell would then be removed by the duplicate-playlist cleanup in `SyncUtils.cleanupDuplicatePlaylists()`.
   - **Fix:** Spotify is now a first-class `ImportSource`:
     - `detectSource()` recognizes `open.spotify.com`, `spotify.com/playlist`, and `spotify.link/` short links.
     - `fetchPlaylistWithSongs()` fetches playlist metadata + tracks via `SpotifyLibraryRepository` (requires the user to be authenticated via **Settings → Integrations → Spotify**) and resolves each `SpotifyTrack` to a YouTube Music match via `SpotifyPlaybackResolver`, which uses bigram-similarity scoring to pick the best match and gracefully skips tracks below the match threshold.
     - The repository is accessed via a new Hilt `@EntryPoint` (`SpotifyRepositoryEntryPoint`) so the dialog (a plain Composable) can reach it without a ViewModel.
   - Updated strings: `cross_service_import_playlist_supported`, `cross_service_import_playlist_url_placeholder`, and `cross_service_import_entry_desc` now mention Spotify.

#### Files changed (Part A)

- **NEW** `app/src/main/kotlin/moe/rukamori/archivetune/di/SpotifyRepositoryEntryPoint.kt` — Hilt entry point exposing `SpotifyLibraryRepository`.
- `app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt` — new `ImportSource.SPOTIFY`, new `fetchPlaylistWithSongs()` returning `List<MediaMetadata>`, Spotify URL parser, Spotify track resolver.
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt` — uses `fetchPlaylistWithSongs()`, inserts songs in a transaction before `addSongToPlaylist`, removes unused `YouTubePlaylistImportFetcher`.
- `app/src/main/res/values/strings.xml` — strings now mention Spotify.

### Part B — Previous UX/perf bundle (commit `018d20849`)

The 9 tasks the user requested across previous sessions, all bundled here so they ship in one PR:

1. **Queue opens at currently-playing song** — `Queue.kt` tracks prev-isCollapsed state and scrolls on collapse→expand transition; retry loop lets the scroll succeed even when the queue windows haven't populated on first composition.
2. **FLAC nerd-stats shows total size in MB** — `MusicService.persistDirectStreamFormat` fires a HEAD request when `DirectStream.contentLength` is null and backfills the `FormatEntity`. `DebugSettings` NerdStatsSection has a 500ms-poll fallback that sums cached bytes across all source-prefixed keys.
3. **Faster downloads (PRDownloader kept)** — parallel downloads 8→12, max http requests 128/64→256/96, idle connections 64→96, write buffer 12MB→16MB, fragment size 64MB→128MB. `App.kt` PRDownloaderConfig: connect timeout 30s→15s, explicit user agent for HTTP/2 connection reuse.
4. **Faster playback start** — `MusicService` buffer constants: `PRIMARY_BUFFER_FOR_PLAYBACK_MS` 250→150, `PRIMARY_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS` 1000→750.
5. **Download source picker only exposes YouTube Music and Auto** — `PlayerSettings.kt` switched from `EnumListPreference` to `ListPreference` with `[AUTO, YOUTUBE_MUSIC]` values. Qobuz/Tidal/Deezer remain in the enum so existing preferences deserialize, but are no longer selectable — the AUTO chain still picks them up automatically.
6. **Smoother lyrics panel open animation on low-mid range phones** — `Player.kt` MikoLyricsTransition defers `LyricsScreen` composition until the spring is past 50% travel. `LyricsScreen.kt` 120ms delay before kicking off Palette extraction.
7. **New 'Download cover' option in song overflow menu** — `SongMenu.kt` + `YouTubeSongMenu.kt` fetch the song thumbnail via Coil and save it to `Pictures/ArchiveTune/` via MediaStore (Android 10+) or `cacheDir` + FileProvider (pre-Q). New `ComposeToImage.saveCoverArtworkFromUrl()` helper.
8. **Album thumbnail loops animated visual art** — `CanvasArtworkPlayer` visibility changed from internal → public. `MediaDetailHero` has new optional `canvasPrimaryUrl` / `canvasFallbackUrl` / `canvasIsPlaying` params. `AlbumViewModel.canvasArtwork` StateFlow fetches via `ArchiveTuneCanvas.getByAlbumId` with fallback to `AppleMusicProvider.getByAlbumArtist`.
9. **Strings** — new `download_cover`, `cover_saved`, `cover_save_failed`, `cover_save_no_artwork`, `cover_saving`.

## Test plan

- [ ] CI build passes (Kotlin 2.4.0 + Compose + Room + Hilt).
- [ ] Import a YouTube Music playlist URL via **Settings → Integrations → Import playlist from URL** — should succeed without `FOREIGN KEY constraint failed`, and the resulting local playlist should contain the songs and be playable.
- [ ] Import a Spotify playlist URL (with Spotify connected in Integrations) — should resolve each Spotify track to its YouTube Music match, insert the songs, and create a local playlist with the resolved songs.
- [ ] Import a Spotify playlist URL **without** Spotify connected — should show a friendly error explaining that Spotify requires a connected account.
- [ ] Re-import the same URL — should reuse the existing playlist (update name + bookmark) rather than creating a duplicate.
- [ ] Open the queue mid-playlist — should scroll to the currently-playing song.
- [ ] Play a FLAC — nerd stats should show total size in MB.
- [ ] Open an album with an Apple Music animated cover — thumbnail should animate.
- [ ] Tap 'Download cover' in a song's overflow menu — cover should be saved to `Pictures/ArchiveTune/`.

## Notes

- PRDownloader is KEPT (per the user's explicit instruction across multiple sessions).
- The Qobuz/Tidal/Deezer source-pool download chain (from PR #62) is preserved — only the UI picker was simplified.
- `SegmentedParallelDataSource` is not touched in this PR.
