### PR TITLE
feat(qobuz): add QobuzAudioProvider.invalidate to drop a cached stream entry

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzAudioProvider.kt
@@ -442,6 +442,23 @@ object QobuzAudioProvider {
             else -> "FLAC"
         }
 
+    /**
+     * Drops any cached stream/failure entry for [query], forcing the next [resolve] to hit the
+     * network.
+     *
+     * Needed by the download path: proxy URLs are signed with a short `etsp` expiry, so a cached URL
+     * can be syntactically fine but already dead. Without this, retrying a download would keep
+     * replaying the same expired link until the cache aged out on its own.
+     */
+    fun invalidate(
+        query: Query,
+        formatId: Int,
+    ) {
+        val key = query.cacheKey() + ":" + formatId
+        streamCache.remove(key)
+        failureCache.remove(key)
+    }
+
     // -------------------------------------------------------------------------
     // Search + download
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Adds a small public `invalidate(query, formatId)` to `QobuzAudioProvider` that removes the `streamCache` and `failureCache` entries for a track, forcing the next `resolve()` to hit the network.

**Why:** Qobuz proxy URLs are signed with a short `etsp` expiry, so a cached URL can be syntactically fine but already dead. A download retry would otherwise keep replaying the same expired link until the cache aged out on its own. The method mirrors the cache-key construction `resolve()` already uses (`query.cacheKey() + ":" + formatId`), so it clears exactly the entry `resolve()` would have returned.

**No behaviour change** for existing callers — nothing calls this yet. It's the hook a download/retry path needs to force a fresh signed URL.

(Context: my fork's lossless-download path calls this. Right now it only survives in my tree because I re-add it after every mirror; having it upstream means the mirror stops reverting it.)