### PR TITLE
ci: stop writing the same release notes on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -593,20 +593,37 @@ jobs:
           MOBILE_UNIVERSAL_APK=$(find downloaded_artifacts/app-gms-mobile-universal-release -name "*.apk" | head -n 1)
           OTHER_APKS=$(find downloaded_artifacts -path "*/app-*-release/*.apk" ! -path "*/app-gms-mobile-universal-release/*")
 
-          cat > release_notes.md <<'NOTES'
-          ## What's new 🎵
-
-          - 🎧 **Qobuz & Tidal integration** — the app now auto-discovers and connects to community-shared streaming accounts so you can play music right away
-          - 🖼️ **Fixed app icon on home screen** — the icon now displays correctly on all launchers
-          - ✨ **Smoother animations** — transitions and UI interactions feel noticeably more fluid throughout the app
-          - 🔧 **Various bug fixes and stability improvements** from the latest upstream updates
-
-          ---
-          NOTES
-
-          cat >> release_notes.md <<EOF
+          # Release notes are ONLY the generated changelog.
+          #
+          # This used to start with a hardcoded "What's new 🎵" block in a *quoted* heredoc
+          # (<<'NOTES'). Quoting means no expansion, so those four bullets were written out
+          # byte-identical on every single release. They described one specific past build --
+          # "Fixed app icon on home screen", "Smoother animations" -- and then kept advertising
+          # those same changes on every release afterwards, while pushing the real per-release
+          # list further down the page. That is why every changelog looked the same; the
+          # generator below was always working correctly.
+          #
+          # Anything newsworthy belongs in a commit subject, where build_changelog picks it up and
+          # files it under Features/Fixes/Performance automatically.
+          cat > release_notes.md <<EOF
           ${{ steps.build_changelog.outputs.changelog }}
           EOF
+
+          # With the static block gone the changelog is the only content, so an empty generator
+          # result (bad tag range, nothing categorised) would publish blank release notes.
+          # Fall back to a compare link instead of shipping an empty body.
+          if [ -z "$(tr -d '[:space:]' < release_notes.md)" ]; then
+            PREV_TAG="${{ steps.changelog_range.outputs.from_ref }}"
+            {
+              echo "# Changelog"
+              echo
+              echo "No categorised commits were found for this range."
+              if [ -n "$PREV_TAG" ]; then
+                echo
+                echo "Full diff: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ needs.check-version.outputs.new_version }}"
+              fi
+            } > release_notes.md
+          fi
 
           gh release create "v${{ needs.check-version.outputs.new_version }}" \
             --target "${{ github.sha }}" \


### PR DESCRIPTION
Every stable release has had the same changelog. The cause is the release-notes step in `.github/workflows/release.yml`:

```sh
cat > release_notes.md <<'NOTES'
## What's new 🎵

- 🎧 **Qobuz & Tidal integration** — the app now auto-discovers ...
- 🖼️ **Fixed app icon on home screen** — ...
- ✨ **Smoother animations** — ...
- 🔧 **Various bug fixes and stability improvements** ...
NOTES

cat >> release_notes.md <<EOF
${{ steps.build_changelog.outputs.changelog }}
EOF
```

The delimiter is **quoted** (`<<'NOTES'`), so there is no expansion and no per-release content — those four bullets were written out byte-identical on every run. They describe one specific past build ("Fixed app icon on home screen", "Smoother animations"), and kept advertising those same changes on every release afterwards, while pushing the real generated list further down the page.

Worth being clear that `build_changelog` was never broken — it correctly categorises commits into Features / Fixes / Performance and does differ per release. It was just buried under a static block that read as *the* changelog.

## Change

Notes are now only the generated changelog. Anything newsworthy goes in a commit subject and gets picked up automatically, instead of being hand-maintained in CI where it goes stale silently.

Since the changelog is now the only content, an empty generator result (bad tag range, nothing categorised) would publish blank notes — so there's a fallback to a compare link.

## Notes

- No change to triggers, versioning, build, or artifacts. Only the notes text.
- Deliberately opened as a PR rather than pushed to `main`: this workflow runs on push to `main`, so a direct push would immediately cut a release.