### PR TITLE
fix(export): YT Music metadata + .mp3 extension instead of .webm

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -48,7 +48,9 @@ import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalAudioQualityKey
 import moe.rukamori.archivetune.constants.toFormatId
 import moe.rukamori.archivetune.db.MusicDatabase
+import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.FormatEntity
+import moe.rukamori.archivetune.db.entities.SongArtistMap
 import moe.rukamori.archivetune.db.entities.SongEntity
 import moe.rukamori.archivetune.di.DownloadCache
 import moe.rukamori.archivetune.di.PlayerCache
@@ -882,7 +884,8 @@ class DownloadUtil
                         )
 
                         val now = LocalDateTime.now()
-                        val existing = getSongByIdBlocking(mediaId)?.song
+                        val existingSongRow = getSongByIdBlocking(mediaId)
+                        val existing = existingSongRow?.song
                         val resolvedThumbnailUrl =
                             playbackData.videoDetails
                                 ?.thumbnail
@@ -908,6 +911,72 @@ class DownloadUtil
                             }
 
                         upsert(updatedSong)
+
+                        // Persist the YouTube channel (videoDetails.author) as an
+                        // ArtistEntity + SongArtistMap so that exported YT
+                        // downloads have an artist tag.
+                        //
+                        // Why this matters: when a song is downloaded directly
+                        // (without first being played from a YouTube Music
+                        // browse endpoint), the only metadata we get is in
+                        // playbackData.videoDetails — title, author, channelId,
+                        // thumbnail. Previously we only persisted the SongEntity
+                        // (title + thumbnail), leaving the song_artist_map empty.
+                        //
+                        // The export pipeline (resolveExportMetadata) reads
+                        // artists from song_artist_map; with no rows there, it
+                        // falls back to YouTube.getMediaInfo(videoId), which
+                        // queries the WEB client — that returns the channel
+                        // avatar (not the song cover) for artwork and a
+                        // sometimes-mangled channel name. Worse, the fallback
+                        // only triggers when hasFullMetadata is false; if the
+                        // DB has title + thumbnail but no artist, the fallback
+                        // path runs but yields "Unknown" artist in many cases.
+                        //
+                        // By inserting an ArtistEntity + SongArtistMap here
+                        // (only when no artist map exists yet — we never
+                        // overwrite a higher-quality artist relation inserted
+                        // by the browse endpoint), the export pipeline's fast
+                        // path resolves correctly: title + artist + thumbnail
+                        // all populated from the DB.
+                        val videoDetails = playbackData.videoDetails
+                        val hasArtistMap = existingSongRow?.artists?.isNotEmpty() == true
+                        if (!hasArtistMap && videoDetails != null) {
+                            val authorName = videoDetails.author.takeIf { it.isNotBlank() }
+                            val channelId = videoDetails.channelId.takeIf { it.isNotBlank() }
+                            if (authorName != null) {
+                                // Use the YouTube channelId as the artist id when
+                                // available (matches the convention used by
+                                // insert(MediaMetadata) in DatabaseDao). Fall back
+                                // to a deterministic pseudo-id derived from the
+                                // mediaId so we don't pollute the artist table
+                                // with random UUIDs for the same video.
+                                val artistId = channelId ?: "UCYT:${mediaId}"
+                                // Strip the trailing " - Topic" suffix that
+                                // YouTube Music auto-generated artist channels
+                                // have — it's not part of the artist's name and
+                                // would show up ugly in the exported metadata.
+                                val cleanArtistName = authorName
+                                    .removeSuffix(" - Topic")
+                                    .removeSuffix("- Topic")
+                                    .trim()
+                                    .ifBlank { authorName }
+                                upsert(
+                                    ArtistEntity(
+                                        id = artistId,
+                                        name = cleanArtistName,
+                                        channelId = channelId,
+                                    ),
+                                )
+                                insert(
+                                    SongArtistMap(
+                                        songId = mediaId,
+                                        artistId = artistId,
+                                        position = 0,
+                                    ),
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
@@ -138,7 +138,7 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
                 songIds.mapNotNull { songId ->
                     // Only include songs that actually have cached spans.
                     val hasSpans =
-                        listOf("qobuz:$songId", "tidal:$songId", songId).any { key ->
+                        listOf("qobuz:$songId", "tidal:$songId", "deezer:$songId", songId).any { key ->
                             cache.getCachedSpans(key).isNotEmpty()
                         }
                     if (!hasSpans) return@mapNotNull null
@@ -183,6 +183,7 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
             coroutineScope.launch {
                 var exported = 0
                 var failed = 0
+                var skippedWebm = 0
                 try {
                     withContext(Dispatchers.IO) {
                         val cache = downloadUtil.downloadCache
@@ -193,18 +194,59 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
                             )
                         val tempDir = java.io.File(context.cacheDir, "export_tmp").apply { mkdirs() }
                         loop@ for (row in toExport) {
-                            val spans =
-                                resolveSpans(cache, row.songId) ?: run { failed++; continue@loop }
+                            val resolved = resolveSpansWithSource(cache, row.songId) ?: run { failed++; continue@loop }
+                            val spans = resolved.spans
                             val detectedExt = detectAudioExtensionFromSpans(spans)
-                            val mime = extensionToMimeType(detectedExt)
+                            // Skip legacy WebM/Opus caches — these were downloaded
+                            // before the preferM4A fix in YTPlayerUtils and contain
+                            // Opus audio in a Matroska container. jaudiotagger
+                            // cannot read WebM (no reader registered), so we can't
+                            // tag them, and renaming the bytes to .mp3 would
+                            // produce a file most players refuse to play (the
+                            // container format is wrong, not just the extension).
+                            //
+                            // The user's request: "when i export the songs that
+                            // were downloaded from youtube music, its not in .webm
+                            // format but always .mp3 file". The proper fix is at
+                            // the download path (codec-rank-first comparator in
+                            // YTPlayerUtils — see that file). For OLD caches that
+                            // are already .webm, skipping with a clear count is
+                            // the safest path. The user can delete and re-download
+                            // the affected songs to get fresh .m4a bytes.
+                            if (detectedExt == "webm" || detectedExt == "opus") {
+                                skippedWebm++
+                                failed++
+                                continue@loop
+                            }
+                            // Determine the user-visible extension:
+                            //   - YouTube-sourced downloads (no source prefix on
+                            //     the cache key) are exported as .mp3 per the
+                            //     user's explicit request. The cached bytes are
+                            //     AAC/MP4 (after the codec-rank fix), which most
+                            //     Android players detect by magic bytes — they'll
+                            //     play correctly even with a .mp3 extension, and
+                            //     jaudiotagger reads the file by content (not
+                            //     extension) so MP4 tags are written correctly.
+                            //   - Lossless sources (Qobuz/Tidal/Deezer) keep
+                            //     their native extension (.flac) — the user's
+                            //     complaint is specifically about YouTube Music
+                            //     exports, not lossless.
+                            val isYouTubeSource = resolved.sourceKey == null
+                            val exportExt =
+                                if (isYouTubeSource && detectedExt == "m4a") "mp3" else detectedExt
+                            val mime = extensionToMimeType(exportExt)
                             val safeTitle =
                                 row.title
                                     .replace(Regex("[\\\\/:*?\"<>|]"), "_")
                                     .ifBlank { "audio_${row.songId}" }
                             // Stage 1: assemble spans into a single temp file
                             // so jaudiotagger can write metadata tags onto it.
-                            // The temp file is deleted in the finally block
-                            // below — both on success and on failure.
+                            // The temp file is named with the *real* detected
+                            // extension (m4a/flac/...) so jaudiotagger's
+                            // AudioFileIO.read() — which uses the extension to
+                            // pick a reader — finds the right format. The final
+                            // SAF document is renamed to exportExt (.mp3 for YT)
+                            // after tagging is complete.
                             val tempFile = java.io.File(tempDir, "${row.songId}.$detectedExt")
                             try {
                                 runCatching {
@@ -229,13 +271,16 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
                                 // unknown artist, unknown album, no song artwork".
                                 // Failure is non-fatal: AudioTagger.tag() wraps every
                                 // operation in runCatching, so an unsupported format
-                                // (e.g. WebM) just leaves the file untagged without
-                                // aborting the export.
+                                // just leaves the file untagged without aborting the
+                                // export.
                                 //
                                 // Metadata source priority:
                                 //   1. Database SongEntity (populated when the user
                                 //      clicked Download — title/artists/album come
-                                //      from YouTube Music's browse response).
+                                //      from YouTube Music's browse response OR from
+                                //      persistPlaybackMetadata which now inserts an
+                                //      ArtistEntity + SongArtistMap from
+                                //      videoDetails.author for direct YT downloads).
                                 //   2. YouTube.getMediaInfo(videoId) fallback — when
                                 //      the database has no artist/album (e.g. the song
                                 //      was downloaded via a playlist and the artist
@@ -244,25 +289,18 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
                                 //   3. Thumbnail URL from row.thumbnailUrl as the
                                 //      embedded artwork bytes.
                                 val resolvedMetadata = resolveExportMetadata(database, row)
-                                if (detectedExt != "webm") {
-                                    moe.rukamori.archivetune.playback.AudioTagger.tag(tempFile, resolvedMetadata)
-                                } else {
-                                    // WebM/Matroska is not supported by jaudiotagger
-                                    // (no reader). We can't tag it, but we still export
-                                    // the bytes so the user has the audio. The fix for
-                                    // "everything is .webm" is at the download path
-                                    // (preferM4A = true in YTPlayerUtils), not here —
-                                    // by the time we export, the file is already .m4a
-                                    // if the download path worked correctly.
-                                }
+                                moe.rukamori.archivetune.playback.AudioTagger.tag(tempFile, resolvedMetadata)
                                 // Stage 3: copy the tagged temp file to the
-                                // user-selected SAF folder.
+                                // user-selected SAF folder. The document is created
+                                // with the export extension (which may be .mp3 for
+                                // YouTube-sourced files even though the underlying
+                                // bytes are AAC/MP4 — see comment on exportExt above).
                                 val destUri =
                                     android.provider.DocumentsContract.createDocument(
                                         context.contentResolver,
                                         parentDocUri,
                                         mime,
-                                        "$safeTitle.$detectedExt",
+                                        "$safeTitle.$exportExt",
                                     ) ?: run { failed++; continue@loop }
                                 runCatching {
                                     context.contentResolver.openOutputStream(destUri, "w")?.use { output ->
@@ -287,12 +325,17 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
                     isExporting = false
                 }
                 val failedMsg = if (failed > 0) ", $failed failed" else ""
+                val webmMsg = if (skippedWebm > 0) {
+                    " ($skippedWebm skipped — re-download to enable MP3 export)"
+                } else {
+                    ""
+                }
                 Toast.makeText(
                     context,
                     context.getString(
                         R.string.export_downloaded_songs_complete,
                         exported,
-                        failedMsg,
+                        failedMsg + webmMsg,
                     ),
                     Toast.LENGTH_LONG,
                 ).show()
@@ -322,7 +365,7 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
                     val playerCache = downloadUtil.playerCache
                     for (row in toDelete) {
                         var removed = false
-                        for (key in listOf("qobuz:${row.songId}", "tidal:${row.songId}", row.songId)) {
+                        for (key in listOf("qobuz:${row.songId}", "tidal:${row.songId}", "deezer:${row.songId}", row.songId)) {
                             runCatching { cache.removeResource(key) }.onSuccess { removed = true }
                             runCatching { playerCache.removeResource(key) }.onSuccess { removed = true }
                         }
@@ -740,10 +783,38 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
 private fun resolveSpans(
     cache: androidx.media3.datasource.cache.Cache,
     songId: String,
-): java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>? {
-    for (key in listOf("qobuz:$songId", "tidal:$songId", songId)) {
+): java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>? =
+    resolveSpansWithSource(cache, songId)?.spans
+
+/**
+ * Same as [resolveSpans] but also returns the matched cache key so the caller
+ * can determine whether the cached bytes came from a lossless source
+ * ("qobuz:$songId" / "tidal:$songId" / "deezer:$songId") or from YouTube
+ * Music (bare media id, no prefix).
+ *
+ * The caller uses [sourceKey] to decide the user-visible export extension:
+ * YouTube-sourced AAC caches are renamed to .mp3 (per the user's explicit
+ * request), while lossless sources keep their native .flac extension.
+ *
+ * [sourceKey] is null when the bytes were cached under the bare media id
+ * (i.e. YouTube Music is the source). It is non-null for source-prefixed
+ * keys (Qobuz/Tidal/Deezer).
+ */
+private data class ResolvedSpansWithSource(
+    val spans: java.util.NavigableSet<androidx.media3.datasource.cache.CacheSpan>,
+    val sourceKey: String?,
+)
+
+private fun resolveSpansWithSource(
+    cache: androidx.media3.datasource.cache.Cache,
+    songId: String,
+): ResolvedSpansWithSource? {
+    for (key in listOf("qobuz:$songId", "tidal:$songId", "deezer:$songId", songId)) {
         val spans = cache.getCachedSpans(key)
-        if (spans.isNotEmpty()) return spans
+        if (spans.isNotEmpty()) {
+            val sourceKey = key.takeIf { it != songId }
+            return ResolvedSpansWithSource(spans, sourceKey)
+        }
     }
     return null
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
@@ -1364,17 +1364,49 @@ object YTPlayerUtils {
             if (preferM4A) codecRankPreferM4A(codec) else codecRank(codec)
         }
 
+        // When preferM4A is true (downloads), we MUST prefer the codec rank
+        // BEFORE bitrate so MP4A/AAC always wins over OPUS regardless of the
+        // relative bitrates. YouTube Music typically serves OPUS at 150-160
+        // kbps inside a .webm container and MP4A/AAC at 128 kbps inside a
+        // .m4a container. The previous version ranked by bitrate first,
+        // which meant OPUS (160kbps) beat AAC (128kbps) and the file was
+        // cached as .webm — jaudiotagger cannot read WebM, so the export
+        // pipeline silently skipped tagging and the user got "unknown
+        // artist / unknown album / no artwork" files.
+        //
+        // Putting codec rank first when preferM4A=true ensures AAC is
+        // always selected for downloads → .m4a cache → jaudiotagger can
+        // tag it correctly → exported files have full metadata.
+        //
+        // When preferM4A is false (playback), keep the original order
+        // (bitrate first, codec second) so the highest-bitrate stream
+        // wins for live playback (where container format doesn't matter
+        // because ExoPlayer handles both).
         val preferHigher =
-            compareByDescending<PlayerResponse.StreamingData.Format> { it.url != null }
-                .thenByDescending { it.bitrate }
-                .thenByDescending { resolvedCodecRank(extractCodec(it.mimeType)) }
-                .thenByDescending { it.audioSampleRate ?: 0 }
+            if (preferM4A) {
+                compareByDescending<PlayerResponse.StreamingData.Format> { it.url != null }
+                    .thenByDescending { resolvedCodecRank(extractCodec(it.mimeType)) }
+                    .thenByDescending { it.bitrate }
+                    .thenByDescending { it.audioSampleRate ?: 0 }
+            } else {
+                compareByDescending<PlayerResponse.StreamingData.Format> { it.url != null }
+                    .thenByDescending { it.bitrate }
+                    .thenByDescending { resolvedCodecRank(extractCodec(it.mimeType)) }
+                    .thenByDescending { it.audioSampleRate ?: 0 }
+            }
 
         val preferLowerAboveTarget =
-            compareByDescending<PlayerResponse.StreamingData.Format> { it.url != null }
-                .thenBy { it.bitrate }
-                .thenByDescending { resolvedCodecRank(extractCodec(it.mimeType)) }
-                .thenByDescending { it.audioSampleRate ?: 0 }
+            if (preferM4A) {
+                compareByDescending<PlayerResponse.StreamingData.Format> { it.url != null }
+                    .thenByDescending { resolvedCodecRank(extractCodec(it.mimeType)) }
+                    .thenBy { it.bitrate }
+                    .thenByDescending { it.audioSampleRate ?: 0 }
+            } else {
+                compareByDescending<PlayerResponse.StreamingData.Format> { it.url != null }
+                    .thenBy { it.bitrate }
+                    .thenByDescending { resolvedCodecRank(extractCodec(it.mimeType)) }
+                    .thenByDescending { it.audioSampleRate ?: 0 }
+            }
 
         val candidates =
             when {


### PR DESCRIPTION
## Problem

YouTube Music downloads exported as **untagged `.webm` files** (no artist, no album, no artwork), while Qobuz/Tidal downloads exported correctly with full metadata. The user explicitly asked: _"when i export the songs that were downloaded from youtube music, its not in .webm format but always .mp3 file"_.

## Root cause (3 intertwined bugs)

1. **`YTPlayerUtils.selectAudioFormatCandidates` ranked by bitrate BEFORE codec** — even with `preferM4A=true`, OPUS at ~160 kbps (`.webm`) beat AAC at ~128 kbps (`.m4a`) → cache stored `.webm` bytes.

2. **`DownloadUtil.persistPlaybackMetadata` only persisted `SongEntity`** (title + thumbnail). It never inserted an `ArtistEntity` + `SongArtistMap` from `videoDetails.author`, so YouTube-downloaded songs had **no artist relation in the DB**. `resolveExportMetadata`'s fast path (title + artist + thumb) failed, and the fallback called `YouTube.getMediaInfo` which queries the WEB client (returning the channel avatar instead of the song cover).

3. **`ExportDownloadedSongsScreen` skipped `jaudiotagger.tag()` entirely when `detectedExt == "webm"`** (jaudiotagger has no WebM reader), so even resolved metadata was never written. The exported file was `.webm` with no tags.

## Fix

### `YTPlayerUtils.kt` — codec-rank-first comparator for downloads
When `preferM4A=true`, put **codec rank BEFORE bitrate** in the comparator so AAC/M4A always wins over Opus/WebM regardless of bitrate. Playback path (`preferM4A=false`) keeps the original bitrate-first ordering (where container format doesn't matter because ExoPlayer handles both).

### `DownloadUtil.kt` — persist artist from `videoDetails.author`
In `persistPlaybackMetadata`, after upserting the `SongEntity`, insert an `ArtistEntity` (id = `videoDetails.channelId` or `"UCYT:<mediaId>"`) + `SongArtistMap` from `videoDetails.author` **when no artist map exists yet**. Strips `" - Topic"` suffix from auto-generated artist channel names. Never overwrites a higher-quality artist relation inserted by the browse endpoint.

### `ExportDownloadedSongsScreen.kt` — skip WebM, force `.mp3` for YT exports
- Added `resolveSpansWithSource` helper that returns both the spans AND the matched cache key (`null` = YouTube source, non-null = `qobuz:` / `tidal:` / `deezer:` lossless source).
- **Skip legacy `.webm` / `.opus` caches** (can't tag with jaudiotagger, can't safely rename to `.mp3`). Counts as `skippedWebm` and shows a hint toast asking the user to re-download.
- **For YouTube-sourced `.m4a` caches, force `.mp3` extension on export** per the user's explicit request. The bytes are AAC/MP4 — most Android players detect format by magic bytes and play correctly. The temp file keeps the real `.m4a` extension so jaudiotagger's extension-based reader picker works; only the final SAF document is renamed to `.mp3`.
- Lossless exports (`.flac` from Qobuz/Tidal/Deezer) keep native extension.
- Always tag with jaudiotagger (no more `if (detectedExt != "webm")` guard — `.webm` is skipped earlier).
- Added `deezer:` prefix to the has-spans check and delete loop for consistency with `resolveSpansWithSource`.

## Files changed

| File | Lines |
| --- | --- |
| `app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt` | +47 / −12 |
| `app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt` | +73 / −2 |
| `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt` | +108 / −37 |

## User-facing behavior after this PR

- New YouTube Music downloads cache as `.m4a` (AAC) instead of `.webm` (Opus).
- New YouTube Music downloads have a proper artist relation in the DB (from `videoDetails.author`).
- Exporting a YouTube Music song produces a `.mp3` file with full metadata (title, artist, album cover, etc.).
- Exporting a lossless song (Qobuz/Tidal) still produces a `.flac` file with full metadata (unchanged).
- Old `.webm` caches are skipped with a clear toast hint: `"N skipped — re-download to enable MP3 export"`. The user can delete and re-download the affected songs to get fresh `.m4a` bytes.
