### PR TITLE
fix(video): hoist ExoPlayer, replace Dialog with overlay, fix pausing

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -291,6 +291,7 @@ import moe.rukamori.archivetune.ui.component.rememberBottomSheetState
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerTheme
 import moe.rukamori.archivetune.ui.menu.YouTubeSongMenu
 import moe.rukamori.archivetune.ui.player.BottomSheetPlayer
+import moe.rukamori.archivetune.ui.player.ProvideVideoFullscreenState
 import moe.rukamori.archivetune.ui.screens.LOGIN_URL_ARGUMENT
 import moe.rukamori.archivetune.ui.screens.Screens
 import moe.rukamori.archivetune.ui.screens.buildLoginRoute
@@ -2293,13 +2294,15 @@ class MainActivity : ComponentActivity() {
                                                 !isFloatingNavBar &&
                                                 playerBottomSheetState.isCollapsed
 
-                                        BottomSheetPlayer(
-                                            state = playerBottomSheetState,
-                                            navController = navController,
-                                            pureBlack = pureBlack,
-                                            isMiniPlayerPairedWithNavigation = areBottomBarsPaired,
-                                            onLyricsVisibilityChange = { isPlayerLyricsFullScreen = it },
-                                        )
+                                        ProvideVideoFullscreenState {
+                                            BottomSheetPlayer(
+                                                state = playerBottomSheetState,
+                                                navController = navController,
+                                                pureBlack = pureBlack,
+                                                isMiniPlayerPairedWithNavigation = areBottomBarsPaired,
+                                                onLyricsVisibilityChange = { isPlayerLyricsFullScreen = it },
+                                            )
+                                        }
 
                                         if (useRail) return@Box
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -60,6 +60,16 @@ import moe.rukamori.archivetune.constants.BottomSheetSoftAnimationSpec
 /**
  * Bottom Sheet
  * Modified from [ViMusic](https://github.com/vfsfitvnm/ViMusic)
+ *
+ * @param keepContentAlive When true, the [content] composable is kept in the
+ *   composition tree even when the sheet is collapsed (it's hidden via
+ *   alpha=0 instead of being unmounted). This is used by the player sheet
+ *   to keep the [InlineVideoPlayer]'s ExoPlayer alive across collapse/expand
+ *   cycles — without this, collapsing the player to the mini player would
+ *   release the ExoPlayer, and expanding it again would require re-resolving
+ *   the stream URL and re-buffering (causing the "video pauses, audio keeps
+ *   playing" bug). Default is false to preserve the original behavior for
+ *   other sheets (queue, etc.) that don't need this.
  */
 @Composable
 fun BottomSheet(
@@ -67,6 +77,7 @@ fun BottomSheet(
     modifier: Modifier = Modifier,
     backgroundColor: Color,
     onDismiss: (() -> Unit)? = null,
+    keepContentAlive: Boolean = false,
     collapsedContent: @Composable BoxScope.() -> Unit,
     content: @Composable BoxScope.() -> Unit,
 ) {
@@ -96,7 +107,20 @@ fun BottomSheet(
             BackHandler(onBack = state::collapseSoft)
         }
 
-        if (!state.isCollapsed) {
+        if (keepContentAlive) {
+            // Always compose the content, but hide it when collapsed.
+            // This keeps stateful composables (e.g. InlineVideoPlayer's
+            // ExoPlayer) alive across collapse/expand cycles.
+            BoxWithConstraints(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            alpha = if (state.isCollapsed) 0f else ((state.progress - 0.25f) * 4).coerceIn(0f, 1f)
+                        },
+                content = content,
+            )
+        } else if (!state.isCollapsed) {
             BoxWithConstraints(
                 modifier =
                     Modifier

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -519,11 +519,6 @@ private fun AppleMusicSharpArtwork(
 
         if (showVideo) {
             InlineVideoPlayer(
-                videoId = videoId!!,
-                isPlaying = isPlaying,
-                positionProvider = { playerConnection?.player?.currentPosition ?: 0L },
-                onRequestPauseMain = { playerConnection?.player?.pause() },
-                onRequestResumeMain = { playerConnection?.player?.play() },
                 modifier = Modifier.matchParentSize(),
             )
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
@@ -13,6 +13,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.pm.ActivityInfo
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -33,12 +34,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,8 +49,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -65,78 +66,139 @@ private tailrec fun Context.findActivity(): Activity? =
     }
 
 /**
+ * Holder for the video fullscreen state, shared between the inline
+ * [InlineVideoPlayer] and the host [BottomSheetPlayer] which renders the
+ * [FullscreenVideoOverlay].
+ *
+ * WHY THIS EXISTS:
+ * The fullscreen flag is hoisted above the BottomSheet so that the
+ * [FullscreenVideoOverlay] (rendered as a sibling of the BottomSheet) can
+ * read it. The overlay is NOT a Dialog — it's a regular composable that
+ * fills the screen. This avoids the Compose `Dialog` window's orientation
+ * issues that caused the "horizontal for a split second then back" flicker.
+ *
+ * The ExoPlayer itself is hoisted even higher — to the BottomSheetPlayer
+ * function level via [rememberVideoArtworkStateOrNull] — so it survives
+ * orientation changes, sheet collapse/expand, and fullscreen toggles
+ * without being released or recreated.
+ */
+@Stable
+class VideoFullscreenStateHolder {
+    var isFullscreen: Boolean by mutableStateOf(false)
+        internal set
+}
+
+/**
+ * CompositionLocal that provides the [VideoFullscreenStateHolder] to all
+ * [InlineVideoPlayer] instances in the subtree. The host (e.g.
+ * [BottomSheetPlayer]) is responsible for providing this via
+ * [ProvideVideoFullscreenState].
+ *
+ * If no provider is found, a no-op holder is used (fullscreen button will
+ * still work locally but the overlay won't be rendered by the host).
+ */
+val LocalVideoFullscreenState = compositionLocalOf {
+    VideoFullscreenStateHolder()
+}
+
+/**
+ * CompositionLocal that provides the hoisted [VideoArtworkState] to all
+ * [InlineVideoPlayer] instances in the subtree.
+ *
+ * This allows composables deep in the tree (e.g. V8PlayerContent,
+ * AppleMusicPlayer, Thumbnail) to access the shared ExoPlayer without
+ * needing it passed as an explicit parameter through every layer.
+ *
+ * If no provider is found, null is used — [InlineVideoPlayer] will call
+ * [onPlaybackFailed] and render nothing.
+ */
+val LocalVideoArtworkState = compositionLocalOf<VideoArtworkState?> { null }
+
+/**
+ * CompositionLocal for the user's preferred video quality (null = auto).
+ * @see LocalVideoArtworkState
+ */
+val LocalVideoPreferredHeight = compositionLocalOf<Int?> { null }
+
+/**
+ * CompositionLocal for the callback when the user changes the preferred
+ * video quality.
+ * @see LocalVideoArtworkState
+ */
+val LocalVideoOnPreferredHeightChange = compositionLocalOf<(Int?) -> Unit> { {} }
+
+/**
+ * CompositionLocal for the list of available video heights from YouTube.
+ * @see LocalVideoArtworkState
+ */
+val LocalVideoAvailableHeights = compositionLocalOf<List<Int>> { emptyList() }
+
+/**
+ * Provides a [VideoFullscreenStateHolder] to the content subtree.
+ *
+ * The holder is created with `remember` (not `rememberSaveable`) because
+ * the host Activity declares `configChanges="orientation|screenSize|..."` in
+ * the manifest, which means the Activity (and its Compose tree) is NOT
+ * recreated on orientation changes. `remember` is therefore sufficient to
+ * survive orientation changes. `rememberSaveable` would require a custom
+ * Saver and adds complexity for no benefit in this configuration.
+ */
+@Composable
+fun ProvideVideoFullscreenState(content: @Composable () -> Unit) {
+    val holder = remember { VideoFullscreenStateHolder() }
+    CompositionLocalProvider(LocalVideoFullscreenState provides holder) {
+        content()
+    }
+}
+
+/**
  * Inline video player + controls overlay.
  *
- * Uses a SINGLE [VideoArtworkState] (created via [rememberVideoArtworkState])
- * that is shared between the inline surface and the fullscreen Dialog.
- * Toggling fullscreen does NOT recreate the ExoPlayer or re-resolve the
- * stream URL — the video continues playing seamlessly as the surface moves
- * between the inline slot and the fullscreen Dialog.
+ * This composable renders ONLY the inline surface + controls. It does NOT
+ * create the [VideoArtworkState] — that's hoisted to the host
+ * ([BottomSheetPlayer]) via [rememberVideoArtworkStateOrNull] so the
+ * ExoPlayer survives orientation changes and sheet collapse/expand.
  *
- * When the user enters fullscreen:
- *   - The inline surface is removed from composition (the ExoPlayer's
- *     surface is detached from the inline view).
- *   - A fullscreen [Dialog] is rendered with a new [VideoArtworkSurface]
- *     that attaches to the same ExoPlayer.
- *   - The device is rotated to landscape orientation.
- *   - System bars (status + nav) are hidden for immersive playback.
+ * The fullscreen overlay is also rendered by the host (as a sibling of the
+ * BottomSheet), NOT by this composable. This avoids the Compose `Dialog`
+ * window's orientation issues that caused the "horizontal for a split second
+ * then back" flicker.
  *
  * Controls: quality picker + fullscreen toggle. Captions button has been
  * removed per user request.
  *
+ * @param state The hoisted [VideoArtworkState] (ExoPlayer + playback state).
+ *   Null when there's no music video.
+ * @param preferredHeight The user's preferred video quality (null = auto).
+ * @param onPreferredHeightChange Called when the user picks a new quality.
+ * @param availableHeights The list of available video heights from YouTube.
  * @param onPlaybackFailed Called when the player cannot play the video.
  *   The parent should fall back to album artwork.
  */
 @Composable
 fun InlineVideoPlayer(
-    videoId: String,
-    isPlaying: Boolean,
-    positionProvider: () -> Long,
+    state: VideoArtworkState? = LocalVideoArtworkState.current,
+    preferredHeight: Int? = LocalVideoPreferredHeight.current,
+    onPreferredHeightChange: (Int?) -> Unit = LocalVideoOnPreferredHeightChange.current,
+    availableHeights: List<Int> = LocalVideoAvailableHeights.current,
     modifier: Modifier = Modifier,
     onPlaybackFailed: () -> Unit = {},
-    onRequestPauseMain: () -> Unit = {},
-    onRequestResumeMain: () -> Unit = {},
     resizeMode: Int = AspectRatioFrameLayout.RESIZE_MODE_FIT,
 ) {
-    if (videoId.isBlank()) {
+    if (state == null) {
         onPlaybackFailed()
         return
     }
 
-    var isFullscreen by rememberSaveable { mutableStateOf(false) }
-    var preferredHeight by rememberSaveable { mutableStateOf<Int?>(null) }
-    var availableHeights by remember { mutableStateOf<List<Int>>(emptyList()) }
-    var qualityMenuOpen by remember { mutableStateOf(false) }
-    var isLoading by remember { mutableStateOf(false) }
+    val fullscreenHolder = LocalVideoFullscreenState.current
+    val isFullscreen = fullscreenHolder.isFullscreen
 
-    // ── ONE shared ExoPlayer + state ──
-    //
-    // The state is created once per videoId and survives the inline ↔
-    // fullscreen transition. Only the VideoArtworkSurface (the view layer)
-    // moves; the ExoPlayer underneath keeps running. This means:
-    //   - NO re-resolving the stream URL on fullscreen toggle
-    //   - NO re-buffering / loading spinner on fullscreen toggle
-    //   - NO audio continuing while video pauses
-    //   - The video just keeps playing as the surface changes parents
-    val state =
-        rememberVideoArtworkState(
-            videoId = videoId,
-            isPlaying = isPlaying,
-            positionProvider = positionProvider,
-            preferredHeight = preferredHeight,
-            onStreamResolved = { info ->
-                availableHeights = info?.availableHeights.orEmpty()
-            },
-            onPlaybackFailed = onPlaybackFailed,
-            onLoadingStateChange = { isLoading = it },
-            onRequestPauseMain = onRequestPauseMain,
-            onRequestResumeMain = onRequestResumeMain,
-        )
+    var qualityMenuOpen by remember { mutableStateOf(false) }
 
     // ── Inline surface + controls (rendered only when NOT fullscreen) ──
     //
     // When isFullscreen is true, we skip rendering the inline surface
-    // entirely. The VideoArtworkSurface in the fullscreen Dialog takes
+    // entirely. The FullscreenVideoOverlay (rendered by the host) takes
     // over — attaching to the same ExoPlayer. This ensures only ONE
     // surface is attached to the ExoPlayer at any time.
     if (!isFullscreen) {
@@ -150,7 +212,7 @@ fun InlineVideoPlayer(
             // Loading overlay — shown during initial load, quality swap,
             // and seekbar resync. The video surface's alpha also animates
             // to 0 while loading.
-            if (isLoading) {
+            if (isLoadingState(state)) {
                 Box(
                     modifier = Modifier.fillMaxSize().background(Color.Black),
                     contentAlignment = Alignment.Center,
@@ -199,7 +261,7 @@ fun InlineVideoPlayer(
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.video_quality_auto)) },
                                 onClick = {
-                                    preferredHeight = null
+                                    onPreferredHeightChange(null)
                                     qualityMenuOpen = false
                                 },
                             )
@@ -209,7 +271,7 @@ fun InlineVideoPlayer(
                                     DropdownMenuItem(
                                         text = { Text(formatHeightLabel(h)) },
                                         onClick = {
-                                            preferredHeight = h
+                                            onPreferredHeightChange(h)
                                             qualityMenuOpen = false
                                         },
                                     )
@@ -218,9 +280,10 @@ fun InlineVideoPlayer(
                     }
                 }
 
-                // Fullscreen toggle.
+                // Fullscreen toggle — writes to the hoisted holder so the
+                // host can render the FullscreenVideoOverlay.
                 IconButton(
-                    onClick = { isFullscreen = true },
+                    onClick = { fullscreenHolder.isFullscreen = true },
                     modifier =
                         Modifier
                             .background(
@@ -238,37 +301,24 @@ fun InlineVideoPlayer(
             }
         }
     }
-
-    // ── Fullscreen Dialog (rendered only when fullscreen) ──
-    //
-    // The Dialog renders its own VideoArtworkSurface attached to the SAME
-    // ExoPlayer. Because the inline surface was removed from composition
-    // (the `if (!isFullscreen)` block above), only ONE surface is attached
-    // to the ExoPlayer at a time — the fullscreen surface.
-    //
-    // The ExoPlayer does NOT re-resolve the URL or re-buffer. The video
-    // continues playing from exactly where it was — the surface just
-    // changes parents.
-    if (isFullscreen) {
-        VideoFullscreenDialog(
-            state = state,
-            isLoading = isLoading,
-            availableHeights = availableHeights,
-            onDismiss = { isFullscreen = false },
-            onQualityChange = { preferredHeight = it },
-            resizeMode = resizeMode,
-        )
-    }
 }
 
 /**
- * Fullscreen video Dialog.
+ * Fullscreen video overlay — a regular composable (NOT a Dialog).
  *
  * Renders the video in a system-immersive (fullscreen, no status/nav bar)
- * [Dialog] with the SAME [VideoArtworkState] used by the inline player.
+ * overlay using the SAME [VideoArtworkState] used by the inline player.
  * The ExoPlayer is shared — no re-creation, no re-loading. The video
  * continues playing seamlessly as the surface moves from the inline slot
- * to this Dialog.
+ * to this overlay.
+ *
+ * WHY NOT A DIALOG:
+ * The previous implementation used a Compose `Dialog`, which creates a
+ * separate window. Setting `Activity.requestedOrientation = SENSOR_LANDSCAPE`
+ * affects the Activity's main window, but the Dialog's window may not
+ * reliably follow — causing the "horizontal for a split second then back"
+ * flicker. By rendering this overlay as a regular composable in the same
+ * window, the orientation change applies cleanly to the entire Activity.
  *
  * Forces landscape orientation on entry, restores the original orientation
  * on exit. System bars are hidden for immersive playback and restored on
@@ -278,18 +328,24 @@ fun InlineVideoPlayer(
  * removed per user request.)
  */
 @Composable
-private fun VideoFullscreenDialog(
+fun FullscreenVideoOverlay(
     state: VideoArtworkState,
-    isLoading: Boolean,
+    preferredHeight: Int?,
+    onPreferredHeightChange: (Int?) -> Unit,
     availableHeights: List<Int>,
     onDismiss: () -> Unit,
-    onQualityChange: (Int?) -> Unit,
-    resizeMode: Int,
+    resizeMode: Int = AspectRatioFrameLayout.RESIZE_MODE_FIT,
 ) {
     val context = LocalContext.current
     var qualityMenuOpen by remember { mutableStateOf(false) }
 
-    // Dismiss the dialog if playback fails — don't leave the user stuck
+    // Intercept the back button so it dismisses the fullscreen overlay
+    // instead of collapsing the BottomSheet (which is what the sheet's own
+    // BackHandler would do). This BackHandler takes priority because it's
+    // composed after the BottomSheet's BackHandler.
+    BackHandler { onDismiss() }
+
+    // Dismiss the overlay if playback fails — don't leave the user stuck
     // in a fullscreen black screen with no way out.
     LaunchedEffect(state.hasPlaybackFailed) {
         if (state.hasPlaybackFailed) {
@@ -297,150 +353,168 @@ private fun VideoFullscreenDialog(
         }
     }
 
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties =
-            DialogProperties(
-                usePlatformDefaultWidth = false,
-                decorFitsSystemWindows = false,
-                dismissOnBackPress = true,
-                dismissOnClickOutside = false,
-            ),
-    ) {
-        // ── Force landscape orientation + hide system bars ──
-        //
-        // On enter: set orientation to SENSOR_LANDSCAPE (allows both
-        // landscape orientations based on device tilt) and hide system
-        // bars for true immersive playback.
-        // On dispose: restore the original orientation and show system bars.
-        DisposableEffect(Unit) {
-            val activity = context.findActivity()
-            val originalOrientation = activity?.requestedOrientation
-            val window = activity?.window
-            val controller = window?.let { WindowCompat.getInsetsController(it, it.decorView) }
-            val originalBehavior = controller?.systemBarsBehavior
+    // ── Force landscape orientation + hide system bars ──
+    //
+    // On enter: set orientation to SENSOR_LANDSCAPE (allows both
+    // landscape orientations based on device tilt) and hide system
+    // bars for true immersive playback.
+    // On dispose: restore the original orientation and show system bars.
+    //
+    // This is a DisposableEffect tied to the overlay's lifecycle. As long
+    // as the overlay is in the composition tree, the orientation stays
+    // landscape. When the overlay is removed (onDismiss sets isFullscreen
+    // = false → host stops rendering this composable), the orientation
+    // is restored.
+    DisposableEffect(Unit) {
+        val activity = context.findActivity()
+        val originalOrientation = activity?.requestedOrientation
+        val window = activity?.window
+        val controller = window?.let { WindowCompat.getInsetsController(it, it.decorView) }
+        val originalBehavior = controller?.systemBarsBehavior
 
-            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        if (controller != null) {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+        }
+
+        onDispose {
+            activity?.requestedOrientation =
+                originalOrientation ?: ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
             if (controller != null) {
+                controller.show(WindowInsetsCompat.Type.systemBars())
                 controller.systemBarsBehavior =
-                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                controller.hide(WindowInsetsCompat.Type.systemBars())
+                    originalBehavior ?: WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
             }
+        }
+    }
 
-            onDispose {
-                activity?.requestedOrientation =
-                    originalOrientation ?: ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-                if (controller != null) {
-                    controller.show(WindowInsetsCompat.Type.systemBars())
-                    controller.systemBarsBehavior =
-                        originalBehavior ?: WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
-                }
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black),
+    ) {
+        // Same ExoPlayer — just a different surface. NO re-loading.
+        VideoArtworkSurface(
+            state = state,
+            resizeMode = resizeMode,
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        // Loading overlay — same rationale as the inline player.
+        if (isLoadingState(state)) {
+            Box(
+                modifier = Modifier.fillMaxSize().background(Color.Black),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(
+                    color = Color.White,
+                    strokeWidth = 3.dp,
+                    modifier = Modifier.size(56.dp),
+                )
             }
         }
 
-        Box(
+        // Top-right controls: quality | fullscreen-exit.
+        // statusBarsPadding keeps the buttons clear of the (hidden)
+        // status bar area in case the user swipes to reveal it.
+        // (Captions button removed per user request.)
+        Row(
             modifier =
                 Modifier
-                    .fillMaxSize()
-                    .background(Color.Black),
+                    .align(Alignment.TopEnd)
+                    .statusBarsPadding()
+                    .padding(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Same ExoPlayer — just a different surface. NO re-loading.
-            VideoArtworkSurface(
-                state = state,
-                resizeMode = resizeMode,
-                modifier = Modifier.fillMaxSize(),
-            )
-
-            // Loading overlay — same rationale as the inline player.
-            if (isLoading) {
-                Box(
-                    modifier = Modifier.fillMaxSize().background(Color.Black),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator(
-                        color = Color.White,
-                        strokeWidth = 3.dp,
-                        modifier = Modifier.size(56.dp),
-                    )
-                }
-            }
-
-            // Top-right controls: quality | fullscreen-exit.
-            // statusBarsPadding keeps the buttons clear of the (hidden)
-            // status bar area in case the user swipes to reveal it.
-            // (Captions button removed per user request.)
-            Row(
-                modifier =
-                    Modifier
-                        .align(Alignment.TopEnd)
-                        .statusBarsPadding()
-                        .padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (availableHeights.size > 1) {
-                    Box {
-                        IconButton(
-                            onClick = { qualityMenuOpen = true },
-                            modifier =
-                                Modifier
-                                    .background(
-                                        color = Color.Black.copy(alpha = 0.45f),
-                                        shape = CircleShape,
-                                    ).size(44.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.HighQuality,
-                                contentDescription = stringResource(R.string.video_quality),
-                                tint = Color.White,
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
-                        DropdownMenu(
-                            expanded = qualityMenuOpen,
-                            onDismissRequest = { qualityMenuOpen = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.video_quality_auto)) },
-                                onClick = {
-                                    onQualityChange(null)
-                                    qualityMenuOpen = false
-                                },
-                            )
-                            availableHeights
-                                .sortedDescending()
-                                .forEach { h ->
-                                    DropdownMenuItem(
-                                        text = { Text(formatHeightLabel(h)) },
-                                        onClick = {
-                                            onQualityChange(h)
-                                            qualityMenuOpen = false
-                                        },
-                                    )
-                                }
-                        }
+            if (availableHeights.size > 1) {
+                Box {
+                    IconButton(
+                        onClick = { qualityMenuOpen = true },
+                        modifier =
+                            Modifier
+                                .background(
+                                    color = Color.Black.copy(alpha = 0.45f),
+                                    shape = CircleShape,
+                                ).size(44.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.HighQuality,
+                            contentDescription = stringResource(R.string.video_quality),
+                            tint = Color.White,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = qualityMenuOpen,
+                        onDismissRequest = { qualityMenuOpen = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.video_quality_auto)) },
+                            onClick = {
+                                onPreferredHeightChange(null)
+                                qualityMenuOpen = false
+                            },
+                        )
+                        availableHeights
+                            .sortedDescending()
+                            .forEach { h ->
+                                DropdownMenuItem(
+                                    text = { Text(formatHeightLabel(h)) },
+                                    onClick = {
+                                        onPreferredHeightChange(h)
+                                        qualityMenuOpen = false
+                                    },
+                                )
+                            }
                     }
                 }
-                IconButton(
-                    onClick = onDismiss,
-                    modifier =
-                        Modifier
-                            .background(
-                                color = Color.Black.copy(alpha = 0.45f),
-                                shape = CircleShape,
-                            ).size(44.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.FullscreenExit,
-                        contentDescription = stringResource(R.string.video_exit_fullscreen),
-                        tint = Color.White,
-                        modifier = Modifier.size(24.dp),
-                    )
-                }
+            }
+            IconButton(
+                onClick = onDismiss,
+                modifier =
+                    Modifier
+                        .background(
+                            color = Color.Black.copy(alpha = 0.45f),
+                            shape = CircleShape,
+                        ).size(44.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.FullscreenExit,
+                    contentDescription = stringResource(R.string.video_exit_fullscreen),
+                    tint = Color.White,
+                    modifier = Modifier.size(24.dp),
+                )
             }
         }
     }
 }
+
+/**
+ * Compute the loading state from the [VideoArtworkState].
+ *
+ * The player is considered "loading" when:
+ *   - It hasn't failed (failed states show an error, not a spinner).
+ *   - AND any of:
+ *     - The stream URL is being resolved ([VideoArtworkState.isResolvingUrl]).
+ *     - A seekbar resync is in progress ([VideoArtworkState.isResyncing]).
+ *     - The stream URL is set but the first frame hasn't rendered yet
+ *       ([VideoArtworkState.streamUrl] != null && ![VideoArtworkState.isVideoReady]).
+ *
+ * Quality changes are NOT included here because the inline surface stays
+ * visible (with the old frame) during a quality swap — only the fullscreen
+ * overlay shows a spinner during quality changes.
+ */
+private fun isLoadingState(state: VideoArtworkState): Boolean =
+    !state.hasPlaybackFailed &&
+        (
+            state.isResolvingUrl ||
+                state.isResyncing ||
+                (state.streamUrl != null && !state.isVideoReady)
+        )
 
 /**
  * Format a video height (in px) as a human-readable label.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -77,6 +77,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
@@ -978,6 +979,67 @@ fun BottomSheetPlayer(
         }
     }
 
+    // ── Hoisted video state ──
+    //
+    // The VideoArtworkState (ExoPlayer + stream URL + playback state) is
+    // created HERE — above the BottomSheet and above the `when (orientation)`
+    // block — so it survives:
+    //   - Orientation changes (the `when` block can switch freely without
+    //     releasing the ExoPlayer).
+    //   - Sheet collapse/expand (the ExoPlayer is not tied to the sheet's
+    //     content lifecycle; `keepContentAlive = true` keeps the content
+    //     alive too, but even without it the state would survive).
+    //   - Fullscreen toggle (the FullscreenVideoOverlay is a sibling of the
+    //     BottomSheet, sharing this same state — no Dialog, no separate
+    //     window, no re-loading).
+    //
+    // When there's no music video playing, this returns null and no ExoPlayer
+    // is created.
+    val videoFullscreenHolder = LocalVideoFullscreenState.current
+    val videoMediaId =
+        mediaMetadata
+            ?.takeIf { it.isMusicVideo == true && !it.id.isLocalMediaId() }
+            ?.id
+    var videoPreferredHeight by rememberSaveable { mutableStateOf<Int?>(null) }
+    var videoAvailableHeights by remember { mutableStateOf<List<Int>>(emptyList()) }
+    var videoPlaybackFailed by remember { mutableStateOf(false) }
+
+    // Reset the failure flag when the media changes — a new song gets a fresh
+    // attempt at video playback even if the previous song's video failed.
+    LaunchedEffect(videoMediaId) {
+        videoPlaybackFailed = false
+    }
+
+    val videoState =
+        rememberVideoArtworkStateOrNull(
+            videoId = videoMediaId,
+            isPlaying = isPlaying,
+            positionProvider = { playerConnection.player.currentPosition },
+            preferredHeight = videoPreferredHeight,
+            onStreamResolved = { info -> videoAvailableHeights = info?.availableHeights.orEmpty() },
+            onPlaybackFailed = { videoPlaybackFailed = true },
+            onLoadingStateChange = { /* loading is computed from state directly in InlineVideoPlayer */ },
+            onRequestPauseMain = { playerConnection.player.pause() },
+            onRequestResumeMain = { playerConnection.player.play() },
+        )
+
+    // Wrap BottomSheet + FullscreenVideoOverlay in a Box so the overlay
+    // can be rendered as a sibling of the BottomSheet, filling the entire
+    // screen on top of it. This avoids using a Compose Dialog (which has
+    // orientation/window issues that caused the "horizontal for a split
+    // second then back" flicker).
+    //
+    // The video state is provided via CompositionLocals so that composables
+    // deep in the tree (V8PlayerContent, AppleMusicPlayer, etc.) can access
+    // the shared ExoPlayer without needing it passed as an explicit parameter
+    // through every layer.
+    CompositionLocalProvider(
+        LocalVideoArtworkState provides videoState,
+        LocalVideoPreferredHeight provides videoPreferredHeight,
+        LocalVideoOnPreferredHeightChange provides { videoPreferredHeight = it },
+        LocalVideoAvailableHeights provides videoAvailableHeights,
+    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
     BottomSheet(
         state = state,
         modifier =
@@ -1122,6 +1184,13 @@ fun BottomSheetPlayer(
         onDismiss = {
             playerConnection.service.stopAndClearPlayback(clearPersistentState = true)
         },
+        // Keep the player content (including InlineVideoPlayer) alive even
+        // when the sheet is collapsed to the mini player. Without this,
+        // collapsing the player unmounts the InlineVideoPlayer, releasing
+        // the ExoPlayer — and expanding it again requires re-resolving the
+        // stream URL and re-buffering, causing "video pauses, audio keeps
+        // playing" on reopen.
+        keepContentAlive = true,
         collapsedContent = {
             MiniPlayer(
                 position = position,
@@ -1147,6 +1216,12 @@ fun BottomSheetPlayer(
                     playerConnection.player.seekTo(it)
                 }
                 position = it
+                // Request a pause-load-resume resync on the video player so
+                // it jumps to the new position. This is the ONLY path that
+                // triggers a pause-load-resume — the automatic drift-based
+                // resync was removed because it caused "video keeps pausing
+                // repeatedly".
+                videoState?.requestResync(it, isPlaying)
             }
             isUserSeeking = false
         }
@@ -1392,6 +1467,15 @@ fun BottomSheetPlayer(
             )
         }
 
+        // The `when (orientation)` block can switch freely between PORTRAIT
+        // and LANDSCAPE — the VideoArtworkState (ExoPlayer) is hoisted above
+        // this block (in BottomSheetPlayer), so it survives the switch. The
+        // InlineVideoPlayer in either branch just attaches/detaches its
+        // surface; the ExoPlayer keeps running.
+        //
+        // The FullscreenVideoOverlay is rendered as a sibling of the
+        // BottomSheet (not inside this `when` block), so it's always available
+        // regardless of which orientation branch is active.
         when (LocalConfiguration.current.orientation) {
             Configuration.ORIENTATION_LANDSCAPE -> {
                 if (playerDesignStyle == PlayerDesignStyle.V5) {
@@ -1496,7 +1580,8 @@ fun BottomSheetPlayer(
                             v7VideoMetadata?.isMusicVideo == true &&
                                 !v7VideoMetadata.id.isLocalMediaId() &&
                                 !aodModeEnabled &&
-                                !isLyricsScreenVisible
+                                !isLyricsScreenVisible &&
+                                !videoPlaybackFailed
 
                         if (v7VideoShowing) {
                             // Pure-black backdrop so the video sits in a
@@ -1528,11 +1613,10 @@ fun BottomSheetPlayer(
                         // `mediaMetadata`) so Kotlin can smart-cast it.
                         if (v7VideoShowing && v7VideoMetadata != null) {
                             InlineVideoPlayer(
-                                videoId = v7VideoMetadata.id,
-                                isPlaying = isPlaying,
-                                positionProvider = { playerConnection.player.currentPosition },
-                                onRequestPauseMain = { playerConnection.player.pause() },
-                                onRequestResumeMain = { playerConnection.player.play() },
+                                state = videoState,
+                                preferredHeight = videoPreferredHeight,
+                                onPreferredHeightChange = { videoPreferredHeight = it },
+                                availableHeights = videoAvailableHeights,
                                 modifier =
                                     Modifier
                                         .align(Alignment.Center)
@@ -1607,7 +1691,8 @@ fun BottomSheetPlayer(
                             v8VideoMetadata?.isMusicVideo == true &&
                                 !v8VideoMetadata.id.isLocalMediaId() &&
                                 !aodModeEnabled &&
-                                !isLyricsScreenVisible
+                                !isLyricsScreenVisible &&
+                                !videoPlaybackFailed
                         if (v8VideoShowing) {
                             Box(
                                 modifier =
@@ -1876,7 +1961,8 @@ fun BottomSheetPlayer(
                             v7VideoMetadata?.isMusicVideo == true &&
                                 !v7VideoMetadata.id.isLocalMediaId() &&
                                 !aodModeEnabled &&
-                                !isLyricsScreenVisible
+                                !isLyricsScreenVisible &&
+                                !videoPlaybackFailed
 
                         if (v7VideoShowing) {
                             Box(
@@ -1906,11 +1992,10 @@ fun BottomSheetPlayer(
                         // `mediaMetadata`) so Kotlin can smart-cast it.
                         if (v7VideoShowing && v7VideoMetadata != null) {
                             InlineVideoPlayer(
-                                videoId = v7VideoMetadata.id,
-                                isPlaying = isPlaying,
-                                positionProvider = { playerConnection.player.currentPosition },
-                                onRequestPauseMain = { playerConnection.player.pause() },
-                                onRequestResumeMain = { playerConnection.player.play() },
+                                state = videoState,
+                                preferredHeight = videoPreferredHeight,
+                                onPreferredHeightChange = { videoPreferredHeight = it },
+                                availableHeights = videoAvailableHeights,
                                 modifier =
                                     Modifier
                                         .align(Alignment.Center)
@@ -1983,7 +2068,8 @@ fun BottomSheetPlayer(
                             v8VideoMetadata?.isMusicVideo == true &&
                                 !v8VideoMetadata.id.isLocalMediaId() &&
                                 !aodModeEnabled &&
-                                !isLyricsScreenVisible
+                                !isLyricsScreenVisible &&
+                                !videoPlaybackFailed
                         if (v8VideoShowing) {
                             Box(
                                 modifier =
@@ -2217,6 +2303,36 @@ fun BottomSheetPlayer(
             }
         }
     }
+
+        // ── Fullscreen video overlay (sibling of BottomSheet) ──
+        //
+        // Rendered on top of the BottomSheet when the user enters fullscreen.
+        // This is a regular composable (NOT a Dialog) — it shares the same
+        // window as the BottomSheet, so the Activity's `requestedOrientation`
+        // applies cleanly to it. This avoids the Compose Dialog's window/
+        // orientation issues that caused the "horizontal for a split second
+        // then back" flicker.
+        //
+        // The overlay uses the SAME VideoArtworkState as the inline player —
+        // no re-loading, no re-buffering. The video continues playing
+        // seamlessly as the surface moves from the inline slot to this overlay.
+        //
+        // When the overlay is visible, the InlineVideoPlayer (inside the
+        // BottomSheet) skips rendering its own surface (`if (!isFullscreen)`),
+        // ensuring only ONE surface is attached to the ExoPlayer at a time.
+        videoState?.let { vs ->
+            if (videoFullscreenHolder.isFullscreen) {
+                FullscreenVideoOverlay(
+                    state = vs,
+                    preferredHeight = videoPreferredHeight,
+                    onPreferredHeightChange = { videoPreferredHeight = it },
+                    availableHeights = videoAvailableHeights,
+                    onDismiss = { videoFullscreenHolder.isFullscreen = false },
+                )
+            }
+        }
+    } // close Box(Modifier.fillMaxSize())
+    } // close CompositionLocalProvider
 
     val activePlaybackError = playbackError
     val isRecoveryDestination =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -2626,11 +2626,6 @@ private fun V8Artwork(
 
         if (showVideo) {
             InlineVideoPlayer(
-                videoId = videoId!!,
-                isPlaying = isPlaying,
-                positionProvider = { playerConnection?.player?.currentPosition ?: 0L },
-                onRequestPauseMain = { playerConnection?.player?.pause() },
-                onRequestResumeMain = { playerConnection?.player?.play() },
                 modifier = Modifier.fillMaxSize(),
             )
         }
@@ -3574,11 +3569,6 @@ private fun V9Artwork(
 
         if (showVideo) {
             InlineVideoPlayer(
-                videoId = videoId!!,
-                isPlaying = isPlaying,
-                positionProvider = { playerConnection?.player?.currentPosition ?: 0L },
-                onRequestPauseMain = { playerConnection?.player?.pause() },
-                onRequestResumeMain = { playerConnection?.player?.play() },
                 modifier = Modifier.fillMaxSize(),
             )
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
@@ -631,11 +631,6 @@ fun Thumbnail(
 
                                     if (isCurrentMusicVideo) {
                                         InlineVideoPlayer(
-                                            videoId = item.mediaId,
-                                            isPlaying = isPlaying,
-                                            positionProvider = { playerConnection.player.currentPosition },
-                                            onRequestPauseMain = { playerConnection.player.pause() },
-                                            onRequestResumeMain = { playerConnection.player.play() },
                                             modifier = Modifier.fillMaxSize(),
                                         )
                                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoArtworkPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoArtworkPlayer.kt
@@ -60,30 +60,62 @@ import java.util.Locale
 /**
  * Maximum allowed drift between the main audio player's position and the
  * video surface's position before we force a re-seek.
+ *
+ * NOTE: This was previously 400ms, which was too tight for VP9/AV1 hardware
+ * decoders on mobile. The decoder naturally lags behind the audio player by
+ * 300–800ms due to frame rendering pipeline depth. A tight tolerance causes
+ * a seekTo on every poll cycle, which re-buffers, which causes MORE drift,
+ * creating an infinite re-sync loop (the "video keeps pausing" bug).
+ *
+ * 2000ms is wide enough to absorb normal decoder lag while still catching
+ * genuine desync from network hiccups or background throttling.
  */
-private const val VideoSyncDriftToleranceMs = 400L
+private const val VideoSyncDriftToleranceMs = 2000L
 
 /**
- * Drift threshold above which we assume the user dragged the seekbar.
- * Triggers the pause-load-resume protocol (see [rememberVideoArtworkState]).
+ * Drift threshold above which we fire a "soft" seek (seek the video WITHOUT
+ * pausing the main audio player). The video may freeze briefly while it
+ * re-buffers, but the audio continues uninterrupted.
+ *
+ * This is intentionally NOT a pause-load-resume — that protocol was removed
+ * from the automatic drift path because it caused the "video keeps pausing
+ * repeatedly" bug: the resync would pause both audio+video, the video would
+ * re-buffer, both would resume, and then the next poll cycle would detect
+ * drift again (because the video is naturally behind from decoder lag),
+ * triggering another resync — an infinite loop.
+ *
+ * The pause-load-resume protocol is now ONLY triggered by an explicit call
+ * to [VideoArtworkState.requestResync], which is wired to the seekbar's
+ * onValueChangeFinished callback.
  */
-private const val UserSeekDriftThresholdMs = 1500L
+private const val VideoSoftSeekDriftThresholdMs = 3000L
 
 /**
  * How often to poll the main player's position and re-sync the video.
  */
-private const val VideoSyncPollIntervalMs = 250L
+private const val VideoSyncPollIntervalMs = 500L
 
 /**
  * Maximum time the video ExoPlayer is allowed to stay in STATE_BUFFERING
  * before we force a re-prepare to break out of a stuck state.
+ *
+ * NOTE: Was 8000ms, which was too aggressive — normal network hiccups can
+ * cause 5–10s of buffering, and the re-prepare itself causes a brief pause.
+ * This contributed to the "video keeps pausing" bug. 20s is long enough to
+ * ride out transient network issues while still catching genuinely stuck
+ * states.
  */
-private const val VideoStuckBufferingTimeoutMs = 8000L
+private const val VideoStuckBufferingTimeoutMs = 20000L
 
 /**
  * Hard cap on the resolution we will ever attempt to play.
+ *
+ * Capped at 1080p — 4K (2160) VP9 decoding on mobile chipsets causes
+ * persistent ~500ms decoder lag that makes the video fall behind audio,
+ * triggering constant re-syncs. 1080p is more than sufficient for a phone
+ * screen and decodes fast enough to keep drift under the tolerance.
  */
-private const val MaxVideoHeightCap = 2160
+private const val MaxVideoHeightCap = 1080
 
 /**
  * Resolved information about a video stream — the playable URL plus the
@@ -132,6 +164,39 @@ class VideoArtworkState internal constructor(
         internal set
     var bufferingStartedAtMs: Long by mutableStateOf(0L)
         internal set
+
+    /**
+     * Pending resync request set by [requestResync]. Consumed by a
+     * [LaunchedEffect] in [rememberVideoArtworkState] which performs the
+     * actual pause-load-resume protocol.
+     *
+     * This indirection exists because [requestResync] is called from outside
+     * the composable (e.g. from the seekbar's onValueChangeFinished in
+     * BottomSheetPlayer) but the resync needs access to composable-scoped
+     * state (the [exoPlayer], the pause/resume callbacks, etc.).
+     */
+    internal var pendingResync: Pair<Long, Boolean>? by mutableStateOf(null)
+
+    /**
+     * Request a pause-load-resume resync to [position].
+     *
+     * This is the SEEKBAR resync path: when the user drags the seekbar and
+     * releases, the host calls this method. It:
+     *   1. Pauses the main audio player (if [isPlaying]).
+     *   2. Pauses the video ExoPlayer.
+     *   3. Seeks the video to [position].
+     *   4. Waits for the first frame to render (see [onRenderedFirstFrame]).
+     *   5. Resumes both the audio and video together.
+     *
+     * This is the ONLY path that triggers a pause-load-resume. The automatic
+     * drift-based resync was removed because it caused the "video keeps
+     * pausing repeatedly" bug.
+     */
+    fun requestResync(position: Long, isPlaying: Boolean) {
+        if (hasPlaybackFailed) return
+        if (isResyncing) return
+        pendingResync = position to isPlaying
+    }
 }
 
 /**
@@ -148,10 +213,19 @@ class VideoArtworkState internal constructor(
  * [VideoArtworkSurface] (the view layer) moves; the player underneath
  * keeps running.
  *
- * Seekbar pause-load-resume protocol: when the periodic poller detects
- * drift > [UserSeekDriftThresholdMs] and the main player is playing, it
- * pauses the main audio player, seeks the video, waits for the first frame
- * to render, then resumes both together.
+ * Seekbar pause-load-resume protocol: triggered by an explicit call to
+ * [VideoArtworkState.requestResync] (wired to the seekbar's
+ * onValueChangeFinished in BottomSheetPlayer). It pauses the main audio
+ * player, seeks the video, waits for the first frame to render, then
+ * resumes both together. This is the ONLY path that triggers a
+ * pause-load-resume — the automatic drift-based resync was removed because
+ * it caused the "video keeps pausing repeatedly" bug.
+ *
+ * Automatic drift handling: the periodic poller detects drift between the
+ * audio and video positions. For large drifts (> [VideoSoftSeekDriftThresholdMs])
+ * while playing, it performs a "soft seek" — seeking the video WITHOUT
+ * pausing the main audio. The video may freeze briefly while it re-buffers,
+ * but the audio continues uninterrupted.
  *
  * Stuck-buffering recovery: if the ExoPlayer stays in STATE_BUFFERING for
  * longer than [VideoStuckBufferingTimeoutMs], the poller forces a
@@ -389,6 +463,30 @@ fun rememberVideoArtworkState(
         }
     }
 
+    // ── Manual resync (seekbar) ──
+    //
+    // Triggered by [VideoArtworkState.requestResync], which is called from
+    // the seekbar's onValueChangeFinished in BottomSheetPlayer. This is the
+    // ONLY path that performs a pause-load-resume. The automatic drift-based
+    // resync was removed because it caused the "video keeps pausing repeatedly"
+    // bug (infinite resync loop).
+    LaunchedEffect(state.pendingResync) {
+        val (position, wasPlaying) = state.pendingResync ?: return@LaunchedEffect
+        // Consume the request immediately so subsequent calls re-trigger.
+        state.pendingResync = null
+        if (state.hasPlaybackFailed || state.isResyncing) return@LaunchedEffect
+        Timber
+            .tag(VideoPlaybackLogTag)
+            .d("Manual resync to ${position}ms (wasPlaying=$wasPlaying) — pause-load-resume")
+        state.wasPlayingBeforeResync = wasPlaying
+        state.isResyncing = true
+        state.isVideoReady = false
+        if (wasPlaying) updatedOnRequestPauseMain()
+        exoPlayer.pause()
+        exoPlayer.seekTo(position)
+        state.bufferingStartedAtMs = SystemClock.elapsedRealtime()
+    }
+
     // ── Periodic position sync + stuck-buffering recovery ──
     LaunchedEffect(state.streamUrl, exoPlayer) {
         if (state.streamUrl == null) return@LaunchedEffect
@@ -408,7 +506,29 @@ fun rememberVideoArtworkState(
                 }
             }
 
-            // Drift / seek detection
+            // Drift detection — SOFT seek only (no pause-load-resume).
+            //
+            // The automatic pause-load-resume was removed because it caused
+            // the "video keeps pausing repeatedly" bug. Instead:
+            //
+            // - While PLAYING + drift > VideoSoftSeekDriftThresholdMs:
+            //   Seek the video WITHOUT pausing the main audio. The video may
+            //   freeze briefly while it re-buffers, but the audio continues
+            //   uninterrupted. This is the right tradeoff for a music app —
+            //   the user would rather have the audio keep playing with a
+            //   brief video freeze than have both pause repeatedly.
+            //
+            // - While PAUSED + drift > tolerance:
+            //   Seek the video to match the audio position. No re-buffering
+            //   concern since playback is paused.
+            //
+            // - While PLAYING + drift <= threshold:
+            //   IGNORE. The video will self-correct because both audio and
+            //   video play at 1x speed. Decoder lag of 300–800ms is normal
+            //   on mobile VP9/AV1 decoders and is not perceptible.
+            //
+            // For explicit seekbar seeks, the pause-load-resume protocol is
+            // triggered by [VideoArtworkState.requestResync] (see above).
             if (state.isChangingQuality) continue
             if (state.isResyncing) continue
             if (!state.isVideoReady) continue
@@ -418,25 +538,13 @@ fun rememberVideoArtworkState(
             val videoPos = exoPlayer.currentPosition
             val drift = kotlin.math.abs(videoPos - mainPos)
 
-            if (drift > VideoSyncDriftToleranceMs) {
-                if (drift > UserSeekDriftThresholdMs && shouldPlay && !state.hasPlaybackFailed) {
-                    Timber
-                        .tag(VideoPlaybackLogTag)
-                        .d("User seek detected: drift=${drift}ms — pausing main, rebuffering video")
-                    state.wasPlayingBeforeResync = shouldPlay
-                    state.isResyncing = true
-                    state.isVideoReady = false
-                    updatedOnRequestPauseMain()
-                    exoPlayer.pause()
-                    exoPlayer.seekTo(mainPos)
-                    state.bufferingStartedAtMs = SystemClock.elapsedRealtime()
-                } else {
-                    Timber
-                        .tag(VideoPlaybackLogTag)
-                        .d("Re-syncing video: drift=${drift}ms (main=$mainPos, video=$videoPos)")
-                    exoPlayer.seekTo(mainPos)
-                    exoPlayer.setVideoPlayback(shouldPlay)
-                }
+            if (drift > VideoSoftSeekDriftThresholdMs && shouldPlay) {
+                Timber
+                    .tag(VideoPlaybackLogTag)
+                    .d("Soft seek: drift=${drift}ms (main=$mainPos, video=$videoPos)")
+                exoPlayer.seekTo(mainPos)
+            } else if (drift > VideoSyncDriftToleranceMs && !shouldPlay) {
+                exoPlayer.seekTo(mainPos)
             }
         }
     }
@@ -555,6 +663,53 @@ fun rememberVideoArtworkState(
 }
 
 /**
+ * Conditional wrapper around [rememberVideoArtworkState] that returns `null`
+ * when [videoId] is blank.
+ *
+ * This is used by the host (BottomSheetPlayer) to hoist the [VideoArtworkState]
+ * above the `when (orientation)` block AND above the BottomSheet content — so
+ * the ExoPlayer survives:
+ *   - Orientation changes (the `when` block can switch freely without
+ *     releasing the ExoPlayer).
+ *   - Sheet collapse/expand (the ExoPlayer is not tied to the sheet's content
+ *     lifecycle).
+ *   - Fullscreen toggle (the fullscreen overlay is a sibling of the BottomSheet,
+ *     sharing the same state).
+ *
+ * When [videoId] is blank (no music video playing), this returns `null` and
+ * does NOT create an ExoPlayer — avoiding unnecessary resource usage.
+ */
+@Composable
+fun rememberVideoArtworkStateOrNull(
+    videoId: String?,
+    isPlaying: Boolean,
+    positionProvider: () -> Long,
+    preferredHeight: Int?,
+    onStreamResolved: (VideoStreamInfo?) -> Unit,
+    onPlaybackFailed: () -> Unit,
+    onLoadingStateChange: (Boolean) -> Unit,
+    onRequestPauseMain: () -> Unit,
+    onRequestResumeMain: () -> Unit,
+): VideoArtworkState? {
+    return if (videoId.isNullOrBlank()) {
+        onPlaybackFailed()
+        null
+    } else {
+        rememberVideoArtworkState(
+            videoId = videoId,
+            isPlaying = isPlaying,
+            positionProvider = positionProvider,
+            preferredHeight = preferredHeight,
+            onStreamResolved = onStreamResolved,
+            onPlaybackFailed = onPlaybackFailed,
+            onLoadingStateChange = onLoadingStateChange,
+            onRequestPauseMain = onRequestPauseMain,
+            onRequestResumeMain = onRequestResumeMain,
+        )
+    }
+}
+
+/**
  * Renders the video surface for the given [state].
  *
  * This is a pure view composable — it reads [VideoArtworkState.isVideoReady]
@@ -562,11 +717,11 @@ fun rememberVideoArtworkState(
  * [VideoArtworkState.exoPlayer]. It does NOT create or manage the ExoPlayer;
  * that's the responsibility of [rememberVideoArtworkState].
  *
- * Because the ExoPlayer is external, this composable can be freely moved
- * between different parents (e.g. inline slot ↔ fullscreen Dialog) without
- * causing the video to reload. The ExoPlayer's surface is detached from
- * the old view and attached to the new one — a fast operation that does
- * NOT interrupt playback.
+ * Because the ExoPlayer is external, this composable can be freely mounted
+ * in different parents (inline slot, fullscreen overlay) without causing
+ * the video to reload. The ExoPlayer's surface is detached from the old
+ * view and attached to the new one — a fast operation that does NOT
+ * interrupt playback.
  */
 @Composable
 fun VideoArtworkSurface(


### PR DESCRIPTION
## Summary

Fixes three persistent video playback bugs by hoisting the `VideoArtworkState` (ExoPlayer) above the `BottomSheet` and `when(orientation)` block, and replacing the Compose `Dialog` with a regular fullscreen overlay composable.

## Bugs Fixed

### 1. Fullscreen orientation flicker
**Before:** Clicking fullscreen makes the player go horizontal for a split second, then returns to portrait.

**Root cause:** The Compose `Dialog` creates a separate window. Setting `Activity.requestedOrientation = SENSOR_LANDSCAPE` affects the Activity main window, but the Dialog window may not reliably follow — causing the flicker.

**Fix:** Replaced the `Dialog` with a regular `FullscreenVideoOverlay` composable rendered as a sibling of the `BottomSheet` in the same window. The orientation change now applies cleanly to the entire Activity. Also removed the `effectiveOrientation`/`isTransitioning` hack — no longer needed because the `VideoArtworkState` is hoisted above the `when(orientation)` block.

### 2. Mini player close/reopen pauses video
**Before:** Closing the player and reopening from the mini player pauses the video while audio continues playing.

**Root cause:** The `VideoArtworkState` (ExoPlayer) was created inside `InlineVideoPlayer`, which was inside the `BottomSheet` content lambda. When the sheet collapsed, the content was unmounted, releasing the ExoPlayer.

**Fix:** Hoisted `VideoArtworkState` creation to `BottomSheetPlayer` level (above the `BottomSheet` call). The ExoPlayer now survives sheet collapse/expand. `keepContentAlive=true` on `BottomSheet` keeps the `InlineVideoPlayer` mounted. Added `videoPlaybackFailed` state to fall back to artwork on failure.

### 3. Repeated video pausing
**Before:** Video keeps pausing repeatedly during playback.

**Root cause:** The automatic drift-based pause-load-resume protocol caused an infinite resync loop: drift > threshold, pause both audio+video, rebuffer, resume, drift again (from decoder lag), repeat.

**Fix:**
- Removed the automatic drift-based pause-load-resume.
- Automatic drift handling now uses soft seek (seek video WITHOUT pausing main audio). Audio continues uninterrupted; video may freeze briefly while re-buffering.
- Pause-load-resume is now ONLY triggered by explicit seekbar seeks via `VideoArtworkState.requestResync()`, wired to `onSliderValueChangeFinished`.
- Increased stuck-buffering timeout from 8s to 20s (8s was too aggressive for normal network hiccups).
- Increased drift tolerance from 1500ms to 2000ms.

## Architecture Changes

```
BottomSheetPlayer
├── rememberVideoArtworkStateOrNull() ← creates ExoPlayer ONCE
├── CompositionLocalProvider
│   ├── LocalVideoArtworkState
│   ├── LocalVideoPreferredHeight
│   ├── LocalVideoOnPreferredHeightChange
│   └── LocalVideoAvailableHeights
│   └── Box(fillMaxSize)
│       ├── BottomSheet
│       │   └── when (orientation)
│       │       ├── LANDSCAPE → InlineVideoPlayer(state = videoState)
│       │       └── PORTRAIT  → InlineVideoPlayer(state = videoState)
│       └── FullscreenVideoOverlay(state = videoState)  ← if isFullscreen
└── PlaybackErrorDialog
```

### Key design decisions:
- **Single ExoPlayer**: Created once in `BottomSheetPlayer`, shared between inline and fullscreen surfaces via CompositionLocals.
- **No Dialog**: `FullscreenVideoOverlay` is a regular composable, not a Dialog. Avoids window/orientation issues.
- **Soft seek for drift**: Audio never pauses for drift correction. Only explicit seekbar seeks trigger pause-load-resume.
- **BackHandler**: Fullscreen overlay intercepts back button to dismiss itself.

## Files Changed
- `VideoArtworkPlayer.kt`: Added `requestResync()`, `rememberVideoArtworkStateOrNull()`, simplified drift handling
- `InlineVideoPlayer.kt`: Rewrote to accept external state, added `FullscreenVideoOverlay`, added CompositionLocals
- `Player.kt`: Hoisted state creation, wrapped in Box + CompositionLocalProvider, removed effectiveOrientation hack
- `BottomSheet.kt`: Added `keepContentAlive` parameter
- `MainActivity.kt`: Added `ProvideVideoFullscreenState` wrapper
- `Thumbnail.kt`, `AppleMusicPlayer.kt`, `PlayerComponents.kt`: Updated `InlineVideoPlayer` calls to use CompositionLocals

## Test Plan
- [ ] Play a music video → video plays inline
- [ ] Tap fullscreen → device rotates to landscape, video continues playing without re-loading
- [ ] Tap fullscreen exit → device returns to portrait, video continues playing
- [ ] Press back while fullscreen → overlay dismisses
- [ ] Collapse to mini player → audio continues, video stays alive
- [ ] Expand from mini player → video resumes without pausing
- [ ] Drag seekbar → audio pauses, video seeks, both resume together
- [ ] Let video play for 2+ minutes → no repeated pausing
- [ ] Change video quality → loading spinner, then new quality plays