### PR TITLE
fix(lyrics+playback+ui): respect provider priority, harden source-switch mute, fix pre-S moving blur black bar

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import moe.rukamori.archivetune.constants.LyricsProviderOrderKey
 import moe.rukamori.archivetune.constants.PreferredLyricsProvider
 import moe.rukamori.archivetune.constants.deserializeLyricsProviderOrder
@@ -188,20 +189,29 @@ class LyricsHelper
         }
 
         /**
-         * Streams provider results as they arrive and returns the first acceptable lyrics payload,
-         * rather than waiting for every provider to complete (the previous implementation joined
-         * every `async` before ranking, which meant a single slow provider could hold up the panel
-         * for its full 15–20s timeout).
+         * Streams provider results as they arrive and returns the best acceptable lyrics payload
+         * while still respecting the user-configured provider priority order.
          *
          * Strategy:
-         *  - All enabled providers run in parallel on `Dispatchers.IO`.
-         *  - The first `word-synced` or `line-synced` result wins and is returned immediately —
-         *    pending providers are cancelled. Returning the first synced result lets a fast
-         *    provider (e.g. LRCLIB ~100ms) win over a slow one (e.g. Musixmatch token refresh
-         *    ~3–15s) without making the user wait for the better-quality-but-slow result.
-         *  - Plain (unsynced) lyrics are kept as a fallback; if no synced result arrives, the
-         *    first plain result is returned after every provider finishes.
+         *  - All enabled providers run in parallel on `Dispatchers.IO` (so a slow provider can't
+         *    block a fast one — keeps the panel load latency low).
+         *  - Results are collected as they arrive. Each result is classified as word-synced,
+         *    line-synced, or plain (unsynced).
+         *  - When a synced result arrives, a short "grace period" starts (or continues). During
+         *    the grace period we keep collecting so higher-priority providers get a chance to
+         *    respond — this is what restores the priority order: a fast low-priority line-synced
+         *    result no longer preempts a slightly slower top-priority word-synced result.
+         *  - We early-exit when:
+         *      * the top-priority provider returns a synced result (priority 0 — can't be beaten), or
+         *      * all providers have completed (no point waiting for the grace period), or
+         *      * the grace period has elapsed since the first synced result arrived.
+         *  - At decision time we pick the best result by (sync tier: word > line > plain, then by
+         *    priority index — lower index wins).
          *  - `LYRICS_NOT_FOUND` is returned only if every provider failed/returned nothing.
+         *
+         * Grace period is short (1.2s) so the perceived load latency stays low — typical provider
+         * latency spreads (LRCLIB ~100ms, Musixmatch ~3–15s) mean the top-priority provider either
+         * responds within the grace period or wasn't going to win on speed anyway.
          */
         private suspend fun fetchPriorityLyricsResult(
             providers: List<LyricsProvider>,
@@ -212,15 +222,19 @@ class LyricsHelper
             val artist = mediaMetadata.artists.joinToString { it.name }
 
             return coroutineScope {
+                // (priorityIndex, providerName, lyrics) — priorityIndex is the position in the
+                // user-ordered provider list (0 = highest priority).
+                data class ProviderResult(val priority: Int, val providerName: String, val lyrics: String)
+
                 // UNLIMITED so `trySend` never blocks a provider coroutine; we close the channel
                 // ourselves once we have a winner.
-                val channel = Channel<Pair<String, String>>(Channel.UNLIMITED)
+                val channel = Channel<ProviderResult>(Channel.UNLIMITED)
                 val providerJobs: List<Job> =
-                    providers.map { provider ->
+                    providers.mapIndexed { index, provider ->
                         launch(Dispatchers.IO) {
                             val lyrics = fetchProviderLyrics(provider, mediaMetadata, artist)
                             if (lyrics != null) {
-                                channel.trySend(provider.name to lyrics)
+                                channel.trySend(ProviderResult(index, provider.name, lyrics))
                             }
                         }
                     }
@@ -234,27 +248,86 @@ class LyricsHelper
                     }
 
                 try {
-                    var fallback: Pair<String, String>? = null
-                    for ((providerName, lyrics) in channel) {
-                        // Word-synced is the best we can get — return immediately and cancel the
-                        // remaining providers so we don't keep their network requests alive.
-                        if (LyricsUtils.hasWordSyncedLyrics(lyrics)) {
-                            return@coroutineScope LyricsResult(providerName = providerName, lyrics = lyrics)
+                    val collected = mutableListOf<ProviderResult>()
+                    // Hard ceiling on total wait — if no winner emerges after this, return the best
+                    // we have so a single hung provider can't pin the panel for its full timeout.
+                    val hardTimeoutMs = 8_000L
+                    // Grace window after the first synced result arrives — gives higher-priority
+                    // providers a chance to respond before we commit to a lower-priority winner.
+                    val gracePeriodMs = 1_200L
+
+                    val startedAtMs = System.currentTimeMillis()
+                    var firstSyncedAtMs: Long? = null
+
+                    fun isSynced(result: ProviderResult): Boolean =
+                        LyricsUtils.hasWordSyncedLyrics(result.lyrics) ||
+                            LyricsUtils.isLineSyncedLrc(result.lyrics)
+
+                    // Best result so far: prefer word-synced > line-synced > plain, then by
+                    // priority index (lower = higher priority).
+                    fun pickBest(): ProviderResult? =
+                        collected
+                            .filter { isSynced(it) }
+                            .sortedWith(
+                                compareByDescending<ProviderResult> {
+                                    if (LyricsUtils.hasWordSyncedLyrics(it.lyrics)) 2 else 1
+                                }.thenBy { it.priority },
+                            ).firstOrNull()
+                            ?: collected.minByOrNull { it.priority }
+
+                    fun allProvidersDone(): Boolean = providerJobs.all { !it.isActive }
+
+                    while (true) {
+                        val elapsedMs = System.currentTimeMillis() - startedAtMs
+                        val remainingMs = hardTimeoutMs - elapsedMs
+                        if (remainingMs <= 0) break
+
+                        val nextResult = withTimeoutOrNull(remainingMs) { channel.receiveCatching().getOrNull() }
+                        if (nextResult == null) {
+                            // Channel closed (all providers done) or hard timeout — exit and pick best.
+                            break
                         }
-                        // Line-synced is good enough for an instant-load UX — return immediately.
-                        if (LyricsUtils.isLineSyncedLrc(lyrics)) {
-                            return@coroutineScope LyricsResult(providerName = providerName, lyrics = lyrics)
+
+                        collected.add(nextResult)
+
+                        if (!isSynced(nextResult)) continue
+
+                        if (firstSyncedAtMs == null) {
+                            firstSyncedAtMs = System.currentTimeMillis()
                         }
-                        // Plain (unsynced) lyrics — keep the first one as a fallback while we keep
-                        // waiting for a synced variant.
-                        if (fallback == null) {
-                            fallback = providerName to lyrics
+
+                        val best = pickBest() ?: continue
+
+                        // Early-exit case 1: top-priority provider returned a synced result.
+                        // Nothing can beat it (no higher priority exists), so commit immediately.
+                        if (best.priority == 0 && LyricsUtils.hasWordSyncedLyrics(best.lyrics)) {
+                            return@coroutineScope LyricsResult(providerName = best.providerName, lyrics = best.lyrics)
                         }
+                        // Note: we deliberately do NOT early-exit on priority-0 line-synced,
+                        // because a slightly later word-synced result from any provider would
+                        // be strictly better — the grace period lets that arrive.
+
+                        // Early-exit case 2: all providers have completed — no point waiting.
+                        if (allProvidersDone()) {
+                            return@coroutineScope LyricsResult(providerName = best.providerName, lyrics = best.lyrics)
+                        }
+
+                        // Early-exit case 3: grace period has elapsed since the first synced
+                        // result arrived. Commit the best we have.
+                        val firstSyncedAt = firstSyncedAtMs
+                        if (firstSyncedAt != null) {
+                            val sinceFirstSyncedMs = System.currentTimeMillis() - firstSyncedAt
+                            if (sinceFirstSyncedMs >= gracePeriodMs) {
+                                return@coroutineScope LyricsResult(providerName = best.providerName, lyrics = best.lyrics)
+                            }
+                        }
+                        // Otherwise loop back to keep collecting — higher-priority providers
+                        // might still return a better result before the grace period expires.
                     }
-                    // Channel closed = every provider finished without producing a synced result.
-                    // Return the first plain result we saw, if any.
-                    fallback?.let { (name, lyrics) ->
-                        return@coroutineScope LyricsResult(providerName = name, lyrics = lyrics)
+
+                    // All providers completed or hard timeout — pick the best result.
+                    pickBest()?.let { best ->
+                        return@coroutineScope LyricsResult(providerName = best.providerName, lyrics = best.lyrics)
                     }
                     LyricsResult(providerName = "", lyrics = LYRICS_NOT_FOUND)
                 } finally {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -2545,10 +2545,20 @@ class MusicService :
 
         val expectedVolume = currentEffectivePlayerVolume()
         if (expectedVolume <= MIN_AUDIBLE_EFFECTIVE_VOLUME) return
-        if (player.volume > STUCK_MUTED_VOLUME_EPSILON) return
+        // Two recovery triggers:
+        //  1. player.volume ≈ 0 — classic stuck-muted (e.g., after crossfade handoff or
+        //     after a source switch interleaved with the reactive volume pipeline).
+        //  2. player.volume significantly below expected (below AUDIBLE_VOLUME_RECOVERY_RATIO
+        //     of expected). This catches the "quiet but not zero" state that the previous
+        //     epsilon-only check missed — e.g., when an audio-focus duck factor or a half-
+        //     finished ramp leaves the primary player pinned at ~5–15% of the target while
+        //     the user perceives it as muted.
+        if (player.volume > STUCK_MUTED_VOLUME_EPSILON &&
+            player.volume >= expectedVolume * AUDIBLE_VOLUME_RECOVERY_RATIO
+        ) return
 
         Timber.tag(TAG).w(
-            "Restoring muted primary player volume during active playback: reason=%s expected=%s actual=%s",
+            "Restoring muted/quiet primary player volume during active playback: reason=%s expected=%s actual=%s",
             reason,
             expectedVolume,
             player.volume,
@@ -7792,7 +7802,7 @@ class MusicService :
      * immediately so the change takes effect without the user having to skip the track. Passing a
      * null [source] clears the override for that song.
      *
-     * Two bugs are addressed here that the previous implementation had:
+     * Bugs addressed here:
      *
      * 1. **"Sometimes changing source only restarts the song but doesn't change the source."**
      *    `directStreamCache[mediaId]` and the bare-keyed `contentLengthCache[mediaId]` were not
@@ -7806,12 +7816,20 @@ class MusicService :
      *    the actual re-resolution happens on ExoPlayer's internal thread, and any of the reactive
      *    volume pipeline (`playerVolume × normalizeFactor × audioFocusVolumeFactor`), audio focus
      *    state, or crossfade ramp can interleave with it and leave the primary player's volume
-     *    pinned low (the [ensureAudiblePlaybackVolume] watchdog only fires when `player.volume`
-     *    is essentially 0, so a "quiet but not zero" state slips past it). We now explicitly:
-     *    - cancel any pending crossfade and reset its volume,
+     *    pinned low. The previous fix only restored the volume once (synchronously) right after
+     *    `prepare()` returned — but `prepare()` is async, so subsequent state transitions
+     *    (STATE_BUFFERING → STATE_READY, audio session ID change triggering audio-effect rebind,
+     *    reactive volume flow re-firing with a stale duck factor) can pin the volume low AGAIN
+     *    after our synchronous restore. The previous watchdog only fired when `player.volume ≈ 0`,
+     *    so a "quiet but not zero" state slipped past it. We now:
+     *    - cancel any pending crossfade and reset its volume (before prepare),
+     *    - re-claim audio focus BEFORE computing the effective volume (so the volume we apply
+     *      uses the post-focus-restore `audioFocusVolumeFactor` instead of a stale ducked one),
      *    - apply the effective volume immediately (no ramp),
-     *    - re-claim audio focus,
-     *    - kick the audible-playback watchdog.
+     *    - kick the audible-playback watchdog (now with a 30%-of-expected threshold instead of
+     *      epsilon-only — catches "quiet but not zero"),
+     *    - schedule a delayed re-apply (~250ms later) so any state transitions that happen
+     *      during the async prepare() that pin the volume low get corrected.
      */
     fun setSongSourceOverride(
         mediaId: String,
@@ -7848,16 +7866,34 @@ class MusicService :
             // Cancel any in-flight crossfade so its volume ramp / secondary player can't pin the
             // primary player's volume low while the new source is preparing.
             cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)
+            // Re-claim audio focus BEFORE computing/applying the effective volume. The previous
+            // order applied the volume first (which would multiply by a stale ducked
+            // audioFocusVolumeFactor if focus had been transiently lost) and then restored
+            // focus — leaving the player pinned at the ducked volume until the reactive volume
+            // flow happened to re-fire. Restoring focus first means currentEffectivePlayerVolume()
+            // reflects the restored 1.0 factor.
+            ensureAudioFocusForActivePlayback()
             player.prepare()
             player.seekTo(0)
             player.playWhenReady = true
             // Restore the effective volume immediately (bypass the smooth ramp) so the new source
-            // doesn't briefly play muted while the ramp catches up. Re-claim audio focus in case
-            // the prepare transition dropped it, and start the audible-playback watchdog so any
-            // later volume dip gets corrected within the next polling window.
+            // doesn't briefly play muted while the ramp catches up. Start the audible-playback
+            // watchdog so any later volume dip gets corrected within the next polling window.
             applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())
-            ensureAudioFocusForActivePlayback()
             updateAudiblePlaybackRecovery()
+            // Defensive delayed re-apply: player.prepare() is async, and the state transitions
+            // it triggers (BUFFERING → READY, audio session ID change, audio-effect rebind,
+            // reactive volume flow re-firing) can interleave with the synchronous restore above
+            // and re-pin the volume low. Re-apply once more after the prepare pipeline has
+            // settled so the user never hears a muted stream.
+            scope.launch {
+                delay(SOURCE_SWITCH_VOLUME_REASSERT_MS)
+                if (player.currentMediaItem?.mediaId == mediaId && player.playWhenReady) {
+                    ensureAudioFocusForActivePlayback()
+                    applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())
+                    ensureAudiblePlaybackVolume("source_switch_reassert")
+                }
+            }
         }
     }
 
@@ -10037,6 +10073,28 @@ class MusicService :
         const val MIN_AUDIBLE_EFFECTIVE_VOLUME = 0.01f
         const val STUCK_MUTED_VOLUME_EPSILON = 0.001f
         const val AUDIBLE_PLAYBACK_VOLUME_CHECK_MS = 2_000L
+        /**
+         * Volume recovery ratio for [ensureAudiblePlaybackVolume]. If the primary player's
+         * actual volume falls below this fraction of the expected effective volume (while
+         * playback is active and the user hasn't muted), the watchdog restores it.
+         *
+         * 0.3f means "restore if actual < 30% of expected" — catches the "quiet but not
+         * zero" state where a half-finished ramp or interleaved audio-focus transition
+         * leaves the player pinned at ~5–15% of target (perceptibly muted) without ever
+         * hitting the epsilon-only zero check.
+         */
+        const val AUDIBLE_VOLUME_RECOVERY_RATIO = 0.3f
+        /**
+         * Delay before the post-source-switch volume re-assert in [setSongSourceOverride].
+         * `player.prepare()` is async — ExoPlayer's internal thread does the actual re-resolution
+         * and the BUFFERING → READY transition fires later, potentially interleaving with audio
+         * session ID changes and reactive volume flow re-fires that can re-pin the volume low
+         * after our synchronous restore. 250ms is enough for the typical prepare pipeline to
+         * settle (ExoPlayer's primary buffer for-playback is 150ms; full state transition usually
+         * completes within one frame after that) without being so long that the user perceives a
+         * muted gap.
+         */
+        const val SOURCE_SWITCH_VOLUME_REASSERT_MS = 250L
         private const val ArchiveTuneExtractorHost = "moriextractor.koyeb.app"
         private const val ArchiveTuneExtractorCacheFingerprintPrefix = "archivetune_extractor:"
         private const val ArchiveTuneExtractorExpirySafetyMs = 30_000L

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -780,12 +781,38 @@ private fun MovingBlurBackground(
     val imageLoader = context.imageLoader
     val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
 
-    Box(
+    // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). On Android S+,
+    // Modifier.blur(64.dp) clamps edge pixels and effectively extends the visible content ~64dp
+    // beyond the layout bounds — which hides the black bar that would otherwise show when the
+    // drift offset pushes the scaled image past the screen edge. Pre-S uses a pre-blurred bitmap
+    // instead, so there's no such edge extension, and at scale 1.4 with drift up to ±120dp the
+    // image's 20% slack (~72dp on a 360dp-wide screen) is less than the max drift — a black
+    // bar shows along the edge during the drift animation.
+    //
+    // Fix: compute the minimum scale that guarantees the image always covers the screen at max
+    // drift on pre-S. Required slack on each side = maxDrift + safety. Slack = (scale-1)/2 * size,
+    // so scale = 1 + 2 * (maxDrift + safety) / size. We take the max of the X and Y requirements
+    // (X is usually binding because phones are taller than wide) and never go below 1.4 (the
+    // post-S scale, kept as a floor so pre-S doesn't look more zoomed than necessary on huge
+    // screens). BoxWithConstraints gives us the actual screen dimensions for the math.
+    BoxWithConstraints(
         modifier =
             modifier
                 .fillMaxSize()
                 .background(AppleMusicFallbackGradient.last()),
     ) {
+        val preSDriftScale =
+            if (isPreS) {
+                val driftMaxX = 120.dp
+                val driftMaxY = 90.dp
+                val safetyMargin = 24.dp
+                val requiredScaleX = 1f + 2f * (driftMaxX + safetyMargin) / maxWidth
+                val requiredScaleY = 1f + 2f * (driftMaxY + safetyMargin) / maxHeight
+                maxOf(requiredScaleX, requiredScaleY, 1.4f)
+            } else {
+                1.4f
+            }
+
         AnimatedContent(
             targetState = mediaMetadata.thumbnailUrl,
             transitionSpec = { fadeIn(tween(700)) togetherWith fadeOut(tween(700)) },
@@ -826,8 +853,8 @@ private fun MovingBlurBackground(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .graphicsLayer {
-                                    scaleX = 1.4f
-                                    scaleY = 1.4f
+                                    scaleX = preSDriftScale
+                                    scaleY = preSDriftScale
                                 }
                                 .offset(x = driftX.dp, y = driftY.dp)
                                 .alpha(0.86f),
@@ -844,8 +871,8 @@ private fun MovingBlurBackground(
                         modifier = Modifier
                             .fillMaxSize()
                             .graphicsLayer {
-                                scaleX = 1.4f
-                                scaleY = 1.4f
+                                scaleX = preSDriftScale
+                                scaleY = preSDriftScale
                             }
                             .blur(64.dp)
                             .offset(x = driftX.dp, y = driftY.dp)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -806,8 +806,8 @@ private fun MovingBlurBackground(
                 val driftMaxX = 120.dp
                 val driftMaxY = 90.dp
                 val safetyMargin = 24.dp
-                val requiredScaleX = 1f + 2f * (driftMaxX + safetyMargin) / maxWidth
-                val requiredScaleY = 1f + 2f * (driftMaxY + safetyMargin) / maxHeight
+                val requiredScaleX = 1f + 2f * (driftMaxX.value + safetyMargin.value) / maxWidth.value
+                val requiredScaleY = 1f + 2f * (driftMaxY.value + safetyMargin.value) / maxHeight.value
                 maxOf(requiredScaleX, requiredScaleY, 1.4f)
             } else {
                 1.4f


### PR DESCRIPTION
Follow-up to #90. Three issues the user reported after that PR landed:

## 1. Lyrics provider priority broken

**Bug:** Played a song and got line-by-line lyrics even though word-to-word was available from the top-priority provider.

**Root cause:** #90's `fetchPriorityLyricsResult` returned the **first** synced result that arrived, cancelling all pending providers. A fast low-priority line-synced provider would preempt a slightly slower top-priority word-synced provider — so priority order was effectively ignored.

**Fix:** Keep the parallel streaming (fast) but add a short grace period (1.2 s) once the first synced result arrives. During the grace period we keep collecting so higher-priority providers get a chance to respond. At decision time we pick the best result by `(sync tier: word > line > plain, then by priority index — lower wins)`. Early-exit immediately only when the top-priority provider returns a word-synced result (can't be beaten). Hard ceiling 8 s so a single hung provider can't pin the panel.

## 2. Source-switch mute still happening (Qobuz → YouTube)

**Bug:** After #90, changing source from Qobuz to YouTube still played the new stream muted. Workaround was to play a previous song then replay.

**Root cause:** #90's synchronous volume restore right after `player.prepare()` wasn't enough. `prepare()` is async — the state transitions it triggers (`BUFFERING → READY`, audio session ID change → audio-effect rebind, reactive volume flow re-firing with a stale duck factor) can re-pin the player volume low **after** our synchronous restore. Plus the watchdog only fired when `player.volume ≈ 0`, so a "quiet but not zero" state slipped past it. Also, the order of calls was wrong: volume was applied *before* audio focus was restored, so if focus was ducked the volume was computed with the stale ducked factor.

**Fix (three changes):**
- **Reorder:** `ensureAudioFocusForActivePlayback()` is now called *before* `applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())`, so the volume is computed with the restored `audioFocusVolumeFactor = 1f` instead of a stale ducked value.
- **Smarter watchdog:** `ensureAudiblePlaybackVolume` now also restores when `player.volume < 30%` of expected (`AUDIBLE_VOLUME_RECOVERY_RATIO = 0.3f`), not just when `player.volume ≈ 0`. Catches the "quiet but not zero" state.
- **Delayed re-apply:** Schedule a `scope.launch { delay(250); ... }` after `prepare()` that re-asserts focus + volume + the watchdog check, so any state transitions that happen during the async prepare get corrected. 250 ms is enough for the typical prepare pipeline to settle (ExoPlayer's primary buffer-for-playback is 150 ms).

## 3. Moving blur lyrics background black bar on pre-Android S

**Bug:** On older Android versions (< API 31), the moving blur lyrics background showed a black bar along the edge during the drift animation.

**Root cause:** On Android S+, `Modifier.blur(64.dp)` uses `RenderEffect` with edge-treatment clamp, which effectively extends the visible content ~64 dp beyond the layout bounds — hiding the black bar that would otherwise show when drift pushes the scaled image past the screen edge. Pre-S uses a pre-blurred bitmap (no edge extension), so at `scale 1.4` with drift up to ±120 dp the image's 20% slack (~72 dp on a 360 dp-wide screen) is less than the max drift — a black bar shows.

**Fix:** Switched `MovingBlurBackground`'s outer `Box` to `BoxWithConstraints` and compute the minimum scale that guarantees full-screen coverage at max drift on pre-S: `scale = 1 + 2 * (maxDrift + safety) / screenSize`. The post-S path is unchanged (scale stays `1.4`, blur handles edge coverage).

## Build status

Could not run the full Gradle build locally — container is RAM-constrained at 4 GB / 0 swap, Gradle OOM-kills the Kotlin daemon during compile (same constraint as #90). Changes have been reviewed manually for syntax and type correctness; CI build on this PR will verify.
