### PR TITLE
fix(queue+ui): current song on top + static blur & disabled frosted on pre-S

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -172,11 +172,12 @@ fun FloatingNavigationToolbar(
             }
         } ?: MaterialTheme.shapes.extraLarge
     // True backdrop blur on Android 12+ uses RenderEffect (hardware-accelerated, every frame).
-    // Below API 31, RenderEffect is unavailable — the pre-S path falls back to a periodically
-    // captured + CPU-blurred bitmap (see [rememberPreSFrostedBitmap]) so the frosted setting
-    // still has a visible effect on older devices instead of degrading to a plain solid bar.
-    val canBlurBackdrop = frostedBlur && frostedBackdrop != null
+    // Below API 31 the frosted effect is disabled entirely: the pre-S CPU-blurred-bitmap fallback
+    // produced visible glitches and tearing on older devices, so we degrade to a plain solid bar.
+    // The Settings screen surfaces a "not supported on Android versions below 12" warning under
+    // the toggle when running on pre-S.
     val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+    val canBlurBackdrop = frostedBlur && frostedBackdrop != null && !isPreS
     val navigationContainerColor =
         if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
     val motionScheme = MaterialTheme.motionScheme

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import android.graphics.Bitmap
 import android.os.Build
@@ -75,6 +76,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -262,13 +264,17 @@ fun FloatingNavigationToolbar(
         contentAlignment = Alignment.Center,
     ) {
         var barPositionInRoot by remember { mutableStateOf(Offset.Zero) }
+        var barSize by remember { mutableStateOf(IntSize.Zero) }
         Surface(
             modifier =
                 Modifier
                     .widthIn(max = if (isFloating) FloatingNavigationBarMaxWidth else NavigationBarMaxWidth)
                     .fillMaxWidth()
                     .height(NavigationBarHeight)
-                    .onGloballyPositioned { barPositionInRoot = it.positionInRoot() },
+                    .onGloballyPositioned {
+                        barPositionInRoot = it.positionInRoot()
+                        barSize = it.size
+                    },
             shape = navigationShape,
             color = navigationContainerColor,
             tonalElevation = NavigationBarDefaults.Elevation,
@@ -277,13 +283,17 @@ fun FloatingNavigationToolbar(
             if (canBlurBackdrop && frostedBackdrop != null) {
                 if (isPreS) {
                     // Pre-Android 12: RenderEffect is unavailable. Capture the app-content
-                    // GraphicsLayer periodically (see [rememberPreSFrostedBitmap]), blur it on
-                    // the CPU via ImageBlurUtils, and composite the result on top of the opaque
-                    // bar at the same bounded alpha as the S+ path. The bar surface's shape
-                    // already clips its content, so the overlay is correctly clipped to the
-                    // pill shape.
+                    // GraphicsLayer periodically (see [rememberPreSFrostedBitmap]), extract just
+                    // the slice under the bar, blur it on the CPU via ImageBlurUtils, and composite
+                    // the small blurred slice on top of the opaque bar at the same bounded alpha as
+                    // the S+ path. The bar surface's shape already clips its content, so the
+                    // overlay is correctly clipped to the pill shape. The blurred slice is already
+                    // aligned to the bar's top-left (the helper extracts it from the bar's position
+                    // in root), so we draw it at (0, 0) — no translate, no clip needed.
                     val blurredBitmap = rememberPreSFrostedBitmap(
                         backdrop = frostedBackdrop,
+                        barPositionInRoot = barPositionInRoot,
+                        barSize = barSize,
                         blurRadiusPx = FrostedNavBarBlurRadiusPx,
                     )
                     if (blurredBitmap != null) {
@@ -295,10 +305,7 @@ fun FloatingNavigationToolbar(
                                         alpha = FrostedNavBarOverlayAlpha
                                         clip = true
                                     }.drawBehind {
-                                        val offset = frostedBackdrop.contentOffsetInRoot - barPositionInRoot
-                                        translate(offset.x, offset.y) {
-                                            drawImage(blurredBitmap)
-                                        }
+                                        drawImage(blurredBitmap)
                                     },
                         )
                     }
@@ -485,39 +492,153 @@ fun FloatingNavigationToolbar(
  * [ImageBlurUtils.blur] (a pure-CPU stack blur that needs no RenderEffect), and publishing the
  * result as an [ImageBitmap] the caller draws with the same offset/alpha as the S+ path.
  *
- * Throttling: the capture+blur runs on [Dispatchers.Default] every [updateIntervalMs] (default
- * ~5 fps). Frosted glass doesn't need 60 fps — the underlying content rarely changes faster than
- * that, and a full-screen stack blur every frame would tank pre-S hardware. The first frame is
- * captured immediately so the bar isn't transparent for a full interval on first composition.
+ * SLICE OPTIMIZATION (fixes the "weird glitchy blur" the user reported on pre-S):
+ * The original implementation captured the FULL app-content layer (typically 1080x2400 px on a
+ * phone), blurred the entire thing, then drew a small slice of it on the bar via translate+clip.
+ * That had three problems on pre-S hardware:
+ *   1. The full-screen capture + full-screen blur was slow, forcing a 200 ms update interval
+ *      (5 fps) — visible "jumps" as content scrolled, reading as glitchiness.
+ *   2. [ImageBlurUtils.blur] downscales any source >720 px to 720 px before stack-blurring, then
+ *      upscales back. On a full-screen source the downscale factor was ~0.3, so the blurred
+ *      result was extremely low-resolution and looked pixelated/muddy when upscaled.
+ *   3. Allocating a full-screen ARGB_8888 bitmap (~10 MB) every frame caused heavy GC pressure,
+ *      adding stutter on top of the slow blur.
  *
- * Returns `null` while the layer has no size (before first `record { ... }`) or if the capture
- * fails — the caller should keep the opaque base surface in that case.
+ * The slice path fixes all three: we capture the full layer ONCE per update (unavoidable —
+ * GraphicsLayer has no region capture), but then immediately extract just the small rectangle
+ * that lies under the bar (e.g. 1080x240 px) via [Bitmap.createBitmap] before blurring. The
+ * slice is small enough that [ImageBlurUtils.blur]'s 720 px downscale threshold either doesn't
+ * trigger or triggers at a much milder factor (~0.67 instead of ~0.3), so the blur keeps real
+ * resolution. The slice is also ~10x smaller, so allocation/GC is ~10x lighter and we can push
+ * the update interval down to 80 ms (~12 fps) for visibly smoother tracking. The slice is
+ * extracted with [blurRadiusPx] of padding on every side so the stack blur has neighboring
+ * pixels to sample at the bar's edges — without padding the blur would just clamp the bar's own
+ * edge pixels and the frost would look wrong at the boundary.
+ *
+ * The caller receives the small blurred slice (already aligned to the bar's top-left) and draws
+ * it at (0, 0) — no translate, no clip — at the same bounded alpha as the S+ path. If the bar
+ * moves between slice extraction and draw, the slice shows the content that was at the bar's
+ * extraction-time position; for the navigation bar (which is fixed) and the mini player (which
+ * only moves during drag), this is imperceptible.
+ *
+ * Returns `null` while the layer has no size (before first `record { ... }`), while the bar
+ * hasn't been positioned yet, or if the capture fails — the caller should keep the opaque base
+ * surface in that case.
+ *
+ * @param backdrop The shared capture handle (layer + content offset in root).
+ * @param barPositionInRoot The bar's current top-left position in root coordinates. Read fresh
+ *   each capture via [rememberUpdatedState], so the slice tracks the bar as it moves.
+ * @param barSize The bar's current size in pixels. Read fresh each capture.
+ * @param blurRadiusPx Blur radius in raw pixels (clamped to 0.5..48 by [ImageBlurUtils.blur]).
+ * @param updateIntervalMs Capture+blur throttle. Default 80 ms (~12 fps) — fast enough for
+ *   smooth frosted tracking, slow enough to not tank pre-S hardware.
  */
 @Composable
 internal fun rememberPreSFrostedBitmap(
     backdrop: NavigationBarBackdrop?,
+    barPositionInRoot: Offset,
+    barSize: IntSize,
     blurRadiusPx: Float,
-    updateIntervalMs: Long = 200L,
+    updateIntervalMs: Long = 80L,
 ): ImageBitmap? {
     if (backdrop == null) return null
     var blurred by remember(backdrop, blurRadiusPx, updateIntervalMs) {
         mutableStateOf<ImageBitmap?>(null)
     }
+    // rememberUpdatedState lets the LaunchedEffect's coroutine read the LATEST bar position/size
+    // without re-launching on every layout pass (the LaunchedEffect's keys are intentionally
+    // coarse — backdrop/blurRadius/interval — so the capture loop isn't torn down and rebuilt
+    // every time the bar moves).
+    val barPositionState = rememberUpdatedState(barPositionInRoot)
+    val barSizeState = rememberUpdatedState(barSize)
+
     LaunchedEffect(backdrop, blurRadiusPx, updateIntervalMs) {
-        // First frame: capture immediately so the bar isn't opaque-only for a full interval.
         while (isActive) {
             val layer = backdrop.layer
-            val w = layer.size.width
-            val h = layer.size.height
-            if (w > 0 && h > 0) {
+            val layerW = layer.size.width
+            val layerH = layer.size.height
+            if (layerW > 0 && layerH > 0) {
                 try {
                     val next = withContext(Dispatchers.Default) {
+                        // Read the latest bar geometry. These States are updated by the caller's
+                        // onGloballyPositioned, which fires on the main thread during layout.
+                        val pos = barPositionState.value
+                        val size = barSizeState.value
+                        if (size.width <= 0 || size.height <= 0) return@withContext null
+
+                        // The slice is the bar's bounds expressed in the LAYER's coordinate
+                        // system (layer's top-left is contentOffsetInRoot in root coords).
+                        val contentOffset = backdrop.contentOffsetInRoot
+                        val rawX = (pos.x - contentOffset.x).toInt()
+                        val rawY = (pos.y - contentOffset.y).toInt()
+
+                        // Padding around the slice so the stack blur has neighboring pixels to
+                        // sample at the bar's edges. Without this, the blur clamps the bar's own
+                        // edge pixels and the frost looks wrong at the boundary.
+                        val pad = blurRadiusPx.toInt().coerceIn(8, 64)
+
+                        // Clamp the padded slice to the layer's bounds. If the bar is partially
+                        // off-layer (e.g. floating bar that overshoots), we still capture what we
+                        // can — the missing pixels are filled with the layer's edge color via
+                        // stack blur's edge clamping, which is acceptable.
+                        val paddedX = rawX - pad
+                        val paddedY = rawY - pad
+                        val paddedW = size.width + 2 * pad
+                        val paddedH = size.height + 2 * pad
+                        val clampedX = paddedX.coerceIn(0, layerW - 1)
+                        val clampedY = paddedY.coerceIn(0, layerH - 1)
+                        val clampedRight = (paddedX + paddedW).coerceIn(1, layerW)
+                        val clampedBottom = (paddedY + paddedH).coerceIn(1, layerH)
+                        val clampedW = clampedRight - clampedX
+                        val clampedH = clampedBottom - clampedY
+                        if (clampedW <= 0 || clampedH <= 0) return@withContext null
+
+                        // Capture the full layer to a bitmap. This is the expensive part (GPU→CPU
+                        // readback) but is unavoidable — GraphicsLayer has no region capture API.
                         val imageBitmap = layer.toImageBitmap()
-                        val androidBmp: Bitmap = imageBitmap.asAndroidBitmap()
-                        val blurredBmp = ImageBlurUtils.blur(androidBmp, blurRadiusPx)
-                        blurredBmp.asImageBitmap()
+                        val fullBitmap = imageBitmap.asAndroidBitmap()
+
+                        // Extract just the small slice under the bar (with padding). This is a
+                        // cheap pixel copy; the slice is ~10x smaller than the full bitmap.
+                        val sliceBitmap = Bitmap.createBitmap(
+                            fullBitmap,
+                            clampedX,
+                            clampedY,
+                            clampedW,
+                            clampedH,
+                        )
+
+                        // Blur the small slice directly. Because the slice is small, the 720 px
+                        // downscale threshold in ImageBlurUtils either doesn't trigger or triggers
+                        // at a mild factor, so the blur keeps real resolution (no muddy upscale).
+                        val blurredSlice = ImageBlurUtils.blur(sliceBitmap, blurRadiusPx)
+
+                        // Crop the bar's actual bounds out of the (padded) blurred slice. The
+                        // slice's top-left corresponds to layer coords (clampedX, clampedY), so
+                        // the bar's top-left in the slice is at (rawX - clampedX, rawY - clampedY).
+                        // In the common case (no edge clipping) this is (pad, pad). If the bar
+                        // was near the layer's edge and padding was clipped, the offset is
+                        // smaller but never negative (clampedX <= rawX because the bar is inside
+                        // the layer, so rawX - clampedX >= 0).
+                        val barXInSlice = (rawX - clampedX).coerceIn(0, blurredSlice.width - 1)
+                        val barYInSlice = (rawY - clampedY).coerceIn(0, blurredSlice.height - 1)
+                        val barW = size.width.coerceAtMost(blurredSlice.width - barXInSlice)
+                        val barH = size.height.coerceAtMost(blurredSlice.height - barYInSlice)
+                        if (barW <= 0 || barH <= 0) {
+                            // Degenerate slice — return as-is and let the caller clip.
+                            blurredSlice.asImageBitmap()
+                        } else if (barXInSlice == 0 && barYInSlice == 0 &&
+                            blurredSlice.width == size.width && blurredSlice.height == size.height
+                        ) {
+                            // No padding was added (pad == 0, impossible here since pad >= 8) or
+                            // slice is already exactly the bar size — skip the extra allocation.
+                            blurredSlice.asImageBitmap()
+                        } else {
+                            Bitmap.createBitmap(blurredSlice, barXInSlice, barYInSlice, barW, barH)
+                                .asImageBitmap()
+                        }
                     }
-                    blurred = next
+                    if (next != null) blurred = next
                 } catch (_: Throwable) {
                     // Capture or blur failed (e.g. OOM, native crash on some devices) — keep the
                     // previous frame; the opaque base surface is still visible underneath.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -781,13 +781,20 @@ private fun MovingBlurBackground(
 
     // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). We use sang's
     // pure-Kotlin stack-blur fallback (rukamori/ArchiveTune#924): load the thumbnail, blur it
-    // once with ImageBlurUtils, render via Image. The drift animation IS preserved — the bitmap
-    // is scaled up well beyond the screen and the drift is applied via graphicsLayer
-    // translationX/Y (NOT Modifier.offset, which moves layout position and can leave gaps). The
-    // parent BoxWithConstraints clips to bounds so the oversized bitmap never spills. The scale
-    // is computed to guarantee full coverage at max drift + 48dp safety margin (the S+ path uses
-    // 1.4 + Modifier.blur's ~64dp edge clamping for the same effect; pre-S has no edge clamping
-    // so we need more scale).
+    // once with ImageBlurUtils, render via Image. The drift animation is preserved by applying
+    // it through Modifier.offset(x = driftX.dp, y = driftY.dp) — the SAME mechanism the S+ path
+    // uses. Earlier attempts tried graphicsLayer { translationX = driftX.dp.toPx() } instead,
+    // but on pre-S devices the graphicsLayer block did not reliably re-evaluate each animation
+    // frame, so the background appeared static even though driftX was animating. Modifier.offset
+    // is a layout modifier that definitely invalidates layout when its Dp arguments change, so
+    // the bitmap is re-placed every frame.
+    //
+    // The bitmap is scaled up well beyond the screen (preSDriftScale, computed below) so that
+    // at max drift the scaled+drifted drawing still covers the screen with no black bars. The
+    // parent BoxWithConstraints has clipToBounds() so the oversized drawing never spills. The
+    // 48dp safety margin guarantees full coverage at max drift (the S+ path doesn't need this
+    // because Modifier.blur's TileMode.Clamp extends the visible content ~64dp beyond the
+    // layout bounds; pre-S has no such edge extension).
     BoxWithConstraints(
         modifier =
             modifier
@@ -846,9 +853,8 @@ private fun MovingBlurBackground(
                                 .graphicsLayer {
                                     scaleX = preSDriftScale
                                     scaleY = preSDriftScale
-                                    translationX = driftX.dp.toPx()
-                                    translationY = driftY.dp.toPx()
                                 }
+                                .offset(x = driftX.dp, y = driftY.dp)
                                 .alpha(0.86f),
                         )
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -755,8 +755,24 @@ private fun MovingBlurBackground(
             )
         }
 
+    val context = LocalContext.current
+    val imageLoader = context.imageLoader
+    val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+
+    // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). We use sang's
+    // pure-Kotlin stack-blur fallback (rukamori/ArchiveTune#924): load the thumbnail, blur it
+    // once with ImageBlurUtils, render via Image. The drift animation is NOT applied on pre-S —
+    // the pre-S fallback uses a single pre-blurred bitmap, and animating its offset every frame
+    // caused visible glitches and tearing on older devices (and the moving-blur effect relies
+    // on per-frame Modifier.blur re-evaluation that pre-S simply cannot do). Instead the pre-S
+    // path renders the blurred bitmap statically at a fixed scale that covers the screen with
+    // no black bars, giving a clean static blurred background. The drift animation runs only on
+    // Android 12+ where Modifier.blur is hardware-accelerated and re-blurs every frame.
+    //
+    // Effective drift values: animated on S+, hard-zero on pre-S so the offset modifier is a
+    // no-op and the bitmap stays pinned.
     val transition = rememberInfiniteTransition(label = "moving-blur-drift")
-    val driftX by transition.animateFloat(
+    val animatedDriftX by transition.animateFloat(
         initialValue = -120f,
         targetValue = 120f,
         animationSpec = infiniteRepeatable(
@@ -765,7 +781,7 @@ private fun MovingBlurBackground(
         ),
         label = "moving-blur-x",
     )
-    val driftY by transition.animateFloat(
+    val animatedDriftY by transition.animateFloat(
         initialValue = -90f,
         targetValue = 90f,
         animationSpec = infiniteRepeatable(
@@ -774,27 +790,8 @@ private fun MovingBlurBackground(
         ),
         label = "moving-blur-y",
     )
-
-    val context = LocalContext.current
-    val imageLoader = context.imageLoader
-    val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
-
-    // Pre-Android S can't use Modifier.blur (it requires RenderEffect, API 31+). We use sang's
-    // pure-Kotlin stack-blur fallback (rukamori/ArchiveTune#924): load the thumbnail, blur it
-    // once with ImageBlurUtils, render via Image. The drift animation is preserved by applying
-    // it through Modifier.offset(x = driftX.dp, y = driftY.dp) — the SAME mechanism the S+ path
-    // uses. Earlier attempts tried graphicsLayer { translationX = driftX.dp.toPx() } instead,
-    // but on pre-S devices the graphicsLayer block did not reliably re-evaluate each animation
-    // frame, so the background appeared static even though driftX was animating. Modifier.offset
-    // is a layout modifier that definitely invalidates layout when its Dp arguments change, so
-    // the bitmap is re-placed every frame.
-    //
-    // The bitmap is scaled up well beyond the screen (preSDriftScale, computed below) so that
-    // at max drift the scaled+drifted drawing still covers the screen with no black bars. The
-    // parent BoxWithConstraints has clipToBounds() so the oversized drawing never spills. The
-    // 48dp safety margin guarantees full coverage at max drift (the S+ path doesn't need this
-    // because Modifier.blur's TileMode.Clamp extends the visible content ~64dp beyond the
-    // layout bounds; pre-S has no such edge extension).
+    val driftX = if (isPreS) 0f else animatedDriftX
+    val driftY = if (isPreS) 0f else animatedDriftY
     BoxWithConstraints(
         modifier =
             modifier

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.palette.graphics.Palette
@@ -356,18 +357,25 @@ private fun MiniPlayerBackground(
             if (backdrop == null) {
                 Box(modifier = modifier.background(baseColor))
             } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-                // Pre-S: CPU-blurred bitmap fallback. The bitmap is updated a few times per
-                // second (see [rememberPreSFrostedBitmap]) — enough for a frosted-glass effect
-                // without the per-frame cost that would tank pre-S hardware.
+                // Pre-S: CPU-blurred bitmap fallback. The bitmap is the small slice under the
+                // mini player (not the full screen), captured and blurred every ~80 ms — fast
+                // enough for smooth frosted tracking without tanking pre-S hardware. The blurred
+                // slice is already aligned to the mini player's top-left, so we draw at (0, 0).
+                var positionInRoot by remember { mutableStateOf(Offset.Zero) }
+                var miniPlayerSize by remember { mutableStateOf(IntSize.Zero) }
                 val blurredBitmap = rememberPreSFrostedBitmap(
                     backdrop = backdrop,
+                    barPositionInRoot = positionInRoot,
+                    barSize = miniPlayerSize,
                     blurRadiusPx = FrostedMiniPlayerBlurRadiusPx,
                 )
-                var positionInRoot by remember { mutableStateOf(Offset.Zero) }
                 Box(
                     modifier =
                         modifier
-                            .onGloballyPositioned { positionInRoot = it.positionInRoot() }
+                            .onGloballyPositioned {
+                                positionInRoot = it.positionInRoot()
+                                miniPlayerSize = it.size
+                            }
                             .background(baseColor),
                 ) {
                     if (blurredBitmap != null) {
@@ -379,10 +387,7 @@ private fun MiniPlayerBackground(
                                         alpha = FrostedMiniPlayerOverlayAlpha
                                         clip = true
                                     }.drawBehind {
-                                        val offset = backdrop.contentOffsetInRoot - positionInRoot
-                                        translate(offset.x, offset.y) {
-                                            drawImage(blurredBitmap)
-                                        }
+                                        drawImage(blurredBitmap)
                                     },
                         )
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -337,7 +337,17 @@ private fun MiniPlayerBackground(
     palette: MiniPlayerBackgroundPalette?,
     modifier: Modifier = Modifier,
 ) {
-    when (style) {
+    // Frosted blur on the mini player relies on RenderEffect (API 31+). On pre-S the CPU-blurred
+    // bitmap fallback produced visible glitches on older devices, so FROSTED is forcibly
+    // downgraded to THEME. The Settings screen surfaces a "not supported on Android versions
+    // below 12" warning under the mini player background selector when running on pre-S.
+    val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+    val effectiveStyle = if (isPreS && style == MiniPlayerBackgroundStyle.FROSTED) {
+        MiniPlayerBackgroundStyle.THEME
+    } else {
+        style
+    }
+    when (effectiveStyle) {
         MiniPlayerBackgroundStyle.THEME -> {
             Box(
                 modifier = modifier.background(MaterialTheme.colorScheme.surfaceContainerHigh),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -722,7 +722,13 @@ fun Queue(
                         draggedItemUid = draggedItemUid,
                         destination =
                             if (toQueueIndex == 0) {
-                                QueueDragDestination.Start
+                                // In the filtered queue list the current song is always at
+                                // index 0, so dropping at position 0 means "make this the
+                                // next song after the current one" rather than "move to the
+                                // very start of the full timeline" (which would place it
+                                // before already-played songs and is not visible anyway).
+                                currentPlayingUid?.let { QueueDragDestination.After(itemUid = it) }
+                                    ?: QueueDragDestination.Start
                             } else {
                                 QueueDragDestination.After(
                                     itemUid = mutableQueueWindows[toQueueIndex - 1].uid,
@@ -730,7 +736,7 @@ fun Queue(
                             },
                     )
 
-                if (selection && currentWindowIndex in mutableQueueWindows.indices) {
+                if (selection) {
                     val currentItem = queueWindows.getOrNull(currentWindowIndex)
 
                     if (currentItem?.uid == draggedItemUid) {
@@ -749,7 +755,7 @@ fun Queue(
                 }
             }
 
-        LaunchedEffect(queueWindows, reorderableState.isAnyItemDragging) {
+        LaunchedEffect(queueWindows, currentWindowIndex, reorderableState.isAnyItemDragging) {
             if (reorderableState.isAnyItemDragging) return@LaunchedEffect
 
             val completedDrag = dragInfo
@@ -781,9 +787,16 @@ fun Queue(
                 }
             }
 
+            // Only display the current song and upcoming songs in the queue list.
+            // Previously-played songs are excluded so the currently playing track is
+            // always at the top of the queue list — matching the "Continue Playing"
+            // header and the behaviour of mainstream music apps (Spotify, Apple Music).
+            // The full `queueWindows` (including played songs) is still used for
+            // queue stats, clear-queue, and drag-source resolution.
             Snapshot.withMutableSnapshot {
                 mutableQueueWindows.clear()
-                mutableQueueWindows.addAll(queueWindows)
+                val startIndex = currentWindowIndex.coerceAtLeast(0)
+                mutableQueueWindows.addAll(queueWindows.drop(startIndex))
             }
         }
 
@@ -1061,7 +1074,7 @@ fun Queue(
                                                                 selectedItems.add(currentItem)
                                                             }
                                                         } else {
-                                                            if (index == currentWindowIndex) {
+                                                            if (isActive) {
                                                                 playerConnection.player.togglePlayPause()
                                                             } else {
                                                                 val joined =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -786,6 +786,19 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                                 }
                             },
                         )
+                        // Pre-Android 12 disclaimer: the moving-blur background relies on per-frame
+                        // Modifier.blur (RenderEffect, API 31+). On pre-S the fallback renders a
+                        // single pre-blurred bitmap with no drift animation, so the blur is static.
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
+                            lyricsBackground == LyricsBackgroundStyle.MOVING_BLUR
+                        ) {
+                            Text(
+                                text = stringResource(R.string.moving_blur_static_disclaimer),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(start = 56.dp, top = 4.dp, end = 16.dp),
+                            )
+                        }
                     }
                 }
 
@@ -813,6 +826,19 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                                 }
                             },
                         )
+                        // Pre-Android 12 warning: frosted mini player uses RenderEffect (API 31+).
+                        // On pre-S the FROSTED style is silently downgraded to THEME — surface a
+                        // warning so users on older devices know why their selection isn't applying.
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
+                            miniPlayerBackground == MiniPlayerBackgroundStyle.FROSTED
+                        ) {
+                            Text(
+                                text = stringResource(R.string.frosted_mini_player_unsupported),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(start = 56.dp, top = 4.dp, end = 16.dp),
+                            )
+                        }
                     }
                 }
 
@@ -1017,13 +1043,26 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.navigation_bar_frosted_blur)) },
-                        description = stringResource(R.string.navigation_bar_frosted_blur_desc),
-                        icon = { Icon(painterResource(R.drawable.blur_on), null) },
-                        checked = navigationBarFrostedBlur,
-                        onCheckedChange = onNavigationBarFrostedBlurChange,
-                    )
+                    Column {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.navigation_bar_frosted_blur)) },
+                            description = stringResource(R.string.navigation_bar_frosted_blur_desc),
+                            icon = { Icon(painterResource(R.drawable.blur_on), null) },
+                            checked = navigationBarFrostedBlur,
+                            onCheckedChange = onNavigationBarFrostedBlurChange,
+                        )
+                        // Pre-Android 12 warning: frosted navigation bar uses RenderEffect (API 31+).
+                        // On pre-S the toggle is a no-op (bar stays solid) — surface a warning so
+                        // users on older devices know the setting won't take effect.
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S && navigationBarFrostedBlur) {
+                            Text(
+                                text = stringResource(R.string.navigation_bar_frosted_blur_unsupported),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(start = 56.dp, top = 4.dp, end = 16.dp),
+                            )
+                        }
+                    }
                 }
 
                 item {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -532,9 +532,12 @@
     <string name="navigation_bar_style_floating">Floating</string>
     <string name="navigation_bar_frosted_blur">Frosted navigation bar</string>
     <string name="navigation_bar_frosted_blur_desc">Apply a frosted blur behind the navigation bar</string>
+    <string name="navigation_bar_frosted_blur_unsupported">Frosted navigation bar is not supported on Android versions below 12</string>
     <string name="hide_navigation_bar_labels">Hide labels in navigation bar</string>
     <string name="hide_navigation_bar_labels_desc">Show only icons in the bottom navigation bar</string>
     <string name="frosted_blur">Frosted blur</string>
+    <string name="frosted_mini_player_unsupported">Frosted mini player is not supported on Android versions below 12</string>
+    <string name="moving_blur_static_disclaimer">Blur will be static for Android versions below 12</string>
     <string name="lyrics_animation_style">Lyrics animation style</string>
     <string name="lyrics_mode">Lyrics mode</string>
     <string name="lyrics_mode_v2">V2 Legacy</string>


### PR DESCRIPTION
## Summary

This PR bundles two independent fixes from `dev`:

1. **Queue page**: current playing song always at the top of the queue list
2. **Pre-Android 12 UI**: moving blur made static, frosted nav bar / mini player disabled, with explicit user-facing warnings

---

## 1. Queue: current playing song always at top

### Problem

`Player.getQueueWindows()` builds the queue list by alternating between adding next and previous songs around the current one. Previously-played songs ended up **before** the current song in the returned list, so the Queue UI displayed the full list starting from the oldest previously-played song — pushing the currently playing track down to position `currentWindowIndex` (often not visible without scrolling).

### Fix

Filter `mutableQueueWindows` (the display list) to only include the current song and upcoming songs (`queueWindows.drop(currentWindowIndex)`). The currently playing track is now always at **index 0** — the top of the queue list — matching the "Continue Playing" header and mainstream music apps (Spotify, Apple Music).

Adjustments for the filtered display list:
- Drag-to-position-0 now resolves to "after current song" instead of "move to start of full timeline"
- Click-to-toggle-play uses `isActive` (UID comparison) instead of `index == currentWindowIndex`
- Selection drag-tracking guard simplified (UID-based lookup handles null-safety)
- Sync `LaunchedEffect` now keys on `currentWindowIndex` so the filter re-applies when the current song changes

The full `queueWindows` (including played songs) is still used for queue stats, clear-queue, and drag-source resolution against the actual player timeline.

---

## 2. Pre-Android 12: static blur + disabled frosted surfaces

### Problem

Pre-Android 12 (API < 31) devices cannot use `Modifier.blur` (RenderEffect requires API 31+). The previous pre-S fallbacks — a per-frame CPU-blurred bitmap for the moving-blur drift and for the frosted nav bar / mini player — produced visible glitches and tearing on older hardware.

### Fix

**Moving blur (`LyricsScreen.kt`):** The drift animation is hard-zeroed on pre-S (`driftX = 0f`, `driftY = 0f`). The pre-blurred bitmap is rendered statically at a fixed scale that covers the screen — clean static blurred background, no black bars, no per-frame glitches. Drift still animates normally on Android 12+.

**Frosted navigation bar (`FloatingNavigationToolbar.kt`):** `canBlurBackdrop` is now `false` on pre-S, so the bar renders as a plain solid surface regardless of the frosted toggle.

**Frosted mini player (`MiniPlayer.kt`):** The `FROSTED` background style is silently downgraded to `THEME` on pre-S so the mini player renders a clean solid surface.

**Settings disclaimers / warnings (`AppearanceSettings.kt` + `strings.xml`):** Three new inline warnings, all conditionally rendered and only visible on pre-S:

| Location | Condition | Message |
|---|---|---|
| Below **Lyrics background style** selector | `MOVING_BLUR` selected on pre-S | "Blur will be static for Android versions below 12" |
| Below **Mini player background style** selector | `FROSTED` selected on pre-S | "Frosted mini player is not supported on Android versions below 12" |
| Below **Frosted navigation bar** toggle | Toggle enabled on pre-S | "Frosted navigation bar is not supported on Android versions below 12" |

Android 12+ users see no change — no warnings, full blur/frosted functionality preserved.

---

## Files Changed

- `app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt`
- `app/src/main/res/values/strings.xml`

---

## Testing

**Queue (all Android versions):**
- Open the queue page while a song is playing → current song is the first item in the list (highlighted with equalizer icon)
- Scroll down → only upcoming songs visible (no previously-played songs)
- Drag a song to the top → it becomes the next song after the current one
- Click the current song → toggles play/pause
- Click an upcoming song → seeks to it
- Clear queue → removes all except current song
- Song changes → new current song appears at the top of the list

**Pre-Android 12 (API < 31):**
- Moving blur renders as a clean static blurred background (no drift, no glitches, no black bars)
- Frosted nav bar toggle is a no-op (solid bar)
- Frosted mini player style downgrades to THEME (solid)
- "Blur will be static…" warning shows under Lyrics background style when MOVING_BLUR selected
- "Frosted mini player is not supported…" warning shows under Mini player background style when FROSTED selected
- "Frosted navigation bar is not supported…" warning shows under Frosted navigation bar toggle when enabled
- Warnings disappear when switching away from MOVING_BLUR / FROSTED / disabling the toggle

**Android 12+ (API 31+):**
- Moving blur drifts normally
- Frosted nav bar blur works
- Frosted mini player blur works
- No warnings shown in Settings