### PR TITLE
feat(deezer): full Premium streaming with Blowfish decryption

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/TrackMatching.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/TrackMatching.kt
@@ -1,0 +1,189 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ */
+
+package moe.rukamori.archivetune.audiosource
+
+import java.text.Normalizer
+import java.util.Locale
+import kotlin.math.abs
+
+/**
+ * Shared heuristics for deciding whether a catalog search hit is actually the track we asked for.
+ *
+ * Every lossless provider searches a third-party catalog by text and has to judge the results, so the
+ * same scoring is needed by each one. `TidalAudioProvider` and `QobuzAudioProvider` predate this file
+ * and still carry their own private copies of these functions; this exists so Deezer did not become a
+ * third copy. Migrating those two onto this object is a mechanical but behaviour-visible change to
+ * working providers, so it is deliberately left as its own future change rather than bundled into the
+ * commit that adds Deezer.
+ *
+ * The thresholds here are copied from those providers verbatim so all three sources agree on what
+ * counts as a match.
+ */
+internal object TrackMatching {
+    /** Minimum score for a candidate to be accepted at all. */
+    const val MIN_MATCH_SCORE = 60
+
+    /** Ignored when comparing token sets, since they carry no identifying information. */
+    private val STOP_WORDS = setOf("the", "a", "an", "of", "and", "feat", "ft", "featuring", "with")
+
+    /**
+     * Words that distinguish otherwise identically-titled recordings. A mismatch on any of these is
+     * treated as a hard rejection, because serving a live take for a studio track is worse than
+     * serving nothing and falling through to the next source.
+     */
+    private val VERSION_TOKENS =
+        setOf("remix", "acoustic", "live", "instrumental", "demo", "edit", "mix", "version")
+
+    /** Runtimes this far apart are still considered the same recording. */
+    private const val DURATION_TOLERANCE_MS = 45_000L
+
+    /**
+     * Scores [candidateTitle]/[candidateArtist] against what we wanted. Returns [Int.MIN_VALUE] for a
+     * hard rejection; otherwise higher is better and callers should require [MIN_MATCH_SCORE].
+     */
+    fun score(
+        wantedTitle: String,
+        wantedArtists: List<String>,
+        candidateTitle: String,
+        candidateArtist: String,
+        wantedDurationMs: Long?,
+        candidateDurationMs: Long?,
+    ): Int {
+        if (wantedTitle.isBlank() || candidateTitle.isBlank()) return Int.MIN_VALUE
+        if (hasVersionMismatch(" $wantedTitle ", " $candidateTitle ")) return Int.MIN_VALUE
+        val titleOverlap = tokenOverlap(significantTokens(wantedTitle), significantTokens(candidateTitle))
+        if (titleOverlap < 0.5) return Int.MIN_VALUE
+        var score = (titleOverlap * 100).toInt()
+        if (wantedArtists.isNotEmpty() && candidateArtist.isNotBlank()) {
+            val artistOverlap =
+                wantedArtists.maxOf { tokenOverlap(significantTokens(it), significantTokens(candidateArtist)) }
+            score += (artistOverlap * 60).toInt()
+        }
+        if (wantedDurationMs != null && candidateDurationMs != null) {
+            // A duration agreement is weak evidence but a disagreement is strong counter-evidence, so
+            // the penalty deliberately outweighs the bonus.
+            if (durationMatches(wantedDurationMs, candidateDurationMs)) score += 30 else score -= 40
+        }
+        return score
+    }
+
+    /** What the player asked for. */
+    data class Target(
+        val title: String,
+        val artists: List<String>,
+        val album: String?,
+        val durationMs: Long?,
+    )
+
+    /**
+     * One search hit from a provider's catalog, normalized so [best] can rank hits from any source.
+     * [id] is the provider's own track identifier and is opaque here.
+     */
+    data class Candidate(
+        val id: String,
+        val title: String,
+        val artists: List<String>,
+        val album: String?,
+        val durationMs: Long?,
+    )
+
+    /**
+     * Picks the highest-scoring candidate that clears [MIN_MATCH_SCORE], or null when none does.
+     *
+     * Returning null is the intended outcome for a track the catalog does not carry: the caller falls
+     * through to the next source rather than playing a wrong recording. Note this is only the
+     * provider-internal choice of "which hit is best" — the playback layer still re-checks the winner
+     * with [TitleMatch], so a provider cannot bypass the shared safety gate by scoring loosely here.
+     */
+    fun best(
+        target: Target,
+        candidates: List<Candidate>,
+    ): Candidate? =
+        candidates
+            .asSequence()
+            .map { candidate ->
+                candidate to
+                    score(
+                        wantedTitle = normalizeTitle(target.title),
+                        wantedArtists = target.artists.map { normalize(it) },
+                        candidateTitle = normalizeTitle(candidate.title),
+                        candidateArtist = normalize(candidate.artists.firstOrNull()),
+                        wantedDurationMs = target.durationMs,
+                        candidateDurationMs = candidate.durationMs,
+                    )
+            }.filter { (_, score) -> score >= MIN_MATCH_SCORE }
+            .maxByOrNull { (_, score) -> score }
+            ?.first
+
+    private fun significantTokens(value: String): Set<String> =
+        value
+            .split(' ')
+            .map { it.trim() }
+            .filter { it.length >= 2 && it !in STOP_WORDS }
+            .toSet()
+
+    private fun tokenOverlap(
+        wanted: Set<String>,
+        candidate: Set<String>,
+    ): Double {
+        if (wanted.isEmpty() || candidate.isEmpty()) return 0.0
+        val shared = wanted.intersect(candidate).size
+        // Divide by the larger set so that a candidate padded with extra words cannot score a perfect
+        // overlap just by containing every wanted token.
+        return shared.toDouble() / wanted.size.coerceAtLeast(candidate.size).toDouble()
+    }
+
+    fun durationMatches(
+        wantedDurationMs: Long?,
+        candidateDurationMs: Long?,
+    ): Boolean {
+        if (wantedDurationMs == null || candidateDurationMs == null) return true
+        return abs(wantedDurationMs - candidateDurationMs) <= DURATION_TOLERANCE_MS
+    }
+
+    private fun hasVersionMismatch(
+        wanted: String,
+        candidate: String,
+    ): Boolean = VERSION_TOKENS.any { token -> wanted.contains(" $token ") != candidate.contains(" $token ") }
+
+    /** Lowercased, accent-stripped, punctuation-collapsed form used for all token comparisons. */
+    fun normalize(value: String?): String =
+        value
+            ?.lowercase(Locale.US)
+            ?.let { Normalizer.normalize(it, Normalizer.Form.NFD) }
+            ?.replace(Regex("\\p{Mn}+"), "")
+            ?.replace(Regex("[^a-z0-9]+"), " ")
+            ?.trim()
+            .orEmpty()
+
+    /** Strips featured-artist and edition noise that catalogs disagree about. */
+    fun normalizeTitle(value: String): String =
+        normalize(value)
+            .replace(Regex("""\b(feat|ft|featuring)\b.*$"""), "")
+            .replace(Regex("""\b(explicit|clean|remaster|remastered|version|audio|official)\b"""), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+    /** Cleans a title for use as a search query, keeping original casing and diacritics. */
+    fun searchTitle(value: String): String =
+        value
+            .trim()
+            .replace(Regex("""\s*[\[(]\s*(feat\.?|ft\.?|featuring)\b.*?[\])]""", RegexOption.IGNORE_CASE), "")
+            .replace(
+                Regex("""\s*-\s*(explicit|clean|remaster(?:ed)?|audio|official)\b.*$""", RegexOption.IGNORE_CASE),
+                "",
+            ).replace(Regex("\\s+"), " ")
+            .trim()
+
+    /** Primary artist only; catalogs list collaborators inconsistently. */
+    fun searchArtist(value: String): String =
+        value
+            .trim()
+            .substringBefore(',')
+            .replace(Regex("\\s+"), " ")
+            .trim()
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -999,6 +999,27 @@ val AudioSearchSourceKey = stringPreferencesKey("audioSearchSource")
 // When logged in, try the user's own Tidal account (official API) before the public instances.
 val TidalAccountFirstKey = booleanPreferencesKey("tidalAccountFirst")
 
+// ---------------------------------------------------------------------------
+// Deezer source
+// ---------------------------------------------------------------------------
+// Unlike Tidal/Qobuz there is no self-hosted proxy tier: Deezer streams come from accounts
+// authenticated with an `arl` cookie, supplied by the pool or by a manual sign-in. Defaults OFF
+// because the source is inert without accounts.
+val DeezerEnabledKey = booleanPreferencesKey("deezerEnabled")
+
+// A manually captured `arl` cookie. Kept separate from the pool cache: the pool is wiped and
+// rewritten on every refresh and is gated behind PoolAccountManager.isEnabled, so storing a
+// user's own credential there would lose it on the next sync.
+val DeezerArlKey = stringPreferencesKey("deezerArl")
+
+// Display label for the manually signed-in account, so the settings row can say who is signed in
+// without keeping the ARL itself anywhere near the UI.
+val DeezerAccountNameKey = stringPreferencesKey("deezerAccountName")
+
+// Whether the manual account reported a lossless-capable plan. Only orders resolution attempts;
+// the provider still verifies the real tier per track.
+val DeezerAccountPremiumKey = booleanPreferencesKey("deezerAccountPremium")
+
 val WebClientPoTokenEnabledKey = booleanPreferencesKey("webClientPoTokenEnabled")
 val PoTokenGvsKey = stringPreferencesKey("poTokenGvs")
 val PoTokenPlayerKey = stringPreferencesKey("poTokenPlayer")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -36,15 +36,12 @@ import java.util.concurrent.TimeUnit
  * All calls run blocking network I/O and must not be made from the main thread.
  */
 object DeezerAudioProvider {
-    data class Query(
-        val mediaId: String,
-        val title: String,
-        val artists: List<String>,
-        val album: String?,
-        val durationMs: Long?,
-    )
-
-    data class Resolved(
+    /**
+     * Catalogue metadata for a track, with no playable stream attached. Returned by [lookup] and kept
+     * separate from [Resolved] because callers that only enrich stored metadata (artwork, album name,
+     * ISRC) must not have to satisfy the streaming contract.
+     */
+    data class Metadata(
         val trackId: String,
         val title: String,
         val artist: String?,
@@ -563,7 +560,7 @@ object DeezerAudioProvider {
      * credentials. The returned [Resolved] is used for ISRC lookup, artwork fallback, and
      * downloaded-song metadata enrichment.
      */
-    suspend fun lookup(query: Query): Resolved? =
+    suspend fun lookup(query: Query): Metadata? =
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             runCatching {
                 val q = buildSearchQuery(query)
@@ -594,7 +591,7 @@ object DeezerAudioProvider {
                             val preview = obj.optString("preview").ifBlank { null }
                             val cover = obj.optJSONObject("album")?.optString("cover_big")?.ifBlank { null }
                             val score = scoreCandidate(query, title, artist, album, durationSec)
-                            Resolved(
+                            Metadata(
                                 trackId = obj.optLong("id").toString(),
                                 title = title,
                                 artist = artist,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -36,7 +36,27 @@ import java.util.concurrent.TimeUnit
  * All calls run blocking network I/O and must not be made from the main thread.
  */
 object DeezerAudioProvider {
+    data class Query(
+        val mediaId: String,
+        val title: String,
+        val artists: List<String>,
+        val album: String?,
+        val durationMs: Long?,
+    )
+
+    data class Resolved(
+        val trackId: String,
+        val title: String,
+        val artist: String?,
+        val album: String?,
+        val isrc: String?,
+        val durationMs: Long?,
+        val previewUrl: String?,
+        val coverUrl: String?,
+    )
+
     private const val TAG = "Deezer"
+    private const val MIN_MATCH_SCORE = 0.55
     private const val SEARCH_LIMIT = 10
     private const val SEARCH_CACHE_MS = 10 * 60 * 1000L
     private const val STREAM_CACHE_MS = 30 * 60 * 1000L
@@ -534,4 +554,117 @@ object DeezerAudioProvider {
     }
 
     private val JSON_MEDIA = "application/json; charset=utf-8".toMediaTypeOrNull()
+
+    /**
+     * Searches Deezer's public catalogue for [query] and returns the best-matching track's metadata.
+     * Returns null when no match is found or the Deezer API is unreachable.
+     *
+     * This does NOT return a streamable URL — full-track streaming requires Deezer Premium
+     * credentials. The returned [Resolved] is used for ISRC lookup, artwork fallback, and
+     * downloaded-song metadata enrichment.
+     */
+    suspend fun lookup(query: Query): Resolved? =
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            runCatching {
+                val q = buildSearchQuery(query)
+                val req =
+                    Request
+                        .Builder()
+                        .url("https://api.deezer.com/search?q=${java.net.URLEncoder.encode(q, "UTF-8")}&limit=10")
+                        .header("Accept", "application/json")
+                        .build()
+                client.newCall(req).execute().use { res ->
+                    if (!res.isSuccessful) {
+                        Timber.tag(TAG).w("search HTTP %d for '%s'", res.code, q)
+                        return@use null
+                    }
+                    val body = res.body?.string() ?: return@use null
+                    val root = JSONObject(body)
+                    val data = root.optJSONArray("data") ?: return@use null
+                    if (data.length() == 0) return@use null
+
+                    val candidates =
+                        (0 until data.length()).mapNotNull { i ->
+                            val obj = data.optJSONObject(i) ?: return@mapNotNull null
+                            val title = obj.optString("title").ifBlank { return@mapNotNull null }
+                            val artist = obj.optJSONObject("artist")?.optString("name")?.ifBlank { null }
+                            val album = obj.optJSONObject("album")?.optString("title")?.ifBlank { null }
+                            val durationSec = obj.optLong("duration", 0L).takeIf { it > 0 }
+                            val isrc = obj.optString("isrc").ifBlank { null }
+                            val preview = obj.optString("preview").ifBlank { null }
+                            val cover = obj.optJSONObject("album")?.optString("cover_big")?.ifBlank { null }
+                            val score = scoreCandidate(query, title, artist, album, durationSec)
+                            Resolved(
+                                trackId = obj.optLong("id").toString(),
+                                title = title,
+                                artist = artist,
+                                album = album,
+                                isrc = isrc,
+                                durationMs = durationSec?.times(1000L),
+                                previewUrl = preview,
+                                coverUrl = cover,
+                            ) to score
+                        }
+                    val best = candidates.maxByOrNull { it.second } ?: return@use null
+                    if (best.second < MIN_MATCH_SCORE) {
+                        Timber.tag(TAG).d("best candidate score %.2f below threshold for '%s'", best.second, q)
+                        return@use null
+                    }
+                    best.first
+                }
+            }.getOrNull()
+        }
+
+    private fun buildSearchQuery(query: Query): String {
+        val parts = mutableListOf<String>()
+        query.artists.firstOrNull()?.takeIf(String::isNotBlank)?.let { parts.add("artist:\"$it\"") }
+        parts.add("track:\"${query.title}\"")
+        query.album?.takeIf(String::isNotBlank)?.let { parts.add("album:\"$it\"") }
+        return parts.joinToString(" ")
+    }
+
+    private fun scoreCandidate(
+        query: Query,
+        candidateTitle: String,
+        candidateArtist: String?,
+        candidateAlbum: String?,
+        candidateDurationSec: Long?,
+    ): Double {
+        val titleScore = normalizedSimilarity(query.title, candidateTitle)
+        val artistScore =
+            query.artists.firstOrNull()?.let { a ->
+                candidateArtist?.let { c -> normalizedSimilarity(a, c) }
+            } ?: 0.0
+        val albumScore =
+            query.album?.let { q ->
+                candidateAlbum?.let { c -> normalizedSimilarity(q, c) }
+            } ?: 0.5
+        val durationScore =
+            query.durationMs?.let { qd ->
+                candidateDurationSec?.let { cs ->
+                    val cd = cs * 1000L
+                    val diff = kotlin.math.abs(qd - cd)
+                    when {
+                        diff < 2_000L -> 1.0
+                        diff < 5_000L -> 0.85
+                        diff < 10_000L -> 0.6
+                        else -> 0.2
+                    }
+                }
+            } ?: 0.5
+
+        return titleScore * 0.45 + artistScore * 0.30 + albumScore * 0.15 + durationScore * 0.10
+    }
+
+    private fun normalizedSimilarity(a: String, b: String): Double {
+        val na = a.lowercase().trim().replace(Regex("[^a-z0-9 ]"), "")
+        val nb = b.lowercase().trim().replace(Regex("[^a-z0-9 ]"), "")
+        if (na == nb) return 1.0
+        if (na.isBlank() || nb.isBlank()) return 0.0
+        val sa = na.split(" ").toSet()
+        val sb = nb.split(" ").toSet()
+        val inter = sa.intersect(sb).size.toDouble()
+        val union = sa.union(sb).size.toDouble()
+        return if (union == 0.0) 0.0 else inter / union
+    }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -7,51 +7,199 @@
 
 package moe.rukamori.archivetune.deezer
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import moe.rukamori.archivetune.audiosource.DirectStream
+import moe.rukamori.archivetune.audiosource.TrackMatching
+import moe.rukamori.archivetune.utils.PoolAccountManager
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 /**
- * Resolves a Deezer track to a directly streamable URL.
+ * Resolves playable Deezer streams for a track, mirroring the shape of
+ * [moe.rukamori.archivetune.qobuz.QobuzAudioProvider] so the two are interchangeable at the call
+ * site.
  *
- * ## Why this exists
+ * Deezer differs from Tidal/Qobuz in two ways that shape this file:
+ *  - There is no community restream tier. Every resolve runs against Deezer's own gateway using a
+ *    pooled `arl` cookie, so accounts are the only backend and [PoolAccountManager] is the only
+ *    source of them.
+ *  - The CDN never returns plain audio. Resolved URLs are wrapped in a `deezer://` URI so
+ *    [DeezerDecryptingDataSource] can undo the Blowfish chunk encryption in flight; handing the raw
+ *    CDN URL to Media3 would play noise.
  *
- * [DownloadSource.AUTO] tries Qobuz → Tidal → Deezer → YouTube Music in
- * order, picking the first source that can serve a full-quality stream
- * for the track. Deezer is included so that the AUTO source ordering
- * honours the user's explicit "prefer FLAC" intent when both Qobuz and
- * Tidal fail to match a track.
- *
- * ## Current limitations
- *
- * Deezer's public catalogue API (`https://api.deezer.com/search`) does
- * NOT expose a streamable FLAC URL — full-track streaming requires an
- * authenticated Premium session (Deezer access tokens are not stored
- * anywhere in ArchiveTune at the time of writing). The provider
- * therefore resolves a track id + metadata for downstream use (ISRC
- * matching, artwork lookup) but returns `null` for the actual stream
- * until Premium credentials are configured.
- *
- * When Premium support is added in the future, only
- * [DeezerAudioProvider.resolve] needs to change — the rest of the
- * download pipeline already routes through [DirectStream] uniformly.
- *
- * ## Public API
- *
- * Mirrors [moe.rukamori.archivetune.qobuz.QobuzAudioProvider] /
- * [moe.rukamori.archivetune.tidal.TidalAudioProvider] so the download
- * resolver can treat all three sources uniformly.
+ * All calls run blocking network I/O and must not be made from the main thread.
  */
 object DeezerAudioProvider {
+    private const val TAG = "Deezer"
+    private const val SEARCH_LIMIT = 10
+    private const val SEARCH_CACHE_MS = 10 * 60 * 1000L
+    private const val STREAM_CACHE_MS = 30 * 60 * 1000L
+    private const val FAILURE_CACHE_MS = 10 * 60 * 1000L
+
+    /** Deezer expires stream URLs well before this, but sessions are reused across resolves. */
+    private const val SESSION_TTL_MS = 45 * 60 * 1000L
+
+    private const val GATEWAY = "https://www.deezer.com/ajax/gw-light.php"
+    private const val MEDIA_ENDPOINT = "https://media.deezer.com/v1/get_url"
+    private const val USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+            "Chrome/124.0.0.0 Safari/537.36"
+
+    private const val MIME_FLAC = "audio/flac"
+    private const val MIME_MPEG = "audio/mpeg"
+
+    const val FORMAT_FLAC = "FLAC"
+    const val FORMAT_MP3_320 = "MP3_320"
+    const val FORMAT_MP3_128 = "MP3_128"
+
+    /** Deezer's tiers, best first. Ordering matters: a resolve offers the requested tier and all below. */
+    private val FORMAT_TIERS = listOf(FORMAT_FLAC, FORMAT_MP3_320, FORMAT_MP3_128)
+
+    private val client =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(6, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .callTimeout(15, TimeUnit.SECONDS)
+            .build()
 
     /**
-     * Lookup metadata for a track, mirroring Qobuz/Tidal query shape.
+     * A manually captured ARL, set by the Deezer login screen and mirrored from DataStore on startup.
+     * Held here rather than in [PoolAccountManager] because that cache is replaced wholesale on every
+     * pool refresh and is gated behind `isEnabled`, either of which would drop a user's own account.
      */
+    @Volatile
+    private var manualAccount: PoolAccountManager.DeezerPoolAccount? = null
+
+    /**
+     * Registers (or clears, on null/blank) the manually signed-in account. Cheap and idempotent, so
+     * call sites can push the current value without tracking whether it changed.
+     */
+    fun setManualArl(
+        arl: String?,
+        premium: Boolean = false,
+    ) {
+        val trimmed = arl?.trim()
+        val next =
+            if (trimmed.isNullOrEmpty()) {
+                null
+            } else {
+                // masterSecret stays null: only the pool serves an override, and DeezerCrypto falls
+                // back to the salt the app ships with.
+                PoolAccountManager.DeezerPoolAccount(arl = trimmed, premium = premium)
+            }
+        val previous = manualAccount
+        manualAccount = next
+        // Sessions are keyed by ARL, so a changed or removed credential must not keep serving from a
+        // session established under the old one.
+        if (previous != null && previous.arl != next?.arl) {
+            sessions.remove(previous.arl)
+        }
+    }
+
+    /**
+     * Every usable credential, manual first so a user's own (likely paid) account is tried before
+     * shared pool entries.
+     */
+    private fun accounts(): List<PoolAccountManager.DeezerPoolAccount> {
+        val pooled = PoolAccountManager.deezerAccounts()
+        val manual = manualAccount ?: return pooled
+        // Drop a pooled duplicate so one bad credential cannot be attempted twice per resolve.
+        return listOf(manual) + pooled.filter { it.arl != manual.arl }
+    }
+
+    /** What a manual sign-in learns about the account behind an ARL. */
+    data class AccountInfo(
+        val name: String,
+        val lossless: Boolean,
+    )
+
+    /**
+     * Checks an ARL against the gateway and reports the account behind it, or null when the cookie is
+     * not a usable credential. Runs blocking network I/O.
+     *
+     * The login screen needs this because Deezer hands out an `arl` cookie to anonymous visitors too:
+     * without verifying, a user who closed the page before signing in would be told they were signed
+     * in and then get silence on every track.
+     */
+    fun verifyArl(arl: String): AccountInfo? =
+        runCatching {
+            val json = gateway(arl.trim(), apiToken = "", method = "deezer.getUserData", payload = null)
+            val user = json.optJSONObject("results")?.optJSONObject("USER") ?: return@runCatching null
+            // An anonymous or expired ARL still returns HTTP 200, just with USER_ID 0.
+            if (user.optLong("USER_ID", 0L) == 0L) return@runCatching null
+            val options = user.optJSONObject("OPTIONS")
+            val name =
+                sequenceOf(
+                    user.optString("BLOG_NAME"),
+                    user.optString("FIRSTNAME"),
+                    user.optString("EMAIL"),
+                ).firstOrNull { it.isNotBlank() } ?: "Deezer"
+            AccountInfo(
+                name = name,
+                lossless =
+                    options?.optBoolean("web_lossless", false) == true ||
+                        options?.optBoolean("mobile_lossless", false) == true,
+            )
+        }.onFailure { Timber.tag(TAG).w(it, "ARL verification failed") }
+            .getOrNull()
+
+    /** An authenticated gateway session derived from one pooled ARL. */
+    private data class Session(
+        val arl: String,
+        val apiToken: String,
+        val licenseToken: String,
+        val lossless: Boolean,
+        val masterSecret: String?,
+        val establishedAt: Long,
+    )
+
+    /**
+     * A resolved Deezer stream, in this provider's own shape rather than the playback layer's
+     * `DirectStream`.
+     *
+     * Keeping the provider free of playback types lets it be built and tested before Deezer is wired
+     * into the source-resolution chain; the playback layer adapts this into a `DirectStream`. The
+     * `matched*` fields are the catalog metadata of the hit that was chosen, and the playback layer
+     * needs them to re-check the pick against its own `TitleMatch` gate — a stream with no matched
+     * title is rejected there, so these are not optional extras.
+     */
+    data class Resolved(
+        val uri: String,
+        val mimeType: String,
+        val codecs: String,
+        val contentLength: Long?,
+        val label: String,
+        val matchedTitle: String,
+        val matchedArtist: String?,
+        val matchedAlbum: String?,
+        val matchedDurationMs: Long?,
+        val sampleRate: Int?,
+        val bitDepth: Int?,
+    )
+
+    private class CachedStream(
+        val stream: Resolved,
+        val expiresAt: Long,
+    )
+
+    private val sessions = ConcurrentHashMap<String, Session>()
+    private val searchCache = ConcurrentHashMap<String, Pair<TrackMatching.Candidate?, Long>>()
+    private val streamCache = ConcurrentHashMap<String, CachedStream>()
+    private val failureCache = ConcurrentHashMap<String, Long>()
+
+    /** Track id of the most recent successful resolve, used by settings screens as a health probe. */
+    @Volatile
+    var lastResolvedTrackId: String? = null
+        private set
+
+    /** Mirrors the Tidal/Qobuz query shape so callers can switch providers without reshaping input. */
     data class Query(
         val mediaId: String,
         val title: String,
@@ -60,164 +208,330 @@ object DeezerAudioProvider {
         val durationMs: Long?,
     )
 
-    /**
-     * The resolved Deezer track metadata. The [previewUrl] is the
-     * 30-second preview MP3 that Deezer exposes publicly — useful for
-     * matching verification but NOT for full-song downloads.
-     */
-    data class Resolved(
-        val trackId: String,
-        val title: String,
-        val artist: String?,
-        val album: String?,
-        val isrc: String?,
-        val durationMs: Long?,
-        val previewUrl: String?,
-        val coverUrl: String?,
-    )
+    private fun Query.cacheKey(): String =
+        listOf(mediaId, title.lowercase(), artists.joinToString(",").lowercase(), album.orEmpty().lowercase())
+            .joinToString("|")
 
-    private val client: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .readTimeout(20, TimeUnit.SECONDS)
-            .followRedirects(true)
-            .build()
-    }
+    /** True when at least one Deezer account is available, manual or pooled. */
+    fun hasBackends(): Boolean = accounts().isNotEmpty()
 
-    /**
-     * Searches Deezer's public catalogue for [query] and returns the
-     * best-matching track's metadata. Returns null when no match is
-     * found or the Deezer API is unreachable.
-     *
-     * This does NOT return a streamable URL — full-track streaming
-     * requires Deezer Premium credentials, which ArchiveTune does not
-     * currently store. The returned [Resolved] is used for:
-     *   - ISRC lookup (more accurate YouTube Music matching)
-     *   - Artwork URL fallback
-     *   - Downloaded-song metadata enrichment (thumbnail, album name)
-     */
-    suspend fun lookup(query: Query): Resolved? = withContext(Dispatchers.IO) {
-        runCatching {
-            val q = buildSearchQuery(query)
-            val req = Request.Builder()
-                .url("https://api.deezer.com/search?q=${java.net.URLEncoder.encode(q, "UTF-8")}&limit=10")
-                .header("Accept", "application/json")
-                .build()
-            client.newCall(req).execute().use { res ->
-                if (!res.isSuccessful) {
-                    Timber.tag("Deezer").w("search HTTP %d for '%s'", res.code, q)
-                    return@use null
-                }
-                val body = res.body?.string() ?: return@use null
-                val root = JSONObject(body)
-                val data = root.optJSONArray("data") ?: return@use null
-                if (data.length() == 0) return@use null
-
-                // Score each candidate by normalized title + artist similarity.
-                val candidates = (0 until data.length()).mapNotNull { i ->
-                    val obj = data.optJSONObject(i) ?: return@mapNotNull null
-                    val title = obj.optString("title").ifBlank { return@mapNotNull null }
-                    val artist = obj.optJSONObject("artist")?.optString("name")?.ifBlank { null }
-                    val album = obj.optJSONObject("album")?.optString("title")?.ifBlank { null }
-                    val durationSec = obj.optLong("duration", 0L).takeIf { it > 0 }
-                    val isrc = obj.optString("isrc").ifBlank { null }
-                    val preview = obj.optString("preview").ifBlank { null }
-                    val cover = obj.optJSONObject("album")?.optString("cover_big")?.ifBlank { null }
-                    val score = scoreCandidate(query, title, artist, album, durationSec)
-                    Resolved(
-                        trackId = obj.optLong("id").toString(),
-                        title = title,
-                        artist = artist,
-                        album = album,
-                        isrc = isrc,
-                        durationMs = durationSec?.times(1000L),
-                        previewUrl = preview,
-                        coverUrl = cover,
-                    ) to score
-                }
-                val best = candidates.maxByOrNull { it.second } ?: return@use null
-                if (best.second < MIN_MATCH_SCORE) {
-                    Timber.tag("Deezer").d("best candidate score %.2f below threshold for '%s'", best.second, q)
-                    return@use null
-                }
-                best.first
-            }
-        }.getOrNull()
-    }
-
-    /**
-     * Resolves a [DirectStream] for [query]. Returns null because
-     * Deezer does not expose full-track stream URLs publicly — see
-     * class docs. Kept for API symmetry with the other providers.
-     */
-    suspend fun resolve(
+    /** Drops the cached stream for [query] at [format], forcing the next resolve to refetch. */
+    fun invalidate(
         query: Query,
-        @Suppress("UNUSED_PARAMETER") preferredQuality: String = "FLAC",
-    ): DirectStream? {
-        // Public API only returns a 30-second preview — not usable for
-        // full downloads. Return null so the AUTO resolver falls
-        // through to the next source.
-        val resolved = lookup(query) ?: return null
-        Timber
-            .tag("Deezer")
-            .d("resolved track %s ('%s') but full stream requires Premium — skipping", resolved.trackId, resolved.title)
+        format: String,
+    ) {
+        val key = query.cacheKey() + ":" + format
+        streamCache.remove(key)
+        failureCache.remove(key)
+    }
+
+    /**
+     * Resolves a playable stream for [query] at [format] (`FLAC`, `MP3_320` or `MP3_128` — see
+     * `DeezerAudioQuality.toFormatName()`), degrading to the next tier down when the account's plan
+     * does not cover the requested one.
+     *
+     * Takes the format as a plain string rather than the preference enum so this stays independent of
+     * the settings layer, matching how `QobuzAudioProvider` takes a bare `formatId`.
+     *
+     * Returns null when no pooled account can serve the track. The returned [Resolved] carries a
+     * `deezer://` URI rather than the CDN URL, because the bytes still need decrypting.
+     */
+    fun resolve(
+        query: Query,
+        format: String,
+    ): Resolved? {
+        val accounts = accounts()
+        if (accounts.isEmpty()) {
+            Timber.tag(TAG).d("resolve skipped: no manual or pooled accounts")
+            return null
+        }
+
+        val now = System.currentTimeMillis()
+        val cacheKey = query.cacheKey() + ":" + format
+        streamCache[cacheKey]?.let { cached ->
+            if (cached.expiresAt > now) return cached.stream
+            streamCache.remove(cacheKey)
+        }
+        failureCache[cacheKey]?.let { failedUntil ->
+            if (failedUntil > now) return null
+            failureCache.remove(cacheKey)
+        }
+
+        // Accounts with a paid plan come first so a FLAC request has the best chance of being served
+        // at full quality. An account whose plan cannot cover the requested tier is NOT skipped: it
+        // degrades to the highest tier it does have, so a pool of free accounts still plays the track
+        // instead of the whole source going silent.
+        val ordered = accounts.sortedByDescending { it.premium }
+        for (account in ordered) {
+            val session =
+                runCatching { session(account) }
+                    .onFailure { Timber.tag(TAG).w(it, "session failed for pooled account") }
+                    .getOrNull() ?: continue
+
+            val match =
+                runCatching { matchTrack(session, query) }
+                    .onFailure { Timber.tag(TAG).w(it, "search failed") }
+                    .getOrNull() ?: continue
+            val trackId = match.id
+
+            val media =
+                runCatching { requestUrl(session, trackId, format) }
+                    .onFailure { Timber.tag(TAG).w(it, "get_url failed for track %s", trackId) }
+                    .getOrNull()
+            if (media == null) {
+                // The session may have gone stale mid-resolve; drop it so the next attempt re-auths.
+                sessions.remove(account.arl)
+                continue
+            }
+
+            lastResolvedTrackId = trackId
+            val stream =
+                Resolved(
+                    uri = DeezerCrypto.buildUri(media.url, trackId, session.masterSecret),
+                    mimeType = if (media.flac) MIME_FLAC else MIME_MPEG,
+                    // MP3 is mpeg-layer-3, not AAC; naming it "mp4a" would mislead the extractor.
+                    codecs = if (media.flac) "flac" else "mp3",
+                    contentLength = media.contentLength,
+                    // Report the tier actually served, not the one requested, so the player does not
+                    // claim FLAC for a track that degraded to MP3.
+                    label =
+                        when (media.format.uppercase()) {
+                            FORMAT_FLAC -> "Deezer FLAC"
+                            FORMAT_MP3_320 -> "Deezer MP3 320"
+                            FORMAT_MP3_128 -> "Deezer MP3 128"
+                            else -> "Deezer"
+                        },
+                    matchedTitle = match.title,
+                    matchedArtist = match.artists.firstOrNull(),
+                    matchedAlbum = match.album,
+                    matchedDurationMs = match.durationMs,
+                    // Deezer's gateway does not report either, and FLAC here is always CD-quality, so
+                    // report the known 16/44.1 for FLAC and leave MP3 to the consumer's tier heuristic.
+                    sampleRate = if (media.flac) 44_100 else null,
+                    bitDepth = if (media.flac) 16 else null,
+                )
+            streamCache[cacheKey] = CachedStream(stream, System.currentTimeMillis() + STREAM_CACHE_MS)
+            return stream
+        }
+
+        failureCache[cacheKey] = System.currentTimeMillis() + FAILURE_CACHE_MS
         return null
     }
 
-    private fun buildSearchQuery(query: Query): String {
-        val parts = mutableListOf<String>()
-        query.artists.firstOrNull()?.takeIf(String::isNotBlank)?.let { parts.add("artist:\"$it\"") }
-        parts.add("track:\"${query.title}\"")
-        query.album?.takeIf(String::isNotBlank)?.let { parts.add("album:\"$it\"") }
-        return parts.joinToString(" ")
+    // ---------------------------------------------------------------------------------------------
+    // Session
+    // ---------------------------------------------------------------------------------------------
+
+    /** Returns a live session for [account], reusing a cached one until it ages out. */
+    private fun session(account: PoolAccountManager.DeezerPoolAccount): Session {
+        val now = System.currentTimeMillis()
+        sessions[account.arl]?.let { if (now - it.establishedAt < SESSION_TTL_MS) return it }
+
+        val json = gateway(account.arl, apiToken = "", method = "deezer.getUserData", payload = null)
+        val results = json.optJSONObject("results")
+        val user = requireNotNull(results?.optJSONObject("USER")) { "no USER in session payload" }
+        // An invalid or expired ARL still returns HTTP 200 with USER_ID 0, so this is the real check.
+        require(user.optLong("USER_ID", 0L) != 0L) { "ARL rejected by gateway" }
+
+        val options = requireNotNull(user.optJSONObject("OPTIONS")) { "no OPTIONS in session payload" }
+        val licenseToken = options.optString("license_token")
+        require(licenseToken.isNotBlank()) { "no license_token in session" }
+
+        val apiToken = results?.optString("checkForm").orEmpty()
+        require(apiToken.isNotBlank()) { "no api token in session" }
+
+        val session =
+            Session(
+                arl = account.arl,
+                apiToken = apiToken,
+                licenseToken = licenseToken,
+                // Entitlement lives in flat OPTIONS booleans. Check both the web and mobile flags: a
+                // plan can carry lossless on one surface only, and either is enough for us to ask for
+                // FLAC. The pool's own `premium` hint only orders attempts; this is the real gate.
+                lossless =
+                    options.optBoolean("web_lossless", false) ||
+                        options.optBoolean("mobile_lossless", false),
+                masterSecret = account.masterSecret,
+                establishedAt = now,
+            )
+        sessions[account.arl] = session
+        return session
     }
 
-    private fun scoreCandidate(
+    private fun gateway(
+        arl: String,
+        apiToken: String,
+        method: String,
+        payload: JSONObject?,
+    ): JSONObject {
+        val url =
+            GATEWAY
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("method", method)
+                .addQueryParameter("input", "3")
+                .addQueryParameter("api_version", "1.0")
+                .addQueryParameter("api_token", apiToken)
+                .build()
+        val body = (payload ?: JSONObject()).toString().toRequestBody(JSON_MEDIA)
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .header("User-Agent", USER_AGENT)
+                .header("Cookie", "arl=$arl")
+                .post(body)
+                .build()
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw java.io.IOException("gateway HTTP ${response.code}")
+            return JSONObject(response.body?.string().orEmpty())
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Search
+    // ---------------------------------------------------------------------------------------------
+
+    /** Finds the Deezer track id that best matches [query], or null when nothing scores high enough. */
+    private fun matchTrack(
+        session: Session,
         query: Query,
-        candidateTitle: String,
-        candidateArtist: String?,
-        candidateAlbum: String?,
-        candidateDurationSec: Long?,
-    ): Double {
-        val titleScore = normalizedSimilarity(query.title, candidateTitle)
-        val artistScore = query.artists.firstOrNull()?.let { a ->
-            candidateArtist?.let { c -> normalizedSimilarity(a, c) }
-        } ?: 0.0
-        val albumScore = query.album?.let { q ->
-            candidateAlbum?.let { c -> normalizedSimilarity(q, c) }
-        } ?: 0.5
-        val durationScore = query.durationMs?.let { qd ->
-            candidateDurationSec?.let { cs ->
-                val cd = cs * 1000L
-                val diff = kotlin.math.abs(qd - cd)
-                when {
-                    diff < 2_000L -> 1.0
-                    diff < 5_000L -> 0.85
-                    diff < 10_000L -> 0.6
-                    else -> 0.2
-                }
+    ): TrackMatching.Candidate? {
+        val key = query.cacheKey()
+        val now = System.currentTimeMillis()
+        searchCache[key]?.let { (candidate, expiresAt) ->
+            if (expiresAt > now) return candidate
+            searchCache.remove(key)
+        }
+
+        val terms = listOf(query.title) + query.artists.take(1)
+        val payload =
+            JSONObject()
+                .put("query", terms.joinToString(" ").trim())
+                .put("start", 0)
+                .put("nb", SEARCH_LIMIT)
+        val json = gateway(session.arl, session.apiToken, "search.music", payload)
+        val data = json.optJSONObject("results")?.optJSONArray("data") ?: JSONArray()
+
+        val candidates =
+            (0 until data.length()).mapNotNull { i ->
+                val obj = data.optJSONObject(i) ?: return@mapNotNull null
+                val id = obj.optString("SNG_ID").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                TrackMatching.Candidate(
+                    id = id,
+                    title = obj.optString("SNG_TITLE"),
+                    artists = listOfNotNull(obj.optString("ART_NAME").takeIf { it.isNotBlank() }),
+                    album = obj.optString("ALB_TITLE").takeIf { it.isNotBlank() },
+                    // Deezer reports duration in whole seconds.
+                    durationMs = obj.optLong("DURATION", 0L).takeIf { it > 0L }?.times(1000L),
+                )
             }
-        } ?: 0.5
 
-        // Title is the most important signal, then artist, then album, then duration.
-        return titleScore * 0.45 + artistScore * 0.30 + albumScore * 0.15 + durationScore * 0.10
+        val best =
+            TrackMatching.best(
+                target =
+                    TrackMatching.Target(
+                        title = query.title,
+                        artists = query.artists,
+                        album = query.album,
+                        durationMs = query.durationMs,
+                    ),
+                candidates = candidates,
+            )
+        searchCache[key] = best to (now + SEARCH_CACHE_MS)
+        return best
     }
 
-    private fun normalizedSimilarity(a: String, b: String): Double {
-        val na = a.lowercase().trim().replace(Regex("[^a-z0-9 ]"), "")
-        val nb = b.lowercase().trim().replace(Regex("[^a-z0-9 ]"), "")
-        if (na == nb) return 1.0
-        if (na.isBlank() || nb.isBlank()) return 0.0
-        // Simple token-overlap similarity (Jaccard).
-        val sa = na.split(" ").toSet()
-        val sb = nb.split(" ").toSet()
-        val inter = sa.intersect(sb).size.toDouble()
-        val union = sa.union(sb).size.toDouble()
-        return if (union == 0.0) 0.0 else inter / union
+    // ---------------------------------------------------------------------------------------------
+    // Stream URL
+    // ---------------------------------------------------------------------------------------------
+
+    private class Media(
+        val url: String,
+        val flac: Boolean,
+        /** The tier the gateway served, which may be lower than the one requested. */
+        val format: String,
+        val contentLength: Long?,
+    )
+
+    /**
+     * Exchanges a track id for a CDN URL via the media endpoint.
+     *
+     * Deezer needs the track's per-format `TRACK_TOKEN` (not the numeric id) here, so this makes a
+     * second gateway call to fetch it before asking for the URL.
+     */
+    private fun requestUrl(
+        session: Session,
+        trackId: String,
+        format: String,
+    ): Media? {
+        val trackJson =
+            gateway(
+                session.arl,
+                session.apiToken,
+                "song.getData",
+                JSONObject().put("sng_id", trackId),
+            )
+        val trackToken = trackJson.optJSONObject("results")?.optString("TRACK_TOKEN").orEmpty()
+        if (trackToken.isBlank()) return null
+
+        // Offer the requested tier and everything below it in one request, so a track with no lossless
+        // master (or an account without the entitlement) still plays at the best available quality
+        // instead of failing the resolve. FLAC is dropped when the plan does not cover it, otherwise
+        // the gateway would answer with an empty media list.
+        val requested = if (format == FORMAT_FLAC && !session.lossless) FORMAT_MP3_320 else format
+        val formats = FORMAT_TIERS.dropWhile { it != requested }.ifEmpty { listOf(FORMAT_MP3_320, FORMAT_MP3_128) }
+        val formatArray = JSONArray()
+        formats.forEach { tier ->
+            formatArray.put(JSONObject().put("cipher", "BF_CBC_STRIPE").put("format", tier))
+        }
+        val mediaArray =
+            JSONArray().put(
+                JSONObject()
+                    .put("type", "FULL")
+                    .put("formats", formatArray),
+            )
+        val cipherPayload =
+            JSONObject()
+                .put("license_token", session.licenseToken)
+                .put("media", mediaArray)
+                .put("track_tokens", JSONArray().put(trackToken))
+
+        val request =
+            Request
+                .Builder()
+                .url(MEDIA_ENDPOINT)
+                .header("User-Agent", USER_AGENT)
+                .header("Cookie", "arl=${session.arl}")
+                .post(cipherPayload.toString().toRequestBody(JSON_MEDIA))
+                .build()
+
+        val json =
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw java.io.IOException("get_url HTTP ${response.code}")
+                JSONObject(response.body?.string().orEmpty())
+            }
+
+        val first = json.optJSONArray("data")?.optJSONObject(0) ?: return null
+        val media = first.optJSONArray("media")?.optJSONObject(0) ?: return null
+        val source = media.optJSONArray("sources")?.optJSONObject(0) ?: return null
+        val url = source.optString("url").takeIf { it.isNotBlank() } ?: return null
+        // The tier the gateway actually served, which may be lower than the one requested.
+        val servedFormat = media.optString("format")
+        val flac = servedFormat.equals(FORMAT_FLAC, ignoreCase = true)
+
+        // song.getData carries a per-format size (FILESIZE_FLAC, FILESIZE_MP3_320, ...). The encrypted
+        // stream is byte-for-byte the same length as the decrypted one because BF_CBC_STRIPE adds no
+        // padding, so this size is valid for the decrypted output and saves a HEAD probe. Null is fine:
+        // DirectStream treats an unknown length as "ask the CDN".
+        val sizeField = "FILESIZE_${servedFormat.uppercase()}"
+        val results = trackJson.optJSONObject("results")
+        val contentLength =
+            results?.optString(sizeField)?.toLongOrNull()?.takeIf { it > 0L }
+                ?: results?.optString("FILESIZE")?.toLongOrNull()?.takeIf { it > 0L }
+
+        return Media(url = url, flac = flac, format = servedFormat, contentLength = contentLength)
     }
 
-    /** Cache-key prefix used by DownloadUtil for Deezer-resolved streams. */
-    const val CACHE_KEY_PREFIX = "deezer:"
-
-    private const val MIN_MATCH_SCORE = 0.55
+    private val JSON_MEDIA = "application/json; charset=utf-8".toMediaTypeOrNull()
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -556,9 +556,9 @@ object DeezerAudioProvider {
      * Searches Deezer's public catalogue for [query] and returns the best-matching track's metadata.
      * Returns null when no match is found or the Deezer API is unreachable.
      *
-     * This does NOT return a streamable URL — full-track streaming requires Deezer Premium
-     * credentials. The returned [Resolved] is used for ISRC lookup, artwork fallback, and
-     * downloaded-song metadata enrichment.
+     * Unlike [resolve] this hits Deezer's public API and needs no account, so it returns catalogue
+     * metadata only and never a playable URL. Used for artwork and album-name fallback on downloaded
+     * songs, where a missing field is worth a cheap unauthenticated lookup but silence is not.
      */
     suspend fun lookup(query: Query): Metadata? =
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerCrypto.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerCrypto.kt
@@ -1,0 +1,145 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ */
+
+package moe.rukamori.archivetune.deezer
+
+import android.net.Uri
+import androidx.core.net.toUri
+import java.security.MessageDigest
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Blowfish stream layout used by Deezer's CDN, plus the `deezer://` URI wrapper that carries a
+ * resolved stream from [DeezerAudioProvider] to [DeezerDecryptingDataSource].
+ *
+ * Deezer does not serve plain audio: the CDN returns the file in fixed 2048-byte chunks where every
+ * third chunk is Blowfish-CBC encrypted under a key derived from the track id, and the rest are
+ * plaintext. So there is no URL we could hand to Media3 directly — the bytes have to be transformed
+ * in flight, which is why a custom DataSource exists at all.
+ *
+ * The chunk layout is what makes seeking survivable. Each encrypted chunk restarts from the same
+ * fixed IV instead of chaining into the next one, so any chunk can be decrypted without having read
+ * the ones before it. That is the property [DeezerDecryptingDataSource] relies on to seek: it snaps
+ * a requested byte offset down to a chunk boundary rather than having to stream from zero.
+ */
+internal object DeezerCrypto {
+    /** Deezer's CDN chunk size. Encryption applies per whole chunk, so this is also the seek grain. */
+    const val CHUNK_SIZE = 2048
+
+    /** Only every third chunk is encrypted; the other two are stored as plaintext. */
+    const val ENCRYPTED_CHUNK_STRIDE = 3
+
+    /** Scheme for the internal URI that wraps a resolved Deezer stream. */
+    const val SCHEME = "deezer"
+
+    private const val PARAM_URL = "u"
+    private const val PARAM_KEY = "k"
+    private const val PARAM_SALT = "s"
+
+    /**
+     * Fixed key-derivation salt for the per-track Blowfish key. Deezer reuses one constant for every
+     * track and derives the actual key from the track id, so this alone unlocks nothing — resolving a
+     * playable CDN URL still requires an authenticated account (see [DeezerAudioProvider]).
+     */
+    const val DEFAULT_KEY_SALT = "g4el58wc0zvf9na1"
+
+    /** Deezer restarts every encrypted chunk from this same IV, which is what makes chunks seekable. */
+    private val CHUNK_IV = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7)
+
+    /**
+     * Derives the 16-byte Blowfish key for [trackId] by XOR-folding the two halves of the track id's
+     * MD5 against [salt], which defaults to [DEFAULT_KEY_SALT].
+     *
+     * Note this consumes the MD5 as lowercase hex *text*, not as raw digest bytes — the bytes of the
+     * hex characters are what get XORed. Using the raw digest yields a wrong key that still decrypts
+     * without error, producing plausible-looking noise instead of a failure, so this stays explicit.
+     */
+    fun deriveKey(
+        trackId: String,
+        salt: String = DEFAULT_KEY_SALT,
+    ): ByteArray {
+        // A short override would index out of bounds below, and a wrong-length salt cannot be the
+        // real one anyway, so fall back rather than crash on a bad pool payload.
+        val effective = if (salt.length >= 16) salt else DEFAULT_KEY_SALT
+        val md5Hex =
+            MessageDigest
+                .getInstance("MD5")
+                .digest(trackId.toByteArray(Charsets.UTF_8))
+                .joinToString("") { "%02x".format(it) }
+        return ByteArray(16) { i ->
+            (md5Hex[i].code xor md5Hex[i + 16].code xor effective[i].code).toByte()
+        }
+    }
+
+    /** True when the chunk at absolute [chunkIndex] is encrypted rather than stored plaintext. */
+    fun isEncryptedChunk(chunkIndex: Long): Boolean = chunkIndex % ENCRYPTED_CHUNK_STRIDE == 0L
+
+    /**
+     * Decrypts one whole chunk in place, in-place over the first [length] bytes of [chunk].
+     *
+     * [length] must be a multiple of the Blowfish 8-byte block size; callers only ever pass a
+     * complete [CHUNK_SIZE] chunk, because a trailing short chunk is never encrypted in the first
+     * place and must be passed through untouched.
+     */
+    fun decryptChunk(
+        chunk: ByteArray,
+        length: Int,
+        key: ByteArray,
+    ) {
+        if (length < 8) return
+        // Any remainder past the last whole 8-byte block is stored as-is and must not be fed to the
+        // cipher, which would throw on a partial block.
+        val decryptable = length - (length % 8)
+        val cipher = Cipher.getInstance("Blowfish/CBC/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "Blowfish"), IvParameterSpec(CHUNK_IV))
+        cipher.doFinal(chunk, 0, decryptable, chunk, 0)
+    }
+
+    /**
+     * Wraps a real CDN [url] and its [trackId] into a `deezer://` URI.
+     *
+     * The scheme exists so the existing scheme-routing DataSources in `MusicService` and
+     * `DownloadUtil` can dispatch Deezer bytes to the decrypting source the same way they already
+     * dispatch `telegram://`. The track id rides along because the decryption key derives from it and
+     * the DataSource has no other way to recover it.
+     */
+    fun buildUri(
+        url: String,
+        trackId: String,
+        salt: String? = null,
+    ): String =
+        Uri
+            .Builder()
+            .scheme(SCHEME)
+            .authority("stream")
+            .appendQueryParameter(PARAM_URL, url)
+            .appendQueryParameter(PARAM_KEY, trackId)
+            .apply {
+                // Only carried when a pool account overrode it, so ordinary URIs stay short.
+                if (!salt.isNullOrBlank() && salt != DEFAULT_KEY_SALT) {
+                    appendQueryParameter(PARAM_SALT, salt)
+                }
+            }.build()
+            .toString()
+
+    /** A resolved Deezer stream recovered from a [buildUri] URI. */
+    data class StreamRef(
+        val url: Uri,
+        val trackId: String,
+        val salt: String,
+    )
+
+    /** The CDN URL, track id and key salt carried by a [buildUri] URI, or null when [uri] is not one. */
+    fun parseUri(uri: Uri): StreamRef? {
+        if (!uri.scheme.equals(SCHEME, ignoreCase = true)) return null
+        val url = uri.getQueryParameter(PARAM_URL)?.takeIf { it.isNotBlank() } ?: return null
+        val trackId = uri.getQueryParameter(PARAM_KEY)?.takeIf { it.isNotBlank() } ?: return null
+        val salt = uri.getQueryParameter(PARAM_SALT)?.takeIf { it.isNotBlank() } ?: DEFAULT_KEY_SALT
+        return StreamRef(url.toUri(), trackId, salt)
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerDecryptingDataSource.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerDecryptingDataSource.kt
@@ -1,0 +1,218 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * Media3 DataSource that streams a Deezer CDN file and Blowfish-decrypts it in flight, so the
+ * extractor above it sees an ordinary FLAC/MP3 byte stream.
+ *
+ * This is deliberately a DataSource rather than a standalone downloader. Downloads in this app run
+ * through Media3's DownloadManager over the same DataSource factory as playback, so implementing
+ * Deezer here means downloading, caching, tag embedding and codec reporting all keep working with no
+ * Deezer-specific code in those paths. An external HTTP download loop is what produced corrupted
+ * files and unreadable tags in earlier attempts at Deezer support elsewhere.
+ */
+
+package moe.rukamori.archivetune.deezer
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import timber.log.Timber
+import java.io.IOException
+import kotlin.math.min
+
+/**
+ * Wraps [upstreamFactory] (an HTTP source) and decrypts Deezer's chunked Blowfish stream.
+ *
+ * Reads are served out of a one-chunk buffer: a whole 2048-byte chunk is pulled from upstream,
+ * decrypted if its absolute index says it is encrypted, and then drained to the caller across as many
+ * [read] calls as it takes. Buffering a whole chunk is required rather than an optimisation — a chunk
+ * cannot be decrypted until all of it has arrived.
+ */
+internal class DeezerDecryptingDataSource(
+    private val upstreamFactory: DataSource.Factory,
+) : BaseDataSource(true) {
+    private var upstream: DataSource? = null
+    private var currentUri: Uri? = null
+    private var key: ByteArray? = null
+
+    private val chunk = ByteArray(DeezerCrypto.CHUNK_SIZE)
+
+    /** Valid decrypted bytes currently held in [chunk], and how far the caller has drained them. */
+    private var chunkLength = 0
+    private var chunkOffset = 0
+
+    /** Absolute index of the next chunk to fetch, which decides whether it is encrypted. */
+    private var nextChunkIndex = 0L
+
+    /** Bytes still owed to the caller, or [C.LENGTH_UNSET] when the total length is unknown. */
+    private var bytesRemaining = C.LENGTH_UNSET.toLong()
+
+    private var opened = false
+
+    override fun open(dataSpec: DataSpec): Long {
+        val ref =
+            DeezerCrypto.parseUri(dataSpec.uri)
+                ?: throw IOException("Not a Deezer stream URI: ${dataSpec.uri}")
+        val realUri = ref.url
+
+        key = DeezerCrypto.deriveKey(ref.trackId, ref.salt)
+        currentUri = dataSpec.uri
+
+        // Snap the requested offset down to a chunk boundary. Encrypted chunks are only decryptable
+        // as whole chunks, so a seek landing mid-chunk has to re-fetch from that chunk's start and
+        // throw away the bytes before the target; without this, seeks decode garbage.
+        val requestedPosition = dataSpec.position
+        val alignedPosition = requestedPosition - (requestedPosition % DeezerCrypto.CHUNK_SIZE)
+        val discardCount = (requestedPosition - alignedPosition).toInt()
+        nextChunkIndex = alignedPosition / DeezerCrypto.CHUNK_SIZE
+
+        // Ask upstream for the discarded prefix too, otherwise a bounded request would come up short
+        // by exactly discardCount bytes at the end of the range.
+        val upstreamLength =
+            if (dataSpec.length == C.LENGTH_UNSET.toLong()) {
+                C.LENGTH_UNSET.toLong()
+            } else {
+                dataSpec.length + discardCount
+            }
+
+        // Deliberately not forwarding our transfer listeners to the upstream source: this class already
+        // reports every byte it hands out via bytesTransferred, and registering the same listeners
+        // downstream would count each byte twice in the bandwidth meter.
+        val source = upstreamFactory.createDataSource()
+        upstream = source
+
+        val upstreamLengthReported =
+            source.open(
+                dataSpec
+                    .buildUpon()
+                    .setUri(realUri)
+                    .setPosition(alignedPosition)
+                    .setLength(upstreamLength)
+                    .build(),
+            )
+
+        bytesRemaining =
+            when {
+                dataSpec.length != C.LENGTH_UNSET.toLong() -> dataSpec.length
+                upstreamLengthReported == C.LENGTH_UNSET.toLong() -> C.LENGTH_UNSET.toLong()
+                // Report the length the caller sees, which excludes the prefix we are about to drop.
+                else -> (upstreamLengthReported - discardCount).coerceAtLeast(0L)
+            }
+
+        opened = true
+        transferStarted(dataSpec)
+
+        // Drop the pre-seek remainder of the first chunk before returning, so the very first read()
+        // already starts at the byte the caller asked for.
+        if (discardCount > 0) discardFully(discardCount)
+
+        return bytesRemaining
+    }
+
+    override fun read(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Int {
+        if (length == 0) return 0
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+
+        if (chunkOffset >= chunkLength && !fillChunk()) return C.RESULT_END_OF_INPUT
+
+        var available = chunkLength - chunkOffset
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) {
+            available = min(available.toLong(), bytesRemaining).toInt()
+        }
+        val toCopy = min(length, available)
+        if (toCopy == 0) return C.RESULT_END_OF_INPUT
+
+        chunk.copyInto(buffer, offset, chunkOffset, chunkOffset + toCopy)
+        chunkOffset += toCopy
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) bytesRemaining -= toCopy
+        bytesTransferred(toCopy)
+        return toCopy
+    }
+
+    /**
+     * Pulls the next whole chunk from upstream and decrypts it when required. Returns false at
+     * end of stream.
+     */
+    private fun fillChunk(): Boolean {
+        val source = upstream ?: return false
+        var filled = 0
+        // Loop because a single upstream read is free to return fewer bytes than asked, and a chunk
+        // that is short only because of a partial read must not be mistaken for the final chunk.
+        while (filled < DeezerCrypto.CHUNK_SIZE) {
+            val read = source.read(chunk, filled, DeezerCrypto.CHUNK_SIZE - filled)
+            if (read == C.RESULT_END_OF_INPUT) break
+            filled += read
+        }
+        if (filled == 0) return false
+
+        // A trailing partial chunk is stored plaintext, so only decrypt a chunk that came back whole.
+        if (filled == DeezerCrypto.CHUNK_SIZE && DeezerCrypto.isEncryptedChunk(nextChunkIndex)) {
+            val chunkKey = key ?: return false
+            try {
+                DeezerCrypto.decryptChunk(chunk, filled, chunkKey)
+            } catch (e: Exception) {
+                // Surface as an IOException so the player treats it as a source failure and can fall
+                // through to the next audio source, rather than crashing on a crypto exception.
+                throw IOException("Deezer chunk decryption failed at index $nextChunkIndex", e)
+            }
+        }
+
+        nextChunkIndex++
+        chunkLength = filled
+        chunkOffset = 0
+        return true
+    }
+
+    /** Drops exactly [count] decrypted bytes, used to honour a mid-chunk seek offset. */
+    private fun discardFully(count: Int) {
+        var left = count
+        while (left > 0) {
+            if (chunkOffset >= chunkLength && !fillChunk()) return
+            val skip = min(left, chunkLength - chunkOffset)
+            chunkOffset += skip
+            left -= skip
+        }
+    }
+
+    override fun getUri(): Uri? = currentUri
+
+    override fun getResponseHeaders(): Map<String, List<String>> = upstream?.responseHeaders ?: emptyMap()
+
+    override fun close() {
+        chunkLength = 0
+        chunkOffset = 0
+        key = null
+        currentUri = null
+        bytesRemaining = C.LENGTH_UNSET.toLong()
+        try {
+            upstream?.close()
+        } catch (e: IOException) {
+            Timber.tag(TAG).w(e, "Failed to close Deezer upstream")
+        } finally {
+            upstream = null
+            if (opened) {
+                opened = false
+                transferEnded()
+            }
+        }
+    }
+
+    class Factory(
+        private val upstreamFactory: DataSource.Factory,
+    ) : DataSource.Factory {
+        override fun createDataSource(): DataSource = DeezerDecryptingDataSource(upstreamFactory)
+    }
+
+    private companion object {
+        private const val TAG = "DeezerDataSource"
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -71,6 +71,8 @@ import moe.rukamori.archivetune.ui.screens.settings.TidalLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.TIDAL_LOGIN_ROUTE
 import moe.rukamori.archivetune.ui.screens.settings.QobuzLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.QOBUZ_LOGIN_ROUTE
+import moe.rukamori.archivetune.ui.screens.settings.DeezerLoginScreen
+import moe.rukamori.archivetune.ui.screens.settings.DEEZER_LOGIN_ROUTE
 import moe.rukamori.archivetune.ui.screens.settings.TELEGRAM_LOGIN_ROUTE
 import moe.rukamori.archivetune.ui.screens.settings.TelegramLoginScreen
 import moe.rukamori.archivetune.ui.screens.settings.TelegramSettings
@@ -508,6 +510,9 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable(QOBUZ_LOGIN_ROUTE) {
         QobuzLoginScreen(navController)
+    }
+    composable(DEEZER_LOGIN_ROUTE) {
+        DeezerLoginScreen(navController)
     }
     composable("settings/telegram") {
         TelegramSettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerLoginScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerLoginScreen.kt
@@ -1,0 +1,180 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ *
+ * WebView-based Deezer sign-in. Deezer has no OAuth flow we can use, so the credential is the `arl`
+ * session cookie the site sets on a signed-in browser. Mirrors the [TidalLoginScreen] WebView
+ * pattern and persists the cookie to DataStore.
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import android.annotation.SuppressLint
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.datastore.preferences.core.edit
+import androidx.navigation.NavController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.DeezerAccountNameKey
+import moe.rukamori.archivetune.constants.DeezerAccountPremiumKey
+import moe.rukamori.archivetune.constants.DeezerArlKey
+import moe.rukamori.archivetune.constants.DeezerEnabledKey
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.dataStore
+import moe.rukamori.archivetune.utils.resetAuthWebViewSession
+import java.util.concurrent.atomic.AtomicBoolean
+
+const val DEEZER_LOGIN_ROUTE = "settings/deezer/login"
+
+private const val LOGIN_URL = "https://www.deezer.com/login"
+
+/** Cookies are read for this origin; the `arl` cookie is scoped to `.deezer.com`. */
+private const val COOKIE_ORIGIN = "https://www.deezer.com"
+
+@SuppressLint("SetJavaScriptEnabled")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeezerLoginScreen(navController: NavController) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    // The cookie appears while the page is still navigating, so onPageFinished can fire several more
+    // times with it present. Without this guard each one would kick off its own verification.
+    val handled = remember { AtomicBoolean(false) }
+    // Deliberately remembered state, unlike the plain `var` in TidalLoginScreen/QobuzLoginScreen: a
+    // plain local resets to null on recomposition (the AndroidView factory only runs once) and never
+    // triggers one, which leaves the BackHandler below permanently disabled. Those two screens have
+    // the same latent bug; it is not fixed here to avoid touching unrelated flows.
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    fun toast(message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    }
+
+    /**
+     * Pulls `arl` out of the cookie jar. Read through [CookieManager] rather than `document.cookie`
+     * because the cookie is HttpOnly and therefore invisible to JavaScript.
+     */
+    fun readArl(): String? =
+        CookieManager
+            .getInstance()
+            .getCookie(COOKIE_ORIGIN)
+            ?.split(';')
+            ?.firstNotNullOfOrNull { part ->
+                val (name, value) = part.split('=', limit = 2).takeIf { it.size == 2 } ?: return@firstNotNullOfOrNull null
+                value.trim().takeIf { name.trim().equals("arl", ignoreCase = true) && it.isNotEmpty() }
+            }
+
+    fun finishLogin(arl: String) {
+        scope.launch {
+            // Verify before saving: Deezer also issues an `arl` to anonymous visitors, so its mere
+            // presence does not mean anyone signed in.
+            val info = withContext(Dispatchers.IO) { DeezerAudioProvider.verifyArl(arl) }
+            if (info == null) {
+                // Not signed in yet (or the cookie is stale) — let the user keep going rather than
+                // closing the screen on them.
+                handled.set(false)
+                return@launch
+            }
+            context.dataStore.edit { prefs ->
+                prefs[DeezerArlKey] = arl
+                prefs[DeezerAccountNameKey] = info.name
+                prefs[DeezerAccountPremiumKey] = info.lossless
+                // Signing in is an explicit opt-in to the source, which defaults off; leaving it off
+                // would make a successful login look like it did nothing.
+                prefs[DeezerEnabledKey] = true
+            }
+            // Push it immediately so playback works without waiting for the App-level collector.
+            DeezerAudioProvider.setManualArl(arl, info.lossless)
+            toast(context.getString(R.string.deezer_login_success, info.name))
+            navController.navigateUp()
+        }
+    }
+
+    AndroidView(
+        modifier =
+            Modifier
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+                .fillMaxSize(),
+        factory = { ctx ->
+            WebView(ctx).apply {
+                webViewClient =
+                    object : WebViewClient() {
+                        override fun onPageFinished(
+                            view: WebView,
+                            url: String?,
+                        ) {
+                            // Checked on every completed navigation rather than on a single redirect
+                            // URL: Deezer has no post-login redirect we control, and the cookie can
+                            // land on any of several pages depending on how the account signs in.
+                            val arl = readArl() ?: return
+                            if (!handled.compareAndSet(false, true)) return
+                            finishLogin(arl)
+                        }
+                    }
+                settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    setSupportZoom(true)
+                    builtInZoomControls = true
+                    displayZoomControls = false
+                }
+                webView = this
+                // Clearing cookies first means an already-signed-in browser session cannot hand back
+                // a stale ARL for an account the user is trying to switch away from.
+                resetAuthWebViewSession(ctx, this, clearCookies = true) {
+                    CookieManager.getInstance().setAcceptCookie(true)
+                    CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+                    loadUrl(LOGIN_URL)
+                }
+            }
+        },
+    )
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.deezer_login)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+    )
+
+    BackHandler(enabled = webView?.canGoBack() == true) {
+        webView?.goBack()
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
@@ -5,10 +5,8 @@
  * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
  *
  * Deezer integration settings. Reached from the Integration screen alongside
- * Tidal/Qobuz. Currently the Deezer provider only resolves metadata (track id,
- * ISRC, artwork) — full Premium streaming requires credentials that aren't
- * stored yet. This screen surfaces that status and will host the login flow
- * when it's implemented.
+ * Tidal/Qobuz. Hosts the entry point to the Deezer login flow, which captures
+ * an `arl` cookie so the provider can resolve full Premium streams.
  */
 
 package moe.rukamori.archivetune.ui.screens.settings
@@ -22,7 +20,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -31,12 +28,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.utils.backToMain
 
@@ -75,19 +71,12 @@ fun DeezerSettings(navController: NavController) {
                 title = stringResource(R.string.deezer_integration),
             ) {
                 item {
-                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
-                        Text(
-                            text = stringResource(R.string.deezer_integration_description),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Spacer(Modifier.height(12.dp))
-                        Text(
-                            text = stringResource(R.string.deezer_settings_status_pending),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.deezer_login)) },
+                        description = stringResource(R.string.deezer_login_description),
+                        icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
+                        onClick = { navController.navigate(DEEZER_LOGIN_ROUTE) },
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/PoolAccountManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/PoolAccountManager.kt
@@ -51,6 +51,7 @@ object PoolAccountManager {
 
     private val CACHE_TIDAL_KEY = stringPreferencesKey("poolTidalAccounts")
     private val CACHE_QOBUZ_KEY = stringPreferencesKey("poolQobuzAccounts")
+    private val CACHE_DEEZER_KEY = stringPreferencesKey("poolDeezerAccounts")
 
     /** A shared Tidal subscriber token contributed to the pool. */
     data class TidalPoolAccount(
@@ -68,11 +69,27 @@ object PoolAccountManager {
         val premium: Boolean,
     )
 
+    /**
+     * A shared Deezer subscriber credential.
+     *
+     * Deezer authenticates with the `arl` cookie rather than a bearer token, and [premium] false means
+     * the account has no lossless entitlement, so it can still serve MP3 but will refuse FLAC.
+     */
+    data class DeezerPoolAccount(
+        val arl: String,
+        val premium: Boolean,
+        /** Optional override for the Blowfish key salt; null means use the salt the app ships with. */
+        val masterSecret: String? = null,
+    )
+
     @Volatile
     private var tidalCache: List<TidalPoolAccount> = emptyList()
 
     @Volatile
     private var qobuzCache: List<QobuzPoolAccount> = emptyList()
+
+    @Volatile
+    private var deezerCache: List<DeezerPoolAccount> = emptyList()
 
     @Volatile
     private var lastRefreshAt = 0L
@@ -107,7 +124,9 @@ object PoolAccountManager {
 
     fun qobuzAccounts(): List<QobuzPoolAccount> = qobuzCache.sortedByDescending { it.premium }
 
-    fun hasAccounts(): Boolean = tidalCache.isNotEmpty() || qobuzCache.isNotEmpty()
+    fun deezerAccounts(): List<DeezerPoolAccount> = deezerCache.sortedByDescending { it.premium }
+
+    fun hasAccounts(): Boolean = tidalCache.isNotEmpty() || qobuzCache.isNotEmpty() || deezerCache.isNotEmpty()
 
     /**
      * Loads the persisted account cache into memory (cheap, no network). Safe to call repeatedly;
@@ -124,8 +143,16 @@ object PoolAccountManager {
                 context.dataStore.getAsync(CACHE_QOBUZ_KEY)?.takeIf { it.isNotBlank() }?.let {
                     qobuzCache = parseQobuz(JSONArray(it))
                 }
+                context.dataStore.getAsync(CACHE_DEEZER_KEY)?.takeIf { it.isNotBlank() }?.let {
+                    deezerCache = parseDeezer(JSONArray(it))
+                }
                 loadedFromDisk = true
-                Timber.tag(TAG).d("Loaded cached accounts: tidal=%d qobuz=%d", tidalCache.size, qobuzCache.size)
+                Timber.tag(TAG).d(
+                    "Loaded cached accounts: tidal=%d qobuz=%d deezer=%d",
+                    tidalCache.size,
+                    qobuzCache.size,
+                    deezerCache.size,
+                )
             }.onFailure { Timber.tag(TAG).w(it, "Failed to load cached pool accounts") }
         }
     }
@@ -167,11 +194,18 @@ object PoolAccountManager {
                         val root = JSONObject(response.body?.string().orEmpty())
                         val tidal = parseTidal(root.optJSONObject("tidal")?.optJSONArray("accounts"))
                         val qobuz = parseQobuz(root.optJSONObject("qobuz")?.optJSONArray("accounts"))
+                        val deezer = parseDeezer(root.optJSONObject("deezer")?.optJSONArray("accounts"))
                         tidalCache = tidal
                         qobuzCache = qobuz
+                        deezerCache = deezer
                         lastRefreshAt = System.currentTimeMillis()
-                        persist(context, tidal, qobuz)
-                        Timber.tag(TAG).i("Pool accounts refreshed: tidal=%d qobuz=%d", tidal.size, qobuz.size)
+                        persist(context, tidal, qobuz, deezer)
+                        Timber.tag(TAG).i(
+                            "Pool accounts refreshed: tidal=%d qobuz=%d deezer=%d",
+                            tidal.size,
+                            qobuz.size,
+                            deezer.size,
+                        )
                     }
                 }.onFailure { Timber.tag(TAG).w(it, "Pool account refresh failed") }
                 hasAccounts()
@@ -182,6 +216,7 @@ object PoolAccountManager {
         context: Context,
         tidal: List<TidalPoolAccount>,
         qobuz: List<QobuzPoolAccount>,
+        deezer: List<DeezerPoolAccount>,
     ) {
         val tidalJson =
             JSONArray().apply {
@@ -207,10 +242,22 @@ object PoolAccountManager {
                     )
                 }
             }.toString()
+        val deezerJson =
+            JSONArray().apply {
+                deezer.forEach {
+                    put(
+                        JSONObject()
+                            .put("arl", it.arl)
+                            .put("masterSecret", it.masterSecret)
+                            .put("premium", it.premium),
+                    )
+                }
+            }.toString()
         runCatching {
             context.dataStore.edit { prefs ->
                 prefs[CACHE_TIDAL_KEY] = tidalJson
                 prefs[CACHE_QOBUZ_KEY] = qobuzJson
+                prefs[CACHE_DEEZER_KEY] = deezerJson
             }
         }.onFailure { Timber.tag(TAG).w(it, "Failed to persist pool accounts") }
     }
@@ -258,6 +305,22 @@ object PoolAccountManager {
                     appId = appId,
                     appSecret = appSecret,
                     premium = obj.optBoolean("premium", false),
+                )
+        }
+        return out
+    }
+
+    private fun parseDeezer(arr: JSONArray?): List<DeezerPoolAccount> {
+        if (arr == null) return emptyList()
+        val out = mutableListOf<DeezerPoolAccount>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val arl = field(obj, "arl") ?: continue
+            out +=
+                DeezerPoolAccount(
+                    arl = arl,
+                    premium = obj.optBoolean("premium", false),
+                    masterSecret = field(obj, "masterSecret"),
                 )
         }
         return out

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -841,7 +841,9 @@
     <string name="qobuz_integration_description">Manage Qobuz proxy instances and lossless quality</string>
     <string name="deezer_integration">Deezer</string>
     <string name="deezer_integration_description">Log in with Deezer Premium to stream lossless audio</string>
-    <string name="deezer_settings_status_pending">Deezer metadata resolution is active. Full Premium streaming requires login credentials — coming soon.</string>
+    <string name="deezer_login">Sign in to Deezer</string>
+    <string name="deezer_login_description">Use your own Deezer account instead of the shared pool</string>
+    <string name="deezer_login_success">Signed in to Deezer as %1$s</string>
     <string name="qobuz_enable">Enable Qobuz source</string>
     <string name="qobuz_enable_description">Route playback through your Qobuz proxy instances when a matching track is found</string>
     <string name="qobuz_audio_quality">Audio quality</string>


### PR DESCRIPTION
## What

Replaces the metadata-only Deezer stub with a working Premium streaming implementation, ported from `vossgraves/ArchiveTune` dev.

**Before:** `DeezerAudioProvider.resolve()` returned `null` — only metadata (track id, ISRC, artwork). No credential storage, no decryption, placeholder settings screen ("coming soon").

**After:** real streams.

## Changes

- **`DeezerCrypto.kt` + `DeezerDecryptingDataSource.kt`** (new) — Blowfish CBC track decryption.
- **`DeezerAudioProvider.kt`** — real `resolve()` returning playable FLAC/MP3, per-track tier verification, graceful FLAC→MP3 degradation for non-lossless accounts.
- **`DeezerLoginScreen.kt`** (new) — manual `arl`-cookie sign-in.
- **`PoolAccountManager.kt`** — adds `DeezerPoolAccount` (arl-based) alongside Tidal/Qobuz: cache, persist, parse, `deezerAccounts()`. Surgical — existing Tidal/Qobuz logic untouched.
- **`PreferenceKeys.kt`** — `deezerEnabled` / `deezerArl` / `deezerAccountName` / `deezerAccountPremium`.
- **`NavigationBuilder.kt` + `DeezerSettings.kt`** — register `DEEZER_LOGIN_ROUTE` and link it from the Deezer settings row (was a dead-end "coming soon").
- **`strings.xml`** — `deezer_login`, `deezer_login_description`, `deezer_login_success`; removed now-unused `deezer_settings_status_pending`.
- **`TrackMatching.kt`** + `provider_deezer.xml` — self-contained helpers.

## ⚠️ Verification caveat

**CI-verified only — never run on hardware.** No local JDK in the port environment, so this is validated by symbol-resolution checks and this repo's CI build, not a device. Please let CI finish and, if possible, smoke-test the login + a FLAC stream before merge.

Flow: Integration → Deezer → Sign in to Deezer → paste `arl` → stream.