### PR TITLE
fix(playlist-import): FK constraint on YouTube + empty Spotify playlist

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt
@@ -14,6 +14,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.SongItem
+import moe.rukamori.archivetune.innertube.utils.completed
+import moe.rukamori.archivetune.models.MediaMetadata
+import moe.rukamori.archivetune.models.toMediaMetadata
 import moe.rukamori.archivetune.spotify.Spotify
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -201,6 +204,67 @@ object CrossServicePlaylistImporter {
         }
         results
     }
+
+    /**
+     * Same as [resolveToYouTubeMusic] but returns the fully-resolved
+     * [MediaMetadata] for each matched track (instead of just the song id).
+     *
+     * Callers that need to insert the resolved songs into the local `song`
+     * table — e.g. before linking them to a playlist via
+     * `addSongToPlaylist` — should prefer this overload so they have the
+     * title / artists / thumbnailUrl / album fields required to populate
+     * the `song` row. Otherwise the `playlist_song_map.songId` FOREIGN KEY
+     * → `song.id` constraint will reject the insert.
+     *
+     * Tracks that can't be matched on YouTube Music are skipped.
+     *
+     * @param onProgress optional callback invoked with (resolved, total)
+     *        after each track resolves. Lets the UI show a live counter.
+     */
+    suspend fun resolveToYouTubeMusicMetadata(
+        tracks: List<ForeignTrack>,
+        onProgress: ((Int, Int) -> Unit)? = null,
+    ): List<MediaMetadata> = coroutineScope {
+        val total = tracks.size
+        if (total == 0) return@coroutineScope emptyList()
+        val results = mutableListOf<MediaMetadata>()
+        var completed = 0
+
+        // Process in bounded-concurrency batches so we don't hammer
+        // InnerTube with 100+ parallel searches for a 100-track playlist.
+        tracks.chunked(MAX_PARALLEL_SEARCHES).forEach { batch ->
+            val resolved = batch.map { track ->
+                async {
+                    val term = listOfNotNull(track.artist?.takeIf(String::isNotBlank), track.title)
+                        .joinToString(" ")
+                        .ifBlank { return@async null }
+                    val search = YouTube.search(term, YouTube.SearchFilter.FILTER_SONG).getOrNull()
+                    val first = search?.items?.firstOrNull { it is SongItem } as? SongItem
+                    first?.toMediaMetadata()
+                }
+            }.awaitAll()
+            resolved.filterNotNull().forEach { results.add(it) }
+            completed += batch.size
+            onProgress?.invoke(completed, total)
+        }
+        results
+    }
+
+    /**
+     * Fetches a YouTube Music playlist (following continuation pages)
+     * and returns the fully-resolved [MediaMetadata] for every song.
+     *
+     * Use this instead of `YouTubePlaylistImportFetcher.fetch(...)` when
+     * the caller needs to insert the song rows into the local `song`
+     * table before linking them to a playlist — otherwise the
+     * `playlist_song_map.songId` FOREIGN KEY → `song.id` constraint
+     * will reject the insert.
+     */
+    suspend fun fetchYouTubePlaylistSongs(playlistId: String): List<MediaMetadata> =
+        withContext(Dispatchers.IO) {
+            val page = YouTube.playlist(playlistId).completed().getOrNull() ?: return@withContext emptyList()
+            page.songs.map { it.toMediaMetadata() }
+        }
 
     // ─── Spotify ──────────────────────────────────────────────────────────
     // URL pattern: https://open.spotify.com/playlist/{base62-id}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.db.entities.PlaylistEntity
+import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.playlist.CrossServiceImportCredentials
 import moe.rukamori.archivetune.playlist.CrossServicePlaylistImporter
 import moe.rukamori.archivetune.ui.component.DefaultDialog
@@ -198,13 +199,22 @@ fun CrossServiceImportPlaylistDialog(
                                 return@launch
                             }
 
-                            // For YouTube Music imports we already have song ids —
-                            // skip the per-track search step.
-                            val songIds: List<String> =
+                            // Resolve tracks all the way to fully-populated
+                            // MediaMetadata (title/artists/album/thumbnail)
+                            // so we can insert them into the `song` table
+                            // BEFORE linking them to a playlist. Without this,
+                            // addSongToPlaylist() trips the
+                            // playlist_song_map.songId → song.id FOREIGN KEY
+                            // constraint and the whole import fails with
+                            // "FOREIGN KEY constraint failed (code 787)".
+                            //
+                            // YouTube Music already has the song ids natively
+                            // (no per-track search needed) but we still fetch
+                            // the full SongItems via fetchYouTubePlaylistSongs
+                            // so we have the metadata to populate the song row.
+                            val songs: List<MediaMetadata> =
                                 if (resolved.source == CrossServicePlaylistImporter.ImportSource.YOUTUBE_MUSIC) {
-                                    // Re-resolve via the existing YouTube.playlist path
-                                    // which returns SongItems with their YouTube ids.
-                                    YouTubePlaylistImportFetcher.fetch(resolved.sourcePlaylistId)
+                                    CrossServicePlaylistImporter.fetchYouTubePlaylistSongs(resolved.sourcePlaylistId)
                                 } else {
                                     withContext(Dispatchers.Main) {
                                         statusMessage = context.getString(
@@ -214,7 +224,7 @@ fun CrossServiceImportPlaylistDialog(
                                         totalCount = resolved.tracks.size
                                         resolvedCount = 0
                                     }
-                                    CrossServicePlaylistImporter.resolveToYouTubeMusic(
+                                    CrossServicePlaylistImporter.resolveToYouTubeMusicMetadata(
                                         tracks = resolved.tracks,
                                         onProgress = { done, total ->
                                             resolvedCount = done
@@ -223,7 +233,7 @@ fun CrossServiceImportPlaylistDialog(
                                     )
                                 }
 
-                            if (songIds.isEmpty()) {
+                            if (songs.isEmpty()) {
                                 withContext(Dispatchers.Main) {
                                     statusMessage = null
                                     isLoading = false
@@ -235,6 +245,18 @@ fun CrossServiceImportPlaylistDialog(
                                 }
                                 return@launch
                             }
+
+                            // === Foreign-key-safe insert ===
+                            // Insert every resolved song into the `song` table
+                            // (plus its artist rows via the @Transaction insert
+                            // overload) inside a single transaction so a
+                            // mid-import crash doesn't leave half the songs
+                            // behind. After this, addSongToPlaylist() can
+                            // safely create the playlist_song_map rows.
+                            database.withTransaction {
+                                songs.forEach { meta -> insert(meta) }
+                            }
+                            val songIds = songs.map { it.id }
 
                             // Create the local playlist and insert the song ids.
                             val playlistName = resolved.title.ifBlank {
@@ -309,21 +331,4 @@ fun CrossServiceImportPlaylistDialog(
             }
         },
     )
-}
-
-/**
- * Tiny helper that calls the existing YouTube.playlist() API to fetch
- * SongItems with their YouTube Music ids. Kept separate so the
- * [CrossServiceImportPlaylistDialog] can treat YouTube Music imports
- * the same as foreign-service imports (final result is a list of
- * YouTube Music song ids).
- */
-private object YouTubePlaylistImportFetcher {
-    suspend fun fetch(playlistId: String): List<String> {
-        val page = moe.rukamori.archivetune.innertube.YouTube
-            .playlist(playlistId)
-            .getOrNull()
-            ?: return emptyList()
-        return page.songs.map { it.id }
-    }
 }


### PR DESCRIPTION
## What's broken

Both cross-service playlist import paths (Settings → Integrations → **Import playlist from URL**) were broken:

1. **YouTube Music import fails with `FOREIGN KEY constraint failed (code 787 SQLITE_CONSTRAINT)`** (visible in the screenshot below — toast at the bottom).
   - **Root cause:** the dialog called `database.addSongToPlaylist(playlist, songIds)` with raw YouTube song ids that had **never been inserted** into the local `song` table. `playlist_song_map.songId` has a FK → `song.id`, so SQLite rejected the insert.
   - This bug has existed since the cross-service importer was introduced and survived PR #64 (which added Spotify/Qobuz) because #64 layered Spotify support on top of the same broken insert flow.

2. **Spotify import creates an empty playlist that disappears on its own.**
   - PR #64 already added Spotify support (via the authenticated GQL client with embed-page fallback), so a Spotify URL is now recognized and a playlist shell is created. But because of bug #1, the songs never get linked to the playlist (the `addSongToPlaylist` call silently fails inside its own transaction).
   - The empty playlist shell then lingers until the next `SyncUtils.cleanupDuplicatePlaylists()` pass, which deletes it (or any duplicate of the same `browseId`) keeping only the one with the most songs. An empty playlist has 0 songs, so it always loses that tie-break and gets removed → "disappeared on its own".

## The fix

Resolve the playlist all the way to fully-populated `MediaMetadata` (title / artists / album / thumbnail) and **insert the song rows into the `song` table BEFORE calling `addSongToPlaylist`**. This mirrors the pattern already used by `YouTubePlaylistMenu` → `ImportPlaylistDialog` and `MediaLibrarySessionCallback.addSongEntriesToPlaylist`.

### Changes

**`app/src/main/kotlin/moe/rukamori/archivetune/playlist/CrossServicePlaylistImporter.kt`**

- New `resolveToYouTubeMusicMetadata(tracks, onProgress)`: same bounded-concurrency batch search as `resolveToYouTubeMusic()` but returns `List<MediaMetadata>` (so the caller has the title/artists/album/thumbnail needed to populate the `song` row). Tracks that can't be matched on YouTube Music are skipped, same as before.
- New `fetchYouTubePlaylistSongs(playlistId)`: fetches the full YouTube Music playlist (following continuation pages) via `YouTube.playlist(id).completed()` and maps each `SongItem` to `MediaMetadata`. Used by the dialog for YouTube Music imports so we don't have to re-search YouTube for songs we already have ids for.
- Existing `resolveToYouTubeMusic()` (returns `List<String>`) is preserved for any other call sites — none in the app right now, but it's a public API.

**`app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/CrossServiceImportPlaylistDialog.kt`**

- The Import button's coroutine now resolves to `List<MediaMetadata>` for **both** YouTube Music (via `fetchYouTubePlaylistSongs`) and foreign-service imports (via `resolveToYouTubeMusicMetadata`).
- Before calling `addSongToPlaylist`, the resolved songs are inserted into the `song` table inside a single transaction:
  ```kotlin
  database.withTransaction {
      songs.forEach { meta -> insert(meta) }
  }
  val songIds = songs.map { it.id }
  ```
  The `insert(MediaMetadata)` overload is a `@Transaction` DAO method that also inserts the artist rows + `song_artist_map` rows atomically.
- Removed the now-unused `YouTubePlaylistImportFetcher` helper (its job is done by `fetchYouTubePlaylistSongs`).

### Layered on top of PR #64

This PR does **not** touch any of the source-specific fetch logic that PR #64 added (Spotify GQL + embed fallback, Qobuz, Tidal v1 API, Apple Music `serialized-server-data` walker). It only changes the **post-fetch resolution + insert** path so the FK constraint is satisfied.

## Test plan

- [ ] CI build passes (Kotlin 2.4.0 + Compose + Room + Hilt).
- [ ] **YouTube Music import** — paste `https://music.youtube.com/playlist?list=...` → should succeed (no `FOREIGN KEY constraint failed` toast), the resulting local playlist should contain the songs and be playable end-to-end.
- [ ] **Spotify import (authenticated)** — with Spotify connected in Integrations, paste `https://open.spotify.com/playlist/...` → should resolve each Spotify track to its YouTube Music match, insert the songs, and create a local playlist with the resolved songs. Playlist should NOT disappear after a sync.
- [ ] **Spotify import (anonymous)** — without Spotify connected, paste a public Spotify playlist URL → should fall back to the embed page, resolve tracks, and succeed without needing credentials.
- [ ] **Re-import the same URL** — should reuse the existing playlist (update name + bookmark) rather than creating a duplicate.
- [ ] **Apple Music / Tidal / Deezer / Amazon Music / Qobuz imports** — should still work (resolve via per-track YouTube search, insert songs, add to playlist).

## Notes

- PRDownloader is untouched.
- No DB migration needed — the `song` table schema is unchanged; we're just populating it before the FK-restricted insert.
- The duplicate-playlist cleanup in `SyncUtils.cleanupDuplicatePlaylists()` is unchanged. With this fix, imported playlists are no longer empty, so they won't be removed by the cleanup pass.
