### PR TITLE
feat(video): add 'Enable PiP mode' playback setting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
+            android:supportsPictureInPicture="true"
             android:theme="@style/Theme.ArchiveTune"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -10,6 +10,7 @@
 package moe.rukamori.archivetune
 
 import android.annotation.SuppressLint
+import android.app.PictureInPictureParams
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -22,6 +23,7 @@ import android.os.Bundle
 import android.os.IBinder
 import android.provider.OpenableColumns
 import android.provider.Settings
+import android.util.Rational
 import android.view.View
 import android.view.WindowManager
 import android.webkit.MimeTypeMap
@@ -209,6 +211,8 @@ import moe.rukamori.archivetune.constants.DisableAnimationsKey
 import moe.rukamori.archivetune.constants.DisableScreenshotKey
 import moe.rukamori.archivetune.constants.DynamicThemeKey
 import moe.rukamori.archivetune.constants.EnableHapticFeedbackKey
+import moe.rukamori.archivetune.constants.EnablePipModeKey
+import moe.rukamori.archivetune.constants.EnableVideoPlaybackKey
 import moe.rukamori.archivetune.constants.FontPreferenceKey
 import moe.rukamori.archivetune.constants.HasPressedStarKey
 import moe.rukamori.archivetune.constants.LaunchCountKey
@@ -318,6 +322,7 @@ import moe.rukamori.archivetune.utils.Updater
 import moe.rukamori.archivetune.utils.dataStore
 import moe.rukamori.archivetune.utils.get
 import moe.rukamori.archivetune.utils.isLowRamDevice
+import moe.rukamori.archivetune.utils.isLocalMediaId
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.utils.reportException
@@ -512,6 +517,108 @@ class MainActivity : ComponentActivity() {
             setStatusBarsHidden(true)
         }
     }
+
+    // ── Picture-in-Picture ────────────────────────────────────────────────
+    //
+    // When the user leaves the app while a music video is playing (and the
+    // "Enable PiP mode" setting is ON), the activity enters PiP mode so the
+    // video keeps playing in a small floating window.
+    //
+    // Conditions for entering PiP (checked in onUserLeaveHint):
+    //   1. Build.VERSION.SDK_INT >= O (PiP requires API 26+).
+    //   2. The device supports PiP (packageManager.hasSystemFeature).
+    //   3. EnablePipModeKey is true (user opted in via Playback settings).
+    //   4. EnableVideoPlaybackKey is true (video playback itself is on —
+    //      otherwise there is no video surface to float).
+    //   5. The current media is a music video (isMusicVideo == true) and
+    //      is NOT a local file (we can't PiP a local audio file because
+    //      there is no video stream for it).
+    //   6. Playback is currently playing (not paused) — entering PiP for
+    //      a paused video would show a frozen frame, which is confusing.
+    //
+    // The aspect ratio is computed from the current video's preferred
+    // height (or a sensible 16:9 default). Android requires the aspect
+    // ratio be in the range [1.0, 2.39]; we clamp to that range.
+    //
+    // onPictureInPictureModeChanged is overridden to surface the PiP
+    // state to the rest of the app (the player UI hides non-essential
+    // controls when in PiP). The state is exposed via
+    // `isInPictureInPictureModeState` (a mutableStateOf) so composables
+    // can react to it.
+
+    /** Tracks whether the activity is currently in PiP mode, exposed as
+     *  Compose state so the player UI can adapt (hide controls, etc.). */
+    var isInPictureInPictureModeState by mutableStateOf(false)
+        private set
+
+    /**
+     * Returns true if the current playback session is eligible for PiP:
+     * the setting is on, video playback is on, and the current media is a
+     * non-local music video that is actively playing.
+     *
+     * Called from [onUserLeaveHint] (and could be called from anywhere
+     * else that needs to know). Safe to call from the main thread.
+     */
+    private fun isPipEligible(): Boolean {
+        // PiP requires API 26+ (O). The app's minSdk is 26, so this check
+        // is always true — kept for defensive clarity.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) return false
+        val pipEnabled = dataStore.get(EnablePipModeKey, false)
+        if (!pipEnabled) return false
+        val videoPlaybackEnabled = dataStore.get(EnableVideoPlaybackKey, true)
+        if (!videoPlaybackEnabled) return false
+        val connection = playerConnection ?: return false
+        val metadata = connection.mediaMetadata.value ?: return false
+        if (metadata.isMusicVideo != true) return false
+        if (metadata.id.isLocalMediaId()) return false
+        // Only enter PiP if playback is actually playing — entering PiP
+        // for a paused video would show a frozen frame.
+        if (!connection.isPlaying.value) return false
+        return true
+    }
+
+    /**
+     * Computes the [PictureInPictureParams] for the current playback.
+     *
+     * Uses a 16:9 aspect ratio (the standard for music videos on YouTube)
+     * since the actual video surface bounds aren't easily accessible from
+     * the activity. 16:9 (1.78) is well within Android's supported range
+     * of [1.0, 2.39].
+     *
+     * PiP requires API 26+ (Build.VERSION_CODES.O); the app's minSdk is 26
+     * so no version guard is needed.
+     */
+    private fun buildPipParams(): PictureInPictureParams =
+        PictureInPictureParams
+            .Builder()
+            .setAspectRatio(Rational(16, 9))
+            .build()
+
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        if (isPipEligible()) {
+            try {
+                enterPictureInPictureMode(buildPipParams())
+            } catch (e: IllegalStateException) {
+                // Some OEMs throw ISE if PiP is attempted while the
+                // activity isn't in a valid state. Swallow and continue —
+                // the user simply won't get PiP this time.
+                reportException(e)
+            } catch (e: Exception) {
+                reportException(e)
+            }
+        }
+    }
+
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: Configuration,
+    ) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        isInPictureInPictureModeState = isInPictureInPictureMode
+    }
+    // ── End Picture-in-Picture ────────────────────────────────────────────
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
@@ -1719,6 +1826,7 @@ class MainActivity : ComponentActivity() {
                         moe.rukamori.archivetune.ui.component.LocalBottomSheetPageState provides bottomSheetPageState,
                         moe.rukamori.archivetune.ui.component.LocalMenuState provides menuState,
                         LocalNavigationBarBackdrop provides navBarFrostedBackdrop,
+                        moe.rukamori.archivetune.ui.player.LocalIsInPipMode provides isInPictureInPictureModeState,
                     ) {
                         Row {
                             AnimatedVisibility(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -194,6 +194,11 @@ val HideVideoKey = booleanPreferencesKey("hideVideo")
 // music videos are treated as plain audio (album artwork shown, no video stream is loaded).
 // Distinct from HideVideoKey which filters videos out of the library/queue entirely.
 val EnableVideoPlaybackKey = booleanPreferencesKey("enableVideoPlayback")
+// When ON (default OFF), leaving the app while a music video is playing enters Picture-in-
+// Picture mode so the video keeps playing in a small floating window. Requires video playback
+// to be enabled (EnableVideoPlaybackKey) — if video playback is off, this setting has no
+// effect because there is no video surface to float.
+val EnablePipModeKey = booleanPreferencesKey("enablePipMode")
 val AllowAgeRestrictedKey = booleanPreferencesKey("allowAgeRestricted")
 enum class DownloadSource {
     /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
@@ -184,6 +184,17 @@ val LocalVideoOnPreferredHeightChange = compositionLocalOf<(Int?) -> Unit> { {} 
 val LocalVideoAvailableHeights = compositionLocalOf<List<Int>> { emptyList() }
 
 /**
+ * CompositionLocal that tracks whether the host Activity is currently in
+ * Picture-in-Picture mode. When true, the player UI hides non-essential
+ * controls (overlays, gesture handlers, etc.) so the PiP window shows
+ * only the video surface — matching the standard Android PiP experience.
+ *
+ * Provided by [MainActivity] via [LocalIsInPipMode]. Defaults to false
+ * when no provider is present (e.g. in previews or non-Activity hosts).
+ */
+val LocalIsInPipMode = compositionLocalOf { false }
+
+/**
  * Provides a [VideoFullscreenStateHolder] to the content subtree.
  *
  * The holder is created with `remember` (not `rememberSaveable`) because
@@ -407,8 +418,14 @@ fun FullscreenVideoOverlay(
 ) {
     val context = LocalContext.current
     val playerConnection = LocalPlayerConnection.current
+    // PIP: when the activity is in Picture-in-Picture mode we hide all
+    // controls and gestures — the PiP window shows only the video surface.
+    // Tap-to-toggle, gestures, and the overflow sheet are all suppressed.
+    val isInPipMode = LocalIsInPipMode.current
     var qualityMenuOpen by remember { mutableStateOf(false) }
     var aspectRatioMenuOpen by remember { mutableStateOf(false) }
+    // In PiP mode, controls are ALWAYS hidden (the user can't interact
+    // with the PiP window beyond tap-to-expand, which the system handles).
     var controlsVisible by remember { mutableStateOf(false) }
     var isUserSeeking by remember { mutableStateOf(false) }
     var sliderPosition by remember { mutableStateOf<Long?>(null) }
@@ -575,7 +592,14 @@ fun FullscreenVideoOverlay(
     // dragging the seekbar, has the quality menu open, or has the 3-dot
     // overflow sheet open (those interactions need the controls to stay
     // visible).
-    LaunchedEffect(controlsVisible, isUserSeeking, qualityMenuOpen, showOverflowSheet) {
+    LaunchedEffect(controlsVisible, isUserSeeking, qualityMenuOpen, showOverflowSheet, isInPipMode) {
+        // In PiP mode the controls are never shown — skip the auto-hide
+        // timer entirely (it would be a no-op since controlsVisible is
+        // forced false by the click handler below, but skipping is cleaner).
+        if (isInPipMode) {
+            controlsVisible = false
+            return@LaunchedEffect
+        }
         if (controlsVisible && !isUserSeeking && !qualityMenuOpen && !showOverflowSheet) {
             kotlinx.coroutines.delay(FullscreenControlsAutoHideMs)
             controlsVisible = false
@@ -601,6 +625,11 @@ fun FullscreenVideoOverlay(
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onTap = { offset ->
+                            // PIP: suppress tap-to-toggle in PiP mode — the
+                            // system handles tap-to-expand on the PiP window
+                            // itself, and our controls would be unreadable
+                            // in the small PiP window anyway.
+                            if (isInPipMode) return@detectTapGestures
                             if (showOverflowSheet) {
                                 // Tapping outside the sheet dismisses it instead of toggling overlay.
                                 scope.launch { sheetState.hide() }.invokeOnCompletion {
@@ -614,6 +643,8 @@ fun FullscreenVideoOverlay(
                             }
                         },
                         onDoubleTap = { offset ->
+                            // PIP: suppress double-tap seek in PiP mode.
+                            if (isInPipMode) return@detectTapGestures
                             // Double-tap seek: left half rewinds 10s, right half skips 10s.
                             // Suppress when the overflow sheet is open.
                             if (!showOverflowSheet && playerConnection != null) {
@@ -782,8 +813,13 @@ fun FullscreenVideoOverlay(
         //   - Top-right: quality picker (if >1 height) + 3-dot overflow + fullscreen-exit
         //   - Center: previous | play/pause | next
         //   - Bottom: seekbar (uses selected slider style) + time labels
+        //
+        // PIP: the entire controls overlay is suppressed when in PiP mode
+        // (controlsVisible is forced false by the LaunchedEffect above, and
+        // we also gate the AnimatedVisibility on !isInPipMode for belt-and-
+        // suspenders safety).
         AnimatedVisibility(
-            visible = controlsVisible && !showOverflowSheet,
+            visible = controlsVisible && !showOverflowSheet && !isInPipMode,
             enter = fadeIn(animationSpec = tween(200)),
             exit = fadeOut(animationSpec = tween(200)),
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2327,6 +2327,18 @@ fun BottomSheetPlayer(
         // When the overlay is visible, the InlineVideoPlayer (inside the
         // BottomSheet) skips rendering its own surface (`if (!isFullscreen)`),
         // ensuring only ONE surface is attached to the ExoPlayer at a time.
+        //
+        // PIP: when the activity is in Picture-in-Picture mode we force the
+        // fullscreen overlay on (so the video fills the PiP window) and the
+        // overlay itself hides all controls — the user sees only the video
+        // in the floating window. When PiP ends, the overlay reverts to its
+        // prior state.
+        val isInPipMode = moe.rukamori.archivetune.ui.player.LocalIsInPipMode.current
+        LaunchedEffect(isInPipMode, videoState) {
+            if (isInPipMode && videoState != null) {
+                videoFullscreenHolder.isFullscreen = true
+            }
+        }
         videoState?.let { vs ->
             if (videoFullscreenHolder.isFullscreen) {
                 FullscreenVideoOverlay(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -46,6 +46,7 @@ import moe.rukamori.archivetune.constants.DeviceMutePlaybackRecoveryVolumeKey
 import moe.rukamori.archivetune.constants.DownloadSource
 import moe.rukamori.archivetune.constants.DownloadSourceKey
 import moe.rukamori.archivetune.constants.EnableVideoPlaybackKey
+import moe.rukamori.archivetune.constants.EnablePipModeKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderEnabledKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderPackageKey
 import moe.rukamori.archivetune.constants.HISTORY_DURATION_DEFAULT
@@ -125,6 +126,11 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
         rememberPreference(
             EnableVideoPlaybackKey,
             defaultValue = true,
+        )
+    val (enablePipMode, onEnablePipModeChange) =
+        rememberPreference(
+            EnablePipModeKey,
+            defaultValue = false,
         )
     val (autoSkipNextOnError, onAutoSkipNextOnErrorChange) =
         rememberPreference(
@@ -310,6 +316,22 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                             icon = { Icon(painterResource(R.drawable.slow_motion_video), null) },
                             checked = enableVideoPlayback,
                             onCheckedChange = onEnableVideoPlaybackChange,
+                        )
+                    }
+                }
+
+                item {
+                    Column(modifier = positions.modifierFor("enable_pip_mode")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.enable_pip_mode)) },
+                            description = stringResource(R.string.enable_pip_mode_desc),
+                            icon = { Icon(painterResource(R.drawable.player_pip), null) },
+                            checked = enablePipMode,
+                            onCheckedChange = onEnablePipModeChange,
+                            // PiP requires a video surface to float — disable the toggle
+                            // (and grey it out) when video playback is off, so the user
+                            // can't enable a setting that would have no effect.
+                            isEnabled = enableVideoPlayback,
                         )
                     }
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -35,6 +35,7 @@ import moe.rukamori.archivetune.constants.DisableAnimationsKey
 import moe.rukamori.archivetune.constants.DisableBlurKey
 import moe.rukamori.archivetune.constants.DisableScreenshotKey
 import moe.rukamori.archivetune.constants.EnableVideoPlaybackKey
+import moe.rukamori.archivetune.constants.EnablePipModeKey
 import moe.rukamori.archivetune.constants.DynamicThemeKey
 import moe.rukamori.archivetune.constants.EnableDiscordRPCKey
 import moe.rukamori.archivetune.constants.EnableLastFMScrobblingKey
@@ -179,11 +180,12 @@ fun buildSettingsGroups(
             title = stringResource(R.string.settings_playback_title),
             subtitle = stringResource(R.string.settings_playback_subtitle),
             accentColor = MaterialTheme.colorScheme.tertiary,
-            keywords = listOf("playback", "player", "audio", "quality", "equalizer", "eq", "volume", "crossfade", "gapless", "flac", "lossless", "hi-res", "sample rate", "bitrate", "video", "music video", "video playback"),
+            keywords = listOf("playback", "player", "audio", "quality", "equalizer", "eq", "volume", "crossfade", "gapless", "flac", "lossless", "hi-res", "sample rate", "bitrate", "video", "music video", "video playback", "pip", "picture in picture", "floating", "minimize"),
             onClick = { navController.navigate("settings/player") },
             children = listOf(
                 SettingsChild("Low data mode", "low_data_mode", listOf("data", "data saver", "low quality", "data mode")) { SearchResultSwitch(LowDataModeKey, true) },
                 SettingsChild("Enable video playback", "enable_video_playback", listOf("video", "music video", "mv", "video playback", "captions", "subtitles")) { SearchResultSwitch(EnableVideoPlaybackKey, true) },
+                SettingsChild("Enable PiP mode", "enable_pip_mode", listOf("pip", "picture in picture", "floating video", "minimize", "pop out", "overlay")) { SearchResultSwitch(EnablePipModeKey, false) },
                 SettingsChild("History duration", "history_duration", listOf("history", "duration", "recent", "queue length")),
                 SettingsChild("Crossfade", "crossfade", listOf("crossfade", "fade", "transition", "mix", "blend")) { SearchResultSwitch(CrossfadeEnabledKey, false) },
                 SettingsChild("Crossfade gapless", "crossfade_gapless", listOf("crossfade gapless", "gapless crossfade", "seamless crossfade")) { SearchResultSwitch(CrossfadeGaplessKey, true) },

--- a/app/src/main/res/drawable/player_pip.xml
+++ b/app/src/main/res/drawable/player_pip.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Picture-in-Picture: a large outer rectangle (the screen)
+         with a smaller filled rectangle in the bottom-right (the
+         floating PiP window). Matches the standard Android PiP
+         affordance iconography. -->
+    <!-- Outer screen rectangle (stroke only) -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,5 h18 a2,2 0 0 1 2,2 v10 a2,2 0 0 1 -2,2 h-18 a2,2 0 0 1 -2,-2 v-10 a2,2 0 0 1 2,-2 z
+                          M3,7 v10 h18 v-10 z" />
+    <!-- Inner PiP window (solid fill) in the bottom-right corner -->
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,12 h8 a1,1 0 0 1 1,1 v4 a1,1 0 0 1 -1,1 h-8 a1,1 0 0 1 -1,-1 v-4 a1,1 0 0 1 1,-1 z" />
+</vector>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -411,6 +411,9 @@
     <!-- Enable video playback setting (Player & audio settings) -->
     <string name="enable_video_playback">Enable video playback</string>
     <string name="enable_video_playback_desc">Show music videos inline in the player and keep audio/video in sync. When disabled, music videos play as audio only.</string>
+    <!-- Enable PiP mode setting (Player & audio settings) -->
+    <string name="enable_pip_mode">Enable PiP mode</string>
+    <string name="enable_pip_mode_desc">When a music video is playing and you leave the app, it keeps playing in a small floating window (Picture-in-Picture). Requires video playback to be enabled.</string>
     <string name="percentage_format">%d%%</string>
     <string name="import_online">Import a \"m3u\" playlists</string>
     <string name="import_csv">Import a \"csv\" playlists</string>


### PR DESCRIPTION
## Summary

Adds a new **"Enable PiP mode"** toggle to **Playback settings**. When
enabled, leaving the app while a music video is playing enters Android's
Picture-in-Picture mode — the video keeps playing in a small floating
window over other apps.

User's exact request: *"Add an option in playback settings named Enable
PiP mode. whenever I'm playing a video song and i minimize the app it
should play in player in player mode."*

---

## What it does

When a music video is playing and the user leaves the app (presses Home
or recents), the activity enters PiP mode. The video surface fills the
PiP window — no controls, no overlays, just the video. Tapping the PiP
window expands back to the full app (handled by the system).

The feature is **off by default** (opt-in via the new toggle). It is
also automatically disabled (greyed out in the UI) when "Enable video
playback" is off, since PiP requires a video surface to float.

---

## How it works

### 1. Setting (opt-in, default OFF)

- **New preference key** `EnablePipModeKey` (`booleanPreferencesKey`,
  default `false`) in `PreferenceKeys.kt`.
- **New strings** `enable_pip_mode` + `enable_pip_mode_desc` in
  `archivetune_strings.xml`.
- **New drawable** `player_pip.xml` — a small filled rectangle inside a
  larger outlined rectangle (the standard PiP affordance iconography).
- **New `SwitchPreference`** in `PlayerSettings.kt`, placed immediately
  below the "Enable video playback" toggle, with
  `isEnabled = enableVideoPlayback` so the toggle greys out when video
  playback is off.
- **New `SettingsChild` entry** in `SettingsDataBuilders.kt` so the
  setting is searchable via the settings search (keywords: "pip",
  "picture in picture", "floating video", "minimize", "pop out",
  "overlay").

### 2. AndroidManifest

Added `android:supportsPictureInPicture="true"` to the `MainActivity`
declaration. Without this attribute, calling `enterPictureInPictureMode`
throws `IllegalStateException`.

### 3. MainActivity — PiP entry logic

New overrides + helpers on `MainActivity`:

- **`onUserLeaveHint()`**: called by the system when the user presses
  Home (or otherwise leaves the app via a user-initiated action). If
  the current playback session is PiP-eligible (see `isPipEligible`),
  we call `enterPictureInPictureMode(buildPipParams())`.

- **`isPipEligible()`**: checks ALL of:
  1. `Build.VERSION.SDK_INT >= O` (PiP requires API 26+; the app's
     minSdk is 26 so this is always true — kept for defensive clarity).
  2. Device supports PiP (`PackageManager.FEATURE_PICTURE_IN_PICTURE`).
  3. `EnablePipModeKey` is true (user opted in).
  4. `EnableVideoPlaybackKey` is true (video playback is on).
  5. Current media is a music video (`isMusicVideo == true`) and NOT a
     local file (local audio has no video stream to float).
  6. Playback is actively playing (not paused) — entering PiP for a
     paused video would show a frozen frame.

- **`buildPipParams()`**: builds `PictureInPictureParams` with a 16:9
  aspect ratio (the standard music-video aspect ratio on YouTube Music).
  16:9 (1.78) is well within Android's supported range of [1.0, 2.39].

- **`onPictureInPictureModeChanged(isInPip, newConfig)`**: updates the
  `isInPictureInPictureModeState` Compose state field so the rest of
  the app can react to PiP mode changes.

- **`isInPictureInPictureModeState`**: a `mutableStateOf<Boolean>`
  exposed publicly so composables can read it. Provided to the Compose
  tree via the new `LocalIsInPipMode` CompositionLocal.

### 4. UI adaptation in PiP mode

New CompositionLocal `LocalIsInPipMode` in `InlineVideoPlayer.kt`,
provided by `MainActivity`'s `CompositionLocalProvider` block.

When `LocalIsInPipMode.current` is true:

- **`Player.kt`**: a `LaunchedEffect` forces
  `videoFullscreenHolder.isFullscreen = true` so the
  `FullscreenVideoOverlay` shows (filling the screen with the video
  surface). This ensures the PiP window shows only the video, not the
  BottomSheet content.

- **`FullscreenVideoOverlay`** (`InlineVideoPlayer.kt`):
  - The auto-hide `LaunchedEffect` forces `controlsVisible = false`.
  - The tap-to-toggle handler returns early (no toggling controls).
  - The double-tap seek handler returns early (no seeking).
  - The `AnimatedVisibility` for the controls overlay is gated on
    `!isInPipMode` (belt-and-suspenders safety).

  Result: the PiP window shows **only the video surface** — no controls,
  no gestures, no overlays. The user can tap the PiP window to expand
  back to the full app (handled by the system).

### 5. Error handling

`enterPictureInPictureMode` is wrapped in a try/catch — some OEMs throw
`IllegalStateException` if PiP is attempted while the activity isn't in
a valid state. The exception is swallowed (reported via
`reportException` for telemetry) so the user simply doesn't get PiP
this time rather than seeing a crash.

---

## Files changed (9 files, +211 / -3)

| File | Change |
|------|--------|
| `AndroidManifest.xml` | `+ android:supportsPictureInPicture="true"` on MainActivity |
| `MainActivity.kt` | PiP entry logic (`onUserLeaveHint`, `isPipEligible`, `buildPipParams`, `onPictureInPictureModeChanged`) + `isInPictureInPictureModeState` Compose state + `LocalIsInPipMode` provider |
| `PreferenceKeys.kt` | `+ EnablePipModeKey` |
| `InlineVideoPlayer.kt` | `+ LocalIsInPipMode` CompositionLocal + FullscreenVideoOverlay controls suppression in PiP |
| `Player.kt` | `LaunchedEffect` to force fullscreen on when in PiP |
| `PlayerSettings.kt` | `+ SwitchPreference` for the toggle (with `isEnabled = enableVideoPlayback`) |
| `SettingsDataBuilders.kt` | `+ SettingsChild` search entry |
| `drawable/player_pip.xml` | New vector icon |
| `archivetune_strings.xml` | `+ enable_pip_mode`, `+ enable_pip_mode_desc` |

---

## Build status

Could not run a local Gradle compile — the dev container has only 4 GB
RAM / 0 swap and the Kotlin daemon was OOM-killed before reaching the
compile task (same constraint as PRs #90, #99, #103). All code was
manually reviewed for:
- Correct imports (verified all new imports exist in their respective
  packages).
- Correct API level usage (PiP APIs are API 26+; app minSdk is 26).
- Correct signatures (`onPictureInPictureModeChanged(Boolean,
  Configuration)` matches `Activity.onPictureInPictureModeChanged`).
- Correct CompositionLocal provider pattern (matches existing
  `LocalPlayerConnection provides playerConnection` pattern).

Recommend running `./gradlew assembleGmsMobileUniversalDebug` on CI
before merge.