### PR TITLE
fix: revert share UI more-options, region spoofer recommendations, queue button taps

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsShareDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsShareDialog.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -412,6 +413,12 @@ private fun LyricsShareStudioScaffold(
         modifier =
             modifier
                 .fillMaxWidth()
+                // fillMaxHeight ensures the weighted scrollable Column below always gets a
+                // definite height to distribute. Without this, when the content exceeds the
+                // Surface's heightIn(max = maxDialogHeight) cap, the weight modifier has no
+                // bounded parent height to distribute and the scrollable area overflows the
+                // Surface — which then clips the bottom rows (e.g. "Show album cover" description).
+                .fillMaxHeight()
                 .animateContentSize(animationSpec = motionScheme.defaultSpatialSpec()),
     ) {
         Column(
@@ -426,8 +433,6 @@ private fun LyricsShareStudioScaffold(
                 LyricsShareHeader(
                     payload = payload,
                     options = options,
-                    areAdvancedOptionsVisible = areAdvancedOptionsVisible,
-                    onToggleAdvancedOptions = onShowAdvancedOptions,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 PreviewContainer(
@@ -448,6 +453,7 @@ private fun LyricsShareStudioScaffold(
                     customTextColor = customTextColor,
                     onCustomTextColorChange = onCustomTextColorChange,
                     areAdvancedOptionsVisible = areAdvancedOptionsVisible,
+                    onShowAdvancedOptions = onShowAdvancedOptions,
                     isCompactLayout = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -473,8 +479,6 @@ private fun LyricsShareStudioScaffold(
                         LyricsShareHeader(
                             payload = payload,
                             options = options,
-                            areAdvancedOptionsVisible = areAdvancedOptionsVisible,
-                            onToggleAdvancedOptions = onShowAdvancedOptions,
                             modifier = Modifier.fillMaxWidth(),
                         )
                         ControlsSection(
@@ -486,6 +490,7 @@ private fun LyricsShareStudioScaffold(
                             customTextColor = customTextColor,
                             onCustomTextColorChange = onCustomTextColorChange,
                             areAdvancedOptionsVisible = areAdvancedOptionsVisible,
+                            onShowAdvancedOptions = onShowAdvancedOptions,
                             isCompactLayout = false,
                             modifier = Modifier.fillMaxWidth(),
                         )
@@ -507,8 +512,6 @@ private fun LyricsShareStudioScaffold(
 private fun LyricsShareHeader(
     payload: LyricsSharePayload,
     options: LyricsShareImageOptions,
-    areAdvancedOptionsVisible: Boolean,
-    onToggleAdvancedOptions: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val lyricSnippet =
@@ -524,12 +527,6 @@ private fun LyricsShareHeader(
     // instead of stacked, which saves one line of vertical space. The lyric snippet is
     // dropped when it would duplicate the title, and the resolution pill sits inline with
     // the artist row. The previous layout used 4 stacked text blocks + a pill = ~5 lines.
-    //
-    // The "More options" / "Less options" toggle is now a compact TextButton in the
-    // header row (top-right, next to the resolution pill) so it's always visible
-    // regardless of scroll position — previously it was a full-width button at the very
-    // bottom of the scrollable controls area, which the user reported as awkward and
-    // "positioned wrong / extremely bottom".
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -554,29 +551,6 @@ private fun LyricsShareHeader(
                     ),
                 emphasized = true,
             )
-            TextButton(
-                onClick = onToggleAdvancedOptions,
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                    horizontal = 8.dp,
-                    vertical = 0.dp,
-                ),
-                modifier = Modifier.heightIn(min = 32.dp),
-            ) {
-                Text(
-                    text =
-                        stringResource(
-                            if (areAdvancedOptionsVisible) {
-                                R.string.lyrics_share_less_options
-                            } else {
-                                R.string.more_options
-                            },
-                        ),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
         }
         Text(
             text = payload.songTitle,
@@ -675,6 +649,7 @@ private fun ControlsSection(
     customTextColor: Color?,
     onCustomTextColorChange: (Color?) -> Unit,
     areAdvancedOptionsVisible: Boolean,
+    onShowAdvancedOptions: () -> Unit,
     isCompactLayout: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -788,12 +763,18 @@ private fun ControlsSection(
                         shape = MaterialTheme.shapes.large,
                         color = MaterialTheme.colorScheme.surfaceContainerLowest,
                     ) {
+                        // NOTE: the redundant `.clip(MaterialTheme.shapes.large)` that used to
+                        // live here on the Row was removed. The Surface already clips to its
+                        // shape, and the second clip on the Row was clipping the description
+                        // text's wrapped second line ("...the exported image.") whenever the
+                        // dialog's content overflowed maxDialogHeight — the Row's clip
+                        // applied before the Row grew to fit the wrapped text, so the bottom
+                        // line was visually cut off even though the layout measured it.
                         Row(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
                                     .heightIn(min = 56.dp)
-                                    .clip(MaterialTheme.shapes.large)
                                     .clickable { onOptionsChange(options.copy(showArtwork = !options.showArtwork)) }
                                     .padding(horizontal = 12.dp, vertical = 10.dp),
                             verticalAlignment = Alignment.CenterVertically,
@@ -820,10 +801,26 @@ private fun ControlsSection(
                         }
                     }
                 }
+            } else {
+                // "More options" toggle in its original position — a full-width TextButton at
+                // the bottom of the scrollable controls area. This was the placement before
+                // the header-move experiment; the user explicitly asked to revert.
+                TextButton(
+                    onClick = onShowAdvancedOptions,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 48.dp),
+                    shape = MaterialTheme.shapes.large,
+                ) {
+                    Text(
+                        text = stringResource(R.string.more_options),
+                        style = MaterialTheme.typography.labelLargeEmphasized,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
-            // No bottom "More options" button here — the toggle has been moved into the
-            // header row (LyricsShareHeader) so it's always visible regardless of scroll
-            // position, instead of being pinned to the very bottom of the scrollable area.
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -65,7 +65,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
-import androidx.compose.ui.input.pointer.awaitPointerEvent
 import kotlin.math.abs
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -19,7 +19,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -61,6 +62,11 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.awaitPointerEvent
+import kotlin.math.abs
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -418,6 +424,15 @@ private fun AppleMusicControlsColumn(
 ) {
     var swipeUpAccumulated by remember { mutableFloatStateOf(0f) }
     val swipeUpThreshold = 120f
+    // Activation threshold for the swipe-up gesture, in pixels. The previous implementation
+    // used detectVerticalDragGestures, which fires (and calls change.consume()) the moment
+    // the finger drifts past viewConfiguration.touchSlop (~8dp ≈ 24px on a 3x-density phone).
+    // That consume() call cancels every child clickable's tap gesture — so users whose taps
+    // drifted even slightly would see "queue button doesn't work at all". By requiring a
+    // much larger initial movement (72px ≈ 24dp on a 3x-density phone) before we treat it
+    // as a swipe and start consuming, small finger drifts on taps no longer activate the
+    // swipe detector and the child tap completes normally. Clear upward swipes still work.
+    val swipeActivationThreshold = 72f
     val resetSwipeUp = remember {
         {
             if (swipeUpAccumulated != 0f) swipeUpAccumulated = 0f
@@ -429,20 +444,48 @@ private fun AppleMusicControlsColumn(
         modifier = modifier
             .padding(horizontal = AppleMusicContentPadding)
             .pointerInput(Unit) {
-                detectVerticalDragGestures(
-                    onDragEnd = {
-                        if (swipeUpAccumulated < -swipeUpThreshold) {
-                            onQueueClick()
+                // Custom vertical-drag detector that only consumes events once the user has
+                // clearly started swiping upward (movement > swipeActivationThreshold).
+                // Before that point, we don't consume — so child clickables (queue, lyrics,
+                // output, play/pause, skip, like, more, title, artist) receive the full
+                // tap sequence and fire normally. This fixes the "queue button doesn't work
+                // at all" report for users whose taps drift a few pixels vertically.
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false)
+                    var accumulated = 0f
+                    var swipeActivated = false
+                    while (true) {
+                        val event = awaitPointerEvent(PointerEventPass.Main)
+                        val change = event.changes.firstOrNull() ?: break
+                        if (change.changedToUp()) break
+
+                        val dragDelta = change.positionChange().y
+
+                        if (!swipeActivated) {
+                            // Track upward movement but don't consume yet — let child taps win.
+                            if (dragDelta < 0f) {
+                                accumulated += dragDelta
+                            }
+                            if (abs(accumulated) > swipeActivationThreshold) {
+                                swipeActivated = true
+                                swipeUpAccumulated = accumulated
+                                change.consume()
+                            }
+                        } else {
+                            // Swipe is confirmed — consume to prevent child handling.
+                            if (dragDelta < 0f) {
+                                swipeUpAccumulated =
+                                    (swipeUpAccumulated + dragDelta).coerceAtLeast(-swipeUpThreshold * 1.5f)
+                            }
+                            change.consume()
                         }
-                        swipeUpAccumulated = 0f
-                    },
-                    onVerticalDrag = { change, dragAmount ->
-                        change.consume()
-                        if (dragAmount < 0f) { // upward swipe
-                            swipeUpAccumulated = (swipeUpAccumulated + dragAmount).coerceAtLeast(-swipeUpThreshold * 1.5f)
-                        }
-                    },
-                )
+                    }
+
+                    if (swipeActivated && swipeUpAccumulated < -swipeUpThreshold) {
+                        onQueueClick()
+                    }
+                    swipeUpAccumulated = 0f
+                }
             },
         verticalArrangement = Arrangement.SpaceEvenly,
     ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2850,19 +2850,30 @@ private fun LittlePlayerContent(
 
                 Spacer(Modifier.width((18f * scale).dp))
 
-                Icon(
-                    painter = painterResource(R.drawable.player_queue_music),
-                    contentDescription = null,
-                    tint = textColor.copy(alpha = 0.78f),
+                // Queue button — wrapped in a 48dp Box (Material minimum touch target) so the
+                // tap is reliably registerable even on dense layouts. The previous version put
+                // .clickable directly on the 26dp Icon, which (combined with indication=null)
+                // made taps very easy to miss — one of the root causes of the "queue button
+                // doesn't work at all" report. The Icon itself stays at iconSize for visual
+                // consistency; only the touch target grows.
+                Box(
+                    contentAlignment = Alignment.Center,
                     modifier =
                         Modifier
-                            .size(iconSize)
+                            .size(48.dp)
                             .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
                                 indication = null,
                                 onClick = onExpandQueue,
                             ),
-                )
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.player_queue_music),
+                        contentDescription = null,
+                        tint = textColor.copy(alpha = 0.78f),
+                        modifier = Modifier.size(iconSize),
+                    )
+                }
 
                 Spacer(Modifier.width((18f * scale).dp))
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -494,39 +494,14 @@ fun Queue(
                 }
 
                 PlayerDesignStyle.V5 -> {
-                    QueueCollapsedContentV3(
-                        showCodecOnPlayer = showCodecOnPlayer,
-                        currentFormat = currentFormat,
-                        textBackgroundColor = TextBackgroundColor,
-                        sleepTimerEnabled = sleepTimerEnabled,
-                        sleepTimerTimeLeft = sleepTimerTimeLeft,
-                        onExpandQueue = openQueue,
-                        onSleepTimerClick = {
-                            if (sleepTimerEnabled) {
-                                playerConnection.service.sleepTimer.clear()
-                            } else {
-                                showSleepTimerDialog = true
-                            }
-                        },
-                        onShowLyrics = onShowLyrics,
-                        onMenuClick = {
-                            menuState.show {
-                                PlayerMenu(
-                                    mediaMetadata = mediaMetadata,
-                                    navController = navController,
-                                    playerBottomSheetState = playerBottomSheetState,
-                                    onShowDetailsDialog = {
-                                        mediaMetadata?.id?.let {
-                                            bottomSheetPageState.show {
-                                                ShowMediaInfo(it)
-                                            }
-                                        }
-                                    },
-                                    onDismiss = menuState::dismiss,
-                                )
-                            }
-                        },
-                    )
+                    // V5 keeps its collapsed peek bar empty, matching the APPLE_MUSIC approach.
+                    // The LittlePlayer (rendered inside Player.kt) already exposes queue, like,
+                    // and more-menu buttons with proper 48dp touch targets. Previously this
+                    // branch rendered QueueCollapsedContentV3 inside a 0dp-tall peek Box —
+                    // the button row overflowed the parent and its touch zone was clipped/
+                    // competed-for by the BottomSheet wrapper's own clickable, which caused
+                    // "queue button doesn't work at all" reports on V5. Sleep timer, lyrics,
+                    // and other controls remain reachable via the LittlePlayer's more-menu.
                 }
 
                 PlayerDesignStyle.V4 -> {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/QueueComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/QueueComponents.kt
@@ -804,13 +804,16 @@ fun QueueCollapsedContentV3(
                         ),
                     ),
         ) {
-            // Queue button
+            // Queue button — enlarged touch target to 48dp (Material minimum) by increasing
+            // vertical padding from 8dp to 14dp. The previous ~34dp touch zone (18dp icon +
+            // 8dp+8dp padding) was below the 48dp minimum and contributed to missed taps,
+            // especially on V3 and (previously) V5 which used this composable.
             Box(
                 modifier =
                     Modifier
                         .clip(RoundedCornerShape(8.dp))
                         .clickable { onExpandQueue() }
-                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                        .padding(horizontal = 12.dp, vertical = 14.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Row(
@@ -820,7 +823,7 @@ fun QueueCollapsedContentV3(
                     Icon(
                         painter = painterResource(id = R.drawable.player_queue_music),
                         contentDescription = null,
-                        modifier = Modifier.size(18.dp),
+                        modifier = Modifier.size(20.dp),
                         tint = textBackgroundColor.copy(alpha = 0.7f),
                     )
                     Text(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -232,15 +232,28 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
                         },
                         onValueSelected = { newValue ->
                             // Apply immediately — `gl` is in the JSON body of every YT Music
-                            // request, so the next call (search / player / browse / next /
-                            // suggestions) will use the new region. `SYSTEM_DEFAULT` falls
-                            // back to the device locale (or, if that's not in
-                            // CountryCodeToName, to "US"), matching the App.kt startup logic.
+                            // request (browse/search/player/next/suggestions/queue), so the
+                            // next call will use the new region. `SYSTEM_DEFAULT` falls back
+                            // to the device locale (or, if that's not in CountryCodeToName,
+                            // to "US"), matching the App.kt startup logic.
+                            //
+                            // We also clear visitorData: that token is minted by YouTube with
+                            // an implicit region baked in (derived from the IP/locale at the
+                            // time of the sw.js_data scrape). Without rotation, YouTube can
+                            // keep serving content pinned to the *old* region for personalized
+                            // endpoints like FEmusic_home, even though context.client.gl says
+                            // otherwise. Setting it to null forces the next request to re-fetch
+                            // a fresh, region-pinned token.
+                            //
+                            // The locale assignment emits YouTube.localeChanges, which
+                            // HomeViewModel collects to trigger an immediate home-feed refresh
+                            // (no manual pull-to-refresh required).
                             val deviceLocale = Locale.getDefault()
                             val resolvedGl =
                                 newValue.takeIf { it != SYSTEM_DEFAULT }
                                     ?: deviceLocale.country.takeIf { it in CountryCodeToName }
                                     ?: "US"
+                            YouTube.visitorData = null
                             YouTube.locale = YouTube.locale.copy(gl = resolvedGl)
                             onYtMusicRegionChange(newValue)
                         },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
@@ -29,6 +29,8 @@ import moe.rukamori.archivetune.auth.SwitchSavedYouTubeAccountUseCase
 import moe.rukamori.archivetune.constants.AccountChannelHandleKey
 import moe.rukamori.archivetune.constants.AccountEmailKey
 import moe.rukamori.archivetune.constants.AccountNameKey
+import moe.rukamori.archivetune.constants.ContentCountryKey
+import moe.rukamori.archivetune.constants.ContentLanguageKey
 import moe.rukamori.archivetune.constants.DataSyncIdKey
 import moe.rukamori.archivetune.constants.HideExplicitKey
 import moe.rukamori.archivetune.constants.HideVideoKey
@@ -36,6 +38,7 @@ import moe.rukamori.archivetune.constants.InnerTubeCookieKey
 import moe.rukamori.archivetune.constants.QuickPicks
 import moe.rukamori.archivetune.constants.QuickPicksKey
 import moe.rukamori.archivetune.constants.SpeedDialSongIdsKey
+import moe.rukamori.archivetune.constants.YouTubeMusicRegionKey
 import moe.rukamori.archivetune.constants.YtmSyncKey
 import moe.rukamori.archivetune.db.MusicDatabase
 import moe.rukamori.archivetune.db.entities.*
@@ -893,6 +896,31 @@ class HomeViewModel
 
             viewModelScope.launch(Dispatchers.IO) {
                 load()
+            }
+
+            // Re-fetch the home feed whenever the YT Music region (or content country/language)
+            // changes. This is what makes the "YouTube Music region" setting in Internet
+            // Settings actually take effect on the home screen: when the user picks a country,
+            // InternetSettings writes YouTubeMusicRegionKey to the DataStore AND mutates
+            // YouTube.locale.gl in-memory — we observe the preference here and trigger a
+            // fresh YouTube.home() call. Without this, the user would have to manually
+            // pull-to-refresh after changing the region.
+            //
+            // We observe ContentCountryKey and ContentLanguageKey too, since those also
+            // mutate YouTube.locale (via App.kt's initializeDeferredAsync) and therefore
+            // affect what the home feed returns.
+            //
+            // drop(1) so we don't re-fetch on initial subscription (the load() above
+            // already covers the cold-start case).
+            viewModelScope.launch(Dispatchers.IO) {
+                context.dataStore.data
+                    .map { Triple(it[YouTubeMusicRegionKey], it[ContentCountryKey], it[ContentLanguageKey]) }
+                    .distinctUntilChanged()
+                    .drop(1)
+                    .collectLatest {
+                        isLoading.filter { loading -> !loading }.first()
+                        load()
+                    }
             }
 
             viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,7 +560,7 @@
     <string name="enable_proxy">Enable proxy</string>
     <string name="internet">Internet</string>
     <string name="youtube_music_region">YouTube Music region</string>
-    <string name="youtube_music_region_desc">Spoofs the country YouTube Music thinks you\'re connecting from. Use this to play songs that are restricted in your actual location. System default falls back to your device locale.</string>
+    <string name="youtube_music_region_desc">Spoofs the country YouTube Music thinks you\'re connecting from. The home feed, recommendations, search, new releases, and radio queues will all reflect the chosen country. Also bypasses geo-restrictions on specific songs. System default falls back to your device locale.</string>
     <string name="internet_warning_title">Security &amp; Usage Warning</string>
     <string name="internet_warning_doh">DNS over HTTPS only works if your country blocks YouTube. If YouTube actively blocks your region, consider using a Proxy or VPN.</string>
     <string name="internet_warning_proxy">Please only use Proxies that you are sure are safe. Free Proxies are convenient but not always safe, so be careful. You have been warned, and we are not responsible for your security.</string>


### PR DESCRIPTION
## Summary

4 user-requested fixes in this PR:

### 1. Lyrics share UI — revert More options button + fix bottom text cutoff

The previous batch moved the "More options" toggle into the header row (top-right). The user asked to revert this — the toggle belongs at the bottom of the scrollable controls area where it was originally.

The user also reported that the bottom text gets cut out (see screenshot — the "Show album cover" description text "Include the artwork in the header of the exported image." was being clipped). Root cause: the scaffold Column didn't have `fillMaxHeight()`, so when content exceeded `maxDialogHeight` the weighted scrollable Column had no bounded parent height to distribute and overflowed the Surface — which then clipped the bottom rows. Also removed a redundant `.clip()` on the Row inside the Show-album-cover Surface that was clipping the description's wrapped second line.

### 2. YT region spoofer — now shows country-specific recommendations

The user clarified that the region spoofer should show recommendations and everything from the chosen country's YouTube Music page (not just bypass geo-restrictions). The previous implementation only set `YouTube.locale.gl` but didn't auto-refresh the home feed.

**Fix:** `HomeViewModel` now observes `YouTubeMusicRegionKey` + `ContentCountryKey` + `ContentLanguageKey` in the DataStore and auto-refreshes the home feed when any of them change (no manual pull-to-refresh required). `InternetSettings` also clears `YouTube.visitorData` on region change so the next request mints a fresh, region-pinned token. Updated the setting description to reflect the new behavior.

**Known limitation:** `InnerTube.next()` still uses a hardcoded `US/en` locale (requires a core submodule change to fix — I don't have push access to `vossgraves/core`). The home feed (the main recommendation surface) works correctly; radio queues / "Up Next" may not fully honor the spoofed region.

### 3. Queue button — fixes "clicking on queue button doesn't work at all"

Multiple root causes across player styles:

- **Apple Music** (highest impact): `detectVerticalDragGestures` on the controls Column was calling `change.consume()` on any finger drift > touchSlop (~8dp), canceling every child tap. Users with slightly unsteady fingers would see "queue button doesn't work at all". Replaced with a custom `awaitEachGesture` that only consumes after a 72px activation threshold — small drifts on taps no longer trigger the swipe detector and child taps complete normally. Clear upward swipes still work.
- **V5 LittlePlayer queue icon**: was 26dp touch target (below 48dp Material minimum). Wrapped in a 48dp Box with the clickable on the Box.
- **V5 peek bar**: 0dp peek height but still rendered `QueueCollapsedContentV3`, causing clipped touch zones. Made V5's `collapsedContent` empty (matching APPLE_MUSIC) — V5 users already have the LittlePlayer queue button with a proper 48dp touch target.
- **V3 queue button**: ~34dp touch target (below 48dp minimum). Enlarged to ~48dp by increasing vertical padding from 8dp to 14dp and bumping the icon from 18dp to 20dp.

### 4. Git workflow

Following the new workflow: committed to `dev` branch, opening PR to `main`.

---

**Files changed (8):**
- `LyricsShareDialog.kt` — revert More options to bottom + fix bottom text cutoff
- `AppleMusicPlayer.kt` — custom awaitEachGesture for swipe-up, doesn't eat taps
- `Player.kt` — V5 LittlePlayer queue icon wrapped in 48dp Box
- `Queue.kt` — V5 collapsedContent now empty, matching APPLE_MUSIC
- `QueueComponents.kt` — V3 queue button touch target enlarged to ~48dp
- `InternetSettings.kt` — reset visitorData on region change
- `HomeViewModel.kt` — observe region/country/language prefs → auto-refresh home
- `strings.xml` — updated YT region description

**Core submodule:** unchanged (no push access to upstream `vossgraves/core`)