### PR TITLE
feat(menu): add Video button to song overflow menu

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -97,6 +97,7 @@ import moe.rukamori.archivetune.db.entities.PlaylistSong
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.innertube.YouTube
+import moe.rukamori.archivetune.innertube.models.SongItem
 import moe.rukamori.archivetune.models.toMediaMetadata
 import moe.rukamori.archivetune.playback.ExoDownloadService
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
@@ -108,6 +109,7 @@ import moe.rukamori.archivetune.ui.component.NewAction
 import moe.rukamori.archivetune.ui.component.NewActionGrid
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
+import moe.rukamori.archivetune.ui.screens.buildVideoPlayerRoute
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
 import moe.rukamori.archivetune.ui.utils.YtimgResizePolicy
 import moe.rukamori.archivetune.ui.utils.resize
@@ -454,12 +456,57 @@ fun SongMenu(
     // are hidden for them — they still support play next / add to queue / add to playlist.
     val isTelegramSong = song.song.id.isTelegramMediaId()
 
+    // "Video" action: for songs with a YouTube watch endpoint we navigate
+    // directly to the in-app video player. For local / Telegram songs we
+    // resolve a video by searching YouTube Music for "{title} {artist}"
+    // (FILTER_VIDEO) — the resulting videoId is then handed to the player.
+    var isResolvingVideo by rememberSaveable { mutableStateOf(false) }
+    val onVideoClick: () -> Unit = {
+        if (isLocalSong || isTelegramSong) {
+            coroutineScope.launch {
+                isResolvingVideo = true
+                val term =
+                    listOf(
+                        song.artists.firstOrNull()?.name?.takeIf(String::isNotBlank),
+                        song.title.takeIf(String::isNotBlank),
+                    ).filterNotNull().joinToString(" ").ifBlank {
+                        isResolvingVideo = false
+                        return@launch
+                    }
+                val result =
+                    withContext(Dispatchers.IO) {
+                        runCatching {
+                            YouTube.search(term, YouTube.SearchFilter.FILTER_VIDEO).getOrNull()
+                        }.getOrNull()
+                    }
+                isResolvingVideo = false
+                val videoId =
+                    result?.items
+                        ?.mapNotNull { it as? SongItem }
+                        ?.firstOrNull()
+                        ?.id
+                if (videoId.isNullOrBlank()) {
+                    Toast
+                        .makeText(context, R.string.video_load_failed, Toast.LENGTH_SHORT)
+                        .show()
+                    return@launch
+                }
+                onDismiss()
+                navController.navigate(buildVideoPlayerRoute(videoId, song.title))
+            }
+        } else {
+            onDismiss()
+            navController.navigate(buildVideoPlayerRoute(song.id, song.title))
+        }
+    }
+
     val startRadioText = stringResource(R.string.start_radio)
     val playNextText = stringResource(R.string.play_next)
     val addToQueueText = stringResource(R.string.add_to_queue)
     val addToPlaylistText = stringResource(R.string.add_to_playlist)
     val shareText = stringResource(R.string.share)
     val editText = stringResource(R.string.edit)
+    val videoText = stringResource(R.string.action_video)
 
     val primaryActions =
         remember(
@@ -470,9 +517,13 @@ fun SongMenu(
             addToPlaylistText,
             shareText,
             editText,
+            videoText,
             isLocalSong,
+            isTelegramSong,
+            isResolvingVideo,
             onDismiss,
             playerConnection,
+            onVideoClick,
         ) {
             buildList {
                 if (!isLocalSong && !isTelegramSong) {
@@ -581,6 +632,27 @@ fun SongMenu(
                         },
                         text = editText,
                         onClick = { showEditDialog = true },
+                    ),
+                )
+                add(
+                    NewAction(
+                        icon = {
+                            if (isResolvingVideo) {
+                                CircularWavyProgressIndicator(
+                                    modifier = Modifier.size(28.dp),
+                                )
+                            } else {
+                                Icon(
+                                    painter = painterResource(R.drawable.video),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        },
+                        text = videoText,
+                        enabled = !isResolvingVideo,
+                        onClick = onVideoClick,
                     ),
                 )
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
@@ -95,6 +95,7 @@ import moe.rukamori.archivetune.ui.component.LocalBottomSheetPageState
 import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
 import moe.rukamori.archivetune.ui.component.NewAction
 import moe.rukamori.archivetune.ui.component.NewActionGrid
+import moe.rukamori.archivetune.ui.screens.buildVideoPlayerRoute
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
 import moe.rukamori.archivetune.utils.SpeedDialPin
 import moe.rukamori.archivetune.utils.SpeedDialPinType
@@ -329,6 +330,7 @@ fun YouTubeSongMenu(
     val addToQueueText = stringResource(R.string.add_to_queue)
     val addToPlaylistText = stringResource(R.string.add_to_playlist)
     val shareText = stringResource(R.string.share)
+    val videoText = stringResource(R.string.action_video)
 
     val primaryActions =
         remember(
@@ -338,8 +340,10 @@ fun YouTubeSongMenu(
             addToQueueText,
             addToPlaylistText,
             shareText,
+            videoText,
             onDismiss,
             playerConnection,
+            navController,
         ) {
             listOf(
                 NewAction(
@@ -418,6 +422,25 @@ fun YouTubeSongMenu(
                             }
                         context.startActivity(Intent.createChooser(intent, null))
                         onDismiss()
+                    },
+                ),
+                NewAction(
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.video),
+                            contentDescription = null,
+                            modifier = Modifier.size(28.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    text = videoText,
+                    onClick = {
+                        onDismiss()
+                        // YouTube Music song IDs ARE YouTube video IDs — the IFrame
+                        // Player will play whatever video is at this ID. For audio-only
+                        // ATV variants it shows the cover thumbnail; for OMV/UGC variants
+                        // it plays the actual music video.
+                        navController.navigate(buildVideoPlayerRoute(song.id, song.title))
                     },
                 ),
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -594,4 +594,44 @@ fun NavGraphBuilder.navigationBuilder(
             startUrl = backStackEntry.arguments?.getString(LOGIN_URL_ARGUMENT)?.let(Uri::decode),
         )
     }
+    composable(
+        route = "$VideoPlayerRouteBase/{$VideoPlayerVideoIdArg}?${VideoPlayerTitleArg}={$VideoPlayerTitleArg}",
+        arguments =
+            listOf(
+                navArgument(VideoPlayerVideoIdArg) {
+                    type = NavType.StringType
+                },
+                navArgument(VideoPlayerTitleArg) {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+            ),
+    ) { backStackEntry ->
+        val videoId = backStackEntry.arguments?.getString(VideoPlayerVideoIdArg).orEmpty()
+        val title = backStackEntry.arguments?.getString(VideoPlayerTitleArg)
+        VideoPlayerScreen(
+            navController = navController,
+            videoId = videoId,
+            title = title?.let(Uri::decode),
+        )
+    }
+}
+
+/** Route prefix for the in-app video player screen. */
+const val VideoPlayerRouteBase = "video_player"
+const val VideoPlayerVideoIdArg = "videoId"
+const val VideoPlayerTitleArg = "title"
+
+/**
+ * Builds a navigation route string for the in-app video player. Use this from
+ * menu actions so the URL encoding of the (optional) title is handled
+ * consistently.
+ */
+fun buildVideoPlayerRoute(
+    videoId: String,
+    title: String? = null,
+): String {
+    val safeTitle = title?.takeIf { it.isNotBlank() }?.let { "?title=${Uri.encode(it)}" } ?: ""
+    return "$VideoPlayerRouteBase/$videoId$safeTitle"
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/VideoPlayerScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/VideoPlayerScreen.kt
@@ -1,0 +1,286 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.screens
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.navigation.NavHostController
+import moe.rukamori.archivetune.LocalPlayerConnection
+import moe.rukamori.archivetune.R
+
+/**
+ * Hosts a full-screen YouTube IFrame Player that plays the music video for the
+ * given [videoId]. The audio player is paused while this screen is visible so
+ * the user only hears the video's audio — matching the "Video" toggle behavior
+ * in YouTube Music.
+ *
+ * The screen does NOT auto-resume audio playback on exit; the user can press
+ * play in the mini-player / player sheet when they return.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun VideoPlayerScreen(
+    navController: NavHostController,
+    videoId: String,
+    title: String? = null,
+) {
+    val context = LocalContext.current
+    val playerConnection = LocalPlayerConnection.current
+
+    // Pause the audio player while the video is playing to avoid double audio.
+    // We do NOT auto-resume on dispose — that would surprise the user with
+    // sudden audio playback after they explicitly left the video view.
+    DisposableEffect(Unit) {
+        playerConnection?.player?.playWhenReady = false
+        onDispose {
+            // No-op: user controls when audio resumes.
+        }
+    }
+
+    var isLoading by remember { mutableStateOf(true) }
+    var hasError by remember { mutableStateOf(false) }
+
+    // Bridge so the IFrame API can signal errors / ready state back to Kotlin.
+    val bridge =
+        remember(videoId) {
+            object {
+                @JavascriptInterface
+                fun onReady() {
+                    isLoading = false
+                }
+
+                @JavascriptInterface
+                fun onError(errorCode: Int) {
+                    hasError = true
+                    isLoading = false
+                }
+            }
+        }
+
+    BackHandler { navController.popBackStack() }
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black),
+    ) {
+        AndroidView(
+            factory = { ctx ->
+                WebView(ctx).apply {
+                    setBackgroundColor(android.graphics.Color.BLACK)
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.mediaPlaybackRequiresUserGesture = false
+                    settings.allowFileAccess = false
+                    settings.allowContentAccess = false
+                    // The IFrame player posts messages to a named JS bridge; we expose
+                    // it as `AndroidBridge` so the embedded HTML can call back.
+                    addJavascriptInterface(bridge, "AndroidBridge")
+                    webChromeClient =
+                        object : WebChromeClient() {
+                            override fun onProgressChanged(
+                                view: WebView?,
+                                newProgress: Int,
+                            ) {
+                                if (newProgress >= 80) isLoading = false
+                            }
+                        }
+                    webViewClient =
+                        object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(
+                                view: WebView?,
+                                request: WebResourceRequest?,
+                            ): Boolean = true // Block navigation away from the embedded player
+                        }
+                    loadDataWithBaseURL(
+                        "https://www.youtube.com",
+                        buildPlayerHtml(videoId),
+                        "text/html",
+                        "utf-8",
+                        null,
+                    )
+                }
+            },
+            update = { webView ->
+                // No-op: videoId is fixed for the lifetime of this screen.
+                // Re-loading on every recomposition would restart the video.
+            },
+            onRelease = { webView ->
+                webView.removeJavascriptInterface("AndroidBridge")
+                webView.stopLoading()
+                webView.onPause()
+                webView.destroy()
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        // Top bar overlay (transparent so it doesn't block the video).
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .statusBarsPadding()
+                    .padding(horizontal = 4.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    painter = painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                    tint = Color.White,
+                )
+            }
+            Text(
+                text = title ?: stringResource(R.string.video_player_title),
+                color = Color.White,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = {
+                val intent =
+                    Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com/watch?v=$videoId")).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                runCatching { context.startActivity(intent) }
+            }) {
+                Icon(
+                    painter = painterResource(R.drawable.slow_motion_video),
+                    contentDescription = stringResource(R.string.video_open_in_youtube),
+                    tint = Color.White,
+                )
+            }
+        }
+
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .size(48.dp),
+                color = Color.White,
+            )
+        }
+
+        if (hasError) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(32.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.video_load_failed),
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+        }
+    }
+}
+
+private fun buildPlayerHtml(videoId: String): String =
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+        <style>
+            html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: #000; overflow: hidden; }
+            #player { width: 100vw; height: 100vh; }
+        </style>
+    </head>
+    <body>
+        <div id="player"></div>
+        <script src="https://www.youtube.com/iframe_api"></script>
+        <script>
+            (function() {
+                var apiReady = false;
+                var domReady = false;
+                var attemptedStart = false;
+
+                function tryStart() {
+                    if (!apiReady || !domReady || attemptedStart) return;
+                    attemptedStart = true;
+                    new YT.Player('player', {
+                        videoId: '$videoId',
+                        playerVars: {
+                            'autoplay': 1,
+                            'controls': 1,
+                            'rel': 0,
+                            'modestbranding': 1,
+                            'playsinline': 1,
+                            'fs': 1,
+                            'origin': 'https://www.youtube.com'
+                        },
+                        events: {
+                            'onReady': function(e) {
+                                e.target.playVideo();
+                                if (window.AndroidBridge) { window.AndroidBridge.onReady(); }
+                            },
+                            'onError': function(e) {
+                                if (window.AndroidBridge) { window.AndroidBridge.onError(e.data); }
+                            }
+                        }
+                    });
+                }
+
+                window.onYouTubeIframeAPIReady = function() {
+                    apiReady = true;
+                    tryStart();
+                };
+
+                document.addEventListener('DOMContentLoaded', function() {
+                    domReady = true;
+                    tryStart();
+                });
+            })();
+        </script>
+    </body>
+    </html>
+    """.trimIndent()

--- a/app/src/main/res/drawable/video.xml
+++ b/app/src/main/res/drawable/video.xml
@@ -1,0 +1,16 @@
+<!-- Solar Icons by 480 Design (CC BY 4.0) - solar-icons.vercel.app -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M2,7.5C2,6.395 2.895,5.5 4,5.5H13C14.105,5.5 15,6.395 15,7.5V16.5C15,17.605 14.105,18.5 13,18.5H4C2.895,18.5 2,17.605 2,16.5V7.5Z"
+      android:strokeColor="@android:color/white"
+      android:strokeWidth="1.5"/>
+  <path
+      android:pathData="M17,9.5L21.061,7.219C21.395,7.029 21.806,7.273 21.806,7.658V16.342C21.806,16.727 21.395,16.971 21.061,16.781L17,14.5V9.5Z"
+      android:strokeColor="@android:color/white"
+      android:strokeWidth="1.5"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,11 @@
     <string name="refetch_canvas">Refetch canvas</string>
     <string name="canvas_refetch_failed">Couldn\'t refresh animated canvas</string>
     <string name="share">Share</string>
+    <string name="action_video">Video</string>
+    <string name="video_player_title">Video</string>
+    <string name="video_loading">Loading video…</string>
+    <string name="video_load_failed">Couldn\'t find a video version of this song</string>
+    <string name="video_open_in_youtube">Open in YouTube</string>
     <string name="delete">Delete</string>
     <string name="hide_playlist">Hide playlist</string>
     <string name="unhide_playlist">Unhide playlist</string>


### PR DESCRIPTION
## Summary

Adds a **Video** action to the song overflow menu (both `YouTubeSongMenu` and `SongMenu`). Tapping it opens a new full-screen `VideoPlayerScreen` that hosts a YouTube IFrame Player in a `WebView` and plays the music video for the current song — mirroring the "Video" toggle in YouTube Music.

## Behavior

| Song source | What happens when you tap **Video** |
| --- | --- |
| YouTube Music song (online) | Navigates directly to the video player with the song's `videoId` (YT Music song IDs ARE YouTube video IDs — the IFrame player plays whatever video is at that ID; for audio-only ATV variants it shows the cover, for OMV/UGC variants it plays the actual music video). |
| Local / Telegram song | Searches YouTube Music with `FILTER_VIDEO` using `"{title} {artist}"` and plays the first result. A `CircularWavyProgressIndicator` replaces the icon while the lookup is in flight; if no video is found a toast (`video_load_failed`) is shown. |

While the video screen is visible, the audio player is paused (no double audio). The user manually resumes audio when they return via the back button — auto-resume would surprise them with sudden audio after they explicitly left the video view.

The video player also exposes an "Open in YouTube" action (top-right) that hands off to the system YouTube app / browser for cases where the IFrame player can't play the video (e.g. region-locked content).

## Files

**New:**
- `app/src/main/res/drawable/video.xml` — Solar Icons video-camera vector drawable
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/VideoPlayerScreen.kt` — full-screen WebView + YouTube IFrame Player

**Modified:**
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt` — add Video `NewAction` to the primary actions grid
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt` — add Video `NewAction`; for local/Telegram songs, search YouTube first
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt` — register `video_player/{videoId}?title={title}` route + `buildVideoPlayerRoute()` helper
- `app/src/main/res/values/strings.xml` — `action_video`, `video_player_title`, `video_loading`, `video_load_failed`, `video_open_in_youtube`

## Implementation notes

- The `WebView` is created with `javaScriptEnabled = true` (required for the IFrame API) and a `JavascriptInterface` named `AndroidBridge` so the embedded HTML can signal `onReady` / `onError` back to Kotlin. The interface is removed in `onRelease` and the WebView is explicitly destroyed to avoid leaks (mirrors the pattern in `LoginScreen.kt`).
- The WebView's `webViewClient.shouldOverrideUrlLoading` returns `true` to block any navigation away from the embedded player (e.g. when the user taps a "Watch on YouTube" link inside the player).
- The IFrame API is loaded from `https://www.youtube.com/iframe_api` and the player is created with `autoplay: 1`, `controls: 1`, `rel: 0`, `modestbranding: 1`, `playsinline: 1` so the video autoplays inline with the standard YouTube controls.
- The route argument `title` is URL-encoded via `Uri.encode` and decoded via `Uri.decode` (same pattern as the existing `LOGIN_URL_ARGUMENT`).

## Test plan

- [ ] Open a YouTube Music song's overflow menu → "Video" button is visible
- [ ] Tap "Video" → menu dismisses, full-screen video player opens, video autoplays
- [ ] Audio player is paused while video is playing
- [ ] Tap back → returns to previous screen
- [ ] Open a local song's overflow menu → "Video" button is visible
- [ ] Tap "Video" → spinner shows briefly, then video player opens with the first YouTube search result
- [ ] Tap "Open in YouTube" (top-right) → opens the video in the YouTube app or browser
- [ ] Verify no audio plays simultaneously with the video
