### PR TITLE
fix(compile): rename GoogleDriveSyncWorkerEntryPoint methods to avoid Hilt clash

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncWorker.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncWorker.kt
@@ -43,7 +43,7 @@ class GoogleDriveSyncWorker(
                 applicationContext,
                 GoogleDriveSyncWorkerEntryPoint::class.java,
             )
-        val settings = dependencies.repository().getSettings() ?: return Result.success()
+        val settings = dependencies.googleDriveRepository().getSettings() ?: return Result.success()
         if (!settings.enabled || settings.accountEmail == null) return Result.success()
 
         return try {
@@ -55,10 +55,10 @@ class GoogleDriveSyncWorker(
                     "${applicationContext.getString(R.string.app_name)}_$timestamp"
                 }
             val fileId =
-                dependencies.client().uploadBackup(settings, fileName)
+                dependencies.googleDriveClient().uploadBackup(settings, fileName)
                     ?: return Result.retry()
-            dependencies.repository().recordSyncResult(success = true)
-            dependencies.scheduler().appendNext(
+            dependencies.googleDriveRepository().recordSyncResult(success = true)
+            dependencies.googleDriveScheduler().appendNext(
                 settings.copy(lastSyncEpochMs = System.currentTimeMillis(), lastSyncFailed = false),
             )
             Result.success()
@@ -66,11 +66,11 @@ class GoogleDriveSyncWorker(
             throw cancellation
         } catch (security: SecurityException) {
             reportException(security)
-            dependencies.repository().recordSyncResult(success = false)
+            dependencies.googleDriveRepository().recordSyncResult(success = false)
             Result.failure()
         } catch (exception: Exception) {
             reportException(exception)
-            dependencies.repository().recordSyncResult(success = false)
+            dependencies.googleDriveRepository().recordSyncResult(success = false)
             Result.retry()
         }
     }
@@ -80,12 +80,25 @@ class GoogleDriveSyncWorker(
     }
 }
 
+/**
+ * Hilt entry point used by [GoogleDriveSyncWorker] to access the Drive sync dependencies without
+ * a Hilt-injected constructor (WorkManager instantiates workers via its own factory).
+ *
+ * Method names are prefixed with `googleDrive` because Hilt generates a single `SingletonC`
+ * class that implements EVERY `@EntryPoint` interface installed in `SingletonComponent`. If
+ * two entry points expose methods with the same name and JVM-erased signature (e.g.
+ * `repository()` returning different types), the generated Java class has two methods with the
+ * same name + parameter list but different return types — which the JVM rejects with
+ * "Found conflicting entry point declarations". This was happening between
+ * `ScheduledBackupWorkerEntryPoint` (pre-existing) and this interface, so the Google Drive
+ * entry point uses unique method names to avoid the clash.
+ */
 @EntryPoint
 @InstallIn(SingletonComponent::class)
 interface GoogleDriveSyncWorkerEntryPoint {
-    fun repository(): GoogleDriveSyncRepository
+    fun googleDriveRepository(): GoogleDriveSyncRepository
 
-    fun scheduler(): GoogleDriveSyncScheduler
+    fun googleDriveScheduler(): GoogleDriveSyncScheduler
 
-    fun client(): GoogleDriveClient
+    fun googleDriveClient(): GoogleDriveClient
 }


### PR DESCRIPTION
## Problem

After PR #69 merged, the `:app:hiltJavaCompileGmsTvUniversalRelease` task fails with:

```
App_HiltComponents.java:208: error: Found conflicting entry point declarations.
Getter methods on the component with the same name and signature must be for the
same binding key since the generated component can only implement the method once.
Found:
  public abstract static class SingletonC implements
      FragmentGetContextFix.FragmentGetContextFixEntryPoint,
      ^
  moe.rukamori.archivetune.backup.ScheduledBackupRepository
      ScheduledBackupWorkerEntryPoint.repository()
  moe.rukamori.archivetune.googledrive.GoogleDriveSyncRepository
      GoogleDriveSyncWorkerEntryPoint.repository()

  (same clash for *.scheduler())
```

This happens because Hilt generates a single `SingletonC` Java class that implements **every** `@EntryPoint` interface installed in `SingletonComponent`. Both `ScheduledBackupWorkerEntryPoint` (pre-existing) and `GoogleDriveSyncWorkerEntryPoint` (added in PR #68) declared no-arg methods named `repository()` and `scheduler()` — but with different return types. The JVM class file format does not allow two methods with the same name + parameter list + different return types in the same class, so the generated source fails to compile.

## Fix

Rename the Google Drive entry point methods to be unique:

```kotlin
interface GoogleDriveSyncWorkerEntryPoint {
    fun googleDriveRepository(): GoogleDriveSyncRepository
    fun googleDriveScheduler(): GoogleDriveSyncScheduler
    fun googleDriveClient(): GoogleDriveClient
}
```

Updated all 6 call sites in `GoogleDriveSyncWorker.doWork()` accordingly. The pre-existing `ScheduledBackupWorkerEntryPoint` is left untouched.

A KDoc block was added to the interface explaining the constraint so the next person who adds a `@EntryPoint` doesn't reintroduce the same conflict.

## Validation

CI on this branch will re-run the same `:app:hiltJavaCompileGmsTvUniversalRelease` task that is failing on `main`. Once green here, main will build again.

## Why this slipped through

PR #69's CI ran against a debug build variant (`GmsMobileUniversalDebug`), which happens to only surface the Kotlin compile — the Hilt Java compile happens later in the pipeline for release variants. The Hilt clash only manifested once the release-APK build was triggered.