### PR TITLE
feat(deezer): restore Deezer as a playback source in Sources settings

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.canvas.ArchiveTuneCanvas
 import moe.rukamori.archivetune.constants.*
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
 import moe.rukamori.archivetune.extensions.*
 import moe.rukamori.archivetune.gatekeeper.GatekeeperResult
 import moe.rukamori.archivetune.gatekeeper.RunGatekeeperCheckUseCase
@@ -357,6 +358,18 @@ class App :
                     } else {
                         YouTube.dns = Dns.SYSTEM
                     }
+                }
+        }
+
+        // Mirrors the manually signed-in Deezer account into the provider. A collector rather than a
+        // one-shot read so signing in or out takes effect immediately, and so the value survives the
+        // pool refresh that replaces the pooled account cache.
+        applicationScope.launch(Dispatchers.IO) {
+            dataStore.data
+                .map { (it[DeezerArlKey] ?: "") to (it[DeezerAccountPremiumKey] ?: false) }
+                .distinctUntilChanged()
+                .collect { (arl, premium) ->
+                    DeezerAudioProvider.setManualArl(arl, premium)
                 }
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/ForkPreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/ForkPreferenceKeys.kt
@@ -1,0 +1,53 @@
+package moe.rukamori.archivetune.constants
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+
+/*
+ * Preference keys for this fork's own features, kept OUT of PreferenceKeys.kt on purpose.
+ *
+ * The mirror workflow replaces every file upstream also ships, so a key appended to
+ * PreferenceKeys.kt is silently dropped by the next sync and the fork code referencing it stops
+ * compiling. That already happened once at 21247770f. This file is listed in .mirror-keep, so it
+ * survives.
+ *
+ * Only keys used by fork-only code belong here. Anything upstream also declares must NOT be
+ * repeated -- two declarations of the same name is a Kotlin redeclaration error. The four Deezer
+ * keys are a case in point: upstream merged this fork's Deezer support and now declares
+ * DeezerEnabledKey, DeezerArlKey, DeezerAccountNameKey and DeezerAccountPremiumKey themselves, so
+ * they stay in their file and are deliberately absent here.
+ *
+ * The string passed to booleanPreferencesKey is the on-disk DataStore name. Renaming one orphans
+ * the stored setting on every existing install, so treat these as permanent.
+ */
+
+/** Whether a lossless download should be tagged with metadata and artwork after it completes. */
+val LosslessDownloadTagKey = booleanPreferencesKey("losslessDownloadTag")
+
+// Deezer serves three tiers. FLAC needs a lossless plan, so the provider walks down from the
+// requested tier and a free account silently lands on MP3 rather than failing the track.
+//
+// Unlike the four account keys above, upstream never declared these -- their DeezerSettings is a
+// login link with no quality picker -- so they live here where the mirror cannot drop them.
+enum class DeezerAudioQuality {
+    FLAC,
+    MP3_320,
+    MP3_128,
+}
+
+val DeezerAudioQualityOptions =
+    listOf(
+        DeezerAudioQuality.FLAC,
+        DeezerAudioQuality.MP3_320,
+        DeezerAudioQuality.MP3_128,
+    )
+
+val DeezerAudioQualityKey = stringPreferencesKey("deezerAudioQuality")
+
+/** The `format` string Deezer's media endpoint expects for each tier. */
+fun DeezerAudioQuality.toFormatName(): String =
+    when (this) {
+        DeezerAudioQuality.FLAC -> "FLAC"
+        DeezerAudioQuality.MP3_320 -> "MP3_320"
+        DeezerAudioQuality.MP3_128 -> "MP3_128"
+    }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -990,6 +990,7 @@ val TelegramLosslessOnlyKey = booleanPreferencesKey("telegramLosslessOnly")
 enum class AudioSourceType {
     TIDAL,
     QOBUZ,
+    DEEZER,
     YOUTUBE,
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -200,6 +200,13 @@ import moe.rukamori.archivetune.constants.QobuzAudioQualityKey
 import moe.rukamori.archivetune.constants.QobuzLastProbeTrackKey
 import moe.rukamori.archivetune.constants.QobuzTokensKey
 import moe.rukamori.archivetune.constants.toFormatId
+import moe.rukamori.archivetune.constants.DeezerAudioQuality
+import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
+import moe.rukamori.archivetune.constants.DeezerEnabledKey
+import moe.rukamori.archivetune.constants.toFormatName
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
+import moe.rukamori.archivetune.deezer.DeezerCrypto
+import moe.rukamori.archivetune.deezer.DeezerDecryptingDataSource
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
@@ -7596,12 +7603,26 @@ class MusicService :
             }
         val directFactory = createResolvedUpstreamDataSourceFactory()
         val telegramFactory = TelegramDataSource.Factory()
+        // Deezer needs its own chain rather than cachedFactory's: that one runs the YouTube
+        // resolver over the dataSpec, which would rewrite our deezer:// URI. Decryption sits below
+        // the cache so what gets cached is already-decrypted audio, letting a replay skip both the
+        // CDN fetch and the Blowfish work.
+        val deezerFactory =
+            CacheDataSource
+                .Factory()
+                .setCache(playerCache)
+                .setUpstreamDataSourceFactory(
+                    DeezerDecryptingDataSource.Factory(OkHttpDataSource.Factory(mediaOkHttpClient)),
+                ).setCacheWriteDataSinkFactory(
+                    CacheDataSink.Factory().setCache(playerCache).setFragmentSize(C.LENGTH_UNSET.toLong()),
+                ).setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
 
         return DataSource.Factory {
             SchemeRoutingDataSource(
                 cachedFactory = cachedFactory,
                 directFactory = directFactory,
                 telegramFactory = telegramFactory,
+                deezerFactory = deezerFactory,
             )
         }
     }
@@ -7690,6 +7711,7 @@ class MusicService :
                 // UI and the resolver agree on which sources are active out of the box.
                 AudioSourceType.TIDAL to dataStore.get(TidalEnabledKey, true),
                 AudioSourceType.QOBUZ to dataStore.get(QobuzEnabledKey, false),
+                AudioSourceType.DEEZER to dataStore.get(DeezerEnabledKey, false),
                 AudioSourceType.YOUTUBE to true,
             )
         // The single stored order is authoritative (top = preferred). Only sources listed BEFORE
@@ -7881,6 +7903,7 @@ class MusicService :
                 when (source) {
                     AudioSourceType.TIDAL -> resolveTidalStream(query)
                     AudioSourceType.QOBUZ -> resolveQobuzStream(query)
+                    AudioSourceType.DEEZER -> resolveDeezerStream(query)
                     AudioSourceType.YOUTUBE -> null
                 }
             if (stream == null) {
@@ -8299,6 +8322,66 @@ class MusicService :
     private fun parseQobuzAudioQuality(): QobuzAudioQuality {
         val stored = dataStore.get(QobuzAudioQualityKey, QobuzAudioQuality.FLAC.name)
         return runCatching { QobuzAudioQuality.valueOf(stored) }.getOrDefault(QobuzAudioQuality.FLAC)
+    }
+
+    /**
+     * Resolves a Deezer stream. Unlike Tidal/Qobuz there is no proxy-instance tier, so the pool is the
+     * only credential source and the whole source is a no-op until the pool has accounts.
+     */
+    private fun resolveDeezerStream(query: SourceQuery): DirectStream? {
+        val accounts = PoolAccountManager.deezerAccounts()
+        if (accounts.isEmpty()) {
+            Timber.tag("MusicService").d("Deezer skip: no pool accounts available")
+            return null
+        }
+        val quality = parseDeezerAudioQuality()
+        Timber.tag("MusicService").d(
+            "Deezer resolve start | quality=%s accounts=%d",
+            quality.name,
+            accounts.size,
+        )
+        // No setAccounts equivalent to Qobuz's setTokens: Deezer credentials come only from the pool,
+        // so the provider reads PoolAccountManager itself. The count above is logged for diagnostics.
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                DeezerAudioProvider
+                    .resolve(
+                        query =
+                            DeezerAudioProvider.Query(
+                                mediaId = query.mediaId,
+                                title = query.title,
+                                artists = query.artists,
+                                album = query.album,
+                                durationMs = query.durationMs,
+                            ),
+                        format = quality.toFormatName(),
+                    )?.let { resolved ->
+                        // The provider deliberately returns its own type so it stays independent of the
+                        // playback layer; map it here, at the single point where the two meet.
+                        DirectStream(
+                            uri = resolved.uri,
+                            mimeType = resolved.mimeType,
+                            codecs = resolved.codecs,
+                            contentLength = resolved.contentLength,
+                            label = resolved.label,
+                            source = AudioSourceType.DEEZER,
+                            matchedTitle = resolved.matchedTitle,
+                            matchedArtist = resolved.matchedArtist,
+                            matchedAlbum = resolved.matchedAlbum,
+                            matchedDurationMs = resolved.matchedDurationMs,
+                            sampleRate = resolved.sampleRate,
+                            bitDepth = resolved.bitDepth,
+                        )
+                    }
+            }
+        }.onFailure { error ->
+            Timber.tag("MusicService").w(error, "DEEZER stream resolution failed for %s", query.mediaId)
+        }.getOrNull()
+    }
+
+    private fun parseDeezerAudioQuality(): DeezerAudioQuality {
+        val stored = dataStore.get(DeezerAudioQualityKey, DeezerAudioQuality.FLAC.name)
+        return runCatching { DeezerAudioQuality.valueOf(stored) }.getOrDefault(DeezerAudioQuality.FLAC)
     }
 
     /**
@@ -9001,6 +9084,7 @@ class MusicService :
         private val cachedFactory: DataSource.Factory,
         private val directFactory: DataSource.Factory,
         private val telegramFactory: DataSource.Factory,
+        private val deezerFactory: DataSource.Factory,
     ) : DataSource {
         private val transferListeners = mutableListOf<TransferListener>()
         private var delegate: DataSource? = null
@@ -9017,6 +9101,9 @@ class MusicService :
                     // Telegram tracks stream through TDLib's own partial-file cache; Media3's
                     // caches and the YouTube resolver chain must both stay out of the way.
                     telegramFactory
+                } else if (normalizedScheme == DeezerCrypto.SCHEME) {
+                    // Carries its own cache; the YouTube resolver would rewrite the URI.
+                    deezerFactory
                 } else if (
                     normalizedScheme == "content" ||
                     normalizedScheme == "file" ||

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -1605,6 +1605,7 @@ private fun AudioSourceType.sourceLabelRes(): Int =
     when (this) {
         AudioSourceType.TIDAL -> R.string.source_tidal
         AudioSourceType.QOBUZ -> R.string.source_qobuz
+        AudioSourceType.DEEZER -> R.string.source_deezer
         AudioSourceType.YOUTUBE -> R.string.source_youtube
     }
 
@@ -1612,6 +1613,7 @@ private fun AudioSourceType.sourceIconRes(): Int =
     when (this) {
         AudioSourceType.TIDAL -> R.drawable.provider_tidal
         AudioSourceType.QOBUZ -> R.drawable.provider_qobuz
+        AudioSourceType.DEEZER -> R.drawable.provider_deezer
         AudioSourceType.YOUTUBE -> R.drawable.play
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -48,8 +48,15 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
+import android.widget.Toast
 import moe.rukamori.archivetune.constants.AudioSourceOrderKey
 import moe.rukamori.archivetune.constants.AudioSourceType
+import moe.rukamori.archivetune.constants.DeezerAccountNameKey
+import moe.rukamori.archivetune.constants.DeezerAccountPremiumKey
+import moe.rukamori.archivetune.constants.DeezerArlKey
+import moe.rukamori.archivetune.constants.DeezerAudioQuality
+import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
+import moe.rukamori.archivetune.constants.DeezerEnabledKey
 import moe.rukamori.archivetune.constants.QobuzAudioQuality
 import moe.rukamori.archivetune.constants.QobuzAudioQualityKey
 import moe.rukamori.archivetune.constants.QobuzEnabledKey
@@ -83,6 +90,7 @@ private fun AudioSourceType.displayName(context: android.content.Context): Strin
     when (this) {
         AudioSourceType.TIDAL -> context.getString(R.string.source_tidal)
         AudioSourceType.QOBUZ -> context.getString(R.string.source_qobuz)
+        AudioSourceType.DEEZER -> context.getString(R.string.source_deezer)
         AudioSourceType.YOUTUBE -> context.getString(R.string.source_youtube)
     }
 
@@ -90,6 +98,7 @@ private fun AudioSourceType.iconRes(): Int =
     when (this) {
         AudioSourceType.TIDAL -> R.drawable.provider_tidal
         AudioSourceType.QOBUZ -> R.drawable.provider_qobuz
+        AudioSourceType.DEEZER -> R.drawable.provider_deezer
         AudioSourceType.YOUTUBE -> R.drawable.play
     }
 
@@ -105,6 +114,13 @@ fun PlaybackSourceSections(navController: NavController) {
     val (sourceOrderRaw, onSourceOrderChange) = rememberPreference(AudioSourceOrderKey, "")
     val (tidalEnabled, onTidalEnabledChange) = rememberPreference(TidalEnabledKey, true)
     val (qobuzEnabled, onQobuzEnabledChange) = rememberPreference(QobuzEnabledKey, false)
+    val (deezerEnabled, onDeezerEnabledChange) = rememberPreference(DeezerEnabledKey, false)
+    val (deezerQuality, onDeezerQualityChange) =
+        rememberEnumPreference(DeezerAudioQualityKey, DeezerAudioQuality.FLAC)
+    // Only the setters are needed here; the ARL and tier themselves are never shown in settings.
+    val (_, onDeezerArlChange) = rememberPreference(DeezerArlKey, "")
+    val (deezerAccountName, onDeezerAccountNameChange) = rememberPreference(DeezerAccountNameKey, "")
+    val (_, onDeezerAccountPremiumChange) = rememberPreference(DeezerAccountPremiumKey, false)
 
     val (tidalAccountFirst, onTidalAccountFirstChange) = rememberPreference(TidalAccountFirstKey, true)
     val (audioQuality, onAudioQualityChange) =
@@ -160,6 +176,7 @@ fun PlaybackSourceSections(navController: NavController) {
         when (source) {
             AudioSourceType.TIDAL -> tidalEnabled
             AudioSourceType.QOBUZ -> qobuzEnabled
+            AudioSourceType.DEEZER -> deezerEnabled
             AudioSourceType.YOUTUBE -> true
         }
 
@@ -346,6 +363,70 @@ fun PlaybackSourceSections(navController: NavController) {
                 icon = { Icon(painterResource(R.drawable.integration), null) },
                 onClick = { navController.navigate("settings/integration") },
             )
+        }
+    }
+
+    PreferenceGroup(title = stringResource(R.string.deezer_specific)) {
+        item {
+            SwitchPreference(
+                title = { Text(stringResource(R.string.deezer_enable)) },
+                description = stringResource(R.string.deezer_enable_description),
+                icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
+                checked = deezerEnabled,
+                onCheckedChange = onDeezerEnabledChange,
+            )
+        }
+
+        item {
+            EnumListPreference(
+                title = { Text(stringResource(R.string.deezer_audio_quality)) },
+                icon = { Icon(painterResource(R.drawable.play), null) },
+                selectedValue = deezerQuality,
+                onValueSelected = onDeezerQualityChange,
+                isEnabled = deezerEnabled,
+                valueText = { quality ->
+                    when (quality) {
+                        DeezerAudioQuality.FLAC -> stringResource(R.string.deezer_quality_flac)
+                        DeezerAudioQuality.MP3_320 -> stringResource(R.string.deezer_quality_mp3_320)
+                        DeezerAudioQuality.MP3_128 -> stringResource(R.string.deezer_quality_mp3_128)
+                    }
+                },
+            )
+        }
+
+        // A manual sign-in is offered regardless of `manualSourceLogin`: that flag gates self-hosted
+        // proxy instances, which Deezer does not have. Signing in here is the only way to use Deezer
+        // without waiting on the shared pool.
+        if (deezerAccountName.isEmpty()) {
+            item {
+                PreferenceEntry(
+                    title = { Text(stringResource(R.string.deezer_login)) },
+                    description = stringResource(R.string.deezer_login_description),
+                    icon = { Icon(painterResource(R.drawable.token), null) },
+                    isEnabled = deezerEnabled,
+                    onClick = { navController.navigate(DEEZER_LOGIN_ROUTE) },
+                )
+            }
+        } else {
+            item {
+                PreferenceEntry(
+                    title = { Text(stringResource(R.string.deezer_sign_out)) },
+                    description = stringResource(R.string.deezer_signed_in_as, deezerAccountName),
+                    icon = { Icon(painterResource(R.drawable.logout), null) },
+                    onClick = {
+                        // Clearing the ARL is what actually signs out; App.kt's collector observes it
+                        // and drops the provider's session. Name/premium are display state only.
+                        onDeezerArlChange("")
+                        onDeezerAccountNameChange("")
+                        onDeezerAccountPremiumChange(false)
+                        // The row swapping back to "Sign in" is easy to miss on its own as
+                        // confirmation that anything happened.
+                        Toast
+                            .makeText(context, R.string.deezer_signed_out, Toast.LENGTH_SHORT)
+                            .show()
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/fork_strings.xml
+++ b/app/src/main/res/values/fork_strings.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Strings for this fork's own features, kept OUT of strings.xml on purpose.
+
+  The mirror workflow replaces every shared file with 4nx3b's copy, so a string added to
+  strings.xml or archivetune_strings.xml is reverted by the next sync and the fork code that
+  references it stops compiling. This file is listed in .mirror-keep, so it survives.
+
+  Only add strings here that are used by fork-only code. Anything upstream also ships belongs in
+  their file, so their translations keep working.
+-->
+<resources>
+    <!-- Player chrome (ui/player/AppleMusicSlider.kt) -->
+    <string name="muted">Muted</string>
+
+    <!-- Download quality picker (ui/component/AudioQualityDialogs.kt) -->
+    <string name="download_quality_title">Download quality</string>
+    <string name="download_quality_max">Max</string>
+    <string name="download_quality_max_description">Best the source offers, up to 24-bit/192 kHz</string>
+    <string name="download_quality_hi_res">Hi-Res</string>
+    <string name="download_quality_hi_res_description">24-bit, usually 96 kHz</string>
+    <string name="download_quality_lossless">Lossless</string>
+    <string name="download_quality_lossless_description">CD quality, 16-bit/44.1 kHz</string>
+    <string name="download_quality_remember">Remember this choice and stop asking</string>
+
+    <!-- Export format picker (ui/component/AudioQualityDialogs.kt) -->
+    <string name="export_format_title">Export format</string>
+    <string name="export_format_flac">FLAC</string>
+    <string name="export_format_wav">WAV</string>
+    <string name="export_format_m4a">M4A (AAC)</string>
+    <string name="export_format_webm">WebM (Opus)</string>
+    <string name="export_format_ogg">Ogg</string>
+    <string name="export_format_mp3">MP3</string>
+    <string name="export_format_unavailable_lossy_source">Source is lossy — exporting as FLAC would not add quality</string>
+    <string name="export_format_redownload_lossless">Re-download as lossless, then export</string>
+    <string name="export_format_redownload_lossless_description">Fetches a real lossless file from Qobuz or Tidal first</string>
+
+    <!-- Export results (download/CacheExporter.kt) -->
+    <plurals name="export_result_exported">
+        <item quantity="one">Exported %1$d song</item>
+        <item quantity="other">Exported %1$d songs</item>
+    </plurals>
+    <string name="export_result_skipped">%1$d not downloaded</string>
+    <string name="export_result_failed">%1$d failed</string>
+
+    <!-- Deezer source (ui/screens/settings/PlaybackSourceSections.kt) -->
+    <string name="source_deezer">Deezer</string>
+    <string name="deezer_specific">Deezer</string>
+    <string name="deezer_enable">Enable Deezer source</string>
+    <string name="deezer_enable_description">Route playback through shared Deezer accounts when a matching track is found</string>
+    <string name="deezer_audio_quality">Audio quality</string>
+    <string name="deezer_quality_flac">FLAC (CD 16-bit)</string>
+    <string name="deezer_quality_mp3_320">MP3 320 kbps</string>
+    <string name="deezer_quality_mp3_128">MP3 128 kbps</string>
+    <string name="deezer_login_description">Use your own Deezer account instead of the shared pool</string>
+    <string name="deezer_signed_in_as">Signed in as %1$s</string>
+    <string name="deezer_sign_out">Sign out of Deezer</string>
+    <string name="deezer_sign_out_description">Removes the stored session cookie from this device</string>
+    <string name="deezer_signed_out">Signed out of Deezer</string>
+</resources>


### PR DESCRIPTION
Restores the Deezer section under **Settings → Sources** (enable toggle, audio-quality picker, sign-in/sign-out row) and wires it into playback.

**Why:** Deezer currently only appears under Integration as a login link — there's no way to enable it as a playback source or pick quality from Sources like Tidal/Qobuz.

**What (7 files, +297/-0, purely additive):**
- `PreferenceKeys.kt`: add `DEEZER` to `AudioSourceType`
- `ForkPreferenceKeys.kt` (new): `DeezerAudioQuality` enum + `DeezerAudioQualityKey` + `toFormatName()` — kept in a separate fork file so they don't collide with upstream's `PreferenceKeys.kt`
- `MusicService.kt`: deezer cache+decrypt factory chain, `deezer://` scheme routing, resolution-chain entry, `resolveDeezerStream`/`parseDeezerAudioQuality`
- `App.kt`: collector mirroring the manual Deezer ARL into the provider (survives pool refresh)
- `PlaybackSourceSections.kt`: the Deezer group UI
- `PlayerMenu.kt`: DEEZER branches in the two exhaustive source `when`s (required — they have no `else`)
- `fork_strings.xml` (new): the Deezer strings

Deezer stays **off by default**; no behavior change for existing sources. Login screen and nav route already exist on dev.