### PR TITLE
feat(player): inline Song | Video toggle in player sheet

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -191,6 +191,11 @@ val EnableUnisonLyricsKey = booleanPreferencesKey("enableUnisonLyrics")
 val HideExplicitKey = booleanPreferencesKey("hideExplicit")
 val HideVideoKey = booleanPreferencesKey("hideVideo")
 val AllowAgeRestrictedKey = booleanPreferencesKey("allowAgeRestricted")
+// When true, a "Song | Video" pill is shown at the top of every player style.
+// Tapping "Video" replaces the album artwork with an inline YouTube IFrame
+// player for the current song (mirroring the Song/Video toggle in YouTube
+// Music). When false, the pill is hidden and only audio playback is offered.
+val AllowVideoSwitchKey = booleanPreferencesKey("allowVideoSwitch")
 enum class DownloadSource {
     /**
      * Picks the best available source per song: tries Qobuz → Tidal → Deezer

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -454,6 +454,14 @@ fun SongMenu(
     // are hidden for them — they still support play next / add to queue / add to playlist.
     val isTelegramSong = song.song.id.isTelegramMediaId()
 
+    // NOTE: The "Video" overflow action used to live here. It navigated to
+    // a separate full-screen VideoPlayerScreen that showed "couldn't find a
+    // video version" whenever the YouTube IFrame API rejected the embed.
+    // It has been replaced by the inline Song | Video pill at the top of
+    // the player sheet (see Player.kt + VideoSurface.kt + SongVideoTogglePill.kt),
+    // which mirrors YouTube Music's behavior. Enable it via the
+    // "Allow switching to video" toggle in Playback settings.
+
     val startRadioText = stringResource(R.string.start_radio)
     val playNextText = stringResource(R.string.play_next)
     val addToQueueText = stringResource(R.string.add_to_queue)
@@ -471,6 +479,7 @@ fun SongMenu(
             shareText,
             editText,
             isLocalSong,
+            isTelegramSong,
             onDismiss,
             playerConnection,
         ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
@@ -330,6 +330,15 @@ fun YouTubeSongMenu(
     val addToPlaylistText = stringResource(R.string.add_to_playlist)
     val shareText = stringResource(R.string.share)
 
+    // NOTE: The "Video" overflow action used to live here. It navigated
+    // to a separate full-screen VideoPlayerScreen that showed "couldn't
+    // find a video version" whenever the YouTube IFrame API rejected the
+    // embed. It has been replaced by the inline Song | Video pill at the
+    // top of the player sheet (see Player.kt + VideoSurface.kt +
+    // SongVideoTogglePill.kt), which mirrors YouTube Music's behavior.
+    // Enable it via the "Allow switching to video" toggle in Playback
+    // settings.
+
     val primaryActions =
         remember(
             song,
@@ -340,6 +349,7 @@ fun YouTubeSongMenu(
             shareText,
             onDismiss,
             playerConnection,
+            navController,
         ) {
             listOf(
                 NewAction(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -19,6 +19,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.provider.Settings
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
@@ -60,6 +61,8 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
@@ -86,6 +89,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -154,12 +158,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.canvas.models.CanvasArtwork
+import moe.rukamori.archivetune.constants.AllowVideoSwitchKey
 import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
 import moe.rukamori.archivetune.constants.BackdropBlurAmountKey
 import moe.rukamori.archivetune.constants.BackdropEnabledKey
@@ -188,8 +194,11 @@ import moe.rukamori.archivetune.constants.SliderStyleKey
 import moe.rukamori.archivetune.constants.ThumbnailCornerRadiusKey
 import moe.rukamori.archivetune.extensions.metadata
 import moe.rukamori.archivetune.extensions.togglePlayPause
+import moe.rukamori.archivetune.innertube.YouTube
+import moe.rukamori.archivetune.innertube.models.SongItem
 import moe.rukamori.archivetune.innertube.utils.hasYouTubeLoginCookie
 import moe.rukamori.archivetune.models.MediaMetadata
+import moe.rukamori.archivetune.telegram.isTelegramMediaId
 import moe.rukamori.archivetune.ui.component.BottomSheet
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 import moe.rukamori.archivetune.ui.component.COLLAPSED_ANCHOR
@@ -210,6 +219,7 @@ import moe.rukamori.archivetune.ui.utils.YtimgResizePolicy
 import moe.rukamori.archivetune.ui.utils.getNextFallbackUrl
 import moe.rukamori.archivetune.ui.utils.resize
 import moe.rukamori.archivetune.utils.ImageBlurUtils
+import moe.rukamori.archivetune.utils.isLocalMediaId
 import moe.rukamori.archivetune.utils.makeTimeString
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberLowDataModeActive
@@ -1388,6 +1398,81 @@ fun BottomSheetPlayer(
 
 // distance
 
+        // ── Song | Video toggle (inline YouTube IFrame player) ─────────────────
+        // When AllowVideoSwitchKey is on, a segmented pill is shown at the top
+        // of every player style. Tapping "Video" replaces the album artwork
+        // with an inline YouTube IFrame player for the current song —
+        // mirroring the Song/Video toggle in YouTube Music. Tapping "Song"
+        // restores the artwork and resumes audio.
+        val allowVideoSwitch by rememberPreference(AllowVideoSwitchKey, defaultValue = false)
+        val videoCoroutineScope = rememberCoroutineScope()
+        val videoContext = LocalContext.current
+        // Per-song video state. Resets when the song changes so the user
+        // always starts in Song mode for a new track (matches YouTube Music).
+        var videoMode by rememberSaveable(mediaMetadata?.id) { mutableStateOf(false) }
+        var resolvedVideoId by remember(mediaMetadata?.id) { mutableStateOf<String?>(null) }
+        var isResolvingVideo by remember(mediaMetadata?.id) { mutableStateOf(false) }
+
+        val onVideoSelected: () -> Unit = onVideoSelected@{
+            val metadata = mediaMetadata ?: return@onVideoSelected
+            val songId = metadata.id
+            val isLocal = songId.isLocalMediaId()
+            val isTelegram = songId.isTelegramMediaId()
+            if (!isLocal && !isTelegram) {
+                // YouTube Music song IDs ARE YouTube video IDs — use directly.
+                resolvedVideoId = songId
+                videoMode = true
+                playerConnection.player.playWhenReady = false
+            } else {
+                // Local / Telegram: search YouTube Music for the music video.
+                videoCoroutineScope.launch {
+                    isResolvingVideo = true
+                    val term =
+                        listOf(
+                            metadata.artists.firstOrNull()?.name?.takeIf(String::isNotBlank),
+                            metadata.title.takeIf(String::isNotBlank),
+                        ).filterNotNull().joinToString(" ").ifBlank {
+                            isResolvingVideo = false
+                            return@launch
+                        }
+                    val result =
+                        withContext(Dispatchers.IO) {
+                            runCatching {
+                                YouTube.search(term, YouTube.SearchFilter.FILTER_VIDEO).getOrNull()
+                            }.getOrNull()
+                        }
+                    isResolvingVideo = false
+                    val vid =
+                        result?.items
+                            ?.mapNotNull { it as? SongItem }
+                            ?.firstOrNull()
+                            ?.id
+                    if (vid.isNullOrBlank()) {
+                        Toast
+                            .makeText(videoContext, R.string.video_load_failed, Toast.LENGTH_SHORT)
+                            .show()
+                        return@launch
+                    }
+                    resolvedVideoId = vid
+                    videoMode = true
+                    playerConnection.player.playWhenReady = false
+                }
+            }
+        }
+
+        val onSongSelected: () -> Unit =
+            {
+                videoMode = false
+                // Resume audio so the user hears the song immediately when
+                // switching back from Video — matches YouTube Music.
+                playerConnection.player.playWhenReady = true
+            }
+
+        // The videoId we should hand to VideoSurface, or null if we don't
+        // have one yet (still resolving, or video mode is off).
+        val activeVideoId: String? =
+            if (videoMode) resolvedVideoId?.takeIf { it.isNotBlank() } else null
+
         when (LocalConfiguration.current.orientation) {
             Configuration.ORIENTATION_LANDSCAPE -> {
                 if (playerDesignStyle == PlayerDesignStyle.V5) {
@@ -2045,6 +2130,57 @@ fun BottomSheetPlayer(
                 onDismiss = { isLyricsScreenVisible = false },
                 onQueueClick = openQueue,
             )
+        }
+
+        // ── Song | Video pill overlay ─────────────────────────────────────────
+        // The pill floats at the top-center of the player sheet whenever the
+        // user has enabled "Allow switching to video" in Playback settings
+        // and a song is loaded. Tapping "Video" swaps the artwork area for
+        // an inline YouTube IFrame player (see VideoSurface).
+        if (allowVideoSwitch && mediaMetadata != null && !aodModeEnabled && !isLyricsScreenVisible) {
+            SongVideoTogglePill(
+                isVideoMode = videoMode,
+                isResolving = isResolvingVideo,
+                onSongSelected = onSongSelected,
+                onVideoSelected = onVideoSelected,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopCenter)
+                        .statusBarsPadding()
+                        .padding(top = 8.dp),
+            )
+        }
+
+        // ── Inline video surface overlay ─────────────────────────────────────
+        // When the user has selected "Video", we overlay the entire player
+        // sheet content with a fullscreen black Box that hosts the YouTube
+        // IFrame player. This mirrors YouTube Music: the album artwork is
+        // replaced by the video, the underlying audio is paused, and the
+        // pill stays on top so the user can switch back to "Song".
+        if (videoMode && activeVideoId != null && !aodModeEnabled && !isLyricsScreenVisible) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Black),
+            ) {
+                VideoSurface(
+                    videoId = activeVideoId,
+                    onEmbeddingBlocked = {
+                        // The video can't be embedded (error 101/150/100/2).
+                        // VideoSurface already shows an inline "Open in YouTube"
+                        // button + hands off to the system YouTube app. Flip
+                        // back to Song mode so the user lands on a working
+                        // player instead of a dead video surface.
+                        onSongSelected()
+                    },
+                    modifier =
+                        Modifier
+                            .align(Alignment.Center)
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9f),
+                )
+            }
         }
 
         AnimatedVisibility(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/SongVideoTogglePill.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/SongVideoTogglePill.kt
@@ -1,0 +1,128 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import moe.rukamori.archivetune.R
+
+/**
+ * The Song | Video segmented pill shown at the top of every player style when
+ * [AllowVideoSwitchKey] is enabled. Mirrors the YouTube Music Song/Video
+ * toggle: tapping "Song" shows the album artwork + audio controls, tapping
+ * "Video" replaces the artwork with an inline YouTube IFrame player.
+ *
+ * The two halves of the pill are visually distinct: the active half is filled
+ * with the theme's primary color, the inactive half is translucent.
+ *
+ * @param isVideoMode true when "Video" is currently selected.
+ * @param isResolving true when the videoId is being looked up (for local /
+ *   Telegram songs that need a YouTube search). Shows a spinner instead of
+ *   the "Video" label so the user knows something is happening.
+ * @param onSongSelected invoked when the user taps "Song".
+ * @param onVideoSelected invoked when the user taps "Video".
+ */
+@Composable
+fun SongVideoTogglePill(
+    isVideoMode: Boolean,
+    isResolving: Boolean = false,
+    onSongSelected: () -> Unit,
+    onVideoSelected: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val songLabel = stringResource(R.string.action_song)
+    val videoLabel = stringResource(R.string.action_video)
+    val pillShape = RoundedCornerShape(50)
+    val activeColor = MaterialTheme.colorScheme.primary
+    val onActiveColor = MaterialTheme.colorScheme.onPrimary
+    val inactiveColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.65f)
+    val onInactiveColor = MaterialTheme.colorScheme.onSurfaceVariant
+
+    Row(
+        modifier =
+            modifier
+                .clip(pillShape)
+                .background(inactiveColor)
+                .padding(2.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        PillHalf(
+            label = songLabel,
+            isActive = !isVideoMode,
+            activeColor = activeColor,
+            onActiveColor = onActiveColor,
+            onInactiveColor = onInactiveColor,
+            onClick = onSongSelected,
+        )
+        PillHalf(
+            label = videoLabel,
+            isActive = isVideoMode,
+            activeColor = activeColor,
+            onActiveColor = onActiveColor,
+            onInactiveColor = onInactiveColor,
+            leading = {
+                if (isResolving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        strokeWidth = 2.dp,
+                        color = if (isVideoMode) onActiveColor else onInactiveColor,
+                    )
+                }
+            },
+            onClick = onVideoSelected,
+        )
+    }
+}
+
+@Composable
+private fun PillHalf(
+    label: String,
+    isActive: Boolean,
+    activeColor: Color,
+    onActiveColor: Color,
+    onInactiveColor: Color,
+    onClick: () -> Unit,
+    leading: (@Composable () -> Unit)? = null,
+) {
+    val bg = if (isActive) activeColor else Color.Transparent
+    val fg = if (isActive) onActiveColor else onInactiveColor
+
+    Row(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(50))
+                .background(bg)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        leading?.invoke()
+        Text(
+            text = label,
+            color = fg,
+            style = MaterialTheme.typography.labelLarge,
+        )
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoSurface.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoSurface.kt
@@ -1,0 +1,272 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import moe.rukamori.archivetune.R
+
+/**
+ * Inline YouTube IFrame player that plays the music video for [videoId] in
+ * place of the player's album artwork — mirroring the "Video" toggle in
+ * YouTube Music. The surface fills its parent and is intended to be dropped
+ * into the artwork slot of any player style.
+ *
+ * The original full-screen VideoPlayerScreen showed "Couldn't find a video
+ * version of this song" when the IFrame API rejected the embed (error codes
+ * 101 / 150 / 2 / 100). That message was misleading: the video exists on
+ * YouTube, it just refuses to play embedded. So instead of showing an error,
+ * we show a small inline message + an "Open in YouTube" button that hands
+ * off to the system YouTube app / browser.
+ *
+ * State is surfaced via [onEmbeddingBlocked] so the caller can reset the
+ * Song/Video pill back to "Song" if desired. We deliberately do NOT auto-open
+ * YouTube — that would be jarring.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+fun VideoSurface(
+    videoId: String,
+    modifier: Modifier = Modifier,
+    onEmbeddingBlocked: () -> Unit = {},
+) {
+    val context = LocalContext.current
+    var isLoading by remember(videoId) { mutableStateOf(true) }
+    var embeddingBlocked by remember(videoId) { mutableStateOf(false) }
+
+    val bridge =
+        remember(videoId) {
+            object {
+                @JavascriptInterface
+                fun onReady() {
+                    isLoading = false
+                }
+
+                @JavascriptInterface
+                fun onError(errorCode: Int) {
+                    // 101 / 150 = embedding not allowed. 100 = video not found.
+                    // 2 = invalid videoId parameter. In all error cases the
+                    // video may still exist on YouTube — the IFrame player
+                    // simply can't show it here.
+                    embeddingBlocked = true
+                    isLoading = false
+                }
+            }
+        }
+
+    Box(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(16.dp))
+                .background(Color.Black),
+    ) {
+        AndroidView(
+            factory = { ctx ->
+                WebView(ctx).apply {
+                    setBackgroundColor(android.graphics.Color.BLACK)
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.mediaPlaybackRequiresUserGesture = false
+                    settings.allowFileAccess = false
+                    settings.allowContentAccess = false
+                    addJavascriptInterface(bridge, "AndroidBridge")
+                    webChromeClient =
+                        object : WebChromeClient() {
+                            override fun onProgressChanged(
+                                view: WebView?,
+                                newProgress: Int,
+                            ) {
+                                if (newProgress >= 80) isLoading = false
+                            }
+                        }
+                    webViewClient =
+                        object : WebViewClient() {
+                            override fun shouldOverrideUrlLoading(
+                                view: WebView?,
+                                request: WebResourceRequest?,
+                            ): Boolean = true
+                        }
+                    tag = videoId
+                    loadDataWithBaseURL(
+                        "https://www.youtube.com",
+                        buildPlayerHtml(videoId),
+                        "text/html",
+                        "utf-8",
+                        null,
+                    )
+                }
+            },
+            update = { webView ->
+                // Reload only if the videoId has actually changed since the
+                // last factory pass. This keeps the video from restarting on
+                // every recomposition.
+                if (webView.tag != videoId) {
+                    webView.tag = videoId
+                    isLoading = true
+                    embeddingBlocked = false
+                    webView.loadDataWithBaseURL(
+                        "https://www.youtube.com",
+                        buildPlayerHtml(videoId),
+                        "text/html",
+                        "utf-8",
+                        null,
+                    )
+                }
+            },
+            onRelease = { webView ->
+                webView.removeJavascriptInterface("AndroidBridge")
+                webView.stopLoading()
+                webView.onPause()
+                webView.destroy()
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .size(36.dp),
+                color = Color.White,
+            )
+        }
+
+        if (embeddingBlocked) {
+            // Inline fallback UI — replaces the video with a clear message
+            // and a button. No "couldn't find a video version" lie.
+            Column(
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.video_open_in_youtube_fallback),
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                )
+                TextButton(
+                    onClick = {
+                        runCatching {
+                            val intent =
+                                Intent(
+                                    Intent.ACTION_VIEW,
+                                    Uri.parse("https://www.youtube.com/watch?v=$videoId"),
+                                ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+                            context.startActivity(intent)
+                        }
+                        // Tell the host to flip back to Song mode — the user
+                        // is going to watch the video in the YouTube app, so
+                        // leaving the player stuck on a dead video surface
+                        // would be confusing.
+                        onEmbeddingBlocked()
+                    },
+                ) {
+                    Text(text = stringResource(R.string.video_open_in_youtube), color = Color.White)
+                }
+            }
+        }
+    }
+}
+
+private fun buildPlayerHtml(videoId: String): String =
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+        <style>
+            html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: #000; overflow: hidden; }
+            #player { width: 100vw; height: 100vh; }
+        </style>
+    </head>
+    <body>
+        <div id="player"></div>
+        <script src="https://www.youtube.com/iframe_api"></script>
+        <script>
+            (function() {
+                var apiReady = false;
+                var domReady = false;
+                var attemptedStart = false;
+
+                function tryStart() {
+                    if (!apiReady || !domReady || attemptedStart) return;
+                    attemptedStart = true;
+                    new YT.Player('player', {
+                        videoId: '$videoId',
+                        playerVars: {
+                            'autoplay': 1,
+                            'controls': 1,
+                            'rel': 0,
+                            'modestbranding': 1,
+                            'playsinline': 1,
+                            'fs': 1,
+                            'origin': 'https://www.youtube.com'
+                        },
+                        events: {
+                            'onReady': function(e) {
+                                e.target.playVideo();
+                                if (window.AndroidBridge) { window.AndroidBridge.onReady(); }
+                            },
+                            'onError': function(e) {
+                                if (window.AndroidBridge) { window.AndroidBridge.onError(e.data); }
+                            }
+                        }
+                    });
+                }
+
+                window.onYouTubeIframeAPIReady = function() {
+                    apiReady = true;
+                    tryStart();
+                };
+
+                document.addEventListener('DOMContentLoaded', function() {
+                    domReady = true;
+                    tryStart();
+                });
+            })();
+        </script>
+    </body>
+    </html>
+    """.trimIndent()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AllowVideoSwitchKey
 import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
 import moe.rukamori.archivetune.constants.ArtistSeparatorsKey
 import moe.rukamori.archivetune.constants.AudioNormalizationKey
@@ -141,6 +142,11 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
     val (autoStartOnBluetooth, onAutoStartOnBluetoothChange) =
         rememberPreference(
             AutoStartOnBluetoothKey,
+            defaultValue = false,
+        )
+    val (allowVideoSwitch, onAllowVideoSwitchChange) =
+        rememberPreference(
+            AllowVideoSwitchKey,
             defaultValue = false,
         )
     val (stopMusicOnTaskClear, onStopMusicOnTaskClearChange) =
@@ -443,6 +449,18 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                             icon = { Icon(painterResource(R.drawable.bluetooth), null) },
                             checked = autoStartOnBluetooth,
                             onCheckedChange = onAutoStartOnBluetoothChange,
+                        )
+                    }
+                }
+
+                item {
+                    Column(modifier = positions.modifierFor("allow_video_switch")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.allow_video_switch_title)) },
+                            description = stringResource(R.string.allow_video_switch_desc),
+                            icon = { Icon(painterResource(R.drawable.video), null) },
+                            checked = allowVideoSwitch,
+                            onCheckedChange = onAllowVideoSwitchChange,
                         )
                     }
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AllowVideoSwitchKey
 import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
 import moe.rukamori.archivetune.constants.AudioNormalizationKey
 import moe.rukamori.archivetune.constants.AudioOffload
@@ -192,6 +193,7 @@ fun buildSettingsGroups(
                 SettingsChild("Pause on device mute", "pause_mute", listOf("mute", "pause mute", "headphone", "silence detect")) { SearchResultSwitch(PauseOnDeviceMuteKey, false) },
                 SettingsChild("Device mute recovery volume", "device_mute_recovery_volume", listOf("recovery volume", "mute recovery", "volume restore")),
                 SettingsChild("Auto start on Bluetooth", "bluetooth_auto_start", listOf("bluetooth", "auto start", "auto play", "connect")) { SearchResultSwitch(AutoStartOnBluetoothKey, false) },
+                SettingsChild("Allow switching to video", "allow_video_switch", listOf("video", "song video", "music video", "video toggle", "switch video")) { SearchResultSwitch(AllowVideoSwitchKey, false) },
                 SettingsChild("ArchiveTune Canvas", "archive_tune_canvas", listOf("canvas", "animated artwork", "motion artwork", "live artwork")) { SearchResultSwitch(ArchiveTuneCanvasKey, true) },
                 SettingsChild("Tidal artwork fallback", "tidal_artwork_fallback", listOf("tidal artwork", "artwork fallback", "tidal cover", "hi-res artwork")) { SearchResultSwitch(TidalArtworkFallbackEnabledKey, true) },
                 SettingsChild("Persistent queue", "persistent_queue", listOf("queue", "persistent", "save queue", "resume")) { SearchResultSwitch(PersistentQueueKey, true) },

--- a/app/src/main/res/drawable/video.xml
+++ b/app/src/main/res/drawable/video.xml
@@ -1,0 +1,16 @@
+<!-- Solar Icons by 480 Design (CC BY 4.0) - solar-icons.vercel.app -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M2,7.5C2,6.395 2.895,5.5 4,5.5H13C14.105,5.5 15,6.395 15,7.5V16.5C15,17.605 14.105,18.5 13,18.5H4C2.895,18.5 2,17.605 2,16.5V7.5Z"
+      android:strokeColor="@android:color/white"
+      android:strokeWidth="1.5"/>
+  <path
+      android:pathData="M17,9.5L21.061,7.219C21.395,7.029 21.806,7.273 21.806,7.658V16.342C21.806,16.727 21.395,16.971 21.061,16.781L17,14.5V9.5Z"
+      android:strokeColor="@android:color/white"
+      android:strokeWidth="1.5"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,16 @@
     <string name="refetch_canvas">Refetch canvas</string>
     <string name="canvas_refetch_failed">Couldn\'t refresh animated canvas</string>
     <string name="share">Share</string>
+    <string name="action_video">Video</string>
+    <string name="action_song">Song</string>
+    <string name="video_player_title">Video</string>
+    <string name="video_loading">Loading video…</string>
+    <string name="video_load_failed">Couldn\'t find a video version of this song</string>
+    <string name="video_open_in_youtube">Open in YouTube</string>
+    <string name="allow_video_switch_title">Allow switching to video</string>
+    <string name="allow_video_switch_desc">Show a Song | Video toggle at the top of the player. Video plays inline like YouTube Music.</string>
+    <string name="video_open_in_youtube_fallback">Video can\'t play here. Open in YouTube?</string>
+    <string name="video_resolving">Looking up video…</string>
     <string name="delete">Delete</string>
     <string name="hide_playlist">Hide playlist</string>
     <string name="unhide_playlist">Unhide playlist</string>


### PR DESCRIPTION
## What

Replaces the previous full-screen `VideoPlayerScreen` (opened from the song overflow menu) with a YouTube-Music-style **Song | Video** toggle that lives inline inside the player sheet.

## Why

The old approach had two problems the user reported:

1. **False "couldn't find a video version" error.** The old screen used a WebView YouTube IFrame player. When the IFrame API rejected the embed (error codes 101 / 150 / 100 / 2 — common for music videos that disallow embedding) it showed "Couldn't find a video version of this song". But the video exists on YouTube — the "Open in YouTube" icon in the top-right proved it. The error message was wrong.
2. **Wrong UX — opened a different page.** The user wanted the video to play inline in the player itself, like YouTube Music, not on a separate screen and not as a popup.

## What's new

### Settings
- New **"Allow switching to video"** toggle in **Playback** settings (`AllowVideoSwitchKey`). Off by default. Also indexed in settings search.

### Player UI
- When the toggle is on, a segmented **Song | Video** pill floats at the top of every player style (V1–V9 + Apple Music, portrait and landscape). When off, the pill is hidden.
- **Song** (default for each new track): album artwork + audio controls as usual.
- **Video**: replaces the artwork area with an inline YouTube IFrame player (`VideoSurface.kt`). Audio is paused while the video is mounted; tapping **Song** disposes the video and resumes audio — matching YouTube Music.

### Video lookup
- YouTube Music songs: the songId IS the videoId, used directly.
- Local / Telegram songs: a `YouTube.search("{artist} {title}", FILTER_VIDEO)` lookup is run on a background coroutine; the first `SongItem.id` is used. A spinner replaces the "Video" label in the pill while the lookup is in flight. If nothing is found, a toast is shown.

### Embedding-restricted videos (the bug fix)
When the IFrame API fires `onError` (embedding disabled / video not found / invalid id), we no longer claim "couldn't find a video version". Instead `VideoSurface` shows an inline message "Video can't play here. Open in YouTube?" with a button that hands off to the system YouTube app, and flips back to Song mode so the user lands on a working player.

## Removed
- `VideoPlayerScreen.kt` and its `video_player/{videoId}?title={title}` navigation route + `buildVideoPlayerRoute()` helper.
- The "Video" action item from `SongMenu` and `YouTubeSongMenu` overflow menus (it navigated to the removed screen).

## New files
- `ui/player/VideoSurface.kt` — inline WebView IFrame player with embedding-blocked fallback UI.
- `ui/player/SongVideoTogglePill.kt` — segmented Song | Video pill.
- `res/drawable/video.xml` — video camera icon (kept from the old approach; reused by the new settings toggle).

## New strings
`action_song`, `allow_video_switch_title`, `allow_video_switch_desc`, `video_open_in_youtube_fallback`, `video_resolving`.

## Files changed
- `constants/PreferenceKeys.kt` — add `AllowVideoSwitchKey`.
- `ui/player/Player.kt` — read the setting, manage per-song video state, render the pill + `VideoSurface` overlay.
- `ui/player/VideoSurface.kt` (new).
- `ui/player/SongVideoTogglePill.kt` (new).
- `ui/screens/settings/PlayerSettings.kt` — add the `SwitchPreference`.
- `ui/screens/settings/SettingsDataBuilders.kt` — add a search child for the new toggle.
- `ui/menu/SongMenu.kt` — drop the old Video action.
- `ui/menu/YouTubeSongMenu.kt` — drop the old Video action.
- `ui/screens/NavigationBuilder.kt` — drop the `video_player` route + helpers.
- `res/values/strings.xml` — add new strings.
- `res/drawable/video.xml` (new).

## Notes / follow-ups
- Could not run a full `:app:compileGmsMobileUniversalDebugKotlin` in this environment (4 GB RAM, build needs ~8 GB with the existing gradle/kotlin daemons). One compile error was caught and fixed before push: `resolvedVideoId.takeIf {...}` needed `?.takeIf` because the receiver is nullable. The rest of the code uses standard Compose / Kotlin patterns and should compile cleanly — please verify on a machine with more RAM.
- The pill is positioned `TopCenter` with `statusBarsPadding()`. It overlays the player sheet's content rather than displacing it — this is uniform across all 10 player styles and avoids per-style layout surgery.
- Audio is paused while the video is mounted (`playWhenReady = false`) and resumed when the user taps Song. We don't sync the IFrame player position with ExoPlayer (would require a YouTube stream extractor), so the video starts from 0 when switched to and the audio resumes from its last position when switched back.
