### PR TITLE
fix(drive-sync): SAF folder picker + silent sync (fixes auto-close & share-sheet)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveClient.kt
@@ -7,58 +7,64 @@
 
 package moe.rukamori.archivetune.googledrive
 
-import android.accounts.Account
-import android.accounts.AccountManager
-import android.accounts.AuthenticatorException
 import android.content.Context
-import android.content.Intent
 import android.net.Uri
+import android.provider.DocumentsContract
 import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.backup.BackupArchiveCategory
 import moe.rukamori.archivetune.backup.CreateBackupUseCase
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.MultipartBody
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.asRequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
-import org.json.JSONArray
-import org.json.JSONObject
 import timber.log.Timber
 import java.io.File
 import java.io.IOException
-import java.net.URLEncoder
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Talks to the Google Drive REST API v3 to upload backup files.
+ * Uploads backup files to a cloud folder chosen by the user via the Android Storage Access
+ * Framework (SAF).
  *
- * Why REST + AccountManager instead of the Google Drive Android API or the google-api-client?
- *  - The Drive Android API was deprecated by Google in 2024.
- *  - The google-api-client + google-api-services-drive JARs add ~6 MB to the APK and require
- *    ProGuard keep rules. They're overkill for a "upload a single file" use case.
- *  - AccountManager is built into Android, works on both GMS and FOSS builds, and lets us
- *    request an OAuth2 token for the `drive.file` scope without shipping any extra dependencies.
+ * ## Why SAF instead of the Drive REST API?
  *
- * The flow:
- *   1. User picks a Google account via AccountManager.getAccountsByType("com.google")
- *      (requires GET_ACCOUNTS permission on API ≤ 22).
- *   2. When a sync is due, [uploadBackup] asks AccountManager for an OAuth2 token for the
- *      `https://www.googleapis.com/auth/drive.file` scope.
- *   3. We build a local backup .zip via [CreateBackupUseCase] into `cacheDir/gdrive_backup/`.
- *   4. We list existing Drive files in the target folder with a `q=name='AppName.backup'`
- *      query — if found and overwrite is requested, we PATCH the existing file; otherwise
- *      we POST a new multipart upload.
- *   5. The local temp file is deleted after upload (success or failure).
+ * An earlier implementation used `AccountManager.getAuthToken` to obtain an OAuth2 token for the
+ * `drive.file` scope and then talked to the Drive REST v3 API directly. That approach failed with
+ * `AuthenticatorException: UnregisteredOnApiConsole` because the app's package name + SHA-1
+ * signing key was not registered on Google Cloud Console for that OAuth client — and for an
+ * open-source app that end users build themselves, it never can be (every fork has a different
+ * signing key).
  *
- * The `drive.file` scope is the least permissive Drive scope — it only allows access to files
- * created or opened by this app, which is exactly what we need for backup files.
+ * SAF sidesteps the entire problem:
+ *   - The user picks a folder through the system `OpenDocumentTree` picker. The Drive app (and
+ *     Nextcloud, Dropbox, etc.) exposes its folder tree as a DocumentsProvider, so the picker
+ *     shows the user's actual Google Drive folder hierarchy.
+ *   - The returned tree URI is persisted via `ContentResolver.takePersistableUriPermission`, so
+ *     it survives app restarts and reboots.
+ *   - Each sync writes the backup file directly into that folder via the framework
+ *     [DocumentsContract] / `ContentResolver.openOutputStream` APIs — no OAuth token, no Cloud
+ *     Console registration, no extra dependencies. The cloud provider handles authentication
+ *     and uploading to its backend transparently.
+ *
+ * ## Upload flow
+ *
+ *   1. [uploadBackup] builds a local backup .zip into `cacheDir/gdrive_backup/` via
+ *      [CreateBackupUseCase] (writing to a FileProvider-backed temp file).
+ *   2. It resolves the persisted tree URI from [GoogleDriveSyncSettings.remoteFolderUri] and
+ *      derives the folder's document URI via [DocumentsContract.buildDocumentUriUsingTree].
+ *   3. If [GoogleDriveSyncSettings.overwriteExisting] is true and a child document with the
+ *      target name already exists in the folder, that document is deleted first (SAF providers
+ *      don't reliably overwrite an existing document in place — `createDocument` would produce
+ *      a "name (1)" copy instead, so we delete explicitly to get a clean replace).
+ *   4. A new child document is created with [DocumentsContract.createDocument] and the temp
+ *      backup bytes are streamed into its output stream.
+ *   5. The temp file is deleted on success or unrecoverable failure.
+ *
+ * ## Why DocumentsContract and not androidx.documentfile?
+ *
+ * [DocumentsContract] is a framework API (available since API 19) and needs no extra gradle
+ * dependency. The app already uses it elsewhere (see `CachePlaylistScreen`), so this keeps the
+ * dependency footprint unchanged.
  */
 @Singleton
 class GoogleDriveClient
@@ -67,142 +73,57 @@ class GoogleDriveClient
         @ApplicationContext private val context: Context,
         private val createBackupUseCase: CreateBackupUseCase,
     ) {
-        private val httpClient =
-            OkHttpClient
-                .Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(120, TimeUnit.SECONDS)
-                .writeTimeout(120, TimeUnit.SECONDS)
-                .build()
-
         /**
-         * Lists Google accounts registered on the device.
+         * Result of an upload attempt.
          *
-         * On Android 6.0+ the GET_ACCOUNTS permission is runtime-guarded; the caller must hold
-         * it before invoking this. Returns an empty list if no Google accounts are present.
-         */
-        fun listGoogleAccounts(): List<Account> =
-            try {
-                AccountManager.get(context).getAccountsByType("com.google").toList()
-            } catch (security: SecurityException) {
-                Timber.w(security, "GET_ACCOUNTS permission not granted")
-                emptyList()
-            }
-
-        /**
-         * Returns the human-readable names of all Google accounts on the device.
-         * Used by the account-picker dialog in the UI.
-         */
-        fun listGoogleAccountNames(): List<String> = listGoogleAccounts().map { it.name }
-
-        /**
-         * Fetches an OAuth2 access token for [accountEmail] scoped to `drive.file`.
-         *
-         * Blocks the calling thread — callers MUST be on a background thread. AccountManager
-         * may show a system " granting permission" dialog on first run.
-         *
-         * Returns null if the user denies the permission grant or the account is no longer
-         * present on the device.
-         */
-        @Suppress("DEPRECATION")
-        private fun fetchAuthToken(accountEmail: String): String? {
-            val account =
-                AccountManager.get(context).getAccountsByType("com.google").firstOrNull {
-                    it.name == accountEmail
-                } ?: return null
-            // AccountManager.getAuthToken blocks the calling thread and may surface a
-            // permission-grant dialog if the user hasn't yet approved this app for the
-            // requested scope. We pass null for the notify AuthenticatorException callback
-            // (we're not on the main thread) and rely on the system to show a notification
-            // instead if the user needs to take action.
-            val result =
-                AccountManager
-                    .get(context)
-                    .getAuthToken(
-                        account,
-                        "oauth2:https://www.googleapis.com/auth/drive.file",
-                        null,
-                        false,
-                        null,
-                        null,
-                    )
-            return result?.getResult()?.getString(AccountManager.KEY_AUTHTOKEN)
-        }
-
-        /**
-         * Invalidates the cached OAuth token for [token] so a subsequent [fetchAuthToken] call
-         * re-fetches from the system. Called when the Drive API returns 401 — typically because
-         * the user revoked the permission via the Google account security page.
-         */
-        private fun invalidateAuthToken(token: String) {
-            AccountManager.get(context).invalidateAuthToken("com.google", token)
-        }
-
-        /**
-         * Result of an upload attempt. The caller (the WorkManager worker / UI) needs to know
-         * not just success/failure but WHY it failed, so it can show the right fallback:
-         *
-         *   - [Success] — Drive returned a file ID, backup is on the user's Drive.
-         *   - [NeedsManualUpload] — AccountManager refused to grant the `drive.file` OAuth scope
-         *     (typically `AuthenticatorException: UnregisteredOnApiConsole` — the app's package +
-         *     SHA-1 is not registered on Google Cloud Console for this OAuth client). The temp
-         *     backup file has been built locally and is available via [buildManualUploadIntent]
-         *     so the user can save it to Drive via the system "Save to Drive" share sheet.
-         *   - [TransientFailure] — Network blip, Drive 5xx, or other recoverable error. Caller
-         *     should retry (WorkManager backs off exponentially).
-         *   - [PermanentFailure] — Anything else (account no longer present, etc.). Caller
-         *     should not retry automatically.
+         *   - [Success] — the backup file was written to the picked folder.
+         *   - [TransientFailure] — a recoverable error (the folder URI is temporarily
+         *     unreachable, a provider-side hiccup, or an I/O blip). The caller should retry
+         *     with backoff.
+         *   - [PermanentFailure] — the folder URI is missing/malformed, the permission was
+         *     revoked, or the provider rejected the write. The caller should not retry
+         *     automatically and should surface a message prompting the user to re-pick a
+         *     folder.
          */
         sealed interface UploadResult {
-            data class Success(val fileId: String) : UploadResult
-
-            /**
-             * OAuth grant failed because the app isn't registered on Google Cloud Console for
-             * the `drive.file` scope. The temp backup file is kept at [tempFileUri] (a
-             * FileProvider URI) so the UI can launch an ACTION_SEND intent and let the user
-             * save the file to Drive (or anywhere else) manually.
-             */
-            data class NeedsManualUpload(
-                val tempFileUri: Uri,
-                val fileName: String,
-            ) : UploadResult
+            data class Success(val fileName: String) : UploadResult
 
             data class TransientFailure(val message: String) : UploadResult
+
             data class PermanentFailure(val message: String) : UploadResult
         }
 
         /**
-         * Uploads a single backup file to Google Drive under the configured folder.
+         * Uploads a single backup file to the user-picked cloud folder.
          *
-         * Steps:
-         *   1. Create a temp .backup file locally via [CreateBackupUseCase].
-         *   2. Fetch an OAuth token for the configured account.
-         *      - If AccountManager throws [AuthenticatorException] (typically
-         *        `UnregisteredOnApiConsole`), the OAuth client for this app isn't registered
-         *        on Google Cloud Console. Return [UploadResult.NeedsManualUpload] with the
-         *        temp file URI so the UI can offer a manual save via the system share sheet.
-         *   3. If [settings].overwriteExisting and a file with the same name already exists in
-         *      the target folder, PATCH the existing file's content. Otherwise, POST a new
-         *      multipart upload.
-         *   4. On a 401 response, invalidate the token and retry once with a fresh token.
-         *   5. Delete the temp file on success or unrecoverable failure. The temp file is
-         *      KEPT on [UploadResult.NeedsManualUpload] because the UI needs it for the
-         *      manual upload intent.
-         *
-         * @param settings The current Google Drive sync settings — must have a non-null
-         *   `accountEmail` (caller's responsibility to check before invoking).
-         * @param backupFileName The user-visible name to give the uploaded Drive file (without
+         * @param settings The current sync settings — must have a non-null
+         *   [GoogleDriveSyncSettings.remoteFolderUri] (the caller's responsibility to check
+         *   before invoking).
+         * @param backupFileName The user-visible name to give the uploaded file (without
          *   extension — we append `.backup` here for consistency with local backups).
          */
         suspend fun uploadBackup(settings: GoogleDriveSyncSettings, backupFileName: String): UploadResult =
             withContext(Dispatchers.IO) {
-                val accountEmail = settings.accountEmail
-                    ?: return@withContext UploadResult.PermanentFailure("No Google account configured")
+                val treeUriString = settings.remoteFolderUri
+                    ?: return@withContext UploadResult.PermanentFailure("No backup folder configured")
+                val treeUri =
+                    try {
+                        Uri.parse(treeUriString)
+                    } catch (e: Exception) {
+                        return@withContext UploadResult.PermanentFailure("Invalid folder URI: ${e.message}")
+                    }
+                val folderDocUri =
+                    try {
+                        val folderDocId = DocumentsContract.getTreeDocumentId(treeUri)
+                        DocumentsContract.buildDocumentUriUsingTree(treeUri, folderDocId)
+                    } catch (e: Exception) {
+                        return@withContext UploadResult.PermanentFailure("Could not resolve the picked folder: ${e.message}")
+                    }
+
                 val tempDir = File(context.cacheDir, "gdrive_backup").apply { mkdirs() }
                 val tempFile = File(tempDir, "${System.currentTimeMillis()}_upload.backup")
-                var keepTempFile = false
                 try {
-                    // Stage 1: build the local backup into a temp file.
+                    // Stage 1: build the local backup into a temp file via the FileProvider.
                     val tempUri = FileProvider.getUriForFile(
                         context,
                         "${context.packageName}.FileProvider",
@@ -213,215 +134,108 @@ class GoogleDriveClient
                         categories = BackupArchiveCategory.entries.toSet(),
                     )
 
-                    // Stage 2: fetch an OAuth token. Catch AuthenticatorException explicitly
-                    // — this is the "UnregisteredOnApiConsole" error the user is seeing, and
-                    // we want to surface a manual-upload fallback rather than a silent retry.
-                    val token =
-                        try {
-                            fetchAuthToken(accountEmail)
-                        } catch (auth: AuthenticatorException) {
-                            Timber.w(auth, "GoogleDriveClient: OAuth grant refused for %s", accountEmail)
-                            keepTempFile = true
-                            return@withContext UploadResult.NeedsManualUpload(
-                                tempFileUri = tempUri,
-                                fileName = "$backupFileName.backup",
-                            )
-                        }
-                    if (token == null) {
-                        Timber.w("GoogleDriveClient: failed to obtain OAuth token for %s", accountEmail)
-                        return@withContext UploadResult.TransientFailure("OAuth token unavailable")
-                    }
-
                     val fullFileName = "$backupFileName.backup"
-                    val folderId = settings.remoteFolderId // null = root of My Drive
 
-                    val existingFileId =
-                        if (settings.overwriteExisting) {
-                            findFileByName(token, fullFileName, folderId)
-                        } else {
-                            null
+                    // Stage 2: if overwriting, delete any existing child document with the same
+                    // name first. SAF providers don't reliably truncate/overwrite an existing
+                    // document in place — createDocument would produce a "name (1)" copy.
+                    if (settings.overwriteExisting) {
+                        findChildDocumentId(treeUri, folderDocUri, fullFileName)?.let { existingDocId ->
+                            val existingDocUri =
+                                DocumentsContract.buildDocumentUriUsingTree(treeUri, existingDocId)
+                            runCatching {
+                                DocumentsContract.deleteDocument(context.contentResolver, existingDocUri)
+                            }.onFailure { Timber.w(it, "GoogleDriveClient: could not delete existing backup document") }
                         }
-
-                    val fileId =
-                        if (existingFileId != null) {
-                            patchFileContent(token, existingFileId, tempFile)
-                        } else {
-                            uploadNewFile(token, fullFileName, folderId, tempFile)
-                        }
-
-                    val finalFileId =
-                        if (fileId == null) {
-                            // Token may have been revoked — try one more time with a fresh token.
-                            invalidateAuthToken(token)
-                            val freshToken = fetchAuthToken(accountEmail)
-                                ?: return@withContext UploadResult.TransientFailure("OAuth token refresh failed")
-                            val retryFileId =
-                                if (existingFileId != null) {
-                                    patchFileContent(freshToken, existingFileId, tempFile)
-                                } else {
-                                    uploadNewFile(freshToken, fullFileName, folderId, tempFile)
-                                }
-                            retryFileId
-                        } else {
-                            fileId
-                        }
-
-                    if (finalFileId != null) {
-                        UploadResult.Success(finalFileId)
-                    } else {
-                        UploadResult.TransientFailure("Drive upload returned null file id")
                     }
+
+                    // Stage 3: create the destination document and stream the backup bytes into it.
+                    val targetDocUri =
+                        try {
+                            DocumentsContract.createDocument(
+                                context.contentResolver,
+                                folderDocUri,
+                                BACKUP_MIME_TYPE,
+                                fullFileName,
+                            )
+                        } catch (e: Exception) {
+                            Timber.w(e, "GoogleDriveClient: provider refused to create backup document")
+                            null
+                        } ?: return@withContext UploadResult.TransientFailure(
+                            "The cloud provider refused to create the backup file",
+                        )
+
+                    val written =
+                        try {
+                            context.contentResolver.openOutputStream(targetDocUri, "w")?.use { out ->
+                                tempFile.inputStream().use { input ->
+                                    input.copyTo(out)
+                                }
+                                true
+                            } ?: false
+                        } catch (io: IOException) {
+                            Timber.w(io, "GoogleDriveClient: IOException writing backup to folder")
+                            // Clean up the half-written document so we don't leave a corrupt file.
+                            runCatching {
+                                DocumentsContract.deleteDocument(context.contentResolver, targetDocUri)
+                            }
+                            false
+                        }
+                    if (!written) {
+                        return@withContext UploadResult.TransientFailure("Failed to write backup bytes to the folder")
+                    }
+
+                    UploadResult.Success(fullFileName)
                 } catch (cancellation: kotlinx.coroutines.CancellationException) {
                     throw cancellation
-                } catch (auth: AuthenticatorException) {
-                    Timber.w(auth, "GoogleDriveClient.uploadBackup: AuthenticatorException")
-                    keepTempFile = true
-                    FileProvider.getUriForFile(
-                        context,
-                        "${context.packageName}.FileProvider",
-                        tempFile,
-                    ).let { uri ->
-                        UploadResult.NeedsManualUpload(tempFileUri = uri, fileName = "$backupFileName.backup")
-                    }
+                } catch (security: SecurityException) {
+                    // The persisted URI permission was revoked (e.g. user cleared app data, or
+                    // the provider withdrew access). Surface as permanent so the UI can prompt
+                    // the user to re-pick a folder.
+                    Timber.w(security, "GoogleDriveClient: no permission for folder URI")
+                    UploadResult.PermanentFailure("Folder access was revoked — please re-pick the folder")
                 } catch (e: Exception) {
                     Timber.w(e, "GoogleDriveClient.uploadBackup failed")
                     UploadResult.TransientFailure(e.message ?: "Unknown error")
                 } finally {
-                    if (!keepTempFile) {
-                        runCatching { tempFile.delete() }
-                    }
+                    runCatching { tempFile.delete() }
                 }
             }
 
         /**
-         * Builds an [Intent.ACTION_SEND] for the temp backup file produced by a
-         * [UploadResult.NeedsManualUpload] result. The user can pick "Save to Drive" in the
-         * system share sheet — Google's Drive app accepts arbitrary file types and uploads
-         * them to the user's Drive, prompting for a destination folder.
-         *
-         * This is the fallback path when the OAuth flow refuses with `UnregisteredOnApiConsole`
-         * (i.e. the app's package + SHA-1 is not registered on Google Cloud Console for the
-         * `drive.file` scope). It's a worse UX than automatic upload but it actually works
-         * without cloud console registration.
-         *
-         * The intent grants read permission to the recipient via [Intent.FLAG_GRANT_READ_URI_PERMISSION]
-         * so Drive can read the FileProvider-backed temp file.
+         * Queries the picked folder for a child document with the given [name]. Returns the
+         * matching document ID, or null if no such child exists (or the query failed).
          */
-        fun buildManualUploadIntent(tempFileUri: Uri, fileName: String): Intent =
-            Intent(Intent.ACTION_SEND).apply {
-                type = "application/octet-stream"
-                putExtra(Intent.EXTRA_STREAM, tempFileUri)
-                putExtra(Intent.EXTRA_TITLE, fileName)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            }
-
-        /**
-         * Queries Drive for a file with the given [name] under [folderId] (or root if null).
-         * Returns the first matching file ID, or null if none exists.
-         *
-         * Drive's `files.list` endpoint accepts a `q` parameter with a query like:
-         *   `name = 'AppName.backup' and trashed = false and 'root' in parents`
-         */
-        private fun findFileByName(token: String, name: String, folderId: String?): String? {
-            val escapedName = name.replace("'", "\\'")
-            val parentClause =
-                if (folderId == null) "'root' in parents" else "'$folderId' in parents"
-            val query = "name = '$escapedName' and trashed = false and $parentClause"
-            val url =
-                "https://www.googleapis.com/drive/v3/files?q=" +
-                    URLEncoder.encode(query, "UTF-8") +
-                    "&fields=files(id,name)&pageSize=1"
-            val request =
-                Request
-                    .Builder()
-                    .url(url)
-                    .header("Authorization", "Bearer $token")
-                    .get()
-                    .build()
-            httpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    Timber.w("Drive files.list failed: %d %s", response.code, response.message)
-                    return null
-                }
-                val body = response.body?.string().orEmpty()
-                val files = JSONObject(body).optJSONArray("files") ?: return null
-                if (files.length() == 0) return null
-                return files.optJSONObject(0)?.optString("id")?.takeIf { it.isNotBlank() }
-            }
-        }
-
-        /**
-         * Uploads a new file via Drive's multipart upload endpoint.
-         *
-         * The multipart body has two parts:
-         *   1. `application/json; charset=UTF-8` — the file metadata (name, parents).
-         *   2. `application/octet-stream` — the raw file content.
-         *
-         * Returns the new file ID from the response, or null on failure.
-         */
-        private fun uploadNewFile(token: String, name: String, folderId: String?, file: File): String? {
-            val metadata =
-                JSONObject().apply {
-                    put("name", name)
-                    if (folderId != null) {
-                        val parents = JSONArray()
-                        parents.put(folderId)
-                        put("parents", parents)
-                    }
-                }
-            val metadataBody =
-                metadata
-                    .toString()
-                    .toRequestBody("application/json; charset=UTF-8".toMediaType())
-            val fileBody = file.asRequestBody("application/octet-stream".toMediaType())
-            // Google Drive's multipart upload requires `multipart/related` (RFC 2387).
-            // OkHttp's MultipartBody only exposes MIXED/ALTERNATIVE/DIGEST/PARALLEL/FORM as named
-            // constants, so we construct the MediaType directly and pass it to setType().
-            val multipart =
-                MultipartBody
-                    .Builder()
-                    .setType("multipart/related".toMediaType())
-                    .addPart(metadataBody)
-                    .addPart(fileBody)
-                    .build()
-            val request =
-                Request
-                    .Builder()
-                    .url("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id")
-                    .header("Authorization", "Bearer $token")
-                    .post(multipart)
-                    .build()
-            return executeForFileId(request)
-        }
-
-        /**
-         * Updates an existing file's content via Drive's PATCH media-upload endpoint.
-         * The URL path includes the existing file ID so Drive knows which file to replace.
-         */
-        private fun patchFileContent(token: String, fileId: String, file: File): String? {
-            val fileBody = file.asRequestBody("application/octet-stream".toMediaType())
-            val request =
-                Request
-                    .Builder()
-                    .url("https://www.googleapis.com/upload/drive/v3/files/$fileId?uploadType=media&fields=id")
-                    .header("Authorization", "Bearer $token")
-                    .patch(fileBody)
-                    .build()
-            return executeForFileId(request)
-        }
-
-        private fun executeForFileId(request: Request): String? {
+        private fun findChildDocumentId(treeUri: Uri, folderDocUri: Uri, name: String): String? {
+            val folderDocId = DocumentsContract.getDocumentId(folderDocUri)
+            val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, folderDocId)
             return try {
-                httpClient.newCall(request).execute().use { response: Response ->
-                    if (!response.isSuccessful) {
-                        Timber.w("Drive API call failed: %d %s", response.code, response.message)
-                        return null
+                context.contentResolver.query(
+                    childrenUri,
+                    arrayOf(
+                        DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                        DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                    ),
+                    null,
+                    null,
+                    null,
+                )?.use { cursor ->
+                    while (cursor.moveToNext()) {
+                        val docId = cursor.getString(0) ?: continue
+                        val docName = cursor.getString(1) ?: continue
+                        if (docName == name) return docId
                     }
-                    JSONObject(response.body?.string().orEmpty()).optString("id").takeIf { it.isNotBlank() }
+                    null
                 }
-            } catch (io: IOException) {
-                Timber.w(io, "Drive API call threw IOException")
+            } catch (e: Exception) {
+                Timber.w(e, "GoogleDriveClient: failed to list folder children")
                 null
             }
+        }
+
+        companion object {
+            /** MIME type used when creating the backup document. Octet-stream is accepted by all
+             *  SAF providers and preserves the bytes verbatim. */
+            private const val BACKUP_MIME_TYPE = "application/octet-stream"
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncModels.kt
@@ -16,17 +16,28 @@ import moe.rukamori.archivetune.backup.ScheduledBackupFrequency
  * so the user sees a consistent set of options in both the local scheduled-backup section and the
  * Google Drive sync section of the Backup & Restore screen.
  *
- * @param enabled Whether auto-sync to Google Drive is active. When false, the WorkManager
- *   scheduled job is cancelled and no uploads happen.
+ * ## Implementation note — SAF, not OAuth
+ *
+ * Backups are uploaded via the Android Storage Access Framework (SAF): the user picks a Drive
+ * folder through the system `OpenDocumentTree` picker, the app persists the returned tree URI
+ * (`takePersistableUriPermission`), and each sync writes the backup file directly into that folder
+ * via `ContentResolver.openOutputStream`.
+ *
+ * This replaced an earlier AccountManager + Drive REST API approach that failed with
+ * `AuthenticatorException: UnregisteredOnApiConsole` because the app's package + SHA-1 was not
+ * registered on Google Cloud Console for the `drive.file` OAuth scope. SAF needs no OAuth, no
+ * Cloud Console registration, and no extra dependencies — the Drive app (and any other cloud
+ * provider that exposes a DocumentsProvider) handles authentication itself.
+ *
+ * @param enabled Whether auto-sync is active. When false, the WorkManager scheduled job is
+ *   cancelled and no uploads happen.
  * @param frequency How often the sync should run.
  * @param customDateEpochDay For CUSTOM frequency — the next date at which the sync should run.
  *   Stored as epoch-day (days since 1970-01-01) for locale-independent storage.
- * @param accountEmail The Google account email the user picked at sign-in. Used to look up the
- *   account via AccountManager when fetching an OAuth token for the Drive API.
- * @param remoteFolderId Google Drive folder ID where backups are uploaded. Null means upload to
- *   "My Drive" root. Resolved once at folder-pick time and persisted.
- * @param remoteFolderName Display name of [remoteFolderId] — shown in the UI so the user can
- *   tell at a glance which Drive folder backups land in.
+ * @param remoteFolderUri The persisted SAF tree URI (as a string) of the folder backups are
+ *   written to. Null means no folder has been picked yet — sync is disabled until one is chosen.
+ * @param remoteFolderName Display name of [remoteFolderUri] — shown in the UI so the user can
+ *   tell at a glance which folder backups land in. Derived from `DocumentFile.name`.
  * @param overwriteExisting When true, each sync overwrites the previous backup file (matched by
  *   name) instead of creating a timestamped new file.
  * @param lastSyncEpochMs Epoch-millis of the last successful sync, or null if never synced.
@@ -37,8 +48,7 @@ data class GoogleDriveSyncSettings(
     val enabled: Boolean = false,
     val frequency: ScheduledBackupFrequency = ScheduledBackupFrequency.WEEKLY,
     val customDateEpochDay: Long? = null,
-    val accountEmail: String? = null,
-    val remoteFolderId: String? = null,
+    val remoteFolderUri: String? = null,
     val remoteFolderName: String? = null,
     val overwriteExisting: Boolean = false,
     val lastSyncEpochMs: Long? = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncRepository.kt
@@ -32,9 +32,10 @@ import javax.inject.Singleton
  * All updaters serialize through [updateMutex] to prevent lost updates when multiple fields are
  * changed in rapid succession (e.g. user toggles enable + picks a frequency in quick succession).
  *
- * The settings keys are NOT portable across devices — they reference the local Google account
- * email and a Drive folder ID. They're added to `NON_PORTABLE_PREFERENCE_KEYS` so the
- * BackupArchiveRepository skips them when exporting a portable SETTINGS backup.
+ * The settings keys are NOT portable across devices — they reference a device-specific SAF tree
+ * URI whose persistable permission only exists on the device that granted it. They're added to
+ * `NON_PORTABLE_PREFERENCE_KEYS` so the BackupArchiveRepository skips them when exporting a
+ * portable SETTINGS backup.
  */
 @Singleton
 class GoogleDriveSyncRepository
@@ -46,7 +47,7 @@ class GoogleDriveSyncRepository
 
         fun observeSettings(): Flow<GoogleDriveSyncSettings?> =
             context.dataStore.data.map { preferences ->
-                if (!preferences.contains(ENABLED_KEY) && !preferences.contains(ACCOUNT_EMAIL_KEY)) {
+                if (!preferences.contains(ENABLED_KEY) && !preferences.contains(REMOTE_FOLDER_URI_KEY)) {
                     return@map null
                 }
                 preferences.toSettings()
@@ -54,7 +55,7 @@ class GoogleDriveSyncRepository
 
         suspend fun getSettings(): GoogleDriveSyncSettings? =
             context.dataStore.data.first().let { preferences ->
-                if (!preferences.contains(ENABLED_KEY) && !preferences.contains(ACCOUNT_EMAIL_KEY)) {
+                if (!preferences.contains(ENABLED_KEY) && !preferences.contains(REMOTE_FOLDER_URI_KEY)) {
                     null
                 } else {
                     preferences.toSettings()
@@ -83,16 +84,15 @@ class GoogleDriveSyncRepository
                     }.toSettings()
             }
 
-        suspend fun updateAccount(email: String): GoogleDriveSyncSettings =
-            updateMutex.withLock {
-                context.dataStore.edit { it[ACCOUNT_EMAIL_KEY] = email }.toSettings()
-            }
-
-        suspend fun updateRemoteFolder(id: String?, name: String?): GoogleDriveSyncSettings =
+        /**
+         * Persists the picked SAF folder tree URI and its display name. Pass nulls to clear the
+         * folder (also disables auto-sync, since sync can't run without a target folder).
+         */
+        suspend fun updateRemoteFolder(uri: String?, name: String?): GoogleDriveSyncSettings =
             updateMutex.withLock {
                 context.dataStore
                     .edit {
-                        if (id == null) it.remove(REMOTE_FOLDER_ID_KEY) else it[REMOTE_FOLDER_ID_KEY] = id
+                        if (uri == null) it.remove(REMOTE_FOLDER_URI_KEY) else it[REMOTE_FOLDER_URI_KEY] = uri
                         if (name == null) it.remove(REMOTE_FOLDER_NAME_KEY) else it[REMOTE_FOLDER_NAME_KEY] = name
                     }.toSettings()
             }
@@ -111,12 +111,16 @@ class GoogleDriveSyncRepository
                     }.toSettings()
             }
 
-        suspend fun clearAccount(): GoogleDriveSyncSettings =
+        /**
+         * Clears the picked folder and disables auto-sync. Called when the user taps "Clear
+         * folder" in the UI. The persistable URI permission for the old tree URI is released by
+         * the caller (the UI holds the ContentResolver) before invoking this.
+         */
+        suspend fun clearRemoteFolder(): GoogleDriveSyncSettings =
             updateMutex.withLock {
                 context.dataStore
                     .edit {
-                        it.remove(ACCOUNT_EMAIL_KEY)
-                        it.remove(REMOTE_FOLDER_ID_KEY)
+                        it.remove(REMOTE_FOLDER_URI_KEY)
                         it.remove(REMOTE_FOLDER_NAME_KEY)
                         it[ENABLED_KEY] = false
                     }.toSettings()
@@ -130,8 +134,7 @@ class GoogleDriveSyncRepository
                         ?.let { stored -> ScheduledBackupFrequency.entries.firstOrNull { it.name == stored } }
                         ?: ScheduledBackupFrequency.WEEKLY,
                 customDateEpochDay = this[CUSTOM_DATE_KEY],
-                accountEmail = this[ACCOUNT_EMAIL_KEY],
-                remoteFolderId = this[REMOTE_FOLDER_ID_KEY],
+                remoteFolderUri = this[REMOTE_FOLDER_URI_KEY],
                 remoteFolderName = this[REMOTE_FOLDER_NAME_KEY],
                 overwriteExisting = this[OVERWRITE_KEY] ?: false,
                 lastSyncEpochMs = this[LAST_SYNC_MS_KEY],
@@ -142,8 +145,7 @@ class GoogleDriveSyncRepository
             private val ENABLED_KEY = booleanPreferencesKey("googleDriveSyncEnabled")
             private val FREQUENCY_KEY = stringPreferencesKey("googleDriveSyncFrequency")
             private val CUSTOM_DATE_KEY = longPreferencesKey("googleDriveSyncCustomDateEpochDay")
-            private val ACCOUNT_EMAIL_KEY = stringPreferencesKey("googleDriveSyncAccountEmail")
-            private val REMOTE_FOLDER_ID_KEY = stringPreferencesKey("googleDriveSyncRemoteFolderId")
+            private val REMOTE_FOLDER_URI_KEY = stringPreferencesKey("googleDriveSyncRemoteFolderUri")
             private val REMOTE_FOLDER_NAME_KEY = stringPreferencesKey("googleDriveSyncRemoteFolderName")
             private val OVERWRITE_KEY = booleanPreferencesKey("googleDriveSyncOverwriteExisting")
             private val LAST_SYNC_MS_KEY = longPreferencesKey("googleDriveSyncLastSyncEpochMs")
@@ -151,15 +153,15 @@ class GoogleDriveSyncRepository
 
             /**
              * Keys that should be excluded from portable SETTINGS backups because they reference
-             * device-specific state (the local Google account email + a Drive folder ID).
+             * device-specific state (a SAF tree URI whose persistable permission only exists on
+             * the granting device).
              */
             val NON_PORTABLE_PREFERENCE_KEYS: Set<String> =
                 setOf(
                     ENABLED_KEY.name,
                     FREQUENCY_KEY.name,
                     CUSTOM_DATE_KEY.name,
-                    ACCOUNT_EMAIL_KEY.name,
-                    REMOTE_FOLDER_ID_KEY.name,
+                    REMOTE_FOLDER_URI_KEY.name,
                     REMOTE_FOLDER_NAME_KEY.name,
                     OVERWRITE_KEY.name,
                     LAST_SYNC_MS_KEY.name,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncScheduler.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncScheduler.kt
@@ -98,7 +98,7 @@ class GoogleDriveSyncScheduler
                 ).build()
 
         private fun nextRunAt(settings: GoogleDriveSyncSettings): ZonedDateTime? {
-            if (!settings.enabled || settings.accountEmail == null) return null
+            if (!settings.enabled || settings.remoteFolderUri == null) return null
             val now = ZonedDateTime.now()
             val nextDate =
                 when (settings.frequency) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncUseCases.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncUseCases.kt
@@ -43,17 +43,18 @@ class UpdateGoogleDriveSyncUseCase
         suspend fun setCustomDate(epochDay: Long): GoogleDriveSyncSettings =
             repository.updateCustomDate(epochDay).also(scheduler::replace)
 
-        suspend fun setAccount(email: String): GoogleDriveSyncSettings =
-            repository.updateAccount(email).also(scheduler::replace)
-
-        suspend fun setRemoteFolder(id: String?, name: String?): GoogleDriveSyncSettings =
-            repository.updateRemoteFolder(id, name)
+        suspend fun setRemoteFolder(uri: String?, name: String?): GoogleDriveSyncSettings =
+            repository.updateRemoteFolder(uri, name)
 
         suspend fun setOverwrite(overwrite: Boolean): GoogleDriveSyncSettings =
             repository.updateOverwrite(overwrite)
 
-        suspend fun clearAccount(): GoogleDriveSyncSettings =
-            repository.clearAccount().also { scheduler.cancel() }
+        /**
+         * Clears the picked folder and disables auto-sync. Cancels the scheduled WorkManager job
+         * since sync can't run without a target folder.
+         */
+        suspend fun clearRemoteFolder(): GoogleDriveSyncSettings =
+            repository.clearRemoteFolder().also { scheduler.cancel() }
 
         fun runNow() = scheduler.runNow()
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncWorker.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/googledrive/GoogleDriveSyncWorker.kt
@@ -21,17 +21,17 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 /**
- * WorkManager worker that performs a Google Drive backup sync.
+ * WorkManager worker that performs a cloud backup sync via SAF.
  *
- * Loads settings from [GoogleDriveSyncRepository], bails out if disabled or unconfigured, then
- * delegates to [GoogleDriveClient.uploadBackup]. After a successful upload, schedules the next
- * run via [GoogleDriveSyncScheduler.appendNext].
+ * Loads settings from [GoogleDriveSyncRepository], bails out if disabled or no folder is
+ * configured, then delegates to [GoogleDriveClient.uploadBackup]. After a successful upload,
+ * schedules the next run via [GoogleDriveSyncScheduler.appendNext].
  *
  * Returns:
  *   - `Result.success()` after a successful upload (or when settings are disabled — nothing to do).
- *   - `Result.retry()` on a transient failure (network blip, Drive 5xx, OAuth token expiry
- *     that the client's one-shot retry didn't fix). WorkManager backs off exponentially.
- *   - `Result.failure()` on permanent failure (account no longer present, no Drive permission).
+ *   - `Result.retry()` on a transient failure (the folder URI is temporarily unreachable, a
+ *     provider-side hiccup, or an I/O blip). WorkManager backs off exponentially.
+ *   - `Result.failure()` on permanent failure (folder permission revoked, URI malformed).
  */
 class GoogleDriveSyncWorker(
     context: Context,
@@ -44,7 +44,7 @@ class GoogleDriveSyncWorker(
                 GoogleDriveSyncWorkerEntryPoint::class.java,
             )
         val settings = dependencies.googleDriveRepository().getSettings() ?: return Result.success()
-        if (!settings.enabled || settings.accountEmail == null) return Result.success()
+        if (!settings.enabled || settings.remoteFolderUri == null) return Result.success()
 
         return try {
             val fileName =
@@ -61,17 +61,6 @@ class GoogleDriveSyncWorker(
                         settings.copy(lastSyncEpochMs = System.currentTimeMillis(), lastSyncFailed = false),
                     )
                     Result.success()
-                }
-                is GoogleDriveClient.UploadResult.NeedsManualUpload -> {
-                    // OAuth refused (typically "UnregisteredOnApiConsole"). We can't auto-upload
-                    // without registering the app on Google Cloud Console. Post a notification
-                    // with an ACTION_SEND intent so the user can save the backup to Drive (or
-                    // anywhere else) via the system share sheet.
-                    postManualUploadNotification(result)
-                    // Treat as a permanent failure for the auto-sync path — we don't want
-                    // WorkManager to retry every 5 minutes and pile up notifications.
-                    dependencies.googleDriveRepository().recordSyncResult(success = false)
-                    Result.failure()
                 }
                 is GoogleDriveClient.UploadResult.TransientFailure -> {
                     dependencies.googleDriveRepository().recordSyncResult(success = false)
@@ -96,69 +85,8 @@ class GoogleDriveSyncWorker(
         }
     }
 
-    /**
-     * Posts a high-priority notification with a "Save to Drive" action so the user can manually
-     * upload the temp backup file produced by [GoogleDriveClient.UploadResult.NeedsManualUpload].
-     *
-     * The notification's tap action launches the system share sheet for the temp backup file —
-     * the user picks "Save to Drive" (or any other target) and Drive's own UI prompts for the
-     * destination folder.
-     */
-    private fun postManualUploadNotification(result: GoogleDriveClient.UploadResult.NeedsManualUpload) {
-        val client = EntryPointAccessors.fromApplication(
-            applicationContext,
-            GoogleDriveSyncWorkerEntryPoint::class.java,
-        ).googleDriveClient()
-        val intent = client.buildManualUploadIntent(result.tempFileUri, result.fileName).apply {
-            // Launch as a new task from a notification context.
-            addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        val pendingIntent = android.app.PendingIntent.getActivity(
-            applicationContext,
-            MANUAL_UPLOAD_REQUEST_CODE,
-            android.content.Intent.createChooser(intent, result.fileName).apply {
-                addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-            },
-            android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT,
-        )
-        val notificationManager = androidx.core.app.NotificationManagerCompat.from(applicationContext)
-        if (!notificationManager.areNotificationsEnabled()) return
-
-        val channel = android.app.NotificationChannel(
-            MANUAL_UPLOAD_CHANNEL_ID,
-            applicationContext.getString(R.string.google_drive_sync_manual_upload_channel),
-            android.app.NotificationManager.IMPORTANCE_HIGH,
-        ).apply {
-            description = applicationContext.getString(R.string.google_drive_sync_manual_upload_channel_desc)
-        }
-        notificationManager.createNotificationChannel(channel)
-
-        val notification = androidx.core.app.NotificationCompat
-            .Builder(applicationContext, MANUAL_UPLOAD_CHANNEL_ID)
-            .setSmallIcon(R.drawable.backup)
-            .setContentTitle(applicationContext.getString(R.string.google_drive_sync_manual_upload_title))
-            .setContentText(applicationContext.getString(R.string.google_drive_sync_manual_upload_text))
-            .setStyle(
-                androidx.core.app.NotificationCompat.BigTextStyle()
-                    .bigText(applicationContext.getString(R.string.google_drive_sync_manual_upload_big_text)),
-            )
-            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_HIGH)
-            .setContentIntent(pendingIntent)
-            .setAutoCancel(true)
-            .build()
-        try {
-            notificationManager.notify(MANUAL_UPLOAD_NOTIFICATION_ID, notification)
-        } catch (security: SecurityException) {
-            // Some OEMs gate notifications behind a runtime permission we may not hold.
-            reportException(security)
-        }
-    }
-
     companion object {
         private val FILE_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
-        private const val MANUAL_UPLOAD_CHANNEL_ID = "gdrive_manual_upload"
-        private const val MANUAL_UPLOAD_NOTIFICATION_ID = 4271
-        private const val MANUAL_UPLOAD_REQUEST_CODE = 4271
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -10,7 +10,6 @@
 package moe.rukamori.archivetune.ui.screens.settings
 
 import android.annotation.SuppressLint
-import android.accounts.AccountManager
 import android.content.Intent
 import android.net.Uri
 import android.os.Message
@@ -167,11 +166,6 @@ fun BackupAndRestore(
     var showRestoreValidationError by rememberSaveable { mutableStateOf(false) }
     var restoreValidationErrorMessage by remember { mutableStateOf("") }
     var showSpotifyLogin by rememberSaveable { mutableStateOf(false) }
-    var showGoogleDriveAccountPicker by rememberSaveable { mutableStateOf(false) }
-    var showGoogleDriveFolderPicker by rememberSaveable { mutableStateOf(false) }
-    var pendingManualUpload by remember {
-        mutableStateOf<moe.rukamori.archivetune.googledrive.GoogleDriveClient.UploadResult.NeedsManualUpload?>(null)
-    }
     var pendingBackupCategories by remember { mutableStateOf(BackupCategory.entries.toSet()) }
     var pendingRestoreCategories by remember { mutableStateOf(BackupCategory.entries.toSet()) }
     var pendingRestoreUri by remember { mutableStateOf<Uri?>(null) }
@@ -213,73 +207,34 @@ fun BackupAndRestore(
         rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
             uri?.let(viewModel::onScheduledBackupDirectorySelected)
         }
-    // Google account picker — uses the system AccountManager.newChooseAccountIntent. The
-    // contract returns the chosen account name (email) as a String, or null if the user
-    // cancelled. The activity is launched only when showGoogleDriveAccountPicker becomes true
-    // (see LaunchedEffect below) so the picker isn't triggered on every recomposition.
-    val googleAccountPickerLauncher =
-        rememberLauncherForActivityResult(
-            object : androidx.activity.result.contract.ActivityResultContract<Unit, String?>() {
-                override fun createIntent(context: android.content.Context, input: Unit): Intent =
-                    AccountManager.newChooseAccountIntent(
-                        /* selectedAccount = */ null,
-                        /* allowableAccounts = */ null,
-                        /* allowableAccountTypes = */ arrayOf("com.google"),
-                        /* descriptionOverride = */ null,
-                        /* addAccountLabel = */ null,
-                        /* packageNames = */ null,
-                        /* features = */ null,
-                    )
-
-                override fun parseResult(resultCode: Int, intent: Intent?): String? =
-                    if (resultCode != android.app.Activity.RESULT_OK || intent == null) {
-                        null
-                    } else {
-                        intent.getStringExtra(AccountManager.KEY_ACCOUNT_NAME)
-                    }
-            },
-        ) { accountEmail ->
-            if (!accountEmail.isNullOrBlank()) {
-                viewModel.onGoogleDriveSyncAccountSelected(accountEmail)
+    // SAF folder picker for Google Drive sync. The system OpenDocumentTree picker shows the
+    // user's full document-provider tree — including Google Drive (if the Drive app is
+    // installed), Nextcloud, and any other registered cloud provider — so the user can pick
+    // the exact folder backups should land in. We persist read+write URI permission so the
+    // choice survives app restarts and reboots, then hand the tree URI + its display name to
+    // the ViewModel. This replaced an AccountManager OAuth + Drive REST API approach that
+    // failed with `UnregisteredOnApiConsole` for any non-Cloud-Console-registered build.
+    val gdriveFolderPickerLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri ->
+            if (treeUri == null) return@rememberLauncherForActivityResult
+            // Persist access so the WorkManager worker can write to this folder later, even
+            // after the app process is killed.
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    treeUri,
+                    android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                        android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                )
             }
+            // Derive a display name from the picked tree URI so the UI can show which folder
+            // was chosen. We query the folder's document URI for its COLUMN_DISPLAY_NAME via
+            // the framework DocumentsContract (no extra dependency needed).
+            val folderName = resolveFolderDisplayName(context, treeUri)
+            viewModel.onGoogleDriveSyncRemoteFolderSelected(
+                uri = treeUri.toString(),
+                name = folderName.ifBlank { context.getString(R.string.google_drive_sync_remote_folder_default_name) },
+            )
         }
-    // Manual-upload share-sheet launcher — used when the OAuth flow refuses with
-    // `UnregisteredOnApiConsole`. We launch an ACTION_SEND intent for the temp backup file
-    // produced by GoogleDriveClient.uploadBackup; the user picks "Save to Drive" (or any
-    // other target) in the system share sheet and Drive's own UI prompts for the destination
-    // folder. This is the fallback path that actually works without Google Cloud Console
-    // registration.
-    val manualUploadLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            // The share sheet doesn't return a useful result code — once the user dismisses it
-            // (whether they saved to Drive or not), we just clear the pending upload state.
-            // The temp file is cleaned up by the launcher's own lifecycle (it's in cacheDir).
-            pendingManualUpload = null
-        }
-    LaunchedEffect(Unit) {
-        viewModel.manualUploadRequest.collect { request ->
-            pendingManualUpload = request
-        }
-    }
-    pendingManualUpload?.let { request ->
-        // Auto-launch the share sheet as soon as a manual upload is pending. The user can
-        // dismiss the sheet to cancel; we don't block on a result.
-        LaunchedEffect(request) {
-            val intent =
-                android.content.Intent(android.content.Intent.createChooser(
-                    android.content.Intent(android.content.Intent.ACTION_SEND).apply {
-                        type = "application/octet-stream"
-                        putExtra(android.content.Intent.EXTRA_STREAM, request.tempFileUri)
-                        putExtra(android.content.Intent.EXTRA_TITLE, request.fileName)
-                        addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    },
-                    context.getString(R.string.google_drive_sync_manual_upload_sheet_title),
-                )).apply {
-                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-            manualUploadLauncher.launch(intent)
-        }
-    }
     val restoreLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
             if (uri != null) {
@@ -326,25 +281,6 @@ fun BackupAndRestore(
             showSpotifyLogin = false
         }
     }
-
-    LaunchedEffect(showGoogleDriveAccountPicker) {
-        if (showGoogleDriveAccountPicker) {
-            googleAccountPickerLauncher.launch(Unit)
-            showGoogleDriveAccountPicker = false
-        }
-    }
-    LaunchedEffect(showGoogleDriveFolderPicker) {
-        // No-op — the folder picker is now a custom in-app dialog (see
-        // GoogleDriveSyncFolderPickerDialog below) instead of the SAF OpenDocumentTree
-        // launcher. SAF only shows local / system-registered cloud folders, NOT the user's
-        // Google Drive folder tree, so it was opening the local file picker (which the user
-        // reported as a bug). The custom dialog lets the user paste a Drive folder ID or URL
-        // or pick "My Drive root".
-        if (showGoogleDriveFolderPicker) {
-            showGoogleDriveFolderPicker = false
-        }
-    }
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -429,7 +365,6 @@ fun BackupAndRestore(
                             frequency = ScheduledBackupFrequency.WEEKLY,
                             customDateEpochDay = null,
                             customDateLabel = null,
-                            accountEmail = null,
                             remoteFolderName = null,
                             overwriteExisting = false,
                             showCustomDatePicker = false,
@@ -447,9 +382,8 @@ fun BackupAndRestore(
                 onFrequencySelected = viewModel::onGoogleDriveSyncFrequencySelected,
                 onCustomDateSelected = viewModel::onGoogleDriveSyncCustomDateSelected,
                 onCustomDateDismissed = viewModel::onGoogleDriveSyncCustomDateDismissed,
-                onSignInClick = { showGoogleDriveAccountPicker = true },
-                onSignOutClick = viewModel::onGoogleDriveSyncSignOut,
-                onRemoteFolderClick = { showGoogleDriveFolderPicker = true },
+                onRemoteFolderClick = { gdriveFolderPickerLauncher.launch(null) },
+                onClearFolderClick = viewModel::onGoogleDriveSyncRemoteFolderCleared,
                 onOverwriteChanged = viewModel::onGoogleDriveSyncOverwriteChanged,
                 onSyncNowClick = viewModel::onGoogleDriveSyncRunNow,
                 positions = positions,
@@ -460,29 +394,6 @@ fun BackupAndRestore(
                     selectedEpochDay = googleDriveData.customDateEpochDay,
                     onDateSelected = viewModel::onGoogleDriveSyncCustomDateSelected,
                     onDismiss = viewModel::onGoogleDriveSyncCustomDateDismissed,
-                )
-            }
-
-            if (showGoogleDriveFolderPicker) {
-                GoogleDriveSyncFolderPickerDialog(
-                    currentFolderName = googleDriveData.remoteFolderName,
-                    onUseRoot = {
-                        viewModel.onGoogleDriveSyncRemoteFolderSelected(id = null, name = null)
-                        showGoogleDriveFolderPicker = false
-                    },
-                    onFolderIdSubmitted = { rawInput ->
-                        // Accept either a raw folder ID or a Drive URL like
-                        // https://drive.google.com/drive/folders/<ID>?usp=sharing
-                        val id = extractDriveFolderId(rawInput)
-                        if (id != null) {
-                            viewModel.onGoogleDriveSyncRemoteFolderSelected(
-                                id = id,
-                                name = "Drive folder $id".takeLast(40),
-                            )
-                            showGoogleDriveFolderPicker = false
-                        }
-                    },
-                    onDismiss = { showGoogleDriveFolderPicker = false },
                 )
             }
 
@@ -811,17 +722,19 @@ private val ScheduledBackupFrequency.labelRes: Int
  * Google Drive sync section — mirrors [ScheduledBackupSection] in structure.
  *
  * Layout:
- *   - "Enable Google Drive sync" switch (disabled until an account is picked).
- *   - "Sign in with Google" entry (or "Signed in as …" + "Sign out" if already signed in).
- *   - "Drive folder" entry — opens the SAF folder picker. Shows the picked folder name or
- *     "My Drive (root)" if no folder was picked.
+ *   - "Drive folder" entry — opens the SAF folder picker (OpenDocumentTree). Shows the picked
+ *     folder name, or "Not set — tap to pick" if no folder has been chosen yet. This is the
+ *     primary setup action: picking a folder is what enables the rest of the section.
+ *   - "Clear folder" entry — appears only once a folder is picked. Releases the persisted URI
+ *     permission (via the ViewModel) and disables auto-sync.
+ *   - "Enable Google Drive sync" switch (disabled until a folder is picked).
  *   - "Backup schedule" enum list — DAILY / WEEKLY / MONTHLY / CUSTOM (date picker).
  *   - "Overwrite existing Drive backup" switch.
- *   - "Sync now" entry — triggers an immediate one-shot sync via WorkManager.
+ *   - "Sync now" entry — triggers an immediate one-shot upload to the picked folder.
  *   - "Last synced: …" footer (or "Last sync failed — will retry automatically" on failure).
  *
- * The frequency selector and overwrite switch are gated on `accountEmail != null` — you
- * can't schedule an upload to an account you haven't picked yet.
+ * The frequency selector, overwrite switch, enable toggle, and sync-now entry are all gated on
+ * `remoteFolderName != null` — you can't sync to a folder you haven't picked yet.
  */
 @Composable
 private fun GoogleDriveSyncSection(
@@ -831,17 +744,41 @@ private fun GoogleDriveSyncSection(
     onFrequencySelected: (ScheduledBackupFrequency) -> Unit,
     onCustomDateSelected: (Long) -> Unit,
     onCustomDateDismissed: () -> Unit,
-    onSignInClick: () -> Unit,
-    onSignOutClick: () -> Unit,
     onRemoteFolderClick: () -> Unit,
+    onClearFolderClick: () -> Unit,
     onOverwriteChanged: (Boolean) -> Unit,
     onSyncNowClick: () -> Unit,
     positions: PreferencePositions,
 ) {
+    val folderConfigured = data.remoteFolderName != null
     PreferenceGroup(
         modifier = positions.modifierFor("google_drive_sync"),
         title = stringResource(R.string.google_drive_sync),
     ) {
+        item {
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.google_drive_sync_remote_folder)) },
+                description =
+                    data.remoteFolderName
+                        ?: stringResource(R.string.google_drive_sync_remote_folder_not_set),
+                icon = { Icon(painterResource(R.drawable.snippet_folder), contentDescription = null) },
+                onClick = onRemoteFolderClick,
+                isEnabled = enabled,
+            )
+        }
+
+        if (folderConfigured) {
+            item {
+                PreferenceEntry(
+                    title = { Text(stringResource(R.string.google_drive_sync_clear_folder)) },
+                    description = stringResource(R.string.google_drive_sync_clear_folder_description),
+                    icon = { Icon(painterResource(R.drawable.close), contentDescription = null) },
+                    onClick = onClearFolderClick,
+                    isEnabled = enabled,
+                )
+            }
+        }
+
         item {
             SwitchPreference(
                 title = { Text(stringResource(R.string.google_drive_sync_enabled)) },
@@ -856,39 +793,7 @@ private fun GoogleDriveSyncSection(
                 icon = { Icon(painterResource(R.drawable.sync), contentDescription = null) },
                 checked = data.enabled,
                 onCheckedChange = onEnabledChanged,
-                isEnabled = enabled && data.accountEmail != null,
-            )
-        }
-
-        item {
-            if (data.accountEmail == null) {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.google_drive_sync_sign_in)) },
-                    description = stringResource(R.string.google_drive_sync_sign_in_description),
-                    icon = { Icon(painterResource(R.drawable.account), contentDescription = null) },
-                    onClick = onSignInClick,
-                    isEnabled = enabled,
-                )
-            } else {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.google_drive_sync_signed_in_as, data.accountEmail)) },
-                    description = stringResource(R.string.google_drive_sync_sign_out),
-                    icon = { Icon(painterResource(R.drawable.account), contentDescription = null) },
-                    onClick = onSignOutClick,
-                    isEnabled = enabled,
-                )
-            }
-        }
-
-        item {
-            PreferenceEntry(
-                title = { Text(stringResource(R.string.google_drive_sync_remote_folder)) },
-                description =
-                    data.remoteFolderName
-                        ?: stringResource(R.string.google_drive_sync_remote_folder_root),
-                icon = { Icon(painterResource(R.drawable.snippet_folder), contentDescription = null) },
-                onClick = onRemoteFolderClick,
-                isEnabled = enabled && data.accountEmail != null,
+                isEnabled = enabled && folderConfigured,
             )
         }
 
@@ -905,7 +810,7 @@ private fun GoogleDriveSyncSection(
                 selectedValue = data.frequency,
                 valueText = { frequency -> stringResource(frequency.labelRes) },
                 onValueSelected = onFrequencySelected,
-                isEnabled = enabled && data.accountEmail != null,
+                isEnabled = enabled && folderConfigured,
             )
         }
 
@@ -916,7 +821,7 @@ private fun GoogleDriveSyncSection(
                 icon = { Icon(painterResource(R.drawable.backup), contentDescription = null) },
                 checked = data.overwriteExisting,
                 onCheckedChange = onOverwriteChanged,
-                isEnabled = enabled && data.accountEmail != null,
+                isEnabled = enabled && folderConfigured,
             )
         }
 
@@ -933,7 +838,7 @@ private fun GoogleDriveSyncSection(
                     },
                 icon = { Icon(painterResource(R.drawable.sync), contentDescription = null) },
                 onClick = onSyncNowClick,
-                isEnabled = enabled && data.accountEmail != null && !data.isSyncing,
+                isEnabled = enabled && folderConfigured && !data.isSyncing,
             )
         }
     }
@@ -1639,115 +1544,28 @@ private fun BackupOptionsDialog(
 }
 
 /**
- * Custom Drive folder picker dialog.
+ * Resolves the human-readable display name of a SAF tree URI's root folder by querying its
+ * [DocumentsContract.Document.COLUMN_DISPLAY_NAME]. Used right after the user picks a folder
+ * via `OpenDocumentTree` so the UI can show which folder was chosen.
  *
- * Replaces the previous SAF OpenDocumentTree-based picker, which only showed local /
- * system-registered cloud folders — never the user's actual Google Drive folder tree. The
- * user reported this as "it opens my local folder" and that's exactly what SAF does.
- *
- * This dialog offers two options:
- *   1. "Use My Drive root" — uploads go to the root of the user's My Drive (folderId = null).
- *   2. Paste a Drive folder ID or URL — the user opens Drive in a browser or the Drive app,
- *      copies the folder URL (or the folder ID from the URL), and pastes it here. We extract
- *      the folder ID from either form.
- *
- * The OAuth-restricted automatic upload path (see GoogleDriveClient.UploadResult.NeedsManualUpload)
- * also lands the user on this folder-pick model when they choose "Save with share sheet" — the
- * share sheet itself prompts for the destination folder, so the in-app folder ID is only used
- * for the auto-sync path.
+ * Returns the empty string if the name can't be resolved (the caller falls back to a default
+ * label in that case). Runs a synchronous ContentResolver query — only call from a launcher
+ * callback or a background thread, never from the main recomposition path.
  */
-@Composable
-private fun GoogleDriveSyncFolderPickerDialog(
-    currentFolderName: String?,
-    onUseRoot: () -> Unit,
-    onFolderIdSubmitted: (String) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    var folderInput by remember { mutableStateOf("") }
-    val inputError = remember(folderInput) {
-        if (folderInput.isBlank()) null
-        else if (extractDriveFolderId(folderInput) == null) "Couldn't parse a folder ID from that input."
-        else null
+private fun resolveFolderDisplayName(context: android.content.Context, treeUri: Uri): String {
+    return try {
+        val folderDocId = android.provider.DocumentsContract.getTreeDocumentId(treeUri)
+        val folderDocUri = android.provider.DocumentsContract.buildDocumentUriUsingTree(treeUri, folderDocId)
+        context.contentResolver.query(
+            folderDocUri,
+            arrayOf(android.provider.DocumentsContract.Document.COLUMN_DISPLAY_NAME),
+            null,
+            null,
+            null,
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) cursor.getString(0).orEmpty() else ""
+        } ?: ""
+    } catch (e: Exception) {
+        ""
     }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.google_drive_sync_pick_folder_title)) },
-        text = {
-            Column {
-                Text(
-                    stringResource(R.string.google_drive_sync_pick_folder_hint),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Spacer(Modifier.height(16.dp))
-                Text(
-                    stringResource(R.string.google_drive_sync_pick_folder_paste_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(8.dp))
-                androidx.compose.material3.OutlinedTextField(
-                    value = folderInput,
-                    onValueChange = { folderInput = it },
-                    label = { Text(stringResource(R.string.google_drive_sync_pick_folder_paste)) },
-                    singleLine = true,
-                    isError = inputError != null,
-                    supportingText = {
-                        if (inputError != null) {
-                            Text(
-                                inputError,
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.bodySmall,
-                            )
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                if (currentFolderName != null) {
-                    Spacer(Modifier.height(8.dp))
-                    Text(
-                        "Current: $currentFolderName",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = { onFolderIdSubmitted(folderInput) },
-                enabled = extractDriveFolderId(folderInput) != null,
-            ) { Text("Save") }
-        },
-        dismissButton = {
-            Row {
-                TextButton(onClick = onUseRoot) {
-                    Text(stringResource(R.string.google_drive_sync_pick_folder_use_root))
-                }
-                Spacer(Modifier.width(4.dp))
-                TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
-            }
-        },
-    )
-}
-
-/**
- * Extracts a Google Drive folder ID from a raw user input. Accepts:
- *   - A raw folder ID (e.g. `1A2B3C...XYZ`)
- *   - A Drive URL like `https://drive.google.com/drive/folders/1A2B3C...XYZ?usp=sharing`
- *   - A Drive URL with `open?id=` form
- *
- * Returns null if no folder ID could be extracted.
- */
-internal fun extractDriveFolderId(rawInput: String): String? {
-    val trimmed = rawInput.trim()
-    if (trimmed.isEmpty()) return null
-    // URL form: .../folders/<ID>
-    val foldersMatch = Regex("""/folders/([A-Za-z0-9_-]{20,})""").find(trimmed)
-    if (foldersMatch != null) return foldersMatch.groupValues[1]
-    // URL form: open?id=<ID>
-    val openIdMatch = Regex("""[?&]id=([A-Za-z0-9_-]{20,})""").find(trimmed)
-    if (openIdMatch != null) return openIdMatch.groupValues[1]
-    // Raw ID: Drive IDs are 20+ chars from [A-Za-z0-9_-]
-    if (trimmed.matches(Regex("""[A-Za-z0-9_-]{20,}"""))) return trimmed
-    return null
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/BackupRestoreViewModel.kt
@@ -139,7 +139,6 @@ data class GoogleDriveSyncUiData(
     val frequency: ScheduledBackupFrequency,
     val customDateEpochDay: Long?,
     val customDateLabel: String?,
-    val accountEmail: String?,
     val remoteFolderName: String?,
     val overwriteExisting: Boolean,
     val showCustomDatePicker: Boolean,
@@ -269,18 +268,6 @@ class BackupRestoreViewModel
 
         private val _googleDriveSyncEvent = MutableSharedFlow<Int>(extraBufferCapacity = 1)
         val googleDriveSyncEvent: SharedFlow<Int> = _googleDriveSyncEvent.asSharedFlow()
-
-        /**
-         * Emitted when an auto-upload attempt failed because Google's AccountManager refused to
-         * grant the `drive.file` OAuth scope (typically `AuthenticatorException:
-         * UnregisteredOnApiConsole` — the app's package + SHA-1 is not registered on Google
-         * Cloud Console). The UI catches this and opens the system share sheet so the user can
-         * save the prepared backup file to Drive (or anywhere else) manually.
-         */
-        private val _manualUploadRequest =
-            MutableSharedFlow<GoogleDriveClient.UploadResult.NeedsManualUpload>(extraBufferCapacity = 1)
-        val manualUploadRequest: SharedFlow<GoogleDriveClient.UploadResult.NeedsManualUpload> =
-            _manualUploadRequest.asSharedFlow()
 
         private var googleDriveSettings: GoogleDriveSyncSettings? = null
         private var showGoogleDriveCustomDatePicker = false
@@ -487,18 +474,12 @@ class BackupRestoreViewModel
             publishGoogleDriveSyncState()
         }
 
-        fun onGoogleDriveSyncAccountSelected(email: String) {
-            updateGoogleDriveSync(
-                successMessageRes = null,
-            ) { updateGoogleDriveSync.setAccount(email) }
+        fun onGoogleDriveSyncRemoteFolderSelected(uri: String?, name: String?) {
+            updateGoogleDriveSync { updateGoogleDriveSync.setRemoteFolder(uri, name) }
         }
 
-        fun onGoogleDriveSyncSignOut() {
-            updateGoogleDriveSync { updateGoogleDriveSync.clearAccount() }
-        }
-
-        fun onGoogleDriveSyncRemoteFolderSelected(id: String?, name: String?) {
-            updateGoogleDriveSync { updateGoogleDriveSync.setRemoteFolder(id, name) }
+        fun onGoogleDriveSyncRemoteFolderCleared() {
+            updateGoogleDriveSync { updateGoogleDriveSync.clearRemoteFolder() }
         }
 
         fun onGoogleDriveSyncOverwriteChanged(overwrite: Boolean) {
@@ -510,13 +491,12 @@ class BackupRestoreViewModel
             isGDriveSyncing = true
             publishGoogleDriveSyncState()
             // Run the upload directly (not via WorkManager) so we can react to the result
-            // synchronously and show the manual-upload sheet immediately if OAuth refused.
-            // WorkManager's runNow() is still triggered as a fallback for the scheduled path.
+            // synchronously and show a snackbar immediately. WorkManager's runNow() is still
+            // triggered as a fallback for the scheduled path.
             viewModelScope.launch {
                 try {
                     val settings = googleDriveSettings
-                    val accountEmail = settings?.accountEmail
-                    if (settings == null || !settings.enabled || accountEmail == null) {
+                    if (settings == null || !settings.enabled || settings.remoteFolderUri == null) {
                         // Fall back to the WorkManager path — settings may have changed but not
                         // yet propagated to the local cache. The worker will bail out safely.
                         updateGoogleDriveSync.runNow()
@@ -539,14 +519,6 @@ class BackupRestoreViewModel
                                 googleDriveSyncRepository.recordSyncResult(success = true)
                             }
                             _googleDriveSyncEvent.emit(R.string.google_drive_sync_succeeded)
-                        }
-                        is GoogleDriveClient.UploadResult.NeedsManualUpload -> {
-                            // OAuth refused (UnregisteredOnApiConsole). Surface the manual-upload
-                            // sheet so the user can save the temp file to Drive via share sheet.
-                            updateGoogleDriveSync {
-                                googleDriveSyncRepository.recordSyncResult(success = false)
-                            }
-                            _manualUploadRequest.emit(result)
                         }
                         is GoogleDriveClient.UploadResult.TransientFailure -> {
                             updateGoogleDriveSync {
@@ -574,8 +546,6 @@ class BackupRestoreViewModel
                 }
             }
         }
-
-        fun listGoogleAccounts(): List<String> = googleDriveClient.listGoogleAccountNames()
 
         private fun updateGoogleDriveSync(
             @StringRes successMessageRes: Int? = null,
@@ -634,7 +604,6 @@ class BackupRestoreViewModel
                         frequency = resolved.frequency,
                         customDateEpochDay = resolved.customDateEpochDay,
                         customDateLabel = formattedCustomDate,
-                        accountEmail = resolved.accountEmail,
                         remoteFolderName = resolved.remoteFolderName,
                         overwriteExisting = resolved.overwriteExisting,
                         showCustomDatePicker = showGoogleDriveCustomDatePicker,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1366,6 +1366,10 @@
     <string name="google_drive_sync_remote_folder_description">Choose a Drive folder, or use My Drive root.</string>
     <string name="google_drive_sync_remote_folder_root">My Drive (root)</string>
     <string name="google_drive_sync_remote_folder_pick">Pick a folder</string>
+    <string name="google_drive_sync_remote_folder_not_set">Not set — tap to pick a Drive folder</string>
+    <string name="google_drive_sync_remote_folder_default_name">Drive folder</string>
+    <string name="google_drive_sync_clear_folder">Clear folder</string>
+    <string name="google_drive_sync_clear_folder_description">Forget the picked folder and disable auto-sync. You can pick a different folder afterwards.</string>
     <string name="google_drive_sync_overwrite">Overwrite existing Drive backup</string>
     <string name="google_drive_sync_overwrite_description">Keep one current backup instead of creating a dated history.</string>
     <string name="google_drive_sync_run_now">Sync now</string>
@@ -1383,7 +1387,7 @@
     <string name="google_drive_sync_pick_folder_paste_hint">Open the folder in Drive, copy the last path segment from its URL, or paste the URL here.</string>
     <string name="google_drive_sync_succeeded">Backup uploaded to Google Drive.</string>
     <string name="google_drive_sync_failed_transient">Sync failed — will retry automatically.</string>
-    <string name="google_drive_sync_failed_permanent">Sync failed. Sign in again or pick a different account.</string>
+    <string name="google_drive_sync_failed_permanent">Sync failed. The folder may have been removed or access revoked — try re-picking the folder.</string>
     <string name="google_drive_sync_manual_upload_channel">Manual Drive upload</string>
     <string name="google_drive_sync_manual_upload_channel_desc">Notifications shown when automatic Drive upload isn\'t possible and a manual save is required.</string>
     <string name="google_drive_sync_manual_upload_title">Save backup to Google Drive</string>


### PR DESCRIPTION
## What

Fixes the two Google Drive backup-sync bugs from the latest logs:

1. **"Select folder" opened but immediately auto-closed itself.**
2. **"Sync now" opened a share window instead of actually syncing** to the picked Drive folder.

## Root cause

Both came from the AccountManager OAuth + Drive REST API approach:

- **Folder picker auto-close**: a leftover `LaunchedEffect(showGoogleDriveFolderPicker)` reset the dialog flag to `false` on every recomposition, so the custom paste-a-folder-ID dialog flashed and vanished. That custom dialog was itself a poor substitute for a real folder picker.
- **Sync opens a share sheet**: `AccountManager.getAuthToken` for the `drive.file` scope fails with `AuthenticatorException: UnregisteredOnApiConsole` (visible in the attached log at `16:21:20.591`) because the app's package + SHA-1 isn't registered on Google Cloud Console — and for an open-source app end users self-build, it never can be. The fallback `buildManualUploadIntent` then fired an `ACTION_SEND` share sheet (the "share window" the user saw) instead of uploading.

## Fix — replace OAuth/REST with the Storage Access Framework (SAF)

- **"Select folder"** now launches the system `OpenDocumentTree` picker, which shows the user's real Google Drive folder tree (via the Drive app's DocumentsProvider) plus any other cloud provider. The returned tree URI is persisted with `takePersistableUriPermission` so it survives restarts/reboots. No more auto-closing.
- **"Sync now"** builds the backup into a temp file and writes it directly into the picked folder via `DocumentsContract.createDocument` + `ContentResolver.openOutputStream` — silent, automatic, no share sheet. When overwrite is enabled, the existing same-name document is deleted first (SAF providers don't reliably overwrite in place).

## Changes

- Removed AccountManager OAuth, Drive REST v3 calls, the manual-upload share-sheet fallback, the manual-upload notification channel, the account picker, and the custom paste-folder-ID dialog.
- Settings model: `accountEmail` + `remoteFolderId` → `remoteFolderUri` (a persisted SAF tree URI string).
- UI gating: controls are enabled once a folder is picked (`remoteFolderName != null`) instead of once an account is signed in. Added a "Clear folder" entry to release the persisted permission.
- Uses framework `DocumentsContract` (no new gradle dependency), matching the existing `CachePlaylistScreen` pattern.
- Net **−454 lines** (313 added / 767 removed).

## Files

| File | Change |
|------|-------|
| `googledrive/GoogleDriveClient.kt` | Rewritten: SAF `DocumentsContract` upload; OAuth/REST/manual-upload removed |
| `googledrive/GoogleDriveSyncModels.kt` | `accountEmail`/`remoteFolderId` → `remoteFolderUri` |
| `googledrive/GoogleDriveSyncRepository.kt` | Keys + updaters for `remoteFolderUri`; `clearRemoteFolder()` |
| `googledrive/GoogleDriveSyncUseCases.kt` | Drop account methods; `setRemoteFolder(uri, name)` + `clearRemoteFolder()` |
| `googledrive/GoogleDriveSyncWorker.kt` | Drop manual-upload notification; gate on `remoteFolderUri` |
| `googledrive/GoogleDriveSyncScheduler.kt` | Gate `nextRunAt` on `remoteFolderUri` |
| `viewmodels/BackupRestoreViewModel.kt` | Drop account/manual-upload; `onGoogleDriveSyncRemoteFolderCleared()` |
| `ui/screens/settings/BackupAndRestore.kt` | SAF `OpenDocumentTree` picker; remove broken `LaunchedEffect`, account row, manual-upload launcher, custom folder dialog |
| `res/values/strings.xml` | Add `remote_folder_not_set`, `clear_folder`, `default_name`; fix `failed_permanent` wording |

## How to test

1. Build & install.
2. Settings → Backup & restore → Google Drive sync → **Drive folder** → the system picker opens and stays open. Navigate into Google Drive and pick a folder (requires the Drive app installed).
3. The folder name now shows next to "Drive folder".
4. Toggle **Enable Google Drive sync** on, tap **Sync now** → no share sheet appears; a snackbar says "Backup uploaded to Google Drive" and the file appears in the picked Drive folder.
5. Tap **Clear folder** → the folder is forgotten and auto-sync disabled.

## Notes

- Existing users who had configured the old account-based sync will need to re-pick a folder once (the old `accountEmail`/`remoteFolderId` DataStore keys are simply ignored — they don't map to the new SAF flow). This is expected: the old flow never actually worked (`UnregisteredOnApiConsole`).
- The `GET_ACCOUNTS` permission remains declared in the manifest (now unused by Drive sync) — left intentionally to keep the diff focused; can be removed separately.
