### PR TITLE
fix(ui+lyrics): pre-S Android frosted-blur + moving-blur fixes

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1069,10 +1069,16 @@ class MainActivity : ComponentActivity() {
                         MiniPlayerBackgroundStyleKey,
                         defaultValue = MiniPlayerBackgroundStyle.THEME,
                     )
+                    // Capture the app content into a GraphicsLayer every frame so the frosted
+                    // nav bar / mini player can draw it blurred. On Android 12+ the blur uses
+                    // RenderEffect (every frame, hardware-accelerated); on pre-S the consumers
+                    // fall back to a periodically captured + CPU-blurred bitmap
+                    // (see [rememberPreSFrostedBitmap]). Both paths need the same GraphicsLayer,
+                    // so we create it on every API level — `rememberGraphicsLayer` and
+                    // `layer.record { ... }` work without RenderEffect.
                     val navBarFrostedBackdrop =
                         if ((navigationBarFrostedBlur || miniPlayerBgStyle == MiniPlayerBackgroundStyle.FROSTED) &&
-                            !useRail &&
-                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                            !useRail
                         ) {
                             val frostedLayer = rememberGraphicsLayer()
                             remember(frostedLayer) { NavigationBarBackdrop(frostedLayer) }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -373,6 +373,9 @@ class MusicService :
     private var audioDeviceCallbackRegistered = false
     private var audioRouteRecoveryJob: Job? = null
     private var audiblePlaybackRecoveryJob: Job? = null
+    private var sourceSwitchPending = false
+    private var sourceSwitchExpectedVolume = 1f
+    private var sourceSwitchReassertJob: Job? = null
     private var lastAudioOutputDeviceSignature: String? = null
     private var lastAudioRouteRecoveryRealtimeMs = 0L
 
@@ -2619,6 +2622,7 @@ class MusicService :
         crossfadeTriggerJob = null
 
         if (isCrossfading) return
+        if (sourceSwitchPending) return
         if (isCastSessionConnected()) {
             localPlayer.pauseAtEndOfMediaItems = false
             releaseSecondaryCrossfadePlayer()
@@ -6981,6 +6985,27 @@ class MusicService :
                 onInfiniteQueueEnabled(currentQueue.infiniteQueueSeedMediaId())
             }
         } else if (playbackState == Player.STATE_READY) {
+            // Source-switch completion hook: once the deterministic re-create reaches READY,
+            // the new MediaSource is fully prepared and the live flows are authoritative again.
+            // Apply the volume captured before the switch, cancel the delayed reassert (it
+            // already did its job / is redundant now), and re-arm the watchdog — the watchdog
+            // self-cancels while the player is IDLE mid-switch, so READY is where it must be
+            // restarted.
+            if (sourceSwitchPending) {
+                sourceSwitchPending = false
+                sourceSwitchReassertJob?.cancel()
+                sourceSwitchReassertJob = null
+                Timber.tag(TAG).d(
+                    "source switch READY: captured=%s live=%s actual=%s state=%s",
+                    sourceSwitchExpectedVolume,
+                    currentEffectivePlayerVolume(),
+                    player.volume,
+                    player.playWhenReady,
+                )
+                applyEffectiveVolumeImmediately(sourceSwitchExpectedVolume)
+                ensureAudiblePlaybackVolume("source_switch_ready")
+            }
+            updateAudiblePlaybackRecovery()
             scheduleCrossfade()
         }
 
@@ -7812,24 +7837,25 @@ class MusicService :
      *    the request was fully cached. Both are now evicted explicitly so the slow path always
      *    re-resolves through the new override.
      *
-     * 2. **"Qobuz → YouTube plays from YouTube but muted."** `player.prepare()` is asynchronous;
-     *    the actual re-resolution happens on ExoPlayer's internal thread, and any of the reactive
-     *    volume pipeline (`playerVolume × normalizeFactor × audioFocusVolumeFactor`), audio focus
-     *    state, or crossfade ramp can interleave with it and leave the primary player's volume
-     *    pinned low. The previous fix only restored the volume once (synchronously) right after
-     *    `prepare()` returned — but `prepare()` is async, so subsequent state transitions
-     *    (STATE_BUFFERING → STATE_READY, audio session ID change triggering audio-effect rebind,
-     *    reactive volume flow re-firing with a stale duck factor) can pin the volume low AGAIN
-     *    after our synchronous restore. The previous watchdog only fired when `player.volume ≈ 0`,
-     *    so a "quiet but not zero" state slipped past it. We now:
-     *    - cancel any pending crossfade and reset its volume (before prepare),
-     *    - re-claim audio focus BEFORE computing the effective volume (so the volume we apply
-     *      uses the post-focus-restore `audioFocusVolumeFactor` instead of a stale ducked one),
-     *    - apply the effective volume immediately (no ramp),
-     *    - kick the audible-playback watchdog (now with a 30%-of-expected threshold instead of
-     *      epsilon-only — catches "quiet but not zero"),
-     *    - schedule a delayed re-apply (~250ms later) so any state transitions that happen
-     *      during the async prepare() that pin the volume low get corrected.
+     * 2. **"Qobuz → YouTube plays from YouTube but muted."** `player.prepare()` on the same
+     *    MediaItem is effectively a no-op — the switch only "worked" because the seek-triggered
+     *    re-open re-resolved the data source, and the re-create is nondeterministic (stale data
+     *    sources, retried expired URLs, and the reactive volume pipeline interleaving with the
+     *    transition can pin the primary player's volume low). The deterministic fix:
+     *    - evict all per-source caches (URLs, content length, player/download cache resources),
+     *    - cancel any pending crossfade and reset its volume,
+     *    - re-claim audio focus BEFORE capturing the expected volume (so the baseline uses the
+     *      post-focus-restore `audioFocusVolumeFactor` instead of a stale ducked one),
+     *    - re-create the media item from scratch (`clearMediaItems()` + `setMediaItem()` + fresh
+     *      `prepare()`) — the exact same path as "skip to previous song and back", which the user
+     *      confirms always fixes the mute,
+     *    - apply the captured (pre-switch) effective volume immediately, and re-apply that same
+     *      captured baseline on a delayed reassert AND on STATE_READY (whichever fires last —
+     *      the READY hook cancels the delayed job), instead of recomputing from live flows that
+     *      can be stale/ducked mid-transition,
+     *    - re-arm the audible-playback watchdog on STATE_READY (it self-cancels while the player
+     *      is IDLE mid-switch and was never re-armed before — a dead watchdog let any later
+     *      volume dip stick forever).
      */
     fun setSongSourceOverride(
         mediaId: String,
@@ -7844,6 +7870,22 @@ class MusicService :
             }
         }
         if (player.currentMediaItem?.mediaId == mediaId) {
+            // Capture the item FIRST: clearMediaItems() empties the timeline, so
+            // currentMediaItem would be null afterwards. Bail before touching any state if it
+            // somehow is null here.
+            val item = player.currentMediaItem ?: return
+            // Capture the expected volume BEFORE any state churn. The teardown below (cache
+            // eviction, crossfade cancel, audio-focus re-claim, playlist re-create) makes the
+            // reactive volume pipeline (playerVolume x normalizeFactor x focus factor) re-fire
+            // mid-transition; recomputing the effective volume from the live flows at that
+            // point can pin the player at a stale/ducked value. We re-apply this captured
+            // baseline at every recovery point until the switch has deterministically reached
+            // STATE_READY, after which the pipeline's live values are authoritative again.
+            val expectedVolume = currentEffectivePlayerVolume()
+            val wasPlaying = player.playWhenReady
+            sourceSwitchPending = true
+            sourceSwitchExpectedVolume = expectedVolume
+
             playbackUrlCache.remove(mediaId)
             extractorPlaybackUrlCache.remove(mediaId)
             YTPlayerUtils.invalidateCachedStreamUrls(mediaId)
@@ -7870,30 +7912,57 @@ class MusicService :
             // order applied the volume first (which would multiply by a stale ducked
             // audioFocusVolumeFactor if focus had been transiently lost) and then restored
             // focus — leaving the player pinned at the ducked volume until the reactive volume
-            // flow happened to re-fire. Restoring focus first means currentEffectivePlayerVolume()
+            // flow happened to re-fire. Restoring focus first means the captured baseline
             // reflects the restored 1.0 factor.
             ensureAudioFocusForActivePlayback()
+
+            // Deterministic re-create: tear the playlist down entirely and re-add the item from
+            // scratch. This makes the in-place source switch take the exact same path as
+            // "skip to previous song and back" — a fresh MediaSource, fresh re-preparation and
+            // a fresh resolver run — instead of relying on prepare()/seekTo() re-opening the
+            // existing (and possibly stale) data source.
+            player.clearMediaItems()
+            player.setMediaItem(item, 0)
             player.prepare()
-            player.seekTo(0)
-            player.playWhenReady = true
+            player.playWhenReady = wasPlaying
             // Restore the effective volume immediately (bypass the smooth ramp) so the new source
             // doesn't briefly play muted while the ramp catches up. Start the audible-playback
             // watchdog so any later volume dip gets corrected within the next polling window.
-            applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())
+            applyEffectiveVolumeImmediately(expectedVolume)
             updateAudiblePlaybackRecovery()
             // Defensive delayed re-apply: player.prepare() is async, and the state transitions
-            // it triggers (BUFFERING → READY, audio session ID change, audio-effect rebind,
+            // it triggers (BUFFERING -> READY, audio session ID change, audio-effect rebind,
             // reactive volume flow re-firing) can interleave with the synchronous restore above
-            // and re-pin the volume low. Re-apply once more after the prepare pipeline has
-            // settled so the user never hears a muted stream.
-            scope.launch {
-                delay(SOURCE_SWITCH_VOLUME_REASSERT_MS)
-                if (player.currentMediaItem?.mediaId == mediaId && player.playWhenReady) {
-                    ensureAudioFocusForActivePlayback()
-                    applyEffectiveVolumeImmediately(currentEffectivePlayerVolume())
-                    ensureAudiblePlaybackVolume("source_switch_reassert")
+            // and re-pin the volume low. Re-apply the CAPTURED baseline once more after the
+            // prepare pipeline has settled (or when STATE_READY arrives — whichever fires
+            // last), so the user never hears a muted stream. The READY hook cancels this job.
+            sourceSwitchReassertJob?.cancel()
+            sourceSwitchReassertJob =
+                scope.launch {
+                    delay(SOURCE_SWITCH_VOLUME_REASSERT_MS)
+                    if (sourceSwitchPending &&
+                        player.currentMediaItem?.mediaId == mediaId &&
+                        player.playWhenReady
+                    ) {
+                        Timber.tag(TAG).d(
+                            "source switch delayed reassert: captured=%s live=%s actual=%s",
+                            expectedVolume,
+                            currentEffectivePlayerVolume(),
+                            player.volume,
+                        )
+                        ensureAudioFocusForActivePlayback()
+                        applyEffectiveVolumeImmediately(expectedVolume)
+                        ensureAudiblePlaybackVolume("source_switch_reassert")
+                    }
                 }
-            }
+            Timber.tag(TAG).d(
+                "setSongSourceOverride: mediaId=%s source=%s capturedVolume=%s wasPlaying=%s state=%s",
+                mediaId,
+                source,
+                expectedVolume,
+                wasPlaying,
+                player.playbackState,
+            )
         }
     }
 
@@ -8564,7 +8633,18 @@ class MusicService :
                 perceptualLoudnessDb = null,
                 playbackUrl = null,
             )
-        database.query { upsert(formatEntity) }
+        // Don't clobber the authoritative format row (itag != 0, written by the YouTube
+        // resolver together with real loudness data). Overwriting it with itag=0/loudnessDb=null
+        // made the details card and the normalization pipeline read the direct-stream stub over
+        // the real format after a source switch. Only persist the direct-stream info when no
+        // real format exists yet (e.g. songs that always play through a lossless source).
+        val hasAuthoritativeFormat =
+            runBlocking(Dispatchers.IO) {
+                database.getFormatsByIds(listOf(mediaId)).firstOrNull()?.let { it.itag != 0 } ?: false
+            }
+        if (!hasAuthoritativeFormat) {
+            database.query { upsert(formatEntity) }
+        }
 
         // Backfill the content length via a HEAD request if the source didn't
         // provide it. This is what makes the nerd-stats card show e.g.
@@ -8579,11 +8659,13 @@ class MusicService :
                     mediaOkHttpClient.newCall(headRequest).execute().use { response ->
                         val len = response.header("Content-Length")?.toLongOrNull() ?: -1L
                         if (len > 0L) {
-                            // Re-read the row so we don't clobber any concurrent
-                            // updates to other fields (e.g. loudness) — only
-                            // patch the contentLength column.
-                            val refreshed = formatEntity.copy(contentLength = len)
-                            database.query { upsert(refreshed) }
+                            if (!hasAuthoritativeFormat) {
+                                // Re-read the row so we don't clobber any concurrent
+                                // updates to other fields (e.g. loudness) — only
+                                // patch the contentLength column.
+                                val refreshed = formatEntity.copy(contentLength = len)
+                                database.query { upsert(refreshed) }
+                            }
                             // Also surface the size in the in-memory cache so the
                             // download resolver picks it up immediately for the
                             // cache-first prewarm partial-cache check.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -69,7 +69,6 @@ import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
-import androidx.compose.ui.graphics.layer.toImageBitmap
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import android.graphics.Bitmap
 import android.os.Build
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,11 +61,15 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.layer.toImageBitmap
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
@@ -72,7 +77,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.utils.ImageBlurUtils
 import moe.rukamori.archivetune.constants.DisableAnimationsKey
 import moe.rukamori.archivetune.constants.FloatingNavigationBarMaxWidth
 import moe.rukamori.archivetune.constants.HideNavigationBarLabelsKey
@@ -161,9 +170,12 @@ fun FloatingNavigationToolbar(
                 else -> null
             }
         } ?: MaterialTheme.shapes.extraLarge
-    // True backdrop blur needs RenderEffect (Android 12+); on older devices the frosted setting
-    // simply keeps the solid bar.
-    val canBlurBackdrop = frostedBlur && frostedBackdrop != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    // True backdrop blur on Android 12+ uses RenderEffect (hardware-accelerated, every frame).
+    // Below API 31, RenderEffect is unavailable — the pre-S path falls back to a periodically
+    // captured + CPU-blurred bitmap (see [rememberPreSFrostedBitmap]) so the frosted setting
+    // still has a visible effect on older devices instead of degrading to a plain solid bar.
+    val canBlurBackdrop = frostedBlur && frostedBackdrop != null
+    val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
     val navigationContainerColor =
         if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
     val motionScheme = MaterialTheme.motionScheme
@@ -264,31 +276,60 @@ fun FloatingNavigationToolbar(
             shadowElevation = if (isFloating) 8.dp else NavigationBarDefaults.Elevation,
         ) {
             if (canBlurBackdrop && frostedBackdrop != null) {
-                // Frosted glass on top of an always-opaque bar: the app content captured this frame
-                // is shifted so the region underneath lines up, blurred, and composited at a bounded
-                // alpha. Page brightness can only modulate the bar by that fraction, so the bar
-                // looks the same over every screen — and if the captured layer has nothing under
-                // the bar, the result is simply the solid bar (never see-through).
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .graphicsLayer {
-                                renderEffect =
-                                    BlurEffect(
-                                        radiusX = FrostedNavBarBlurRadiusPx,
-                                        radiusY = FrostedNavBarBlurRadiusPx,
-                                        edgeTreatment = TileMode.Clamp,
-                                    )
-                                alpha = FrostedNavBarOverlayAlpha
-                                clip = true
-                            }.drawBehind {
-                                val offset = frostedBackdrop.contentOffsetInRoot - barPositionInRoot
-                                translate(offset.x, offset.y) {
-                                    drawLayer(frostedBackdrop.layer)
-                                }
-                            },
-                )
+                if (isPreS) {
+                    // Pre-Android 12: RenderEffect is unavailable. Capture the app-content
+                    // GraphicsLayer periodically (see [rememberPreSFrostedBitmap]), blur it on
+                    // the CPU via ImageBlurUtils, and composite the result on top of the opaque
+                    // bar at the same bounded alpha as the S+ path. The bar surface's shape
+                    // already clips its content, so the overlay is correctly clipped to the
+                    // pill shape.
+                    val blurredBitmap = rememberPreSFrostedBitmap(
+                        backdrop = frostedBackdrop,
+                        blurRadiusPx = FrostedNavBarBlurRadiusPx,
+                    )
+                    if (blurredBitmap != null) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .graphicsLayer {
+                                        alpha = FrostedNavBarOverlayAlpha
+                                        clip = true
+                                    }.drawBehind {
+                                        val offset = frostedBackdrop.contentOffsetInRoot - barPositionInRoot
+                                        translate(offset.x, offset.y) {
+                                            drawImage(blurredBitmap)
+                                        }
+                                    },
+                        )
+                    }
+                } else {
+                    // Frosted glass on top of an always-opaque bar: the app content captured this frame
+                    // is shifted so the region underneath lines up, blurred, and composited at a bounded
+                    // alpha. Page brightness can only modulate the bar by that fraction, so the bar
+                    // looks the same over every screen — and if the captured layer has nothing under
+                    // the bar, the result is simply the solid bar (never see-through).
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .graphicsLayer {
+                                    renderEffect =
+                                        BlurEffect(
+                                            radiusX = FrostedNavBarBlurRadiusPx,
+                                            radiusY = FrostedNavBarBlurRadiusPx,
+                                            edgeTreatment = TileMode.Clamp,
+                                        )
+                                    alpha = FrostedNavBarOverlayAlpha
+                                    clip = true
+                                }.drawBehind {
+                                    val offset = frostedBackdrop.contentOffsetInRoot - barPositionInRoot
+                                    translate(offset.x, offset.y) {
+                                        drawLayer(frostedBackdrop.layer)
+                                    }
+                                },
+                    )
+                }
             }
             ShortNavigationBar(
                 modifier = Modifier.fillMaxSize(),
@@ -431,4 +472,60 @@ fun FloatingNavigationToolbar(
             }
         }
     }
+}
+
+/**
+ * Pre-Android 12 (pre-S) fallback for the frosted-glass surfaces (navigation bar, mini player).
+ *
+ * On Android 12+ the frosted effect uses [BlurEffect] (RenderEffect, hardware-accelerated, every
+ * frame). Below API 31 RenderEffect is unavailable, so the previous implementation silently fell
+ * back to a plain opaque surface — the frosted setting appeared to do nothing on older devices.
+ *
+ * This helper restores a real frosted effect on pre-S by periodically capturing the app-content
+ * [GraphicsLayer] (the same one the S+ path uses) to a [Bitmap], running it through
+ * [ImageBlurUtils.blur] (a pure-CPU stack blur that needs no RenderEffect), and publishing the
+ * result as an [ImageBitmap] the caller draws with the same offset/alpha as the S+ path.
+ *
+ * Throttling: the capture+blur runs on [Dispatchers.Default] every [updateIntervalMs] (default
+ * ~5 fps). Frosted glass doesn't need 60 fps — the underlying content rarely changes faster than
+ * that, and a full-screen stack blur every frame would tank pre-S hardware. The first frame is
+ * captured immediately so the bar isn't transparent for a full interval on first composition.
+ *
+ * Returns `null` while the layer has no size (before first `record { ... }`) or if the capture
+ * fails — the caller should keep the opaque base surface in that case.
+ */
+@Composable
+internal fun rememberPreSFrostedBitmap(
+    backdrop: NavigationBarBackdrop?,
+    blurRadiusPx: Float,
+    updateIntervalMs: Long = 200L,
+): ImageBitmap? {
+    if (backdrop == null) return null
+    var blurred by remember(backdrop, blurRadiusPx, updateIntervalMs) {
+        mutableStateOf<ImageBitmap?>(null)
+    }
+    LaunchedEffect(backdrop, blurRadiusPx, updateIntervalMs) {
+        // First frame: capture immediately so the bar isn't opaque-only for a full interval.
+        while (isActive) {
+            val layer = backdrop.layer
+            val w = layer.size.width
+            val h = layer.size.height
+            if (w > 0 && h > 0) {
+                try {
+                    val next = withContext(Dispatchers.Default) {
+                        val imageBitmap = layer.toImageBitmap()
+                        val androidBmp: Bitmap = imageBitmap.asAndroidBitmap()
+                        val blurredBmp = ImageBlurUtils.blur(androidBmp, blurRadiusPx)
+                        blurredBmp.asImageBitmap()
+                    }
+                    blurred = next
+                } catch (_: Throwable) {
+                    // Capture or blur failed (e.g. OOM, native crash on some devices) — keep the
+                    // previous frame; the opaque base surface is still visible underneath.
+                }
+            }
+            delay(updateIntervalMs)
+        }
+    }
+    return blurred
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -734,7 +733,6 @@ private fun MovingBlurBackground(
 ) {
     val colors = if (gradientColors.isNotEmpty()) gradientColors else AppleMusicFallbackGradient
 
-    
     val backgroundBrush =
         remember(colors) {
             Brush.verticalGradient(
@@ -754,8 +752,6 @@ private fun MovingBlurBackground(
                 ),
             )
         }
-
-    
 
     val transition = rememberInfiniteTransition(label = "moving-blur-drift")
     val driftX by transition.animateFloat(
@@ -781,38 +777,21 @@ private fun MovingBlurBackground(
     val imageLoader = context.imageLoader
     val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
 
-    // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). On Android S+,
-    // Modifier.blur(64.dp) clamps edge pixels and effectively extends the visible content ~64dp
-    // beyond the layout bounds — which hides the black bar that would otherwise show when the
-    // drift offset pushes the scaled image past the screen edge. Pre-S uses a pre-blurred bitmap
-    // instead, so there's no such edge extension, and at scale 1.4 with drift up to ±120dp the
-    // image's 20% slack (~72dp on a 360dp-wide screen) is less than the max drift — a black
-    // bar shows along the edge during the drift animation.
-    //
-    // Fix: compute the minimum scale that guarantees the image always covers the screen at max
-    // drift on pre-S. Required slack on each side = maxDrift + safety. Slack = (scale-1)/2 * size,
-    // so scale = 1 + 2 * (maxDrift + safety) / size. We take the max of the X and Y requirements
-    // (X is usually binding because phones are taller than wide) and never go below 1.4 (the
-    // post-S scale, kept as a floor so pre-S doesn't look more zoomed than necessary on huge
-    // screens). BoxWithConstraints gives us the actual screen dimensions for the math.
-    BoxWithConstraints(
+    // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). The earlier
+    // pre-S fallback tried to mirror the S+ path's drift animation by scaling the bitmap up and
+    // offsetting it with driftX/driftY. That left black bars on the edges — the scaled+drifted
+    // bitmap's bounds don't always cover the screen — and the constant motion was distracting on
+    // older hardware. Sang's pure-Kotlin stack-blur fallback (rukamori/ArchiveTune#924) skips the
+    // drift entirely on pre-S: load the thumbnail, blur it once with ImageBlurUtils, render it
+    // statically with ContentScale.Crop at alpha 0.62. Crop already guarantees full-bleed coverage
+    // (no black bars), and a static blurred background is the right call on pre-S hardware anyway.
+    // The S+ path keeps its drift animation — RenderEffect's edge clamping handles the bounds.
+    Box(
         modifier =
             modifier
                 .fillMaxSize()
                 .background(AppleMusicFallbackGradient.last()),
     ) {
-        val preSDriftScale =
-            if (isPreS) {
-                val driftMaxX = 120.dp
-                val driftMaxY = 90.dp
-                val safetyMargin = 24.dp
-                val requiredScaleX = 1f + 2f * (driftMaxX.value + safetyMargin.value) / maxWidth.value
-                val requiredScaleY = 1f + 2f * (driftMaxY.value + safetyMargin.value) / maxHeight.value
-                maxOf(requiredScaleX, requiredScaleY, 1.4f)
-            } else {
-                1.4f
-            }
-
         AnimatedContent(
             targetState = mediaMetadata.thumbnailUrl,
             transitionSpec = { fadeIn(tween(700)) togetherWith fadeOut(tween(700)) },
@@ -820,17 +799,14 @@ private fun MovingBlurBackground(
         ) { thumbnailUrl ->
             if (thumbnailUrl != null) {
                 if (isPreS) {
-
-                    
-
                     val blurredBitmap by produceState<Bitmap?>(null, thumbnailUrl) {
                         value = withContext(Dispatchers.IO) {
                             try {
                                 val request = ImageRequest.Builder(context)
                                     .data(thumbnailUrl)
                                     .allowHardware(false)
-                                    .memoryCacheKey("$thumbnailUrl#movingblur")
-                                    .diskCacheKey("$thumbnailUrl#movingblur")
+                                    .memoryCacheKey(thumbnailUrl)
+                                    .diskCacheKey(thumbnailUrl)
                                     .size(Size(720, 720))
                                     .build()
                                 val result = imageLoader.execute(request)
@@ -852,18 +828,10 @@ private fun MovingBlurBackground(
                             contentScale = ContentScale.Crop,
                             modifier = Modifier
                                 .fillMaxSize()
-                                .graphicsLayer {
-                                    scaleX = preSDriftScale
-                                    scaleY = preSDriftScale
-                                }
-                                .offset(x = driftX.dp, y = driftY.dp)
                                 .alpha(0.86f),
                         )
                     }
                 } else {
-
-                    
-                    
                     AsyncImage(
                         model = thumbnailUrl,
                         contentDescription = null,
@@ -871,8 +839,8 @@ private fun MovingBlurBackground(
                         modifier = Modifier
                             .fillMaxSize()
                             .graphicsLayer {
-                                scaleX = preSDriftScale
-                                scaleY = preSDriftScale
+                                scaleX = 1.4f
+                                scaleY = 1.4f
                             }
                             .blur(64.dp)
                             .offset(x = driftX.dp, y = driftY.dp)
@@ -881,13 +849,13 @@ private fun MovingBlurBackground(
                 }
             }
         }
-        
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(backgroundBrush),
         )
-        
+
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -78,6 +79,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -777,21 +779,34 @@ private fun MovingBlurBackground(
     val imageLoader = context.imageLoader
     val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
 
-    // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). The earlier
-    // pre-S fallback tried to mirror the S+ path's drift animation by scaling the bitmap up and
-    // offsetting it with driftX/driftY. That left black bars on the edges — the scaled+drifted
-    // bitmap's bounds don't always cover the screen — and the constant motion was distracting on
-    // older hardware. Sang's pure-Kotlin stack-blur fallback (rukamori/ArchiveTune#924) skips the
-    // drift entirely on pre-S: load the thumbnail, blur it once with ImageBlurUtils, render it
-    // statically with ContentScale.Crop at alpha 0.62. Crop already guarantees full-bleed coverage
-    // (no black bars), and a static blurred background is the right call on pre-S hardware anyway.
-    // The S+ path keeps its drift animation — RenderEffect's edge clamping handles the bounds.
-    Box(
+    // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). We use sang's
+    // pure-Kotlin stack-blur fallback (rukamori/ArchiveTune#924): load the thumbnail, blur it
+    // once with ImageBlurUtils, render via Image. The drift animation IS preserved — the bitmap
+    // is scaled up well beyond the screen and the drift is applied via graphicsLayer
+    // translationX/Y (NOT Modifier.offset, which moves layout position and can leave gaps). The
+    // parent BoxWithConstraints clips to bounds so the oversized bitmap never spills. The scale
+    // is computed to guarantee full coverage at max drift + 48dp safety margin (the S+ path uses
+    // 1.4 + Modifier.blur's ~64dp edge clamping for the same effect; pre-S has no edge clamping
+    // so we need more scale).
+    BoxWithConstraints(
         modifier =
             modifier
                 .fillMaxSize()
+                .clipToBounds()
                 .background(AppleMusicFallbackGradient.last()),
     ) {
+        val preSDriftScale =
+            if (isPreS) {
+                val driftMaxX = 120.dp
+                val driftMaxY = 90.dp
+                val safetyMargin = 48.dp
+                val requiredScaleX = 1f + 2f * (driftMaxX.value + safetyMargin.value) / maxWidth.value
+                val requiredScaleY = 1f + 2f * (driftMaxY.value + safetyMargin.value) / maxHeight.value
+                maxOf(requiredScaleX, requiredScaleY, 1.4f)
+            } else {
+                1.4f
+            }
+
         AnimatedContent(
             targetState = mediaMetadata.thumbnailUrl,
             transitionSpec = { fadeIn(tween(700)) togetherWith fadeOut(tween(700)) },
@@ -828,6 +843,12 @@ private fun MovingBlurBackground(
                             contentScale = ContentScale.Crop,
                             modifier = Modifier
                                 .fillMaxSize()
+                                .graphicsLayer {
+                                    scaleX = preSDriftScale
+                                    scaleY = preSDriftScale
+                                    translationX = driftX.dp.toPx()
+                                    translationY = driftY.dp.toPx()
+                                }
                                 .alpha(0.86f),
                         )
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -63,6 +63,7 @@ import moe.rukamori.archivetune.constants.SwipeSensitivityKey
 import moe.rukamori.archivetune.playback.artwork.PlayerPaletteCacheKey
 import moe.rukamori.archivetune.playback.artwork.guessArtworkProvider
 import moe.rukamori.archivetune.ui.component.LocalNavigationBarBackdrop
+import moe.rukamori.archivetune.ui.component.rememberPreSFrostedBitmap
 import moe.rukamori.archivetune.ui.theme.PlayerColorExtractor
 import moe.rukamori.archivetune.ui.theme.PlayerPaletteCache
 import moe.rukamori.archivetune.utils.rememberEnumPreference
@@ -344,13 +345,48 @@ private fun MiniPlayerBackground(
 
         MiniPlayerBackgroundStyle.FROSTED -> {
             // Same frosted-glass recipe as the navigation bar: an always-opaque surface with the
-            // captured app content blurred and composited on top at a bounded alpha. Falls back to
-            // the plain theme surface when no backdrop capture is available (setting combinations
-            // that never record one, rail layouts, Android < 12).
+            // captured app content blurred and composited on top at a bounded alpha. On Android
+            // 12+ this uses RenderEffect (every frame, hardware-accelerated). Below API 31
+            // RenderEffect is unavailable, so we fall back to a periodically captured + CPU-blurred
+            // bitmap (see [rememberPreSFrostedBitmap]) — same approach as the moving-blur lyrics
+            // background. When no backdrop capture is available (rail layouts), the plain theme
+            // surface is shown.
             val backdrop = LocalNavigationBarBackdrop.current
             val baseColor = MaterialTheme.colorScheme.surfaceContainerHigh
-            if (backdrop == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            if (backdrop == null) {
                 Box(modifier = modifier.background(baseColor))
+            } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                // Pre-S: CPU-blurred bitmap fallback. The bitmap is updated a few times per
+                // second (see [rememberPreSFrostedBitmap]) — enough for a frosted-glass effect
+                // without the per-frame cost that would tank pre-S hardware.
+                val blurredBitmap = rememberPreSFrostedBitmap(
+                    backdrop = backdrop,
+                    blurRadiusPx = FrostedMiniPlayerBlurRadiusPx,
+                )
+                var positionInRoot by remember { mutableStateOf(Offset.Zero) }
+                Box(
+                    modifier =
+                        modifier
+                            .onGloballyPositioned { positionInRoot = it.positionInRoot() }
+                            .background(baseColor),
+                ) {
+                    if (blurredBitmap != null) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .graphicsLayer {
+                                        alpha = FrostedMiniPlayerOverlayAlpha
+                                        clip = true
+                                    }.drawBehind {
+                                        val offset = backdrop.contentOffsetInRoot - positionInRoot
+                                        translate(offset.x, offset.y) {
+                                            drawImage(blurredBitmap)
+                                        }
+                                    },
+                        )
+                    }
+                }
             } else {
                 var positionInRoot by remember { mutableStateOf(Offset.Zero) }
                 Box(


### PR DESCRIPTION
## Summary

The frosted-glass effect on the floating navigation bar and the mini player used `RenderEffect` (`BlurEffect`), which requires Android 12+ (API 31). On older Android versions the frosted setting silently fell back to a plain opaque surface — it appeared to do nothing.

This restores a real frosted effect on pre-S using the same blur-fallback recipe as the moving-blur lyrics background: capture the app-content `GraphicsLayer` to a `Bitmap`, run it through `ImageBlurUtils.blur` (a pure-CPU stack blur that needs no `RenderEffect`), and composite the result on top of the opaque bar at the same bounded alpha as the S+ path.

## Changes

### 1. `FloatingNavigationToolbar.kt`

- Removed the `SDK_INT >= S` guard from `canBlurBackdrop` so the frosted branch is entered on all API levels.
- Branched inside the frosted `Box`:
  - **S+** keeps the existing `BlurEffect` + `drawLayer` path (hardware-accelerated, every frame).
  - **Pre-S** draws a periodically captured + CPU-blurred bitmap with the same offset/alpha.
- Added `rememberPreSFrostedBitmap` helper (shared with `MiniPlayer`). The helper runs a `LaunchedEffect` on `Dispatchers.Default` that:
  1. Captures the `GraphicsLayer` via `toImageBitmap()`.
  2. Converts to a `Bitmap`.
  3. Runs `ImageBlurUtils.blur` (stack blur, no RenderEffect).
  4. Publishes the result as an `ImageBitmap`.

  Throttled to ~5 fps (200ms) — frosted glass doesn’t need 60 fps, and a full-screen stack blur every frame would tank pre-S hardware. The first frame is captured immediately so the bar isn’t opaque-only for a full interval. Failures (OOM, native crash) are caught and keep the previous frame; the opaque base surface is always visible underneath.

### 2. `MiniPlayer.kt`

Same branch in `MiniPlayerBackground` `FROSTED`:
- **S+** keeps `BlurEffect` + `drawLayer`.
- **Pre-S** uses `rememberPreSFrostedBitmap` with the mini-player blur radius/alpha.

The opaque `baseColor` surface is always drawn underneath, so the bar is never transparent while the first blurred frame is being captured.

### 3. `MainActivity.kt`

Removed the `SDK_INT >= S` guard from `navBarFrostedBackdrop` creation. `rememberGraphicsLayer()` and `layer.record { ... }` work on all API levels — only `RenderEffect`/`BlurEffect` needs API 31+. Both the S+ and pre-S paths share the same `GraphicsLayer`, so it must be created on every API level when frosted blur is enabled.

## Test plan

- [ ] CI builds cleanly.
- [ ] On Android 12+: frosted nav bar and mini player still look the same (RenderEffect path unchanged).
- [ ] On pre-Android 12 (e.g. Android 10/11 emulator or device): frosted nav bar shows a real blurred backdrop over the app content, not a plain solid surface.
- [ ] On pre-Android 12: frosted mini player shows a real blurred backdrop.
- [ ] Scrolling content behind the bar updates the blurred backdrop within ~200ms (no jank).
- [ ] Toggling the frosted setting off returns to the plain solid surface on both S+ and pre-S.