### PR TITLE
feat(ux): popup dismiss, status bar, dark mode, vinyl preview, lyrics source, comment cleanup

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1279,15 +1279,10 @@ class MainActivity : ComponentActivity() {
 
                     var isPlayerLyricsFullScreen by remember { mutableStateOf(false) }
 
-                    // Status bar is hidden when:
-                    //  - The Year-in-Music screen is open, OR
-                    //  - The player sheet is expanded AND the layout is one of the "full-bleed" styles
-                    //    (Immersive V7 or Apple Music) that extend artwork to the top edge, OR
-                    //  - The player sheet is expanded AND the lyrics overlay is open (any style —
-                    //    the lyrics overlay covers the whole sheet so the status bar would draw on
-                    //    top of lyric text otherwise).
                     val shouldHideStatusBars =
                         isYearInMusicScreen ||
+                            bottomSheetPageState.isVisible ||
+                            menuState.isVisible ||
                             (
                                 playerBottomSheetState.isExpandedOrExpanding &&
                                     (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
@@ -261,6 +261,7 @@ object AudioSourceConfig {
         listOf(
             AudioSourceType.TIDAL,
             AudioSourceType.QOBUZ,
+            AudioSourceType.DEEZER,
             AudioSourceType.YOUTUBE,
         )
 
@@ -286,7 +287,7 @@ object AudioSourceConfig {
                 .orEmpty()
         val merged = LinkedHashSet(parsed)
         // Append any sources not present in the stored order in their default position. When nothing
-        // is stored this yields DEFAULT_ORDER (Tidal, Qobuz, YouTube), i.e. YouTube stays last.
+        // is stored this yields DEFAULT_ORDER (Tidal, Qobuz, Deezer, YouTube), i.e. YouTube stays last.
         DEFAULT_ORDER.forEach { merged.add(it) }
         return merged.toList()
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -263,6 +263,12 @@ val AiCustomModelKey = stringPreferencesKey("ai_custom_model")
 // Hides the AI-generated "Top mixes" section in the library Mix tab (and stops auto-generation).
 val HideAiMixKey = booleanPreferencesKey("hide_ai_mix")
 
+val HideLikedSongsCardKey = booleanPreferencesKey("hide_liked_songs_card")
+val HideOfflineCardKey = booleanPreferencesKey("hide_offline_card")
+val HideCachedCardKey = booleanPreferencesKey("hide_cached_card")
+val HideLocalFilesCardKey = booleanPreferencesKey("hide_local_files_card")
+val HideTop50CardKey = booleanPreferencesKey("hide_top50_card")
+
 enum class AiProvider {
     CHATGPT,
     GEMINI,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/DatabaseDao.kt
@@ -1925,6 +1925,19 @@ interface DatabaseDao {
         notFoundLyrics: String,
     ): Int
 
+    @Query(
+        """
+        UPDATE lyrics
+        SET providerName = :providerName, updatedAt = :updatedAt
+        WHERE id = :id AND (providerName IS NULL OR providerName = '') AND :providerName != ''
+        """,
+    )
+    fun backfillLyricsProviderName(
+        id: String,
+        providerName: String,
+        updatedAt: Long = System.currentTimeMillis(),
+    ): Int
+
     @Transaction
     fun replaceLyricsIfAbsentOrNotFound(
         id: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/DatabaseDao.kt
@@ -1895,6 +1895,7 @@ interface DatabaseDao {
         id: String,
         lyrics: String,
         source: String = LyricsEntity.Source.REMOTE.value,
+        providerName: String = "",
         updatedAt: Long = System.currentTimeMillis(),
     ) {
         insert(
@@ -1902,6 +1903,7 @@ interface DatabaseDao {
                 id = id,
                 lyrics = lyrics,
                 source = source,
+                providerName = providerName,
                 updatedAt = updatedAt,
             ),
         )
@@ -1910,7 +1912,7 @@ interface DatabaseDao {
     @Query(
         """
         UPDATE lyrics
-        SET lyrics = :lyrics, source = :source, updatedAt = :updatedAt
+        SET lyrics = :lyrics, source = :source, providerName = :providerName, updatedAt = :updatedAt
         WHERE id = :id AND lyrics = :notFoundLyrics
         """,
     )
@@ -1918,6 +1920,7 @@ interface DatabaseDao {
         id: String,
         lyrics: String,
         source: String,
+        providerName: String,
         updatedAt: Long,
         notFoundLyrics: String,
     ): Int
@@ -1927,6 +1930,7 @@ interface DatabaseDao {
         id: String,
         lyrics: String,
         source: String = LyricsEntity.Source.REMOTE.value,
+        providerName: String = "",
         updatedAt: Long = System.currentTimeMillis(),
     ) {
         val insertedRowId =
@@ -1935,6 +1939,7 @@ interface DatabaseDao {
                     id = id,
                     lyrics = lyrics,
                     source = source,
+                    providerName = providerName,
                     updatedAt = updatedAt,
                 ),
             )
@@ -1943,6 +1948,7 @@ interface DatabaseDao {
                 id = id,
                 lyrics = lyrics,
                 source = source,
+                providerName = providerName,
                 updatedAt = updatedAt,
                 notFoundLyrics = LyricsEntity.LYRICS_NOT_FOUND,
             )
@@ -1954,6 +1960,7 @@ interface DatabaseDao {
         id: String,
         lyrics: String,
         source: String,
+        providerName: String = "",
         updatedAt: Long = System.currentTimeMillis(),
     ) {
         upsert(
@@ -1961,6 +1968,7 @@ interface DatabaseDao {
                 id = id,
                 lyrics = lyrics,
                 source = source,
+                providerName = providerName,
                 updatedAt = updatedAt,
             ),
         )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/MusicDatabase.kt
@@ -59,7 +59,7 @@ import java.util.concurrent.Executor
 import kotlin.coroutines.resume
 
 private const val TAG = "MusicDatabase"
-private const val CURRENT_VERSION = 33
+private const val CURRENT_VERSION = 34
 
 class MusicDatabase(
     private val delegate: InternalDatabase,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
@@ -63,6 +63,11 @@ fun FormatEntity.exportMimeType(): String {
     }
 }
 
+fun FormatEntity.isLossless(): Boolean {
+    val rawCodec = codecs.ifBlank { mimeType.substringAfter("/") }.uppercase()
+    return rawCodec.contains("FLAC") || rawCodec.contains("ALAC")
+}
+
 fun FormatEntity.codecLabel(): String {
     val rawCodec = codecs.ifBlank { mimeType.substringAfter("/") }.uppercase()
     val rawMime = mimeType.substringAfter("/").substringBefore(";").uppercase()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/LyricsEntity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/LyricsEntity.kt
@@ -17,6 +17,8 @@ data class LyricsEntity(
     val lyrics: String,
     @ColumnInfo(defaultValue = "'REMOTE'")
     val source: String = Source.REMOTE.value,
+    @ColumnInfo(defaultValue = "''")
+    val providerName: String = "",
     @ColumnInfo(defaultValue = "0")
     val updatedAt: Long = System.currentTimeMillis(),
 ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -12,12 +12,14 @@ import android.util.Log
 import android.util.LruCache
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.selects.select
-import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.constants.LyricsProviderOrderKey
 import moe.rukamori.archivetune.constants.PreferredLyricsProvider
@@ -119,10 +121,12 @@ class LyricsHelper
                     .filter { it.isEnabled(context) }
                     .filter { supportsMediaId(it, mediaMetadata.id) }
             val providers = if (preferredProviderOnly) ordered.take(1) else ordered
-            val providerName = fetchPriorityProviderName(providers, mediaMetadata)
-            val lyrics = fetchPriorityLyrics(providers, mediaMetadata)
-            val result = LyricsResult(providerName = providerName, lyrics = lyrics)
-            if (isMeaningfulLyrics(lyrics)) {
+            // Single parallel fetch — the previous implementation called fetchPriorityLyricsResult
+            // twice (once for the provider name, once for the lyrics body), which doubled the
+            // worst-case latency because each call waited for the slowest provider. Resolve once
+            // and reuse the result.
+            val result = fetchPriorityLyricsResult(providers, mediaMetadata)
+            if (isMeaningfulLyrics(result.lyrics)) {
                 singleLyricsCache.put(cacheKey, result)
             }
 
@@ -183,16 +187,22 @@ class LyricsHelper
             cache.put(cacheKey, allResult.toList())
         }
 
-        private suspend fun fetchPriorityLyrics(
-            providers: List<LyricsProvider>,
-            mediaMetadata: MediaMetadata,
-        ): String = fetchPriorityLyricsResult(providers, mediaMetadata).lyrics
-
-        private suspend fun fetchPriorityProviderName(
-            providers: List<LyricsProvider>,
-            mediaMetadata: MediaMetadata,
-        ): String = fetchPriorityLyricsResult(providers, mediaMetadata).providerName
-
+        /**
+         * Streams provider results as they arrive and returns the first acceptable lyrics payload,
+         * rather than waiting for every provider to complete (the previous implementation joined
+         * every `async` before ranking, which meant a single slow provider could hold up the panel
+         * for its full 15–20s timeout).
+         *
+         * Strategy:
+         *  - All enabled providers run in parallel on `Dispatchers.IO`.
+         *  - The first `word-synced` or `line-synced` result wins and is returned immediately —
+         *    pending providers are cancelled. Returning the first synced result lets a fast
+         *    provider (e.g. LRCLIB ~100ms) win over a slow one (e.g. Musixmatch token refresh
+         *    ~3–15s) without making the user wait for the better-quality-but-slow result.
+         *  - Plain (unsynced) lyrics are kept as a fallback; if no synced result arrives, the
+         *    first plain result is returned after every provider finishes.
+         *  - `LYRICS_NOT_FOUND` is returned only if every provider failed/returned nothing.
+         */
         private suspend fun fetchPriorityLyricsResult(
             providers: List<LyricsProvider>,
             mediaMetadata: MediaMetadata,
@@ -200,27 +210,58 @@ class LyricsHelper
             if (providers.isEmpty()) return LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
 
             val artist = mediaMetadata.artists.joinToString { it.name }
-            val results =
-                supervisorScope {
-                    providers
-                        .map { provider ->
-                            async(Dispatchers.IO) {
-                                val lyrics = fetchProviderLyrics(provider, mediaMetadata, artist)
-                                if (lyrics == null) null else provider.name to lyrics
+
+            return coroutineScope {
+                // UNLIMITED so `trySend` never blocks a provider coroutine; we close the channel
+                // ourselves once we have a winner.
+                val channel = Channel<Pair<String, String>>(Channel.UNLIMITED)
+                val providerJobs: List<Job> =
+                    providers.map { provider ->
+                        launch(Dispatchers.IO) {
+                            val lyrics = fetchProviderLyrics(provider, mediaMetadata, artist)
+                            if (lyrics != null) {
+                                channel.trySend(provider.name to lyrics)
                             }
-                        }.mapNotNull { it.await() }
+                        }
+                    }
+                val collectorJob =
+                    launch {
+                        try {
+                            providerJobs.joinAll()
+                        } finally {
+                            channel.close()
+                        }
+                    }
+
+                try {
+                    var fallback: Pair<String, String>? = null
+                    for ((providerName, lyrics) in channel) {
+                        // Word-synced is the best we can get — return immediately and cancel the
+                        // remaining providers so we don't keep their network requests alive.
+                        if (LyricsUtils.hasWordSyncedLyrics(lyrics)) {
+                            return@coroutineScope LyricsResult(providerName = providerName, lyrics = lyrics)
+                        }
+                        // Line-synced is good enough for an instant-load UX — return immediately.
+                        if (LyricsUtils.isLineSyncedLrc(lyrics)) {
+                            return@coroutineScope LyricsResult(providerName = providerName, lyrics = lyrics)
+                        }
+                        // Plain (unsynced) lyrics — keep the first one as a fallback while we keep
+                        // waiting for a synced variant.
+                        if (fallback == null) {
+                            fallback = providerName to lyrics
+                        }
+                    }
+                    // Channel closed = every provider finished without producing a synced result.
+                    // Return the first plain result we saw, if any.
+                    fallback?.let { (name, lyrics) ->
+                        return@coroutineScope LyricsResult(providerName = name, lyrics = lyrics)
+                    }
+                    LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
+                } finally {
+                    collectorJob.cancel()
+                    providerJobs.forEach { it.cancel() }
                 }
-
-            if (results.isEmpty()) return LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
-
-            val wordSynced = results.firstOrNull { LyricsUtils.hasWordSyncedLyrics(it.second) }
-            if (wordSynced != null) return LyricsResult(providerName = wordSynced.first, lyrics = wordSynced.second)
-
-            val lineSynced = results.firstOrNull { LyricsUtils.isLineSyncedLrc(it.second) }
-            if (lineSynced != null) return LyricsResult(providerName = lineSynced.first, lyrics = lineSynced.second)
-
-            val first = results.first()
-            return LyricsResult(providerName = first.first, lyrics = first.second)
+            }
         }
 
         private suspend fun fetchProviderLyrics(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -61,7 +61,7 @@ class LyricsHelper
             )
 
         private val cache = LruCache<String, List<LyricsResult>>(MAX_CACHE_SIZE)
-        private val singleLyricsCache = LruCache<String, String>(MAX_CACHE_SIZE)
+        private val singleLyricsCache = LruCache<String, LyricsResult>(MAX_CACHE_SIZE)
 
         suspend fun getLyrics(
             mediaMetadata: MediaMetadata,
@@ -82,9 +82,9 @@ class LyricsHelper
             if (forceRefresh) {
                 invalidateCache(cacheKey)
             } else {
-                singleLyricsCache.get(cacheKey)?.let { lyrics ->
+                singleLyricsCache.get(cacheKey)?.let { cached ->
                     GlobalLog.append(Log.DEBUG, "LyricsHelper", "Found lyrics in cache for ${mediaMetadata.title}")
-                    return LyricsResult(providerName = "", lyrics = lyrics)
+                    return cached
                 }
 
                 val cached = cache.get(cacheKey)?.firstOrNull()
@@ -121,11 +121,12 @@ class LyricsHelper
             val providers = if (preferredProviderOnly) ordered.take(1) else ordered
             val providerName = fetchPriorityProviderName(providers, mediaMetadata)
             val lyrics = fetchPriorityLyrics(providers, mediaMetadata)
+            val result = LyricsResult(providerName = providerName, lyrics = lyrics)
             if (isMeaningfulLyrics(lyrics)) {
-                singleLyricsCache.put(cacheKey, lyrics)
+                singleLyricsCache.put(cacheKey, result)
             }
 
-            return LyricsResult(providerName = providerName, lyrics = lyrics)
+            return result
         }
 
         suspend fun getAllLyrics(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -55,9 +55,8 @@ class LyricsHelper
                 PaxsenixYouTubeLyricsProvider,
                 YouTubeSubtitleLyricsProvider,
                 YouTubeLyricsProvider,
-                // Experimental native Musixmatch provider — gated by
-                // EnableMusixmatchExperimentalKey (off by default). When the toggle
-                // is off, isEnabled() returns false and LyricsHelper skips it.
+
+                
                 MusixmatchExperimentalLyricsProvider,
             )
 
@@ -68,20 +67,30 @@ class LyricsHelper
             mediaMetadata: MediaMetadata,
             preferredProviderOnly: Boolean = false,
             forceRefresh: Boolean = false,
-        ): String {
+        ): String = getLyricsWithProvider(
+            mediaMetadata = mediaMetadata,
+            preferredProviderOnly = preferredProviderOnly,
+            forceRefresh = forceRefresh,
+        ).lyrics
+
+        suspend fun getLyricsWithProvider(
+            mediaMetadata: MediaMetadata,
+            preferredProviderOnly: Boolean = false,
+            forceRefresh: Boolean = false,
+        ): LyricsResult {
             val cacheKey = mediaMetadata.lyricsCacheKey
             if (forceRefresh) {
                 invalidateCache(cacheKey)
             } else {
                 singleLyricsCache.get(cacheKey)?.let { lyrics ->
                     GlobalLog.append(Log.DEBUG, "LyricsHelper", "Found lyrics in cache for ${mediaMetadata.title}")
-                    return lyrics
+                    return LyricsResult(providerName = "", lyrics = lyrics)
                 }
 
                 val cached = cache.get(cacheKey)?.firstOrNull()
                 if (cached != null) {
                     GlobalLog.append(Log.DEBUG, "LyricsHelper", "Found lyrics in cache for ${mediaMetadata.title}")
-                    return cached.lyrics
+                    return cached
                 }
             }
 
@@ -102,7 +111,7 @@ class LyricsHelper
 
             if (!isNetworkAvailable) {
                 GlobalLog.append(Log.WARN, "LyricsHelper", "Network unavailable, aborting lyrics fetch")
-                return LYRICS_NOT_FOUND
+                return LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
             }
 
             val ordered =
@@ -110,12 +119,13 @@ class LyricsHelper
                     .filter { it.isEnabled(context) }
                     .filter { supportsMediaId(it, mediaMetadata.id) }
             val providers = if (preferredProviderOnly) ordered.take(1) else ordered
+            val providerName = fetchPriorityProviderName(providers, mediaMetadata)
             val lyrics = fetchPriorityLyrics(providers, mediaMetadata)
             if (isMeaningfulLyrics(lyrics)) {
                 singleLyricsCache.put(cacheKey, lyrics)
             }
 
-            return lyrics
+            return LyricsResult(providerName = providerName, lyrics = lyrics)
         }
 
         suspend fun getAllLyrics(
@@ -175,8 +185,18 @@ class LyricsHelper
         private suspend fun fetchPriorityLyrics(
             providers: List<LyricsProvider>,
             mediaMetadata: MediaMetadata,
-        ): String {
-            if (providers.isEmpty()) return LYRICS_NOT_FOUND
+        ): String = fetchPriorityLyricsResult(providers, mediaMetadata).lyrics
+
+        private suspend fun fetchPriorityProviderName(
+            providers: List<LyricsProvider>,
+            mediaMetadata: MediaMetadata,
+        ): String = fetchPriorityLyricsResult(providers, mediaMetadata).providerName
+
+        private suspend fun fetchPriorityLyricsResult(
+            providers: List<LyricsProvider>,
+            mediaMetadata: MediaMetadata,
+        ): LyricsResult {
+            if (providers.isEmpty()) return LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
 
             val artist = mediaMetadata.artists.joinToString { it.name }
             val results =
@@ -184,16 +204,22 @@ class LyricsHelper
                     providers
                         .map { provider ->
                             async(Dispatchers.IO) {
-                                fetchProviderLyrics(provider, mediaMetadata, artist)
+                                val lyrics = fetchProviderLyrics(provider, mediaMetadata, artist)
+                                if (lyrics == null) null else provider.name to lyrics
                             }
                         }.mapNotNull { it.await() }
                 }
 
-            if (results.isEmpty()) return LYRICS_NOT_FOUND
+            if (results.isEmpty()) return LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
 
-            results.firstOrNull { LyricsUtils.hasWordSyncedLyrics(it) }?.let { return it }
-            results.firstOrNull { LyricsUtils.isLineSyncedLrc(it) }?.let { return it }
-            return results.first()
+            val wordSynced = results.firstOrNull { LyricsUtils.hasWordSyncedLyrics(it.second) }
+            if (wordSynced != null) return LyricsResult(providerName = wordSynced.first, lyrics = wordSynced.second)
+
+            val lineSynced = results.firstOrNull { LyricsUtils.isLineSyncedLrc(it.second) }
+            if (lineSynced != null) return LyricsResult(providerName = lineSynced.first, lyrics = lineSynced.second)
+
+            val first = results.first()
+            return LyricsResult(providerName = first.first, lyrics = first.second)
         }
 
         private suspend fun fetchProviderLyrics(
@@ -252,10 +278,6 @@ class LyricsHelper
 
         private fun isMeaningfulLyrics(lyrics: String): Boolean = LyricsUtils.hasMeaningfulLyricsContent(lyrics)
 
-        /**
-         * Providers that treat the media id as a YouTube video id can never match local or
-         * Telegram tracks — skip them so the priority race isn't padded with guaranteed misses.
-         */
         private fun supportsMediaId(
             provider: LyricsProvider,
             mediaId: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -7791,6 +7791,27 @@ class MusicService :
      * Applies a per-song "play from" override and, if [mediaId] is the current item, re-resolves it
      * immediately so the change takes effect without the user having to skip the track. Passing a
      * null [source] clears the override for that song.
+     *
+     * Two bugs are addressed here that the previous implementation had:
+     *
+     * 1. **"Sometimes changing source only restarts the song but doesn't change the source."**
+     *    `directStreamCache[mediaId]` and the bare-keyed `contentLengthCache[mediaId]` were not
+     *    evicted, so the resolver's fast path could short-circuit to the previous source's
+     *    resolved URL (when the override happened to be re-applied to the same id) or to a stale
+     *    content-length that made the byte-cache short-circuit in [resolveCachedDataSpec] think
+     *    the request was fully cached. Both are now evicted explicitly so the slow path always
+     *    re-resolves through the new override.
+     *
+     * 2. **"Qobuz → YouTube plays from YouTube but muted."** `player.prepare()` is asynchronous;
+     *    the actual re-resolution happens on ExoPlayer's internal thread, and any of the reactive
+     *    volume pipeline (`playerVolume × normalizeFactor × audioFocusVolumeFactor`), audio focus
+     *    state, or crossfade ramp can interleave with it and leave the primary player's volume
+     *    pinned low (the [ensureAudiblePlaybackVolume] watchdog only fires when `player.volume`
+     *    is essentially 0, so a "quiet but not zero" state slips past it). We now explicitly:
+     *    - cancel any pending crossfade and reset its volume,
+     *    - apply the effective volume immediately (no ramp),
+     *    - re-claim audio focus,
+     *    - kick the audible-playback watchdog.
      */
     fun setSongSourceOverride(
         mediaId: String,
@@ -7809,16 +7830,34 @@ class MusicService :
             extractorPlaybackUrlCache.remove(mediaId)
             YTPlayerUtils.invalidateCachedStreamUrls(mediaId)
             tidalActiveMediaIds.remove(mediaId)
+            // Evict the resolved DirectStream so the slow path re-resolves through the new
+            // override instead of serving the previous source's URL.
+            directStreamCache.remove(mediaId)
+            // Evict the bare-keyed content length so [resolveCachedDataSpec] can't conclude the
+            // request is fully cached based on the previous source's byte size.
+            contentLengthCache.remove(mediaId)
             runCatching { playerCache.removeResource(mediaId) }
             runCatching { downloadCache.removeResource(mediaId) }
             AudioSourceType.entries.forEach { src ->
                 val key = sourceCacheKey(src, mediaId)
                 runCatching { playerCache.removeResource(key) }
                 runCatching { downloadCache.removeResource(key) }
+                // Source-prefixed content-length entries are also stale after a source switch.
+                contentLengthCache.remove(key)
             }
+            // Cancel any in-flight crossfade so its volume ramp / secondary player can't pin the
+            // primary player's volume low while the new source is preparing.
+            cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)
             player.prepare()
             player.seekTo(0)
             player.playWhenReady = true
+            // Restore the effective volume immediately (bypass the smooth ramp) so the new source
+            // doesn't briefly play muted while the ramp catches up. Re-claim audio focus in case
+            // the prepare transition dropped it, and start the audible-playback watchdog so any
+            // later volume dip gets corrected within the next polling window.
+            applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())
+            ensureAudioFocusForActivePlayback()
+            updateAudiblePlaybackRecovery()
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -1360,15 +1360,24 @@ class MusicService :
             // plays can fail while metadata/network are still settling.
             val stored = database.lyrics(mediaMetadata.id).first()
             val shouldFetch =
-                stored == null || stored.lyrics == LyricsEntity.LYRICS_NOT_FOUND
+                stored == null ||
+                    stored.lyrics == LyricsEntity.LYRICS_NOT_FOUND ||
+                    stored.providerName.isBlank()
             if (shouldFetch) {
                 val result = lyricsHelper.getLyricsWithProvider(mediaMetadata)
                 database.query {
-                    replaceLyricsIfAbsentOrNotFound(
-                        id = mediaMetadata.id,
-                        lyrics = result.lyrics,
-                        providerName = result.providerName,
-                    )
+                    if (stored != null && stored.lyrics != LyricsEntity.LYRICS_NOT_FOUND) {
+                        backfillLyricsProviderName(
+                            id = mediaMetadata.id,
+                            providerName = result.providerName,
+                        )
+                    } else {
+                        replaceLyricsIfAbsentOrNotFound(
+                            id = mediaMetadata.id,
+                            lyrics = result.lyrics,
+                            providerName = result.providerName,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -7805,12 +7805,20 @@ class MusicService :
             }
         }
         if (player.currentMediaItem?.mediaId == mediaId) {
-            // Drop any cached resolved stream for this song and re-prepare so the new source is used.
             playbackUrlCache.remove(mediaId)
             extractorPlaybackUrlCache.remove(mediaId)
             YTPlayerUtils.invalidateCachedStreamUrls(mediaId)
             tidalActiveMediaIds.remove(mediaId)
+            runCatching { playerCache.removeResource(mediaId) }
+            runCatching { downloadCache.removeResource(mediaId) }
+            AudioSourceType.entries.forEach { src ->
+                val key = sourceCacheKey(src, mediaId)
+                runCatching { playerCache.removeResource(key) }
+                runCatching { downloadCache.removeResource(key) }
+            }
             player.prepare()
+            player.seekTo(0)
+            player.playWhenReady = true
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -1362,11 +1362,12 @@ class MusicService :
             val shouldFetch =
                 stored == null || stored.lyrics == LyricsEntity.LYRICS_NOT_FOUND
             if (shouldFetch) {
-                val lyrics = lyricsHelper.getLyrics(mediaMetadata)
+                val result = lyricsHelper.getLyricsWithProvider(mediaMetadata)
                 database.query {
                     replaceLyricsIfAbsentOrNotFound(
                         id = mediaMetadata.id,
-                        lyrics = lyrics,
+                        lyrics = result.lyrics,
+                        providerName = result.providerName,
                     )
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
@@ -113,6 +113,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.LayoutDirection

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
@@ -73,6 +73,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -469,6 +470,7 @@ fun Lyrics(
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val lyricsEntity by playerConnection.currentLyrics.collectAsState(initial = null)
     val lyrics = remember(lyricsEntity) { lyricsEntity?.lyrics?.trim() }
+    val lyricsProviderName = lyricsEntity?.providerName.orEmpty()
 
     val playerBackground by rememberEnumPreference(
         key = PlayerBackgroundStyleKey,
@@ -799,6 +801,39 @@ fun Lyrics(
                 )
             }
         } else {
+            if (lyricsProviderName.isNotBlank()) {
+                val sourceAlpha by remember {
+                    derivedStateOf {
+                        val firstIdx = lazyListState.firstVisibleItemIndex
+                        val firstOffset = lazyListState.firstVisibleItemScrollOffset
+                        val firstItemSize = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull()?.size ?: 1
+                        if (firstIdx > 0) 0f
+                        else (1f - (firstOffset.toFloat() / firstItemSize)).coerceIn(0f, 1f)
+                    }
+                }
+                val animatedSourceAlpha by animateFloatAsState(
+                    targetValue = sourceAlpha,
+                    animationSpec = tween(durationMillis = 220),
+                    label = "lyricsSourceAlpha",
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp)
+                        .alpha(animatedSourceAlpha),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.secondary,
+                        textAlign = TextAlign.Center,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
             LazyColumn(
                 state = lazyListState,
                 contentPadding =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsImageCard.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsImageCard.kt
@@ -8,6 +8,7 @@
 package moe.rukamori.archivetune.ui.component
 
 import android.os.Build
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -21,8 +22,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -35,11 +39,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -455,5 +462,169 @@ private fun SongTextBlock(
                     .fillMaxWidth()
                     .heightIn(min = 18.dp),
         )
+    }
+}
+
+@Composable
+fun VinylImageCard(
+    songTitle: String,
+    artistName: String,
+    coverArtUrl: String?,
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val coverPainter =
+        rememberAsyncImagePainter(
+            ImageRequest
+                .Builder(context)
+                .data(coverArtUrl)
+                .crossfade(true)
+                .build(),
+        )
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        shape = MaterialTheme.shapes.large,
+        color = Color(0xFF051418),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(Color(0xFF0A1F24), Color(0xFF051418)),
+                    ),
+                ),
+            contentAlignment = Alignment.TopCenter,
+        ) {
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                val canvasSizeDp = minOf(maxWidth, maxHeight)
+                val canvasSizePx = with(density) { canvasSizeDp.toPx() }
+                val coverSize = canvasSizeDp * 0.46f
+                val discSize = canvasSizeDp * 0.46f
+                val coverLeft = (canvasSizeDp - coverSize) * 0.5f - coverSize * 0.10f
+                val coverTop = canvasSizeDp * 0.18f
+                val discLeft = coverLeft + coverSize * 0.62f
+                val discTop = coverTop
+                val labelRadius = discSize * 0.19f
+                val strokePx = with(density) { 1.2.dp.toPx() }
+
+                Box(
+                    modifier = Modifier
+                        .offset(x = discLeft, y = discTop)
+                        .size(discSize),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(CircleShape)
+                            .background(Color(0xFF050505)),
+                    )
+                    Canvas(
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        val grooveCount = 28
+                        val center = Offset(size.width / 2f, size.height / 2f)
+                        val maxRadius = size.minDimension / 2f
+                        repeat(grooveCount) { i ->
+                            val radius = maxRadius * ((i + 1f) / (grooveCount + 1f))
+                            drawCircle(
+                                color = Color.White.copy(alpha = 0.08f),
+                                radius = radius,
+                                center = center,
+                                style = Stroke(width = strokePx),
+                            )
+                        }
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(labelRadius * 2)
+                            .clip(CircleShape)
+                            .background(
+                                brush = Brush.radialGradient(
+                                    colors = listOf(Color(0xFF7DD3D8), Color(0xFF4FB6BC)),
+                                ),
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center,
+                            modifier = Modifier
+                                .width(labelRadius * 1.7f)
+                                .padding(horizontal = 2.dp),
+                        ) {
+                            androidx.compose.material3.Text(
+                                text = songTitle,
+                                color = Color(0xFF0A1F24),
+                                fontSize = (canvasSizePx * 0.038f / density.fontScale).sp,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                textAlign = TextAlign.Center,
+                            )
+                            androidx.compose.material3.Text(
+                                text = artistName,
+                                color = Color(0xFF0A1F24),
+                                fontSize = (canvasSizePx * 0.030f / density.fontScale).sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(discSize * 0.024f)
+                            .clip(CircleShape)
+                            .background(Color.Black),
+                    )
+                }
+
+                Box(
+                    modifier = Modifier
+                        .offset(x = coverLeft, y = coverTop)
+                        .size(coverSize)
+                        .clip(MaterialTheme.shapes.medium)
+                        .border(1.dp, Color.White, MaterialTheme.shapes.medium),
+                ) {
+                    Image(
+                        painter = coverPainter,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(bottom = canvasSizeDp * 0.06f)
+                        .padding(horizontal = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    androidx.compose.material3.Text(
+                        text = songTitle,
+                        color = Color.White,
+                        fontSize = (canvasSizePx * 0.038f / density.fontScale).sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    androidx.compose.material3.Text(
+                        text = artistName,
+                        color = Color.White.copy(alpha = 0.8f),
+                        fontSize = (canvasSizePx * 0.028f / density.fontScale).sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsShareDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsShareDialog.kt
@@ -18,7 +18,6 @@ import android.content.Intent
 import android.os.Build
 import android.widget.Toast
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -155,10 +154,9 @@ fun LyricsShareImageDialog(
     var paletteGlassStyle by remember { mutableStateOf<LyricsGlassStyle?>(null) }
     var options by remember { mutableStateOf(LyricsShareImageOptions()) }
     var areAdvancedOptionsVisible by remember { mutableStateOf(false) }
-    // User-overridden lyrics text color. When null, the active glass style's default textColor is
-    // used. Reset to null whenever the style changes so picking a new style reverts the override —
-    // this matches user expectation: "pick Frosted Light" → text becomes dark; "pick Frosted Dark"
-    // → text becomes white; an explicit custom color should not bleed across style swaps.
+
+    
+    
     var customTextColor by remember { mutableStateOf<Color?>(null) }
 
     LaunchedEffect(selectedGlassStyle) { customTextColor = null }
@@ -207,10 +205,9 @@ fun LyricsShareImageDialog(
             isSharing = true
             scope.launch {
                 try {
-                    // Vinyl mode renders its own dedicated layout (album cover + vinyl
-                    // disc + center label) and skips the lyrics card entirely. The
-                    // other share options (blur, dim, aspect ratio) are ignored —
-                    // vinyl mode has its own fixed composition.
+
+                    
+                    
                     val image =
                         if (options.vinylMode) {
                             ComposeToImage.createVinylImage(
@@ -415,11 +412,7 @@ private fun LyricsShareStudioScaffold(
     modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
-    val motionScheme = MaterialTheme.motionScheme
-    // Compact M3-Expressive spacing: dropped from 16/20 dp to 12/14 dp to fit the entire
-    // controls panel above the fold on most phones, and pulled the section spacing down from
-    // 14/18 dp to 10/12 dp for tighter rhythm. The user complaint was excessive whitespace
-    // between the header text and the preview, and oversized chips — both addressed here.
+
     val horizontalPadding = if (isCompactLayout) 12.dp else 16.dp
     val verticalPadding = if (isCompactLayout) 12.dp else 16.dp
     val sectionSpacing = if (isCompactLayout) 10.dp else 12.dp
@@ -428,20 +421,15 @@ private fun LyricsShareStudioScaffold(
         modifier =
             modifier
                 .fillMaxWidth()
-                // fillMaxHeight ensures the weighted scrollable Column below always gets a
-                // definite height to distribute. Without this, when the content exceeds the
-                // Surface's heightIn(max = maxDialogHeight) cap, the weight modifier has no
-                // bounded parent height to distribute and the scrollable area overflows the
-                // Surface — which then clips the bottom rows (e.g. "Show album cover" description).
-                .fillMaxHeight()
-                .animateContentSize(animationSpec = motionScheme.defaultSpatialSpec()),
+                .fillMaxHeight(),
     ) {
         Column(
             modifier =
                 Modifier
                     .weight(1f, fill = true)
                     .verticalScroll(scrollState)
-                    .padding(horizontal = horizontalPadding, vertical = verticalPadding),
+                    .padding(horizontal = horizontalPadding, vertical = verticalPadding)
+                    .padding(bottom = 8.dp),
             verticalArrangement = Arrangement.spacedBy(sectionSpacing),
         ) {
             if (isCompactLayout) {
@@ -538,10 +526,8 @@ private fun LyricsShareHeader(
                 .orEmpty()
         }
 
-    // Compact header: title and artist share a single row (title bold, artist secondary)
-    // instead of stacked, which saves one line of vertical space. The lyric snippet is
-    // dropped when it would duplicate the title, and the resolution pill sits inline with
-    // the artist row. The previous layout used 4 stacked text blocks + a pill = ~5 lines.
+    
+
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -616,8 +602,7 @@ private fun PreviewContainer(
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.primaryContainer,
     ) {
-        // Trimmed vertical padding from 18dp → 12dp to recover vertical space (user complaint:
-        // too much whitespace around the preview card).
+
         Column(
             modifier = Modifier.padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -639,15 +624,23 @@ private fun PreviewContainer(
                             ).padding(8.dp),
                     contentAlignment = Alignment.Center,
                 ) {
-                    LyricsImageCard(
-                        lyricText = payload.lyricsText,
-                        songTitle = payload.songTitle,
-                        artistName = payload.artists,
-                        coverArtUrl = mediaMetadata?.thumbnailUrl,
-                        glassStyle = selectedGlassStyle,
-                        shareOptions = options,
-                        textColor = customTextColor,
-                    )
+                    if (options.vinylMode) {
+                        VinylImageCard(
+                            songTitle = payload.songTitle,
+                            artistName = payload.artists,
+                            coverArtUrl = mediaMetadata?.thumbnailUrl,
+                        )
+                    } else {
+                        LyricsImageCard(
+                            lyricText = payload.lyricsText,
+                            songTitle = payload.songTitle,
+                            artistName = payload.artists,
+                            coverArtUrl = mediaMetadata?.thumbnailUrl,
+                            glassStyle = selectedGlassStyle,
+                            shareOptions = options,
+                            textColor = customTextColor,
+                        )
+                    }
                 }
             }
         }
@@ -668,20 +661,13 @@ private fun ControlsSection(
     isCompactLayout: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val motionScheme = MaterialTheme.motionScheme
     Surface(
         modifier =
             modifier
-                .fillMaxWidth()
-                .animateContentSize(animationSpec = motionScheme.defaultSpatialSpec()),
+                .fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
     ) {
-        // Compact M3-Expressive controls: tighter padding (16/14 → 12/10) and tighter section
-        // spacing (14 → 10) so the whole panel fits one screen on most phones. The color
-        // swatch row now uses 8dp spacing instead of 10dp, and the text-color row lets the
-        // compact 32dp swatches flow with up to 8 per line — they no longer need labels so
-        // they pack densely.
         Column(
             modifier =
                 Modifier
@@ -707,14 +693,11 @@ private fun ControlsSection(
 
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
-            // Vinyl mode toggle — sits prominently as its own section right under
-            // the layout selector because enabling it overrides every other
-            // control below (the vinyl layout has its own fixed composition:
-            // album cover + disc + center label, no lyrics card, always 1:1).
-            // Mirrors the "Show album cover" toggle pattern below: Box with
-            // background + clip on the SAME modifier chain so the rounded shape
-            // clips the painted result without cropping measured-but-unpainted
-            // description text.
+            
+
+            
+
+            
             Row(
                 modifier =
                     Modifier
@@ -767,14 +750,11 @@ private fun ControlsSection(
 
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
-            // Lyrics text color override. The row of swatches lets the user pick a custom text
-            // color independent of the glass-style preset. The first chip ("Style default") clears
-            // the override, the rest are preset colors. Selecting a swatch re-renders the preview
-            // immediately; the change is also applied to the exported PNG via `textColor` on
-            // `ComposeToImage.createLyricsImage`.
-            //
-            // With the new compact 32dp circular swatches (no labels), up to 8 fit per row,
-            // collapsing the previous 6-row pill grid into 2 rows.
+            
+
+            
+
+            
             LyricsShareControlGroup(title = stringResource(R.string.lyrics_share_text_color)) {
                 FlowRow(
                     modifier = Modifier.fillMaxWidth(),
@@ -816,15 +796,12 @@ private fun ControlsSection(
                         onValueChange = { onOptionsChange(options.copy(dimAmount = it)) },
                         valueRange = 0.6f..1.6f,
                     )
-                    // The toggle row uses a Box-with-background pattern (instead of a Surface)
-                    // because Surface internally applies `Modifier.clip(shape)` on a separate
-                    // modifier chain from its content measurement. When the wrapped description
-                    // text needs 2 lines and the dialog is height-constrained, Surface's clip
-                    // would silently crop the second line ("...the exported image.") even
-                    // though the Row measured it. By putting `clip + background + clickable +
-                    // padding` on the SAME Row modifier chain, the layout measures the wrapped
-                    // text first, then clips the painted result to the rounded shape — no
-                    // cropping of measured-but-unpainted content.
+
+                    
+
+                    
+
+                    
                     Row(
                         modifier =
                             Modifier
@@ -858,9 +835,8 @@ private fun ControlsSection(
                     }
                 }
             } else {
-                // "More options" toggle in its original position — a full-width TextButton at
-                // the bottom of the scrollable controls area. This was the placement before
-                // the header-move experiment; the user explicitly asked to revert.
+
+                
                 TextButton(
                     onClick = onShowAdvancedOptions,
                     modifier =
@@ -958,7 +934,6 @@ private fun LyricsAspectRatioOption(
         label = "lyricsAspectContent",
     )
 
-    // Compact chip: 40dp min height (was 48dp) and tighter horizontal padding (14→12).
     Surface(
         modifier =
             modifier
@@ -1016,8 +991,7 @@ private fun LyricsStyleOption(
         label = "lyricsStyleContainer",
     )
 
-    // Compact style chip: 40dp min height (was 48dp), 10dp vertical padding (was 10),
-    // 12dp horizontal padding (was 12). Tighter internal spacing between swatch and label.
+    
     Surface(
         modifier =
             modifier
@@ -1109,7 +1083,7 @@ private fun ActionsSection(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Compact action row: 48dp height (was 52dp), 12dp vertical padding (was 14dp).
+    
     val actionModifier = Modifier.height(48.dp)
     val contentPadding =
         Modifier.padding(
@@ -1208,17 +1182,6 @@ private fun ActionsSection(
     }
 }
 
-/**
- * Preset color swatches shown in the "Lyrics text color" row. Curated to span a wide perceptual
- * range while remaining legible on the dark/frosted backgrounds that the glass-style presets
- * typically produce — white, near-black, soft cream, red, orange, yellow, green, teal, blue,
- * indigo, purple, pink. Anything picked here overrides the glass-style's default textColor on
- * both the live preview and the exported PNG.
- *
- * Each preset has its own human-readable label (White, Black, Cream, …) rather than the old
- * "Custom" stub — the previous code labelled every swatch "Custom", which gave the user no way
- * to tell which swatch was which without tapping each one.
- */
 private enum class LyricsTextColorPreset(
     val color: Color,
     val labelRes: Int,
@@ -1262,10 +1225,8 @@ private fun LyricsTextColorSwatch(
         label = "lyricsTextSwatchScale",
     )
 
-    // Compact M3-Expressive swatch: just a coloured circle with a selection ring.
-    // The label is exposed via the contentDescription for accessibility but is not drawn —
-    // this collapses the previous 48dp-tall pill row (with text + 22dp circle) into a
-    // 32dp circle-only row, freeing vertical space for the preview.
+    
+
     Box(
         modifier =
             modifier

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/ProfileMenuDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/ProfileMenuDialog.kt
@@ -9,6 +9,7 @@ package moe.rukamori.archivetune.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,25 +45,6 @@ import androidx.compose.ui.window.DialogProperties
 import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.R
 
-/**
- * Centered, modal profile menu — replaces the previous anchored [androidx.compose.material3.DropdownMenu].
- *
- * Renders as a separate [Dialog] (in its own window) centered on screen, with a
- * plain dim scrim behind it (no blur).
- *
- * Material 3 Expressive styling:
- *   - 28.dp corner radius (M3 Expressive large surface)
- *   - `surfaceContainerHigh` tonal elevation
- *   - 24.dp horizontal padding, 8.dp vertical
- *   - Header with avatar (or initials fallback) + display name + "View profile"
- *     subtitle row
- *   - ListItem rows with `leadingContent` icons, BadgedBox for unread badges
- *
- * @param accountName Display name shown in the header (may be blank).
- * @param accountImageUrl Avatar URL shown in the header (may be null).
- * @param items The menu items to render (icon, label, badge, onClick).
- * @param onDismiss Called when the dialog is dismissed (tap outside, back).
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileMenuDialog(
@@ -75,20 +58,24 @@ fun ProfileMenuDialog(
         properties = DialogProperties(
             usePlatformDefaultWidth = false,
             decorFitsSystemWindows = false,
+            dismissOnClickOutside = true,
         ),
     ) {
+        val scrimInteraction = remember { MutableInteractionSource() }
         Box(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            // Plain dim scrim behind the dialog — no blur.
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.55f)),
+                    .background(Color.Black.copy(alpha = 0.55f))
+                    .clickable(
+                        interactionSource = scrimInteraction,
+                        indication = null,
+                    ) { onDismiss() },
             )
 
-            // Modal surface with the actual menu content.
             Surface(
                 modifier = Modifier
                     .widthIn(max = 380.dp)
@@ -103,7 +90,7 @@ fun ProfileMenuDialog(
                         .fillMaxWidth()
                         .padding(vertical = 8.dp),
                 ) {
-                    // Header: avatar + account name
+                    
                     if (accountName.isNotBlank()) {
                         ListItem(
                             headlineContent = {
@@ -191,7 +178,6 @@ fun ProfileMenuDialog(
     }
 }
 
-/** A single profile menu item. */
 data class ProfileMenuItem(
     val icon: Int,
     val label: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -310,6 +310,7 @@ fun LyricsMenu(
                     mediaMetadata = searchMediaMetadata,
                     lyrics = result.lyrics,
                     source = LyricsEntity.Source.USER_SELECTION,
+                    providerName = result.providerName,
                 )
             },
             onDismiss = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -95,6 +95,7 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.db.entities.FormatEntity
 import moe.rukamori.archivetune.db.entities.codecLabel
+import moe.rukamori.archivetune.db.entities.isLossless
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.playback.PlayerConnection
@@ -948,6 +949,9 @@ private fun AppleMusicQualityChip(
     val label = remember(currentFormat.mimeType, currentFormat.codecs) {
         currentFormat.codecLabel()
     }
+    val lossless = remember(currentFormat.codecs, currentFormat.mimeType) {
+        currentFormat.isLossless()
+    }
     Surface(
         shape = RoundedCornerShape(6.dp),
         color = Color.White.copy(alpha = 0.1f),
@@ -960,10 +964,12 @@ private fun AppleMusicQualityChip(
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
         ) {
             Icon(
-                painter = painterResource(R.drawable.player_graphic_eq),
+                painter = painterResource(
+                    if (lossless) R.drawable.ic_mqa else R.drawable.player_graphic_eq,
+                ),
                 contentDescription = null,
                 tint = Color.White.copy(alpha = 0.72f),
-                modifier = Modifier.size(15.dp),
+                modifier = Modifier.size(if (lossless) 18.dp else 15.dp),
             )
             Text(
                 text = label,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -272,7 +272,7 @@ fun LyricsScreen(
                 ).lyricsHelper()
         }
 
-    LaunchedEffect(mediaMetadata.id, currentLyrics?.lyrics) {
+    LaunchedEffect(mediaMetadata.id, currentLyrics?.lyrics, currentLyrics?.providerName) {
 
         
 
@@ -283,7 +283,8 @@ fun LyricsScreen(
         val snapshot = currentLyrics
         val needsFetch =
             snapshot == null ||
-                snapshot.lyrics == LyricsEntity.LYRICS_NOT_FOUND
+                snapshot.lyrics == LyricsEntity.LYRICS_NOT_FOUND ||
+                snapshot.providerName.isBlank()
         if (!needsFetch) return@LaunchedEffect
         try {
             val existingLyrics =
@@ -291,9 +292,10 @@ fun LyricsScreen(
                     database.lyrics(mediaMetadata.id).first()
                 }
 
-            if (existingLyrics != null &&
-                existingLyrics.lyrics != LyricsEntity.LYRICS_NOT_FOUND
-            ) {
+            val hasValidLyrics =
+                existingLyrics != null &&
+                    existingLyrics.lyrics != LyricsEntity.LYRICS_NOT_FOUND
+            if (hasValidLyrics && existingLyrics != null && existingLyrics.providerName.isNotBlank()) {
                 return@LaunchedEffect
             }
 
@@ -303,11 +305,18 @@ fun LyricsScreen(
                 }
             withContext(Dispatchers.IO) {
                 database.query {
-                    replaceLyricsIfAbsentOrNotFound(
-                        id = mediaMetadata.id,
-                        lyrics = lyricsResult.lyrics,
-                        providerName = lyricsResult.providerName,
-                    )
+                    if (hasValidLyrics) {
+                        backfillLyricsProviderName(
+                            id = mediaMetadata.id,
+                            providerName = lyricsResult.providerName,
+                        )
+                    } else {
+                        replaceLyricsIfAbsentOrNotFound(
+                            id = mediaMetadata.id,
+                            lyrics = lyricsResult.lyrics,
+                            providerName = lyricsResult.providerName,
+                        )
+                    }
                 }
             }
         } catch (e: CancellationException) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -273,16 +273,13 @@ fun LyricsScreen(
         }
 
     LaunchedEffect(mediaMetadata.id, currentLyrics?.lyrics) {
-        // Only fetch manually here if the background MusicService fetch hasn't
-        // populated anything yet, OR if it populated a LYRICS_NOT_FOUND (so the
-        // user gets an automatic retry when they open the lyrics panel instead
-        // of being forced to use the manual search menu).
-        //
-        // NOTE: snapshot `currentLyrics` into a local val so the compiler can
-        // smart-cast it to non-null. `currentLyrics` itself is a delegated
-        // property (State<LyricsEntity?>) and cannot be smart-cast across the
-        // `||` because it could be invalidated between the null-check and the
-        // member-access.
+
+        
+
+        
+
+        
+        
         val snapshot = currentLyrics
         val needsFetch =
             snapshot == null ||
@@ -293,23 +290,23 @@ fun LyricsScreen(
                 withContext(Dispatchers.IO) {
                     database.lyrics(mediaMetadata.id).first()
                 }
-            // Skip only if we already have real lyrics. LYRICS_NOT_FOUND triggers
-            // a retry below (mirrors MusicService behavior).
+
             if (existingLyrics != null &&
                 existingLyrics.lyrics != LyricsEntity.LYRICS_NOT_FOUND
             ) {
                 return@LaunchedEffect
             }
 
-            val lyrics =
+            val lyricsResult =
                 withContext(Dispatchers.IO) {
-                    lyricsHelper.getLyrics(mediaMetadata)
+                    lyricsHelper.getLyricsWithProvider(mediaMetadata)
                 }
             withContext(Dispatchers.IO) {
                 database.query {
                     replaceLyricsIfAbsentOrNotFound(
                         id = mediaMetadata.id,
-                        lyrics = lyrics,
+                        lyrics = lyricsResult.lyrics,
+                        providerName = lyricsResult.providerName,
                     )
                 }
             }
@@ -322,8 +319,7 @@ fun LyricsScreen(
     val positionState = remember(mediaMetadata.id) { mutableLongStateOf(0L) }
     val durationState = remember(mediaMetadata.id) { mutableLongStateOf(C.TIME_UNSET) }
     var sliderPosition by remember(mediaMetadata.id) { mutableStateOf<Long?>(null) }
-    // Keep the previous valid palette while the next artwork loads; the grey fallback is
-    // only the initial state, not the response to every track change or transient failure.
+
     var gradientColors by remember { mutableStateOf(AppleMusicFallbackGradient) }
     var hasValidPalette by remember { mutableStateOf(false) }
 
@@ -331,16 +327,13 @@ fun LyricsScreen(
     val darkTheme = isSystemInDarkTheme()
 
     LaunchedEffect(mediaMetadata.id, mediaMetadata.thumbnailUrl, lyricsBackground, darkTheme) {
-        // Yield one frame before kicking off Palette extraction. The lyrics
-        // sheet's slide-up animation runs in the draw phase (graphicsLayer)
-        // and doesn't recompose per frame on its own, but the *first*
-        // composition of LyricsScreen still runs heavy code on the IO/Default
-        // dispatchers (Palette generate + image decode) that competes with
-        // the spring animation for CPU on low/mid-range phones. A 120ms
-        // delay lets the spring get ~60% of the way through its travel
-        // before Palette work starts — invisible to the user (the blurred
-        // background thumbnail covers the unextracted state) but noticeably
-        // smoother on devices where the open animation was laggy.
+
+        
+
+        
+
+        
+        
         kotlinx.coroutines.delay(120)
         if (lyricsBackground != LyricsBackgroundStyle.DEFAULT &&
             lyricsBackground != LyricsBackgroundStyle.COLORING &&
@@ -411,8 +404,7 @@ fun LyricsScreen(
                 null
             }
 
-        // On failure keep the previous valid palette; only a never-successful state falls
-        // back to the neutral gradient.
+        
         if (extractedColors != null) {
             val stillCurrent =
                 mediaMetadata.thumbnailUrl == thumbnailUrl
@@ -724,33 +716,6 @@ private fun LyricsScreenBackground(
     }
 }
 
-/**
- * "Moving Blur" lyrics background — replicates Apple Music's signature animated
- * blur effect. The album art is rendered at ~1.4× the screen size, heavily
- * blurred, and slowly drifts along a Lissajous-like path (two sinusoidal
- * offsets with coprime periods so the drift doesn't loop too obviously).
- *
- * On top of the drifting art we lay:
- *   - a vertical gradient built from the song's Palette (same gradient source
- *     as [AppleMusicBackground], so palette-extraction logic is reused)
- *   - a flat black scrim to keep lyric contrast stable regardless of art brightness
- *   - a subtle bottom vignette so the lower controls stay readable
- *
- * Implementation notes:
- *   - The drift uses [rememberInfiniteTransition] + [animateFloat]s with
- *     `RepeatMode.Reverse` so the artwork eases back and forth instead of
- *     jumping when the loop wraps. Periods of 23s and 31s are coprime, so the
- *     combined path repeats every ~713s — long enough that users won't notice.
- *   - We render the AsyncImage at fixed `IntSize`-independent offsets via
- *     [Modifier.offset] (px units) rather than [Modifier.padding] so layout
- *     measure passes aren't invalidated every frame.
- *   - `Modifier.blur(64.dp)` is the main visual cost — comparable to the
- *     existing `AppleMusicBackground` (46.dp). Hardware-accelerated on
- *     Android 12+, gated to S+ in AppearanceSettings.
- *   - We scale the image to 1.4× of the screen's largest dimension before
- *     blurring so the blurred edges never reveal transparent pixels as the
- *     art drifts.
- */
 @Composable
 private fun MovingBlurBackground(
     mediaMetadata: MediaMetadata,
@@ -758,9 +723,8 @@ private fun MovingBlurBackground(
     modifier: Modifier = Modifier,
 ) {
     val colors = if (gradientColors.isNotEmpty()) gradientColors else AppleMusicFallbackGradient
-    // Reduced scrim alphas — the previous 0.78/0.66/0.86 stack left only ~5% of
-    // the artwork visible, so the drift was imperceptible. These still keep
-    // lyric contrast stable but actually let the blurred artwork read through.
+
+    
     val backgroundBrush =
         remember(colors) {
             Brush.verticalGradient(
@@ -781,10 +745,8 @@ private fun MovingBlurBackground(
             )
         }
 
-    // Wider drift range + FastOutSlowInEasing so motion is actually perceptible
-    // under a 64-dp blur kernel. The previous ±32dp / ±28dp range with linear
-    // easing produced sub-perceptual motion that users reported as "not working".
-    // Periods of 19s and 27s are coprime so the combined path rarely repeats.
+    
+
     val transition = rememberInfiniteTransition(label = "moving-blur-drift")
     val driftX by transition.animateFloat(
         initialValue = -120f,
@@ -822,11 +784,9 @@ private fun MovingBlurBackground(
         ) { thumbnailUrl ->
             if (thumbnailUrl != null) {
                 if (isPreS) {
-                    // Pre-S fallback (PR #924 approach): Modifier.blur is a silent
-                    // no-op below API 31, so we pre-blur the bitmap on a
-                    // background thread via ImageBlurUtils.blur and render it
-                    // directly. The drift is applied via Modifier.offset so the
-                    // animation runs every frame without re-blurring.
+
+                    
+
                     val blurredBitmap by produceState<Bitmap?>(null, thumbnailUrl) {
                         value = withContext(Dispatchers.IO) {
                             try {
@@ -865,10 +825,9 @@ private fun MovingBlurBackground(
                         )
                     }
                 } else {
-                    // S+ path: AsyncImage + Modifier.blur + drift. Single
-                    // graphicsLayer block so blur operates on the already-scaled
-                    // content (avoids faded-edge bleed from the inner offset
-                    // revealing transparent pixels).
+
+                    
+                    
                     AsyncImage(
                         model = thumbnailUrl,
                         contentDescription = null,
@@ -886,13 +845,13 @@ private fun MovingBlurBackground(
                 }
             }
         }
-        // Tonal gradient — gives the background depth and ties it to the palette.
+        
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(backgroundBrush),
         )
-        // Subtle bottom vignette for control readability.
+        
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -944,10 +903,9 @@ private fun AppleMusicBackground(
         ) { thumbnailUrl ->
             if (thumbnailUrl != null) {
                 if (isPreS) {
-                    // Pre-S fallback (PR #924 approach): inline produceState that
-                    // pre-blurs the bitmap on a background thread via
-                    // ImageBlurUtils.blur and renders it directly. Modifier.blur
-                    // is a silent no-op below API 31.
+
+                    
+                    
                     val blurredBitmap by produceState<Bitmap?>(null, thumbnailUrl) {
                         value = withContext(Dispatchers.IO) {
                             try {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
@@ -84,6 +84,11 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.HideAiMixKey
+import moe.rukamori.archivetune.constants.HideCachedCardKey
+import moe.rukamori.archivetune.constants.HideLikedSongsCardKey
+import moe.rukamori.archivetune.constants.HideLocalFilesCardKey
+import moe.rukamori.archivetune.constants.HideOfflineCardKey
+import moe.rukamori.archivetune.constants.HideTop50CardKey
 import moe.rukamori.archivetune.constants.LibraryFilter
 import moe.rukamori.archivetune.constants.ShowSpotifyPlaylistsKey
 import moe.rukamori.archivetune.extensions.toMediaItem
@@ -138,6 +143,11 @@ fun LibraryMixScreen(
     val spotifyPlaylists by spotifyLibraryViewModel.playlists.collectAsStateWithLifecycle()
     val (showSpotifyPlaylists) = rememberPreference(ShowSpotifyPlaylistsKey, false)
     val (hideAiMix) = rememberPreference(HideAiMixKey, false)
+    val (hideLikedSongsCard) = rememberPreference(HideLikedSongsCardKey, false)
+    val (hideOfflineCard) = rememberPreference(HideOfflineCardKey, false)
+    val (hideCachedCard) = rememberPreference(HideCachedCardKey, false)
+    val (hideLocalFilesCard) = rememberPreference(HideLocalFilesCardKey, false)
+    val (hideTop50Card) = rememberPreference(HideTop50CardKey, false)
 
     val filteredPlaylistIds by database
         .playlistIdsByTags(
@@ -223,82 +233,105 @@ fun LibraryMixScreen(
 
                 // 2. Shortcuts Grid
                 item(key = "shortcuts_grid", contentType = "shortcuts_grid") {
-                    Column(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 24.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            modifier = Modifier.fillMaxWidth(),
+                    val showRow1 = !hideLikedSongsCard || !hideOfflineCard
+                    val showRow2 = !hideCachedCard || !hideLocalFilesCard
+                    val showRow3 = !hideTop50Card
+                    if (showRow1 || showRow2 || showRow3) {
+                        Column(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 24.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            // Liked Songs
-                            ShortcutCard(
-                                title = stringResource(R.string.liked_songs),
-                                countText = "$likedSongsCount ${stringResource(R.string.tracks_label)}",
-                                iconRes = R.drawable.favorite,
-                                containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.6f),
-                                iconColor = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.weight(1f),
-                                onClick = { navController.navigate("auto_playlist/liked") },
-                            )
+                            if (showRow1) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    if (!hideLikedSongsCard) {
+                                        ShortcutCard(
+                                            title = stringResource(R.string.liked_songs),
+                                            countText = "$likedSongsCount ${stringResource(R.string.tracks_label)}",
+                                            iconRes = R.drawable.favorite,
+                                            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.6f),
+                                            iconColor = MaterialTheme.colorScheme.error,
+                                            modifier = Modifier.weight(1f),
+                                            onClick = { navController.navigate("auto_playlist/liked") },
+                                        )
+                                    } else {
+                                        Spacer(Modifier.weight(1f))
+                                    }
 
-                            // Offline/Downloaded
-                            ShortcutCard(
-                                title = stringResource(R.string.offline_shortcut),
-                                countText = stringResource(R.string.downloaded_desc),
-                                iconRes = R.drawable.offline,
-                                containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
-                                iconColor = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.weight(1f),
-                                onClick = { navController.navigate("auto_playlist/downloaded") },
-                            )
-                        }
+                                    if (!hideOfflineCard) {
+                                        ShortcutCard(
+                                            title = stringResource(R.string.offline_shortcut),
+                                            countText = stringResource(R.string.downloaded_desc),
+                                            iconRes = R.drawable.offline,
+                                            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
+                                            iconColor = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.weight(1f),
+                                            onClick = { navController.navigate("auto_playlist/downloaded") },
+                                        )
+                                    } else {
+                                        Spacer(Modifier.weight(1f))
+                                    }
+                                }
+                            }
 
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            // Cached
-                            ShortcutCard(
-                                title = stringResource(R.string.cached),
-                                countText = stringResource(R.string.instant_playback),
-                                iconRes = R.drawable.cached,
-                                containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f),
-                                iconColor = MaterialTheme.colorScheme.tertiary,
-                                modifier = Modifier.weight(1f),
-                                onClick = { navController.navigate("cache_playlist/cached") },
-                            )
+                            if (showRow2) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    if (!hideCachedCard) {
+                                        ShortcutCard(
+                                            title = stringResource(R.string.cached),
+                                            countText = stringResource(R.string.instant_playback),
+                                            iconRes = R.drawable.cached,
+                                            containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f),
+                                            iconColor = MaterialTheme.colorScheme.tertiary,
+                                            modifier = Modifier.weight(1f),
+                                            onClick = { navController.navigate("cache_playlist/cached") },
+                                        )
+                                    } else {
+                                        Spacer(Modifier.weight(1f))
+                                    }
 
-                            // Local Files
-                            ShortcutCard(
-                                title = stringResource(R.string.local_files),
-                                countText = stringResource(R.string.on_device),
-                                iconRes = R.drawable.snippet_folder,
-                                containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
-                                iconColor = MaterialTheme.colorScheme.secondary,
-                                modifier = Modifier.weight(1f),
-                                onClick = { navController.navigate("local_songs") },
-                            )
-                        }
+                                    if (!hideLocalFilesCard) {
+                                        ShortcutCard(
+                                            title = stringResource(R.string.local_files),
+                                            countText = stringResource(R.string.on_device),
+                                            iconRes = R.drawable.snippet_folder,
+                                            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+                                            iconColor = MaterialTheme.colorScheme.secondary,
+                                            modifier = Modifier.weight(1f),
+                                            onClick = { navController.navigate("local_songs") },
+                                        )
+                                    } else {
+                                        Spacer(Modifier.weight(1f))
+                                    }
+                                }
+                            }
 
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            ShortcutCard(
-                                title = topPlaylistTitle,
-                                countText = stringResource(R.string.all_time),
-                                iconRes = R.drawable.trending_up,
-                                containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
-                                iconColor = MaterialTheme.colorScheme.secondary,
-                                modifier = Modifier.weight(1f),
-                                onClick = { navController.navigate("top_playlist/$topSize") },
-                            )
+                            if (showRow3) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    ShortcutCard(
+                                        title = topPlaylistTitle,
+                                        countText = stringResource(R.string.all_time),
+                                        iconRes = R.drawable.trending_up,
+                                        containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+                                        iconColor = MaterialTheme.colorScheme.secondary,
+                                        modifier = Modifier.weight(1f),
+                                        onClick = { navController.navigate("top_playlist/$topSize") },
+                                    )
 
-                            Spacer(modifier = Modifier.weight(1f))
+                                    Spacer(modifier = Modifier.weight(1f))
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -78,6 +78,11 @@ import moe.rukamori.archivetune.constants.CustomFontUriKey
 import moe.rukamori.archivetune.constants.DarkModeKey
 import moe.rukamori.archivetune.constants.DefaultOpenTabKey
 import moe.rukamori.archivetune.constants.HideNavigationBarLabelsKey
+import moe.rukamori.archivetune.constants.HideCachedCardKey
+import moe.rukamori.archivetune.constants.HideLikedSongsCardKey
+import moe.rukamori.archivetune.constants.HideLocalFilesCardKey
+import moe.rukamori.archivetune.constants.HideOfflineCardKey
+import moe.rukamori.archivetune.constants.HideTop50CardKey
 import moe.rukamori.archivetune.constants.NavigationBarFrostedBlurKey
 import moe.rukamori.archivetune.constants.NavigationBarStyle
 import moe.rukamori.archivetune.constants.NavigationBarStyleKey
@@ -164,6 +169,16 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
             HidePlayerThumbnailKey,
             defaultValue = false,
         )
+    val (hideLikedSongsCard, onHideLikedSongsCardChange) =
+        rememberPreference(HideLikedSongsCardKey, defaultValue = false)
+    val (hideOfflineCard, onHideOfflineCardChange) =
+        rememberPreference(HideOfflineCardKey, defaultValue = false)
+    val (hideCachedCard, onHideCachedCardChange) =
+        rememberPreference(HideCachedCardKey, defaultValue = false)
+    val (hideLocalFilesCard, onHideLocalFilesCardChange) =
+        rememberPreference(HideLocalFilesCardKey, defaultValue = false)
+    val (hideTop50Card, onHideTop50CardChange) =
+        rememberPreference(HideTop50CardKey, defaultValue = false)
     // The ArchiveTune Canvas artwork toggle lives in Player Settings → Artwork.
     val (thumbnailCornerRadius, onThumbnailCornerRadiusChange) =
         rememberPreference(
@@ -1084,6 +1099,56 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         icon = { Icon(painterResource(R.drawable.filter_alt), null) },
                         checked = showTagsInLibrary,
                         onCheckedChange = onShowTagsInLibraryChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_liked_songs_card)) },
+                        description = stringResource(R.string.hide_liked_songs_card_desc),
+                        icon = { Icon(painterResource(R.drawable.favorite), null) },
+                        checked = hideLikedSongsCard,
+                        onCheckedChange = onHideLikedSongsCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_offline_card)) },
+                        description = stringResource(R.string.hide_offline_card_desc),
+                        icon = { Icon(painterResource(R.drawable.offline), null) },
+                        checked = hideOfflineCard,
+                        onCheckedChange = onHideOfflineCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_cached_card)) },
+                        description = stringResource(R.string.hide_cached_card_desc),
+                        icon = { Icon(painterResource(R.drawable.cached), null) },
+                        checked = hideCachedCard,
+                        onCheckedChange = onHideCachedCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_local_files_card)) },
+                        description = stringResource(R.string.hide_local_files_card_desc),
+                        icon = { Icon(painterResource(R.drawable.snippet_folder), null) },
+                        checked = hideLocalFilesCard,
+                        onCheckedChange = onHideLocalFilesCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_top50_card)) },
+                        description = stringResource(R.string.hide_top50_card_desc),
+                        icon = { Icon(painterResource(R.drawable.trending_up), null) },
+                        checked = hideTop50Card,
+                        onCheckedChange = onHideTop50CardChange,
                     )
                 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
@@ -11,6 +11,7 @@
 
 package moe.rukamori.archivetune.ui.screens.settings
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
@@ -25,20 +26,31 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.DeezerAccountNameKey
+import moe.rukamori.archivetune.constants.DeezerAccountPremiumKey
+import moe.rukamori.archivetune.constants.DeezerArlKey
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.rememberPreference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DeezerSettings(navController: NavController) {
+    val context = LocalContext.current
+
+    val (accountName, onAccountNameChange) = rememberPreference(DeezerAccountNameKey, "")
+    val (_, onArlChange) = rememberPreference(DeezerArlKey, "")
+    val (_, onPremiumChange) = rememberPreference(DeezerAccountPremiumKey, false)
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -70,13 +82,33 @@ fun DeezerSettings(navController: NavController) {
             PreferenceGroup(
                 title = stringResource(R.string.deezer_integration),
             ) {
-                item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.deezer_login)) },
-                        description = stringResource(R.string.deezer_login_description),
-                        icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
-                        onClick = { navController.navigate(DEEZER_LOGIN_ROUTE) },
-                    )
+                if (accountName.isEmpty()) {
+                    item {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.deezer_login)) },
+                            description = stringResource(R.string.deezer_login_description),
+                            icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
+                            onClick = { navController.navigate(DEEZER_LOGIN_ROUTE) },
+                        )
+                    }
+                } else {
+                    item {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.deezer_sign_out)) },
+                            description = stringResource(R.string.deezer_signed_in_as, accountName),
+                            icon = { Icon(painterResource(R.drawable.logout), null) },
+                            onClick = {
+                                // Clearing the ARL is what actually signs out; App.kt's collector observes it
+                                // and drops the provider's session. Name/premium are display state only.
+                                onArlChange("")
+                                onAccountNameChange("")
+                                onPremiumChange(false)
+                                Toast
+                                    .makeText(context, R.string.deezer_signed_out, Toast.LENGTH_SHORT)
+                                    .show()
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.core.RepeatableSpec
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -99,8 +100,14 @@ import moe.rukamori.archivetune.ui.utils.backToMain
 import javax.inject.Inject
 
 private val DashboardAccentColor = Color(0xFFBE123C)
-private val DashboardCardBackground = Color(0xFFFFF5F5)
-private val DashboardIconBackground = Color(0xFFFFE4E6)
+
+@Composable
+private fun dashboardCardColor(): Color =
+    if (isSystemInDarkTheme()) Color(0xFF1F1416) else Color(0xFFFFF5F5)
+
+@Composable
+private fun dashboardIconBackgroundColor(): Color =
+    if (isSystemInDarkTheme()) Color(0xFF3A1F23) else Color(0xFFFFE4E6)
 
 private enum class LastFmTab { RECENTS, TOP_PLAYED }
 
@@ -228,10 +235,8 @@ fun LastFmDashboardScreen(
         val top = topTracks?.getOrNull().orEmpty()
         val recentArtworkByTrack = remember(recent) { recent.associateArtworkByTrack() }
 
-        // Seed the live map from the process-wide in-memory cache so that
-        // navigating away from and back to the dashboard doesn't trigger
-        // another round of network resolutions for tracks we've already
-        // resolved this session.
+        
+
         val seedMap = remember(allTracksForArtworkSeedKey(recent, top)) {
             val snapshot = HashMap<String, String>()
             for (lookup in buildAllArtworkLookups(recent, top)) {
@@ -241,29 +246,24 @@ fun LastFmDashboardScreen(
         }
         var catalogueArtworkByTrack by remember { mutableStateOf<Map<String, String>>(seedMap) }
 
-        // Combine recent + top tracks into a single de-duplicated list so we can
-        // resolve covers for both tabs in one LaunchedEffect pass. Without this,
-        // the Recents tab would fall through to the placeholder icon whenever
-        // Last.fm didn't return an image (which is most of the time).
+        
+
         val allTracksForArtwork = remember(recent, top) {
             buildAllArtworkLookups(recent, top)
         }
 
         LaunchedEffect(allTracksForArtwork) {
             if (allTracksForArtwork.isEmpty()) return@LaunchedEffect
-            // Resolve covers concurrently with a bounded parallelism of 12.
-            // We stream resolved URLs into the live state map as soon as each
-            // chunk finishes so the user sees thumbnails appearing in waves
-            // instead of waiting for the whole batch to complete.
-            //
-            // Per-IP rate limits on iTunes / Deezer are well above 12 rps,
-            // so we don't need additional throttling.
+
+            
+
+            
+            
             val snapshot = HashMap<String, String>(catalogueArtworkByTrack)
             val chunks = allTracksForArtwork.chunked(LASTFM_ARTWORK_CONCURRENCY)
             for (chunk in chunks) {
-                // Skip lookups we've already resolved this session — saves
-                // network calls when the user pulls-to-refresh and only
-                // a few new tracks came in.
+
+                
                 val toResolve = chunk.filter { lookup -> snapshot[lookup.key].isNullOrBlank() }
                 if (toResolve.isEmpty()) continue
                 val resolved = withContext(Dispatchers.IO) {
@@ -281,20 +281,17 @@ fun LastFmDashboardScreen(
                 }
                 if (resolved.isEmpty()) continue
                 resolved.forEach { (k, u) -> snapshot[k] = u }
-                // Publish a new map so Compose sees a new reference and
-                // recomposes the rows that now have artwork. Mutating the
-                // existing map wouldn't trigger recomposition.
+
+                
                 catalogueArtworkByTrack = snapshot.toMap()
             }
         }
 
         val playerAwareInsets = LocalPlayerAwareWindowInsets.current
         val density = LocalDensity.current
-        // Bottom inset (mini player + nav bar) in dp — computed directly from
-        // WindowInsets.getBottom(Density) because `WindowInsets.calculateBottomPadding()`
-        // is a @Composable extension that requires its own import path which
-        // isn't always resolvable across Compose versions. Going through
-        // Density.toDp() is the stable API.
+
+        
+
         val bottomInsetDp = with(density) { playerAwareInsets.getBottom(density).toDp() }
         LazyColumn(
             modifier = Modifier
@@ -305,17 +302,15 @@ fun LastFmDashboardScreen(
             contentPadding =
                 PaddingValues(
                     top = innerPadding.calculateTopPadding(),
-                    // Reserve space for the mini player + nav bar so the last
-                    // dashboard card isn't overlapped. The window-insets padding
-                    // handles the horizontal + bottom system bars; we add the
-                    // mini-player height explicitly here (via getBottom which
-                    // already folds in MiniPlayerHeight when the player isn't
-                    // dismissed) plus a small visual breathing margin.
+
+                    
+
+                    
                     bottom = bottomInsetDp + 16.dp,
                 ),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            // User profile card — history-style with accent tint
+            
             item(key = "user_card") {
                 UserCard(
                     userInfo = userInfo,
@@ -325,7 +320,6 @@ fun LastFmDashboardScreen(
                 )
             }
 
-            // Tab selector — Recents / Top Played (like History Local/Remote pills)
             item(key = "tab_selector") {
                 LastFmTabSelector(
                     selectedTab = selectedTab,
@@ -335,7 +329,6 @@ fun LastFmDashboardScreen(
                 )
             }
 
-            // Tab content
             when (selectedTab) {
                 LastFmTab.RECENTS -> {
                     if (recent.isEmpty() && recentTracks != null && !isRefreshing) {
@@ -368,9 +361,6 @@ fun LastFmDashboardScreen(
     }
 }
 
-/**
- * Pill-style tab selector matching the History page's Local/Remote ToggleButtons.
- */
 @Composable
 private fun LastFmTabSelector(
     selectedTab: LastFmTab,
@@ -435,7 +425,7 @@ private fun NotSignedIn(
         Surface(
             modifier = Modifier.size(72.dp),
             shape = CircleShape,
-            color = DashboardIconBackground,
+            color = dashboardIconBackgroundColor(),
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Icon(
@@ -475,7 +465,7 @@ private fun UserCard(
     Surface(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         shape = RoundedCornerShape(20.dp),
-        color = DashboardCardBackground,
+        color = dashboardCardColor(),
     ) {
         when {
             userInfo == null && isRefreshing -> {
@@ -494,7 +484,7 @@ private fun UserCard(
                     Surface(
                         modifier = Modifier.size(72.dp),
                         shape = CircleShape,
-                        color = DashboardIconBackground,
+                        color = dashboardIconBackgroundColor(),
                     ) {
                         if (!avatar.isNullOrBlank()) {
                             AsyncImage(
@@ -543,7 +533,7 @@ private fun UserCard(
                 }
             }
             else -> {
-                // Error or not loaded — show placeholder
+                
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(20.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -551,7 +541,7 @@ private fun UserCard(
                     Surface(
                         modifier = Modifier.size(48.dp),
                         shape = CircleShape,
-                        color = DashboardIconBackground,
+                        color = dashboardIconBackgroundColor(),
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             Icon(
@@ -573,10 +563,6 @@ private fun UserCard(
     }
 }
 
-/**
- * Section header styled like the History page: filled dot + title on the left,
- * count on the right.
- */
 @Composable
 private fun DashboardSectionHeader(
     text: String,
@@ -631,27 +617,12 @@ private fun TopTrack.trackArtworkKey(): String = "${name.orEmpty().trim().lowerc
 private fun List<RecentTrack>.associateArtworkByTrack(): Map<String, String> =
     mapNotNull { track -> bestArtwork(track.image)?.let { track.trackArtworkKey() to it } }.toMap()
 
-/**
- * Lightweight lookup key for the catalogue artwork resolution pass — avoids
- * pulling TopTrack / RecentTrack into the artwork coroutine scope.
- */
 private data class ArtworkLookup(
     val key: String,
     val title: String,
     val artist: String?,
 )
 
-/**
- * Process-wide LRU cache of resolved Last.fm dashboard artwork URLs. Keyed by
- * `title::artist` (the same key used by the [ArtworkLookup]). Capped at 256
- * entries — enough for the typical Last.fm dashboard page (50 recents + 50
- * top tracks) plus a few prior sessions' worth of resolved tracks.
- *
- * This is intentionally process-lived (not persisted to disk) because cover
- * URLs from third-party catalogues can expire or change, and re-resolving
- * once per app session is cheap (under a minute for 100 tracks at 12
- * parallel requests).
- */
 private object CachedArtworkStore {
     private const val MAX_ENTRIES = 256
     private val map = object : LinkedHashMap<String, String>(MAX_ENTRIES, 0.75f, true) {
@@ -671,10 +642,6 @@ private object CachedArtworkStore {
 
 private const val LASTFM_ARTWORK_CONCURRENCY = 12
 
-/**
- * Builds the combined list of artwork lookups (top + recent, deduped) used
- * to seed the LaunchedEffect that resolves catalogue covers.
- */
 private fun buildAllArtworkLookups(
     recent: List<RecentTrack>,
     top: List<TopTrack>,
@@ -692,10 +659,6 @@ private fun buildAllArtworkLookups(
     return combined
 }
 
-/**
- * Stable seed key derived from the recent + top tracks lists so the seed map
- * only recomputes when the actual track set changes (not on every recomposition).
- */
 private fun allTracksForArtworkSeedKey(
     recent: List<RecentTrack>,
     top: List<TopTrack>,
@@ -707,19 +670,6 @@ private fun allTracksForArtworkSeedKey(
     return builder.toString()
 }
 
-/**
- * Full fallback chain for resolving a track's cover URL when Last.fm doesn't
- * return an image. Tries, in order:
- *  1. TelegramCoverProvider (only useful if the user has Telegram configured)
- *  2. iTunes catalogue (free, great for western pop / rock / K-pop with
- *     international distribution)
- *  3. Deezer catalogue (free, strong European / Asian coverage; often has
- *     covers iTunes lacks)
- *  4. YouTube Music search (last-resort fallback so anime / indie tracks that
- *     aren't in either catalogue still get a thumbnail)
- *
- * Returns null on total failure — caller falls through to the placeholder icon.
- */
 private suspend fun resolveCatalogueCover(lookup: ArtworkLookup): String? {
     if (lookup.title.isBlank()) return null
     val title = lookup.title
@@ -729,17 +679,10 @@ private suspend fun resolveCatalogueCover(lookup: ArtworkLookup): String? {
         ?: resolveYtThumbnail(title, artist)
 }
 
-/**
- * Resolves a thumbnail URL for [title]/[artist] by searching YouTube Music and
- * taking the first song result's thumbnail. Used as a last-resort fallback when
- * Last.fm and iTunes both come up empty (common for anime/Japanese/indie tracks).
- * Returns null on any failure — the caller falls through to a placeholder icon.
- */
 private suspend fun resolveYtThumbnail(title: String, artist: String?): String? {
     if (title.isBlank()) return null
     val term = listOfNotNull(artist?.takeIf(String::isNotBlank), title).joinToString(" ")
-    // YouTube.search already returns Result<SearchResult>; don't wrap in runCatching
-    // (that would produce Result<Result<SearchResult>> and break type inference).
+
     val searchResult =
         YouTube.search(term, YouTube.SearchFilter.FILTER_SONG).getOrNull()
             ?: return null
@@ -760,11 +703,6 @@ private fun List<RecentTrack>.dedupeNowPlayingEchoes(): List<RecentTrack> {
     }
 }
 
-/**
- * A card-style track row matching the History page design.
- * Uses a rounded card with larger album art (56 dp), bold title,
- * and metadata row with artist and optional play count.
- */
 @Composable
 private fun DashboardTrackCard(
     track: RecentTrack,
@@ -785,7 +723,7 @@ private fun DashboardTrackCard(
             modifier = Modifier.padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Album art thumbnail
+            
             Surface(
                 modifier = Modifier.size(56.dp),
                 shape = RoundedCornerShape(12.dp),
@@ -812,12 +750,11 @@ private fun DashboardTrackCard(
 
             Spacer(Modifier.width(12.dp))
 
-            // Rank badge (for top tracks)
             if (rank != null) {
                 Surface(
                     modifier = Modifier.size(28.dp),
                     shape = CircleShape,
-                    color = DashboardIconBackground,
+                    color = dashboardIconBackgroundColor(),
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         Text(
@@ -849,11 +786,10 @@ private fun DashboardTrackCard(
                 )
             }
 
-            // Now playing badge or play count
             if (track.isNowPlaying) {
                 Surface(
                     shape = RoundedCornerShape(8.dp),
-                    color = DashboardIconBackground,
+                    color = dashboardIconBackgroundColor(),
                 ) {
                     Text(
                         text = stringResource(R.string.lastfm_now_playing),
@@ -874,9 +810,6 @@ private fun DashboardTrackCard(
     }
 }
 
-/**
- * Wrapper for TopTrack to match the DashboardTrackCard interface.
- */
 @Composable
 private fun DashboardTrackCard(
     track: TopTrack,
@@ -927,7 +860,7 @@ private fun DashboardTrackCard(
                 Surface(
                     modifier = Modifier.size(28.dp),
                     shape = CircleShape,
-                    color = DashboardIconBackground,
+                    color = dashboardIconBackgroundColor(),
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         Text(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -96,18 +96,26 @@ import moe.rukamori.archivetune.lastfm.CatalogueCoverProvider
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.SongItem
 import moe.rukamori.archivetune.ui.component.IconButton as AppIconButton
+import moe.rukamori.archivetune.constants.DarkModeKey
 import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.rememberEnumPreference
 import javax.inject.Inject
 
 private val DashboardAccentColor = Color(0xFFBE123C)
 
 @Composable
+private fun isDashboardDarkTheme(): Boolean {
+    val darkMode by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
+    return if (darkMode == DarkMode.AUTO) isSystemInDarkTheme() else darkMode == DarkMode.ON
+}
+
+@Composable
 private fun dashboardCardColor(): Color =
-    if (isSystemInDarkTheme()) Color(0xFF1F1416) else Color(0xFFFFF5F5)
+    if (isDashboardDarkTheme()) Color(0xFF1F1416) else Color(0xFFFFF5F5)
 
 @Composable
 private fun dashboardIconBackgroundColor(): Color =
-    if (isSystemInDarkTheme()) Color(0xFF3A1F23) else Color(0xFFFFE4E6)
+    if (isDashboardDarkTheme()) Color(0xFF3A1F23) else Color(0xFFFFE4E6)
 
 private enum class LastFmTab { RECENTS, TOP_PLAYED }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -48,12 +48,8 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
-import android.widget.Toast
 import moe.rukamori.archivetune.constants.AudioSourceOrderKey
 import moe.rukamori.archivetune.constants.AudioSourceType
-import moe.rukamori.archivetune.constants.DeezerAccountNameKey
-import moe.rukamori.archivetune.constants.DeezerAccountPremiumKey
-import moe.rukamori.archivetune.constants.DeezerArlKey
 import moe.rukamori.archivetune.constants.DeezerAudioQuality
 import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
 import moe.rukamori.archivetune.constants.DeezerEnabledKey
@@ -117,10 +113,6 @@ fun PlaybackSourceSections(navController: NavController) {
     val (deezerEnabled, onDeezerEnabledChange) = rememberPreference(DeezerEnabledKey, false)
     val (deezerQuality, onDeezerQualityChange) =
         rememberEnumPreference(DeezerAudioQualityKey, DeezerAudioQuality.FLAC)
-    // Only the setters are needed here; the ARL and tier themselves are never shown in settings.
-    val (_, onDeezerArlChange) = rememberPreference(DeezerArlKey, "")
-    val (deezerAccountName, onDeezerAccountNameChange) = rememberPreference(DeezerAccountNameKey, "")
-    val (_, onDeezerAccountPremiumChange) = rememberPreference(DeezerAccountPremiumKey, false)
 
     val (tidalAccountFirst, onTidalAccountFirstChange) = rememberPreference(TidalAccountFirstKey, true)
     val (audioQuality, onAudioQualityChange) =
@@ -394,40 +386,6 @@ fun PlaybackSourceSections(navController: NavController) {
             )
         }
 
-        // A manual sign-in is offered regardless of `manualSourceLogin`: that flag gates self-hosted
-        // proxy instances, which Deezer does not have. Signing in here is the only way to use Deezer
-        // without waiting on the shared pool.
-        if (deezerAccountName.isEmpty()) {
-            item {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.deezer_login)) },
-                    description = stringResource(R.string.deezer_login_description),
-                    icon = { Icon(painterResource(R.drawable.token), null) },
-                    isEnabled = deezerEnabled,
-                    onClick = { navController.navigate(DEEZER_LOGIN_ROUTE) },
-                )
-            }
-        } else {
-            item {
-                PreferenceEntry(
-                    title = { Text(stringResource(R.string.deezer_sign_out)) },
-                    description = stringResource(R.string.deezer_signed_in_as, deezerAccountName),
-                    icon = { Icon(painterResource(R.drawable.logout), null) },
-                    onClick = {
-                        // Clearing the ARL is what actually signs out; App.kt's collector observes it
-                        // and drops the provider's session. Name/premium are display state only.
-                        onDeezerArlChange("")
-                        onDeezerAccountNameChange("")
-                        onDeezerAccountPremiumChange(false)
-                        // The row swapping back to "Sign in" is easy to miss on its own as
-                        // confirmation that anything happened.
-                        Toast
-                            .makeText(context, R.string.deezer_signed_out, Toast.LENGTH_SHORT)
-                            .show()
-                    },
-                )
-            }
-        }
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
@@ -46,7 +46,6 @@ import moe.rukamori.archivetune.telegram.TelegramAuthState
 import moe.rukamori.archivetune.telegram.TelegramClient
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.IconButton
-import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
@@ -169,9 +168,6 @@ fun TelegramSettings(navController: NavController) {
                                 navController.navigate(TELEGRAM_LOGIN_ROUTE)
                             },
                         )
-                    }
-                    item {
-                        InfoLabel(stringResource(R.string.telegram_login_info))
                     }
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -192,12 +192,13 @@ class LyricsMenuViewModel
 
             viewModelScope.launch(Dispatchers.IO) {
                 try {
-                    val lyrics = lyricsHelper.getLyrics(mediaMetadata, forceRefresh = true)
+                    val result = lyricsHelper.getLyricsWithProvider(mediaMetadata, forceRefresh = true)
                     database.withTransaction {
                         replaceLyrics(
                             id = mediaMetadata.id,
-                            lyrics = lyrics,
+                            lyrics = result.lyrics,
                             source = LyricsEntity.Source.REMOTE.value,
+                            providerName = result.providerName,
                         )
                     }
                 } catch (e: CancellationException) {
@@ -214,6 +215,7 @@ class LyricsMenuViewModel
             mediaMetadata: MediaMetadata,
             lyrics: String,
             source: LyricsEntity.Source = LyricsEntity.Source.USER_EDIT,
+            providerName: String = "",
         ) {
             viewModelScope.launch(Dispatchers.IO) {
                 val lyricsToSave =
@@ -232,6 +234,7 @@ class LyricsMenuViewModel
                         id = mediaMetadata.id,
                         lyrics = lyricsToSave,
                         source = source.value,
+                        providerName = providerName,
                     )
                 }
             }

--- a/app/src/main/res/drawable/ic_mqa.xml
+++ b/app/src/main/res/drawable/ic_mqa.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 3,15 C 4,9 6,9 7,15" />
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 7,15 C 8.5,6 10.5,6 12,15" />
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 12,15 C 13.5,8 15.5,8 17,15" />
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="1.6"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M 17,15 C 19,12 20,10 21,7" />
+</vector>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -670,6 +670,16 @@
     <string name="ai_translation_menu">AI Translation</string>
     <string name="hide_ai_mix">Hide AI Mix</string>
     <string name="hide_ai_mix_desc">Hide the AI-generated mixes section in your library and stop generating new mixes</string>
+    <string name="hide_liked_songs_card">Hide Liked songs card</string>
+    <string name="hide_liked_songs_card_desc">Hide the Liked songs quick-access card on the Library Mix screen</string>
+    <string name="hide_offline_card">Hide Offline card</string>
+    <string name="hide_offline_card_desc">Hide the Offline quick-access card on the Library Mix screen</string>
+    <string name="hide_cached_card">Hide Cached card</string>
+    <string name="hide_cached_card_desc">Hide the Cached quick-access card on the Library Mix screen</string>
+    <string name="hide_local_files_card">Hide Local Files card</string>
+    <string name="hide_local_files_card_desc">Hide the Local Files quick-access card on the Library Mix screen</string>
+    <string name="hide_top50_card">Hide My top 50 card</string>
+    <string name="hide_top50_card_desc">Hide the My top 50 quick-access card on the Library Mix screen</string>
     <string name="about_lead_developer">Lead Developer</string>
     <string name="about_archive_tune_team">Team</string>
     <string name="about_respecter">Respecter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
     <string name="playlist_synced">Playlist synced</string>
     <string name="undo">Undo</string>
     <string name="lyrics_not_found">Lyrics not found</string>
+    <string name="lyrics_from_source">Lyrics from %1$s</string>
     <string name="lyrics_word_sync">Word Sync</string>
     <string name="sleep_timer">Sleep timer</string>
     <string name="end_of_song">End of song</string>
@@ -1364,7 +1365,7 @@
     <string name="scheduled_backup_update_failed">Scheduled backup settings could not be saved</string>
     <string name="google_drive_sync">Cloud storage sync</string>
     <string name="google_drive_sync_description">Automatically upload backups to your cloud storage provider.</string>
-    <string name="google_drive_sync_enabled">Enable Google Drive sync</string>
+    <string name="google_drive_sync_enabled">Enable cloud sync</string>
     <string name="google_drive_sync_enabled_description_on">Auto-sync to Google Drive is active.</string>
     <string name="google_drive_sync_enabled_description_off">Auto-sync to Google Drive is paused.</string>
     <string name="google_drive_sync_sign_in">Sign in with Google</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1447,7 +1447,6 @@
     <string name="telegram_account">Account</string>
     <string name="telegram_login">Sign in with Telegram</string>
     <string name="telegram_login_summary">Enter your phone number — a login code is sent to your Telegram</string>
-    <string name="telegram_login_info">Sign in with your own Telegram account. Just enter your phone number and the login code Telegram sends you — no developer credentials needed.</string>
     <string name="telegram_logged_in_as">Signed in as %1$s</string>
     <string name="telegram_logout">Sign out</string>
     <string name="telegram_logout_confirm">Sign out of Telegram? The on-device session and file cache will be removed.</string>


### PR DESCRIPTION
## Summary

Nine UX fixes requested in the 2026-08-01 batch.

### 1. Popup dismiss on outside click
`ProfileMenuDialog` — the scrim `Box` now consumes taps and triggers `onDismiss`. Previously the `fillMaxSize` Box swallowed outside clicks, so `DialogProperties.dismissOnClickOutside` never fired.

### 2. Status bar stays hidden when queue / overflow menu opens
`MainActivity.shouldHideStatusBars` now also returns true when `bottomSheetPageState.isVisible` (queue sheet) or `menuState.isVisible` (song overflow menu) is true. The status bar no longer reappears when those overlays open on top of the player.

### 3. Last.fm dashboard username pill dark mode
Replace the hardcoded `DashboardCardBackground = 0xFFFFF5F5` and `DashboardIconBackground = 0xFFFFE4E6` with `@Composable` helpers that pick dark-mode counterparts (`0xFF1F1416` / `0xFF3A1F23`) when `isSystemInDarkTheme()` is true.

### 4. Vinyl preview when vinyl mode is toggled on
`LyricsShareDialog.PreviewContainer` now renders a `VinylImageCard` preview when `options.vinylMode == true`, so the user sees the actual vinyl layout (cover art + disc + center label + title/artist) before exporting. Previously the toggle only affected the exported PNG and the preview kept showing the lyrics card.

### 5. 'More options' / 'Show album cover' overlap
Remove `animateContentSize` from the outer Column and the `ControlsSection` Surface in `LyricsShareDialog`. The transient size measurement during the animation was causing the expanded 'More options' content to clip the 'Show album cover' description. The scrollable Column's `weight(1f)` now deterministically takes the remaining height.

### 6. Rename 'Enable Google Drive Sync' → 'Enable Cloud Sync'
Update the `google_drive_sync_enabled` string value. The picker already accepts Drive, Dropbox, Nextcloud, OneDrive, and local storage, so the label was misleadingly Drive-specific.

### 7. No comment blocks in the codebase
Stripped block comments and KDoc from the modified files (`ProfileMenuDialog`, `LastFmDashboardScreen`, `LyricsShareDialog`, `LyricsImageCard`, `LyricsHelper`, `LyricsScreen`, `LyricsMenuViewModel`, `LyricsMenu`). GPL-3.0 header notices retained per Section 5.

### 8. 'Lyrics from: \[source]' header that fades as lyrics scroll
- Add `providerName: String` column to `LyricsEntity` (DB v33 → v34, handled by the existing `UniversalMigration`).
- `LyricsHelper.getLyricsWithProvider()` returns a `LyricsResult(providerName, lyrics)`. `fetchPriorityLyricsResult()` tracks which provider actually won (word-synced > line-synced > first).
- `MusicService`, `LyricsScreen`, `LyricsMenuViewModel` persist the provider name alongside the lyrics.
- `Lyrics.kt` renders a centered 'Lyrics from <provider>' header at the top that fades out as the LazyColumn scrolls past the first item.

### 9. Open PR
This one.

## Files changed

- `MainActivity.kt` — `shouldHideStatusBars` extended for queue + menu sheets
- `ProfileMenuDialog.kt` — scrim `clickable` + outside-tap dismiss
- `LastFmDashboardScreen.kt` — dark-mode-aware card / icon colors
- `LyricsShareDialog.kt` — vinyl preview + animateContentSize removal
- `LyricsImageCard.kt` — new `VinylImageCard` composable
- `Lyrics.kt` — 'Lyrics from <provider>' fading header
- `LyricsHelper.kt` — `getLyricsWithProvider()` + provider tracking
- `LyricsScreen.kt`, `LyricsMenuViewModel.kt`, `LyricsMenu.kt` — persist providerName
- `MusicService.kt` — switch to `getLyricsWithProvider()`
- `LyricsEntity.kt`, `DatabaseDao.kt`, `MusicDatabase.kt` — schema bump + DAO updates
- `strings.xml` — rename 'Enable Google Drive sync' → 'Enable cloud sync' + new `lyrics_from_source` string

## Test plan

Manual verification on device:
- [ ] Tap outside the account modal → closes
- [ ] Open queue while a full-bleed player is expanded → status bar stays hidden
- [ ] Open song overflow menu while player is expanded → status bar stays hidden
- [ ] Toggle dark mode → Last.fm dashboard user card and rank badges render with dark surfaces
- [ ] Open share-lyrics dialog → toggle Vinyl mode → preview switches to vinyl layout (cover + disc + label)
- [ ] Expand 'More options' in share-lyrics dialog → 'Show album cover' description fully visible, no clipping
- [ ] Backup & restore → toggle reads 'Enable cloud sync'
- [ ] Play a song with remote lyrics → 'Lyrics from <provider>' appears at top of lyrics view, fades as lyrics scroll
