### PR TITLE
fix(lyrics+playback): stream first-result-wins + harden source switch

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -12,12 +12,14 @@ import android.util.Log
 import android.util.LruCache
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.selects.select
-import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.constants.LyricsProviderOrderKey
 import moe.rukamori.archivetune.constants.PreferredLyricsProvider
@@ -119,10 +121,12 @@ class LyricsHelper
                     .filter { it.isEnabled(context) }
                     .filter { supportsMediaId(it, mediaMetadata.id) }
             val providers = if (preferredProviderOnly) ordered.take(1) else ordered
-            val providerName = fetchPriorityProviderName(providers, mediaMetadata)
-            val lyrics = fetchPriorityLyrics(providers, mediaMetadata)
-            val result = LyricsResult(providerName = providerName, lyrics = lyrics)
-            if (isMeaningfulLyrics(lyrics)) {
+            // Single parallel fetch — the previous implementation called fetchPriorityLyricsResult
+            // twice (once for the provider name, once for the lyrics body), which doubled the
+            // worst-case latency because each call waited for the slowest provider. Resolve once
+            // and reuse the result.
+            val result = fetchPriorityLyricsResult(providers, mediaMetadata)
+            if (isMeaningfulLyrics(result.lyrics)) {
                 singleLyricsCache.put(cacheKey, result)
             }
 
@@ -183,16 +187,22 @@ class LyricsHelper
             cache.put(cacheKey, allResult.toList())
         }
 
-        private suspend fun fetchPriorityLyrics(
-            providers: List<LyricsProvider>,
-            mediaMetadata: MediaMetadata,
-        ): String = fetchPriorityLyricsResult(providers, mediaMetadata).lyrics
-
-        private suspend fun fetchPriorityProviderName(
-            providers: List<LyricsProvider>,
-            mediaMetadata: MediaMetadata,
-        ): String = fetchPriorityLyricsResult(providers, mediaMetadata).providerName
-
+        /**
+         * Streams provider results as they arrive and returns the first acceptable lyrics payload,
+         * rather than waiting for every provider to complete (the previous implementation joined
+         * every `async` before ranking, which meant a single slow provider could hold up the panel
+         * for its full 15–20s timeout).
+         *
+         * Strategy:
+         *  - All enabled providers run in parallel on `Dispatchers.IO`.
+         *  - The first `word-synced` or `line-synced` result wins and is returned immediately —
+         *    pending providers are cancelled. Returning the first synced result lets a fast
+         *    provider (e.g. LRCLIB ~100ms) win over a slow one (e.g. Musixmatch token refresh
+         *    ~3–15s) without making the user wait for the better-quality-but-slow result.
+         *  - Plain (unsynced) lyrics are kept as a fallback; if no synced result arrives, the
+         *    first plain result is returned after every provider finishes.
+         *  - `LYRICS_NOT_FOUND` is returned only if every provider failed/returned nothing.
+         */
         private suspend fun fetchPriorityLyricsResult(
             providers: List<LyricsProvider>,
             mediaMetadata: MediaMetadata,
@@ -200,27 +210,58 @@ class LyricsHelper
             if (providers.isEmpty()) return LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
 
             val artist = mediaMetadata.artists.joinToString { it.name }
-            val results =
-                supervisorScope {
-                    providers
-                        .map { provider ->
-                            async(Dispatchers.IO) {
-                                val lyrics = fetchProviderLyrics(provider, mediaMetadata, artist)
-                                if (lyrics == null) null else provider.name to lyrics
+
+            return coroutineScope {
+                // UNLIMITED so `trySend` never blocks a provider coroutine; we close the channel
+                // ourselves once we have a winner.
+                val channel = Channel<Pair<String, String>>(Channel.UNLIMITED)
+                val providerJobs: List<Job> =
+                    providers.map { provider ->
+                        launch(Dispatchers.IO) {
+                            val lyrics = fetchProviderLyrics(provider, mediaMetadata, artist)
+                            if (lyrics != null) {
+                                channel.trySend(provider.name to lyrics)
                             }
-                        }.mapNotNull { it.await() }
+                        }
+                    }
+                val collectorJob =
+                    launch {
+                        try {
+                            providerJobs.joinAll()
+                        } finally {
+                            channel.close()
+                        }
+                    }
+
+                try {
+                    var fallback: Pair<String, String>? = null
+                    for ((providerName, lyrics) in channel) {
+                        // Word-synced is the best we can get — return immediately and cancel the
+                        // remaining providers so we don't keep their network requests alive.
+                        if (LyricsUtils.hasWordSyncedLyrics(lyrics)) {
+                            return@coroutineScope LyricsResult(providerName = providerName, lyrics = lyrics)
+                        }
+                        // Line-synced is good enough for an instant-load UX — return immediately.
+                        if (LyricsUtils.isLineSyncedLrc(lyrics)) {
+                            return@coroutineScope LyricsResult(providerName = providerName, lyrics = lyrics)
+                        }
+                        // Plain (unsynced) lyrics — keep the first one as a fallback while we keep
+                        // waiting for a synced variant.
+                        if (fallback == null) {
+                            fallback = providerName to lyrics
+                        }
+                    }
+                    // Channel closed = every provider finished without producing a synced result.
+                    // Return the first plain result we saw, if any.
+                    fallback?.let { (name, lyrics) ->
+                        return@coroutineScope LyricsResult(providerName = name, lyrics = lyrics)
+                    }
+                    LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
+                } finally {
+                    collectorJob.cancel()
+                    providerJobs.forEach { it.cancel() }
                 }
-
-            if (results.isEmpty()) return LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
-
-            val wordSynced = results.firstOrNull { LyricsUtils.hasWordSyncedLyrics(it.second) }
-            if (wordSynced != null) return LyricsResult(providerName = wordSynced.first, lyrics = wordSynced.second)
-
-            val lineSynced = results.firstOrNull { LyricsUtils.isLineSyncedLrc(it.second) }
-            if (lineSynced != null) return LyricsResult(providerName = lineSynced.first, lyrics = lineSynced.second)
-
-            val first = results.first()
-            return LyricsResult(providerName = first.first, lyrics = first.second)
+            }
         }
 
         private suspend fun fetchProviderLyrics(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -7791,6 +7791,27 @@ class MusicService :
      * Applies a per-song "play from" override and, if [mediaId] is the current item, re-resolves it
      * immediately so the change takes effect without the user having to skip the track. Passing a
      * null [source] clears the override for that song.
+     *
+     * Two bugs are addressed here that the previous implementation had:
+     *
+     * 1. **"Sometimes changing source only restarts the song but doesn't change the source."**
+     *    `directStreamCache[mediaId]` and the bare-keyed `contentLengthCache[mediaId]` were not
+     *    evicted, so the resolver's fast path could short-circuit to the previous source's
+     *    resolved URL (when the override happened to be re-applied to the same id) or to a stale
+     *    content-length that made the byte-cache short-circuit in [resolveCachedDataSpec] think
+     *    the request was fully cached. Both are now evicted explicitly so the slow path always
+     *    re-resolves through the new override.
+     *
+     * 2. **"Qobuz → YouTube plays from YouTube but muted."** `player.prepare()` is asynchronous;
+     *    the actual re-resolution happens on ExoPlayer's internal thread, and any of the reactive
+     *    volume pipeline (`playerVolume × normalizeFactor × audioFocusVolumeFactor`), audio focus
+     *    state, or crossfade ramp can interleave with it and leave the primary player's volume
+     *    pinned low (the [ensureAudiblePlaybackVolume] watchdog only fires when `player.volume`
+     *    is essentially 0, so a "quiet but not zero" state slips past it). We now explicitly:
+     *    - cancel any pending crossfade and reset its volume,
+     *    - apply the effective volume immediately (no ramp),
+     *    - re-claim audio focus,
+     *    - kick the audible-playback watchdog.
      */
     fun setSongSourceOverride(
         mediaId: String,
@@ -7809,16 +7830,34 @@ class MusicService :
             extractorPlaybackUrlCache.remove(mediaId)
             YTPlayerUtils.invalidateCachedStreamUrls(mediaId)
             tidalActiveMediaIds.remove(mediaId)
+            // Evict the resolved DirectStream so the slow path re-resolves through the new
+            // override instead of serving the previous source's URL.
+            directStreamCache.remove(mediaId)
+            // Evict the bare-keyed content length so [resolveCachedDataSpec] can't conclude the
+            // request is fully cached based on the previous source's byte size.
+            contentLengthCache.remove(mediaId)
             runCatching { playerCache.removeResource(mediaId) }
             runCatching { downloadCache.removeResource(mediaId) }
             AudioSourceType.entries.forEach { src ->
                 val key = sourceCacheKey(src, mediaId)
                 runCatching { playerCache.removeResource(key) }
                 runCatching { downloadCache.removeResource(key) }
+                // Source-prefixed content-length entries are also stale after a source switch.
+                contentLengthCache.remove(key)
             }
+            // Cancel any in-flight crossfade so its volume ramp / secondary player can't pin the
+            // primary player's volume low while the new source is preparing.
+            cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)
             player.prepare()
             player.seekTo(0)
             player.playWhenReady = true
+            // Restore the effective volume immediately (bypass the smooth ramp) so the new source
+            // doesn't briefly play muted while the ramp catches up. Re-claim audio focus in case
+            // the prepare transition dropped it, and start the audible-playback watchdog so any
+            // later volume dip gets corrected within the next polling window.
+            applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())
+            ensureAudioFocusForActivePlayback()
+            updateAudiblePlaybackRecovery()
         }
     }
 


### PR DESCRIPTION
## What

Two unrelated user-facing bugs fixed in one PR (both reported in the same chat message).

## Bug 1 — Lyrics panel slow on some songs

**Symptom:** Some songs took 10–20s before the lyrics panel showed anything.

**Root cause:** `LyricsHelper.getLyricsWithProvider` called `fetchPriorityLyricsResult` **twice** — once via `fetchPriorityProviderName` for the provider name, once via `fetchPriorityLyrics` for the lyrics body. Each call ran a full parallel fan-out across every enabled provider and waited for ALL of them via `mapNotNull { it.await() }` before ranking. So worst-case latency was `2 × (slowest provider's 15–20s timeout)`, and a single hung provider (e.g. Musixmatch doing a token refresh) held up the whole panel.

**Fix:**
- Call `fetchPriorityLyricsResult` **once** and reuse the result for both fields.
- Stream provider results back through an unlimited `Channel` as they arrive. The first **word-synced** OR **line-synced** result wins and is returned immediately; pending provider coroutines are cancelled so their network requests don't keep running. Plain (unsynced) lyrics are kept as a fallback and returned only if no synced result arrives before every provider finishes.

**Effect:** a fast provider like LRCLIB (~100ms) wins over a slow one like Musixmatch (3–15s), so the panel typically shows lyrics in under a second instead of waiting for the slowest provider.

## Bug 2 — Source switch mutes / doesn't switch

**Symptom:** Switching source via the player's *Play from* dialog (Qobuz → YouTube in particular) sometimes played the new source muted, and sometimes only restarted the song without actually changing the source. User had to skip to a previous song and back to recover.

**Root causes:**

- **Doesn't switch source:** `directStreamCache[mediaId]` (the resolved `DirectStream` URL cache) and the bare-keyed `contentLengthCache[mediaId]` were NOT evicted by the previous fix in `c15b53768`. The resolver's fast path in `resolveMultiSourceDataSpec` / `resolveCachedDataSpec` could short-circuit to the previous source's URL or treat the request as fully cached based on the previous source's byte size, so the new override never took effect.
- **Muted after switch:** `player.prepare()` is asynchronous on ExoPlayer's internal thread, and the reactive volume pipeline (`playerVolume × normalizeFactor × audioFocusVolumeFactor`), audio focus transitions, and any pending crossfade ramp can interleave with it and leave the primary player's volume pinned low. The `ensureAudiblePlaybackVolume` watchdog only fires when `player.volume ≈ 0`, so a 'quiet but not zero' state slips past it.

**Fix in `MusicService.setSongSourceOverride`:**
- Evict `directStreamCache[mediaId]` and the bare-keyed `contentLengthCache[mediaId]` explicitly so the slow path always re-resolves through the new override.
- Evict source-prefixed `contentLengthCache` entries (`tidal:` / `qobuz:` / `deezer:` / `youtube:`) so the byte-cache short-circuit can't conclude the request is fully cached based on the previous source's size.
- Cancel any in-flight crossfade (`cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)`) **before** `prepare()` so its volume ramp / secondary player can't pin the primary player low while the new source is preparing.
- After `prepare()` + `seekTo(0)` + `playWhenReady = true`, explicitly:
  - `applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())` — restore the correct volume without the smooth ramp,
  - `ensureAudioFocusForActivePlayback()` — re-claim focus if the prepare transition dropped it,
  - `updateAudiblePlaybackRecovery()` — start the audible-playback watchdog so any later volume dip gets corrected within the next polling window.

## Files changed

- `app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt` — streaming first-result-wins fetch + dedupe the double call.
- `app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt` — evict directStreamCache + contentLengthCache; restore volume / focus / watchdog after `prepare()`.

## Verification

Build couldn't be run end-to-end locally (the dev container only has 4 GB RAM and Gradle OOM-kills the Kotlin daemon before compilation finishes). Both modified files were syntax-checked with the standalone Kotlin compiler (`K2JVMCompiler`) against the kotlinx-coroutines + kotlin-stdlib classpath — no parse errors, only unresolved-reference errors for project-internal types (`LyricsProvider`, `LyricsResult`, `MusicService` internals) which are expected when compiling a single file in isolation.

Please run a CI build before merging.

## Why one PR for two bugs

Both bugs were reported in the same user message; keeping them together avoids two round-trips through review.