### PR TITLE
feat+fix: settings reorg (downloads/extras sub-pages, video group) + lyrics auto-translate + YIM share pill fix

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsTranslator.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsTranslator.kt
@@ -7,6 +7,8 @@
 
 package moe.rukamori.archivetune.ai
 
+import kotlinx.coroutines.CancellationException
+
 class AiLyricsTranslator {
     suspend fun translate(
         config: AiServiceConfig,
@@ -24,18 +26,64 @@ class AiLyricsTranslator {
         val translated = mutableMapOf<Int, String>()
         document.segments.chunkedByBudget().forEach { batch ->
             val batchTranslations =
-                AiTextService.translateLines(
+                translateBatchResilient(
                     config = config,
                     targetLanguage = normalizedLanguage,
-                    lines = batch.map { it.text },
+                    batch = batch,
                     formatName = document.formatName,
                 )
             batch.forEachIndexed { index, segment ->
-                translated[segment.id] = batchTranslations[index]
+                translated[segment.id] = batchTranslations.getOrNull(index) ?: segment.text
             }
         }
         return document.rebuild(translated).also { result ->
             synchronized(resultCache) { resultCache[cacheKey] = result }
+        }
+    }
+
+    private suspend fun translateBatchResilient(
+        config: AiServiceConfig,
+        targetLanguage: String,
+        batch: List<AiLyricsSegment>,
+        formatName: String,
+    ): List<String> {
+        if (batch.isEmpty()) return emptyList()
+        return try {
+            val result =
+                AiTextService.translateLines(
+                    config = config,
+                    targetLanguage = targetLanguage,
+                    lines = batch.map { it.text },
+                    formatName = formatName,
+                )
+            if (result.size == batch.size) {
+                result
+            } else {
+                throw AiServiceException("AI response changed the lyric segment count")
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            if (batch.size <= 1) {
+                batch.map { it.text }
+            } else {
+                val mid = batch.size / 2
+                val left =
+                    translateBatchResilient(
+                        config = config,
+                        targetLanguage = targetLanguage,
+                        batch = batch.subList(0, mid),
+                        formatName = formatName,
+                    )
+                val right =
+                    translateBatchResilient(
+                        config = config,
+                        targetLanguage = targetLanguage,
+                        batch = batch.subList(mid, batch.size),
+                        formatName = formatName,
+                    )
+                left + right
+            }
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AutoLyricsTranslator.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AutoLyricsTranslator.kt
@@ -1,0 +1,114 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ai
+
+import android.content.Context
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import moe.rukamori.archivetune.constants.AiApiKeyKey
+import moe.rukamori.archivetune.constants.AiCustomEndpointKey
+import moe.rukamori.archivetune.constants.AiCustomModelKey
+import moe.rukamori.archivetune.constants.AiProvider
+import moe.rukamori.archivetune.constants.AiProviderKey
+import moe.rukamori.archivetune.constants.AiSelectedModelKey
+import moe.rukamori.archivetune.constants.AutoTranslateLyricsKey
+import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
+import moe.rukamori.archivetune.db.MusicDatabase
+import moe.rukamori.archivetune.db.entities.LyricsEntity
+import moe.rukamori.archivetune.extensions.toEnum
+import moe.rukamori.archivetune.models.MediaMetadata
+import moe.rukamori.archivetune.utils.dataStore
+import javax.inject.Inject
+
+class AutoLyricsTranslator
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val database: MusicDatabase,
+    ) {
+        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        private var job: Job? = null
+
+        fun onLyricsFetched(mediaMetadata: MediaMetadata, lyricsText: String?) {
+            job?.cancel()
+            if (lyricsText.isNullOrBlank()) return
+            if (lyricsText == LyricsEntity.LYRICS_NOT_FOUND) return
+            job =
+                scope.launch {
+                    try {
+                        val prefs = context.dataStore.data.first()
+                        val enabled = prefs[AutoTranslateLyricsKey] ?: false
+                        if (!enabled) return@launch
+                        val provider = prefs[AiProviderKey].toEnum(AiProvider.NONE)
+                        if (provider == AiProvider.NONE) return@launch
+                        if (prefs[AiApiKeyKey].isNullOrBlank() && provider != AiProvider.CUSTOM) return@launch
+
+                        val existing = database.lyrics(mediaMetadata.id).first()
+                        if (existing != null && existing.source == LyricsEntity.Source.AI_TRANSLATION.value) return@launch
+
+                        val sample = lyricsText.take(1000)
+                        val nonAsciiCount = sample.count { it.code > 0x7F }
+                        if (nonAsciiCount < 5) return@launch
+
+                        val targetLanguage = prefs[TranslatorTargetLangKey].orEmpty()
+                        val config =
+                            AiServiceConfig(
+                                provider = provider,
+                                apiKey = prefs[AiApiKeyKey].orEmpty(),
+                                customEndpoint = prefs[AiCustomEndpointKey].orEmpty(),
+                                model =
+                                    if (provider == AiProvider.CUSTOM) {
+                                        prefs[AiCustomModelKey].orEmpty()
+                                    } else {
+                                        prefs[AiSelectedModelKey].orEmpty()
+                                    },
+                            )
+                        val translated =
+                            AiLyricsTranslator().translate(
+                                config = config,
+                                lyrics = lyricsText,
+                                targetLanguage = targetLanguage,
+                            )
+                        if (translated.isBlank() || translated == lyricsText) return@launch
+                        database.query {
+                            replaceLyrics(
+                                id = mediaMetadata.id,
+                                lyrics = translated,
+                                source = LyricsEntity.Source.AI_TRANSLATION.value,
+                            )
+                        }
+                        Log.d(TAG, "Auto-translated lyrics for: ${mediaMetadata.title}")
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Auto-translation failed for ${mediaMetadata.title}: ${e.message}")
+                    }
+                }
+        }
+
+        fun cancel() {
+            job?.cancel()
+            job = null
+        }
+
+        fun destroy() {
+            cancel()
+            scope.coroutineContext[Job]?.cancel()
+        }
+
+        companion object {
+            private const val TAG = "AutoLyricsTranslator"
+        }
+    }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -269,6 +269,7 @@ import moe.rukamori.archivetune.playback.artwork.isLocalArtworkUri
 import moe.rukamori.archivetune.innertube.models.response.PlayerResponse
 import moe.rukamori.archivetune.lastfm.LastFM
 import moe.rukamori.archivetune.lyrics.LyricsHelper
+import moe.rukamori.archivetune.ai.AutoLyricsTranslator
 import moe.rukamori.archivetune.lyrics.LyricsPreloadManager
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.models.PersistPlayerState
@@ -589,6 +590,8 @@ class MusicService :
     // before promoting the incoming player.
     private val crossfadeGeneration = AtomicLong(0)
     private var lyricsPreloadManager: LyricsPreloadManager? = null
+    @Inject
+    lateinit var autoLyricsTranslator: AutoLyricsTranslator
 
     // The currently active session-facing player. Replaced when a crossfade promotes the
     // incoming player. Observers (PlayerConnection) must follow this flow instead of
@@ -1366,6 +1369,7 @@ class MusicService :
                 stored == null ||
                     stored.lyrics == LyricsEntity.LYRICS_NOT_FOUND ||
                     stored.providerName.isBlank()
+            val finalLyricsText: String?
             if (shouldFetch) {
                 val result = lyricsHelper.getLyricsWithProvider(mediaMetadata)
                 database.query {
@@ -1382,7 +1386,11 @@ class MusicService :
                         )
                     }
                 }
+                finalLyricsText = result.lyrics
+            } else {
+                finalLyricsText = stored?.lyrics
             }
+            autoLyricsTranslator.onLyricsFetched(mediaMetadata, finalLyricsText)
         }
 
         dataStore.data
@@ -9854,6 +9862,7 @@ class MusicService :
         }
         lyricsPreloadManager?.destroy()
         lyricsPreloadManager = null
+        autoLyricsTranslator.destroy()
         abandonAudioFocus()
         try {
             releaseAudioEffects()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -94,6 +94,7 @@ import moe.rukamori.archivetune.ui.screens.settings.PrivacySettings
 import moe.rukamori.archivetune.ui.screens.settings.SettingsScreen
 import moe.rukamori.archivetune.ui.screens.settings.SourceSettings
 import moe.rukamori.archivetune.ui.screens.settings.StorageSettings
+import moe.rukamori.archivetune.ui.screens.settings.DownloadsSettings
 import moe.rukamori.archivetune.ui.screens.settings.ThemeCreatorScreen
 import moe.rukamori.archivetune.ui.screens.settings.UpdateScreen
 import moe.rukamori.archivetune.viewmodels.OnlineSearchSort
@@ -474,6 +475,12 @@ fun NavGraphBuilder.navigationBuilder(
     }
     composable("settings/storage/export_songs") {
         ExportDownloadedSongsScreen(navController)
+    }
+    composable(
+        route = "settings/downloads?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        DownloadsSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable(
         route = "settings/privacy?scrollTo={scrollTo}",

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -52,6 +52,7 @@ import moe.rukamori.archivetune.ui.screens.settings.AboutScreen
 import moe.rukamori.archivetune.ui.screens.settings.AccountSettings
 import moe.rukamori.archivetune.ui.screens.settings.AiIntegrationSettings
 import moe.rukamori.archivetune.ui.screens.settings.AodCustomizedScreen
+import moe.rukamori.archivetune.ui.screens.settings.AppearanceExtrasSettings
 import moe.rukamori.archivetune.ui.screens.settings.AppearanceSettings
 import moe.rukamori.archivetune.ui.screens.settings.BackupAndRestore
 import moe.rukamori.archivetune.ui.screens.settings.ChangelogScreen
@@ -409,6 +410,9 @@ fun NavGraphBuilder.navigationBuilder(
         arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
     ) {
         AppearanceSettings(navController, it.savedStateHandle["scrollTo"])
+    }
+    composable("settings/appearance/extras") {
+        AppearanceExtrasSettings(navController)
     }
     composable("settings/appearance/icon") {
         IconScreen(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
@@ -213,38 +213,6 @@ private fun YearInMusicRecapScreen(
             modifier = Modifier.fillMaxSize(),
         )
 
-        RecapCardPager(
-            cards = cards,
-            pagerState = pagerState,
-            isShareCaptureMode = isShareCaptureMode,
-            onCardBoundsChanged = { currentCardBounds = it },
-            onTopSongLongClick = { song ->
-                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                menuState.show {
-                    SongMenu(
-                        originalSong = song,
-                        navController = navController,
-                        onDismiss = menuState::dismiss,
-                    )
-                }
-            },
-            onTopArtistLongClick = { artist ->
-                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                menuState.show {
-                    ArtistMenu(
-                        originalArtist = artist,
-                        coroutineScope = coroutineScope,
-                        onDismiss = menuState::dismiss,
-                    )
-                }
-            },
-            onShare = onShare,
-            isGenerating = isGeneratingImage,
-            modifier =
-                Modifier
-                    .fillMaxSize(),
-        )
-
         val onShare: () -> Unit = {
             if (!isGeneratingImage) {
                 isGeneratingImage = true
@@ -304,6 +272,38 @@ private fun YearInMusicRecapScreen(
                 }
             }
         }
+
+        RecapCardPager(
+            cards = cards,
+            pagerState = pagerState,
+            isShareCaptureMode = isShareCaptureMode,
+            onCardBoundsChanged = { currentCardBounds = it },
+            onTopSongLongClick = { song ->
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                menuState.show {
+                    SongMenu(
+                        originalSong = song,
+                        navController = navController,
+                        onDismiss = menuState::dismiss,
+                    )
+                }
+            },
+            onTopArtistLongClick = { artist ->
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                menuState.show {
+                    ArtistMenu(
+                        originalArtist = artist,
+                        coroutineScope = coroutineScope,
+                        onDismiss = menuState::dismiss,
+                    )
+                }
+            },
+            onShare = onShare,
+            isGenerating = isGeneratingImage,
+            modifier =
+                Modifier
+                    .fillMaxSize(),
+        )
 
         if (canShare && pagerState.currentPage > 0) {
             Box(modifier = Modifier.align(Alignment.BottomEnd)) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
@@ -31,9 +31,11 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -702,13 +704,14 @@ private fun IntroRecapCard(
                 lineHeight = 19.sp,
             )
             Row(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min),
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 Box(
                     modifier =
                         Modifier
                             .weight(1f)
+                            .fillMaxHeight()
                             .clip(RoundedCornerShape(999.dp))
                             .background(RecapInk)
                             .padding(vertical = 14.dp),
@@ -719,15 +722,18 @@ private fun IntroRecapCard(
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Black,
                         color = Color.White,
+                        textAlign = TextAlign.Center,
                     )
                 }
                 Box(
                     modifier =
                         Modifier
                             .weight(1f)
+                            .fillMaxHeight()
                             .clip(RoundedCornerShape(999.dp))
                             .background(RecapRed)
-                            .clickable(onClick = onShare),
+                            .clickable(onClick = onShare)
+                            .padding(vertical = 14.dp),
                     contentAlignment = Alignment.Center,
                 ) {
                     Row(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
@@ -238,73 +238,78 @@ private fun YearInMusicRecapScreen(
                     )
                 }
             },
+            onShare = onShare,
+            isGenerating = isGeneratingImage,
             modifier =
                 Modifier
                     .fillMaxSize(),
         )
 
-        if (canShare) {
+        val onShare: () -> Unit = {
+            if (!isGeneratingImage) {
+                isGeneratingImage = true
+                coroutineScope.launch {
+                    try {
+                        isShareCaptureMode = true
+                        awaitNextPreDraw(view)
+                        awaitNextPreDraw(view)
+
+                        val raw =
+                            ComposeToImage.captureViewBitmap(
+                                view = view,
+                                backgroundColor = RecapBlack.toArgb(),
+                            )
+                        val bounds = currentCardBounds
+                        val cardBitmap =
+                            if (bounds != null && bounds.width > 0f && bounds.height > 0f) {
+                                ComposeToImage.cropBitmap(
+                                    source = raw,
+                                    left = bounds.left.toInt().coerceAtLeast(0),
+                                    top = bounds.top.toInt().coerceAtLeast(0),
+                                    width = bounds.width.toInt().coerceAtLeast(1),
+                                    height = bounds.height.toInt().coerceAtLeast(1),
+                                )
+                            } else {
+                                raw
+                            }
+                        val fitted =
+                            ComposeToImage.fitBitmap(
+                                source = cardBitmap,
+                                targetWidth = 1080,
+                                targetHeight = 1920,
+                                backgroundColor = RecapBlack.toArgb(),
+                            )
+                        val uri =
+                            ComposeToImage.saveBitmapAsFile(
+                                context = context,
+                                bitmap = fitted,
+                                fileName = "ArchiveTune_YearInMusic_${content.selectedYear}_${currentPage + 1}",
+                            )
+                        val shareIntent =
+                            Intent(Intent.ACTION_SEND).apply {
+                                type = "image/png"
+                                putExtra(Intent.EXTRA_STREAM, uri)
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                            }
+                        context.startActivity(
+                            Intent.createChooser(
+                                shareIntent,
+                                context.getString(R.string.share_summary),
+                            ),
+                        )
+                    } finally {
+                        isShareCaptureMode = false
+                        isGeneratingImage = false
+                    }
+                }
+            }
+        }
+
+        if (canShare && pagerState.currentPage > 0) {
             Box(modifier = Modifier.align(Alignment.BottomEnd)) {
                 RecapShareButton(
                     isGenerating = isGeneratingImage,
-                    onClick = {
-                        if (isGeneratingImage) return@RecapShareButton
-                        isGeneratingImage = true
-                        coroutineScope.launch {
-                            try {
-                                isShareCaptureMode = true
-                                awaitNextPreDraw(view)
-                                awaitNextPreDraw(view)
-
-                                val raw =
-                                    ComposeToImage.captureViewBitmap(
-                                        view = view,
-                                        backgroundColor = RecapBlack.toArgb(),
-                                    )
-                                val bounds = currentCardBounds
-                                val cardBitmap =
-                                    if (bounds != null && bounds.width > 0f && bounds.height > 0f) {
-                                        ComposeToImage.cropBitmap(
-                                            source = raw,
-                                            left = bounds.left.toInt().coerceAtLeast(0),
-                                            top = bounds.top.toInt().coerceAtLeast(0),
-                                            width = bounds.width.toInt().coerceAtLeast(1),
-                                            height = bounds.height.toInt().coerceAtLeast(1),
-                                        )
-                                    } else {
-                                        raw
-                                    }
-                                val fitted =
-                                    ComposeToImage.fitBitmap(
-                                        source = cardBitmap,
-                                        targetWidth = 1080,
-                                        targetHeight = 1920,
-                                        backgroundColor = RecapBlack.toArgb(),
-                                    )
-                                val uri =
-                                    ComposeToImage.saveBitmapAsFile(
-                                        context = context,
-                                        bitmap = fitted,
-                                        fileName = "ArchiveTune_YearInMusic_${content.selectedYear}_${currentPage + 1}",
-                                    )
-                                val shareIntent =
-                                    Intent(Intent.ACTION_SEND).apply {
-                                        type = "image/png"
-                                        putExtra(Intent.EXTRA_STREAM, uri)
-                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                    }
-                                context.startActivity(
-                                    Intent.createChooser(
-                                        shareIntent,
-                                        context.getString(R.string.share_summary),
-                                    ),
-                                )
-                            } finally {
-                                isShareCaptureMode = false
-                                isGeneratingImage = false
-                            }
-                        }
-                    },
+                    onClick = onShare,
                     modifier =
                         Modifier
                             .windowInsetsPadding(
@@ -414,6 +419,8 @@ private fun RecapCardPager(
     onCardBoundsChanged: (Rect) -> Unit,
     onTopSongLongClick: (Song) -> Unit,
     onTopArtistLongClick: (Artist) -> Unit,
+    onShare: () -> Unit,
+    isGenerating: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -444,6 +451,8 @@ private fun RecapCardPager(
             canAdvance = canAdvance,
             onTopSongLongClick = onTopSongLongClick,
             onTopArtistLongClick = onTopArtistLongClick,
+            onShare = onShare,
+            isGenerating = isGenerating,
             modifier =
                 Modifier
                     .fillMaxSize()
@@ -464,6 +473,8 @@ private fun RecapCardFrame(
     canAdvance: Boolean,
     onTopSongLongClick: (Song) -> Unit,
     onTopArtistLongClick: (Artist) -> Unit,
+    onShare: () -> Unit,
+    isGenerating: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val gradient =
@@ -503,6 +514,8 @@ private fun RecapCardFrame(
                     IntroRecapCard(
                         card = card,
                         applySafeContentInsets = applySafeContentInsets,
+                        onShare = onShare,
+                        isGenerating = isGenerating,
                     )
                 }
 
@@ -587,6 +600,8 @@ private fun EmptyRecapCard(
 private fun IntroRecapCard(
     card: YearInMusicRecapCard.Intro,
     applySafeContentInsets: Boolean,
+    onShare: () -> Unit,
+    isGenerating: Boolean,
 ) {
     Box(
         modifier =
@@ -686,21 +701,60 @@ private fun IntroRecapCard(
                 color = Color.White.copy(alpha = 0.82f),
                 lineHeight = 19.sp,
             )
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(999.dp))
-                        .background(RecapInk)
-                        .padding(vertical = 14.dp),
-                contentAlignment = Alignment.Center,
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Text(
-                    text = stringResource(R.string.year_in_music_swipe_begin),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Black,
-                    color = Color.White,
-                )
+                Box(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(999.dp))
+                            .background(RecapInk)
+                            .padding(vertical = 14.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(R.string.year_in_music_swipe_begin),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Black,
+                        color = Color.White,
+                    )
+                }
+                Box(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(999.dp))
+                            .background(RecapRed)
+                            .clickable(onClick = onShare),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        if (isGenerating) {
+                            CircularWavyProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                color = RecapCream,
+                            )
+                        } else {
+                            Icon(
+                                painter = painterResource(R.drawable.share),
+                                contentDescription = null,
+                                tint = RecapCream,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.year_in_music_current_card),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Black,
+                            color = RecapCream,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
@@ -1,0 +1,165 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.HideCachedCardKey
+import moe.rukamori.archivetune.constants.HideLikedSongsCardKey
+import moe.rukamori.archivetune.constants.HideLocalFilesCardKey
+import moe.rukamori.archivetune.constants.HideOfflineCardKey
+import moe.rukamori.archivetune.constants.HideTop50CardKey
+import moe.rukamori.archivetune.constants.ShowHomeCategoryChipsKey
+import moe.rukamori.archivetune.constants.ShowTagsInLibraryKey
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.PreferenceGroup
+import moe.rukamori.archivetune.ui.component.SwitchPreference
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.rememberPreference
+
+@Composable
+fun AppearanceExtrasSettings(navController: NavController) {
+    val (showHomeCategoryChips, onShowHomeCategoryChipsChange) =
+        rememberPreference(ShowHomeCategoryChipsKey, defaultValue = false)
+    val (showTagsInLibrary, onShowTagsInLibraryChange) =
+        rememberPreference(ShowTagsInLibraryKey, defaultValue = false)
+    val (hideLikedSongsCard, onHideLikedSongsCardChange) =
+        rememberPreference(HideLikedSongsCardKey, defaultValue = false)
+    val (hideOfflineCard, onHideOfflineCardChange) =
+        rememberPreference(HideOfflineCardKey, defaultValue = false)
+    val (hideCachedCard, onHideCachedCardChange) =
+        rememberPreference(HideCachedCardKey, defaultValue = false)
+    val (hideLocalFilesCard, onHideLocalFilesCardChange) =
+        rememberPreference(HideLocalFilesCardKey, defaultValue = false)
+    val (hideTop50Card, onHideTop50CardChange) =
+        rememberPreference(HideTop50CardKey, defaultValue = false)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.extras)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(
+                    LocalPlayerAwareWindowInsets.current.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                    ),
+                ).verticalScroll(scrollState)
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
+            PreferenceGroup(title = stringResource(R.string.extras)) {
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.show_home_category_chips)) },
+                        description = stringResource(R.string.show_home_category_chips_desc),
+                        icon = { Icon(painterResource(R.drawable.home_outlined), null) },
+                        checked = showHomeCategoryChips,
+                        onCheckedChange = onShowHomeCategoryChipsChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.show_tags_in_library)) },
+                        description = stringResource(R.string.show_tags_in_library_desc),
+                        icon = { Icon(painterResource(R.drawable.filter_alt), null) },
+                        checked = showTagsInLibrary,
+                        onCheckedChange = onShowTagsInLibraryChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_liked_songs_card)) },
+                        description = stringResource(R.string.hide_liked_songs_card_desc),
+                        icon = { Icon(painterResource(R.drawable.favorite), null) },
+                        checked = hideLikedSongsCard,
+                        onCheckedChange = onHideLikedSongsCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_offline_card)) },
+                        description = stringResource(R.string.hide_offline_card_desc),
+                        icon = { Icon(painterResource(R.drawable.offline), null) },
+                        checked = hideOfflineCard,
+                        onCheckedChange = onHideOfflineCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_cached_card)) },
+                        description = stringResource(R.string.hide_cached_card_desc),
+                        icon = { Icon(painterResource(R.drawable.cached), null) },
+                        checked = hideCachedCard,
+                        onCheckedChange = onHideCachedCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_local_files_card)) },
+                        description = stringResource(R.string.hide_local_files_card_desc),
+                        icon = { Icon(painterResource(R.drawable.snippet_folder), null) },
+                        checked = hideLocalFilesCard,
+                        onCheckedChange = onHideLocalFilesCardChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.hide_top50_card)) },
+                        description = stringResource(R.string.hide_top50_card_desc),
+                        icon = { Icon(painterResource(R.drawable.trending_up), null) },
+                        checked = hideTop50Card,
+                        onCheckedChange = onHideTop50CardChange,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -78,11 +78,6 @@ import moe.rukamori.archivetune.constants.CustomFontUriKey
 import moe.rukamori.archivetune.constants.DarkModeKey
 import moe.rukamori.archivetune.constants.DefaultOpenTabKey
 import moe.rukamori.archivetune.constants.HideNavigationBarLabelsKey
-import moe.rukamori.archivetune.constants.HideCachedCardKey
-import moe.rukamori.archivetune.constants.HideLikedSongsCardKey
-import moe.rukamori.archivetune.constants.HideLocalFilesCardKey
-import moe.rukamori.archivetune.constants.HideOfflineCardKey
-import moe.rukamori.archivetune.constants.HideTop50CardKey
 import moe.rukamori.archivetune.constants.NavigationBarFrostedBlurKey
 import moe.rukamori.archivetune.constants.NavigationBarStyle
 import moe.rukamori.archivetune.constants.NavigationBarStyleKey
@@ -109,9 +104,7 @@ import moe.rukamori.archivetune.constants.PureBlackKey
 import moe.rukamori.archivetune.constants.QuickPicksDisplayMode
 import moe.rukamori.archivetune.constants.QuickPicksDisplayModeKey
 import moe.rukamori.archivetune.constants.RandomThemeOnStartupKey
-import moe.rukamori.archivetune.constants.ShowHomeCategoryChipsKey
 import moe.rukamori.archivetune.constants.ShowPlayerVolumeBarKey
-import moe.rukamori.archivetune.constants.ShowTagsInLibraryKey
 import moe.rukamori.archivetune.constants.SliderStyle
 import moe.rukamori.archivetune.constants.SliderStyleKey
 import moe.rukamori.archivetune.constants.SwipeSensitivityKey
@@ -168,16 +161,6 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
             HidePlayerThumbnailKey,
             defaultValue = false,
         )
-    val (hideLikedSongsCard, onHideLikedSongsCardChange) =
-        rememberPreference(HideLikedSongsCardKey, defaultValue = false)
-    val (hideOfflineCard, onHideOfflineCardChange) =
-        rememberPreference(HideOfflineCardKey, defaultValue = false)
-    val (hideCachedCard, onHideCachedCardChange) =
-        rememberPreference(HideCachedCardKey, defaultValue = false)
-    val (hideLocalFilesCard, onHideLocalFilesCardChange) =
-        rememberPreference(HideLocalFilesCardKey, defaultValue = false)
-    val (hideTop50Card, onHideTop50CardChange) =
-        rememberPreference(HideTop50CardKey, defaultValue = false)
     // The ArchiveTune Canvas artwork toggle lives in Player Settings → Artwork.
     val (thumbnailCornerRadius, onThumbnailCornerRadiusChange) =
         rememberPreference(
@@ -266,16 +249,6 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
             defaultValue = GridItemSize.SMALL,
         )
 
-    val (showTagsInLibrary, onShowTagsInLibraryChange) =
-        rememberPreference(
-            ShowTagsInLibraryKey,
-            defaultValue = true,
-        )
-    val (showHomeCategoryChips, onShowHomeCategoryChipsChange) =
-        rememberPreference(
-            ShowHomeCategoryChipsKey,
-            defaultValue = true,
-        )
     val (quickPicksDisplayMode, onQuickPicksDisplayModeChange) =
         rememberEnumPreference(
             QuickPicksDisplayModeKey,
@@ -1105,72 +1078,11 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 title = stringResource(R.string.extras),
             ) {
                 item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.show_home_category_chips)) },
-                        description = stringResource(R.string.show_home_category_chips_desc),
-                        icon = { Icon(painterResource(R.drawable.home_outlined), null) },
-                        checked = showHomeCategoryChips,
-                        onCheckedChange = onShowHomeCategoryChipsChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.show_tags_in_library)) },
-                        description = stringResource(R.string.show_tags_in_library_desc),
-                        icon = { Icon(painterResource(R.drawable.filter_alt), null) },
-                        checked = showTagsInLibrary,
-                        onCheckedChange = onShowTagsInLibraryChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.hide_liked_songs_card)) },
-                        description = stringResource(R.string.hide_liked_songs_card_desc),
-                        icon = { Icon(painterResource(R.drawable.favorite), null) },
-                        checked = hideLikedSongsCard,
-                        onCheckedChange = onHideLikedSongsCardChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.hide_offline_card)) },
-                        description = stringResource(R.string.hide_offline_card_desc),
-                        icon = { Icon(painterResource(R.drawable.offline), null) },
-                        checked = hideOfflineCard,
-                        onCheckedChange = onHideOfflineCardChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.hide_cached_card)) },
-                        description = stringResource(R.string.hide_cached_card_desc),
-                        icon = { Icon(painterResource(R.drawable.cached), null) },
-                        checked = hideCachedCard,
-                        onCheckedChange = onHideCachedCardChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.hide_local_files_card)) },
-                        description = stringResource(R.string.hide_local_files_card_desc),
-                        icon = { Icon(painterResource(R.drawable.snippet_folder), null) },
-                        checked = hideLocalFilesCard,
-                        onCheckedChange = onHideLocalFilesCardChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.hide_top50_card)) },
-                        description = stringResource(R.string.hide_top50_card_desc),
-                        icon = { Icon(painterResource(R.drawable.trending_up), null) },
-                        checked = hideTop50Card,
-                        onCheckedChange = onHideTop50CardChange,
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.extras)) },
+                        description = stringResource(R.string.settings_extras_subtitle),
+                        icon = { Icon(painterResource(R.drawable.discover_tune), null) },
+                        onClick = { navController.navigate("settings/appearance/extras") },
                     )
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -116,7 +116,6 @@ import moe.rukamori.archivetune.constants.SliderStyle
 import moe.rukamori.archivetune.constants.SliderStyleKey
 import moe.rukamori.archivetune.constants.SwipeSensitivityKey
 import moe.rukamori.archivetune.constants.SwipeThumbnailKey
-import moe.rukamori.archivetune.constants.SwipeToSongKey
 import moe.rukamori.archivetune.constants.ThumbnailCornerRadiusKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
@@ -265,12 +264,6 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
         rememberEnumPreference(
             GridItemsSizeKey,
             defaultValue = GridItemSize.SMALL,
-        )
-
-    val (swipeToSong, onSwipeToSongChange) =
-        rememberPreference(
-            SwipeToSongKey,
-            defaultValue = false,
         )
 
     val (showTagsInLibrary, onShowTagsInLibraryChange) =
@@ -573,21 +566,6 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         icon = { Icon(painterResource(R.drawable.animation), null) },
                         checked = disableAnimations,
                         onCheckedChange = onDisableAnimationsChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.force_high_refresh_rate)) },
-                        description =
-                            stringResource(
-                                R.string.max_supported_refresh_rate,
-                                supportedHighestFps.roundToInt(),
-                            ),
-                        icon = { Icon(painterResource(R.drawable.speed), null) },
-                        checked = forceHighRefreshRate,
-                        onCheckedChange = onForceHighRefreshRateChange,
-                        isEnabled = isHighRefreshRateSupported,
                     )
                 }
 
@@ -1120,7 +1098,12 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         onValueSelected = onDefaultChipChange,
                     )
                 }
+            }
 
+            PreferenceGroup(
+                modifier = positions.modifierFor("extras"),
+                title = stringResource(R.string.extras),
+            ) {
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.show_home_category_chips)) },
@@ -1188,15 +1171,6 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         icon = { Icon(painterResource(R.drawable.trending_up), null) },
                         checked = hideTop50Card,
                         onCheckedChange = onHideTop50CardChange,
-                    )
-                }
-
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.swipe_song_to_add)) },
-                        icon = { Icon(painterResource(R.drawable.swipe), null) },
-                        checked = swipeToSong,
-                        onCheckedChange = onSwipeToSongChange,
                     )
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
@@ -1,0 +1,230 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AutoDownloadOnLikeKey
+import moe.rukamori.archivetune.constants.DownloadSource
+import moe.rukamori.archivetune.constants.DownloadSourceKey
+import moe.rukamori.archivetune.constants.ExternalDownloaderEnabledKey
+import moe.rukamori.archivetune.constants.ExternalDownloaderPackageKey
+import moe.rukamori.archivetune.ui.component.ActionPromptDialog
+import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.ListPreference
+import moe.rukamori.archivetune.ui.component.PreferenceEntry
+import moe.rukamori.archivetune.ui.component.PreferenceGroup
+import moe.rukamori.archivetune.ui.component.SwitchPreference
+import moe.rukamori.archivetune.ui.component.TextFieldDialog
+import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.rememberEnumPreference
+import moe.rukamori.archivetune.utils.rememberPreference
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+
+@Composable
+fun DownloadsSettings(
+    navController: NavController,
+    scrollTo: String? = null,
+    viewModel: StorageSettingsViewModel = hiltViewModel(),
+) {
+    val (autoDownloadOnLike, onAutoDownloadOnLikeChange) =
+        rememberPreference(AutoDownloadOnLikeKey, defaultValue = false)
+    val (downloadSource, onDownloadSourceChange) =
+        rememberEnumPreference(DownloadSourceKey, defaultValue = DownloadSource.AUTO)
+    val (externalDownloaderEnabled, onExternalDownloaderEnabledChange) =
+        rememberPreference(ExternalDownloaderEnabledKey, defaultValue = false)
+    val (externalDownloaderPackage, onExternalDownloaderPackageChange) =
+        rememberPreference(ExternalDownloaderPackageKey, defaultValue = "")
+
+    var showExternalDownloaderPackageDialog by remember { mutableStateOf(false) }
+    var clearDownloads by remember { mutableStateOf(false) }
+
+    if (showExternalDownloaderPackageDialog) {
+        TextFieldDialog(
+            initialTextFieldValue =
+                androidx.compose.ui.text.input
+                    .TextFieldValue(externalDownloaderPackage),
+            onDone = { pkg ->
+                onExternalDownloaderPackageChange(pkg)
+                showExternalDownloaderPackageDialog = false
+            },
+            onDismiss = { showExternalDownloaderPackageDialog = false },
+            singleLine = true,
+            maxLines = 1,
+        )
+    }
+
+    if (clearDownloads) {
+        ActionPromptDialog(
+            title = stringResource(R.string.clear_all_downloads),
+            onDismiss = { clearDownloads = false },
+            onConfirm = {
+                viewModel.clearDownloads()
+                clearDownloads = false
+            },
+            onCancel = { clearDownloads = false },
+            content = {
+                Text(text = stringResource(R.string.clear_downloads_dialog))
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.downloads)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
+
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+                .verticalScroll(scrollState)
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("downloaded_songs"),
+                title = stringResource(R.string.downloaded_songs),
+            ) {
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.clear_all_downloads)) },
+                        description = stringResource(R.string.clear_downloads_dialog),
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_download),
+                                contentDescription = null,
+                            )
+                        },
+                        onClick = { clearDownloads = true },
+                    )
+                }
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.export_downloaded_songs)) },
+                        description = stringResource(R.string.export_downloaded_songs_description),
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.send),
+                                contentDescription = null,
+                            )
+                        },
+                        onClick = { navController.navigate("settings/storage/export_songs") },
+                    )
+                }
+            }
+
+            PreferenceGroup(
+                modifier = positions.modifierFor("auto_download_like"),
+                title = stringResource(R.string.downloads),
+            ) {
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.auto_download_on_like)) },
+                        description = stringResource(R.string.auto_download_on_like_desc),
+                        icon = { Icon(painterResource(R.drawable.download), null) },
+                        checked = autoDownloadOnLike,
+                        onCheckedChange = onAutoDownloadOnLikeChange,
+                    )
+                }
+
+                item {
+                    val selectableSources = remember {
+                        listOf(DownloadSource.AUTO, DownloadSource.YOUTUBE_MUSIC)
+                    }
+                    ListPreference(
+                        modifier = positions.modifierFor("download_source"),
+                        title = { Text(stringResource(R.string.download_source_title)) },
+                        icon = { Icon(painterResource(R.drawable.download), null) },
+                        selectedValue =
+                            if (downloadSource in selectableSources) {
+                                downloadSource
+                            } else {
+                                DownloadSource.AUTO
+                            },
+                        values = selectableSources,
+                        valueText = {
+                            when (it) {
+                                DownloadSource.AUTO -> stringResource(R.string.download_source_auto)
+                                DownloadSource.YOUTUBE_MUSIC -> stringResource(R.string.download_source_youtube_music)
+                                else -> it.name
+                            }
+                        },
+                        onValueSelected = onDownloadSourceChange,
+                    )
+                }
+            }
+
+            PreferenceGroup(
+                modifier = positions.modifierFor("external_downloader"),
+                title = stringResource(R.string.external_downloader),
+            ) {
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.external_downloader)) },
+                        description = stringResource(R.string.external_downloader_desc),
+                        icon = { Icon(painterResource(R.drawable.download), null) },
+                        checked = externalDownloaderEnabled,
+                        onCheckedChange = onExternalDownloaderEnabledChange,
+                    )
+                }
+
+                item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.external_downloader_package)) },
+                        description = externalDownloaderPackage.ifEmpty { stringResource(R.string.external_downloader_package_desc) },
+                        icon = { Icon(painterResource(R.drawable.integration), null) },
+                        onClick = { showExternalDownloaderPackageDialog = true },
+                        isEnabled = externalDownloaderEnabled,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
@@ -47,6 +47,7 @@ import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
+import moe.rukamori.archivetune.viewmodels.StorageSettingsViewModel
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -36,35 +36,28 @@ import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
 import moe.rukamori.archivetune.constants.ArtistSeparatorsKey
 import moe.rukamori.archivetune.constants.AudioNormalizationKey
 import moe.rukamori.archivetune.constants.AudioOffload
-import moe.rukamori.archivetune.constants.AutoDownloadOnLikeKey
 import moe.rukamori.archivetune.constants.AutoSkipNextOnErrorKey
 import moe.rukamori.archivetune.constants.AutoStartOnBluetoothKey
 import moe.rukamori.archivetune.constants.CrossfadeDurationKey
 import moe.rukamori.archivetune.constants.CrossfadeEnabledKey
 import moe.rukamori.archivetune.constants.CrossfadeGaplessKey
 import moe.rukamori.archivetune.constants.DeviceMutePlaybackRecoveryVolumeKey
-import moe.rukamori.archivetune.constants.DownloadSource
-import moe.rukamori.archivetune.constants.DownloadSourceKey
 import moe.rukamori.archivetune.constants.EnableVideoPlaybackKey
 import moe.rukamori.archivetune.constants.EnablePipModeKey
-import moe.rukamori.archivetune.constants.ExternalDownloaderEnabledKey
-import moe.rukamori.archivetune.constants.ExternalDownloaderPackageKey
 import moe.rukamori.archivetune.constants.HISTORY_DURATION_DEFAULT
 import moe.rukamori.archivetune.constants.HistoryDuration
-import moe.rukamori.archivetune.constants.LowDataModeKey
 import moe.rukamori.archivetune.constants.PauseOnDeviceMuteKey
 import moe.rukamori.archivetune.constants.PermanentShuffleKey
 import moe.rukamori.archivetune.constants.PersistentQueueKey
 import moe.rukamori.archivetune.constants.SeekExtraSeconds
 import moe.rukamori.archivetune.constants.SkipSilenceKey
 import moe.rukamori.archivetune.constants.StopMusicOnTaskClearKey
+import moe.rukamori.archivetune.constants.SwipeToSongKey
 import moe.rukamori.archivetune.constants.TidalArtworkFallbackEnabledKey
 import moe.rukamori.archivetune.constants.TidalEnabledKey
 import moe.rukamori.archivetune.constants.WakelockKey
 import moe.rukamori.archivetune.ui.component.ArtistSeparatorsDialog
 import moe.rukamori.archivetune.ui.component.CrossfadeSliderPreference
-import moe.rukamori.archivetune.ui.component.EnumListPreference
-import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.NumberPickerPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -72,19 +65,12 @@ import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SliderPreference
 import moe.rukamori.archivetune.ui.component.SwitchPreference
 import moe.rukamori.archivetune.ui.component.TagsManagementDialog
-import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.utils.backToMain
-import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
-    val (lowDataMode, onLowDataModeChange) =
-        rememberPreference(
-            LowDataModeKey,
-            defaultValue = true,
-        )
     val (persistentQueue, onPersistentQueueChange) =
         rememberPreference(
             PersistentQueueKey,
@@ -117,11 +103,6 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
             defaultValue = false,
         )
 
-    val (autoDownloadOnLike, onAutoDownloadOnLikeChange) =
-        rememberPreference(
-            AutoDownloadOnLikeKey,
-            defaultValue = false,
-        )
     val (enableVideoPlayback, onEnableVideoPlaybackChange) =
         rememberPreference(
             EnableVideoPlaybackKey,
@@ -206,30 +187,18 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
             ArtistSeparatorsKey,
             defaultValue = ",;/&",
         )
-    val (downloadSource, onDownloadSourceChange) =
-        rememberEnumPreference(
-            DownloadSourceKey,
-            defaultValue = DownloadSource.AUTO,
-        )
-    val (externalDownloaderEnabled, onExternalDownloaderEnabledChange) =
-        rememberPreference(
-            ExternalDownloaderEnabledKey,
-            defaultValue = false,
-        )
-    val (externalDownloaderPackage, onExternalDownloaderPackageChange) =
-        rememberPreference(
-            ExternalDownloaderPackageKey,
-            defaultValue = "",
-        )
-
     val (wakelockEnabled, onWakelockChange) =
         rememberPreference(
             WakelockKey,
             defaultValue = false,
         )
+    val (swipeToSong, onSwipeToSongChange) =
+        rememberPreference(
+            SwipeToSongKey,
+            defaultValue = false,
+        )
     var showArtistSeparatorsDialog by remember { mutableStateOf(false) }
     var showTagsManagementDialog by remember { mutableStateOf(false) }
-    var showExternalDownloaderPackageDialog by remember { mutableStateOf(false) }
 
     if (showArtistSeparatorsDialog) {
         ArtistSeparatorsDialog(
@@ -245,21 +214,6 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
     if (showTagsManagementDialog) {
         TagsManagementDialog(
             onDismiss = { showTagsManagementDialog = false },
-        )
-    }
-
-    if (showExternalDownloaderPackageDialog) {
-        TextFieldDialog(
-            initialTextFieldValue =
-                androidx.compose.ui.text.input
-                    .TextFieldValue(externalDownloaderPackage),
-            onDone = { pkg ->
-                onExternalDownloaderPackageChange(pkg)
-                showExternalDownloaderPackageDialog = false
-            },
-            onDismiss = { showExternalDownloaderPackageDialog = false },
-            singleLine = true,
-            maxLines = 1,
         )
     }
 
@@ -320,19 +274,9 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
             }
 
             PreferenceGroup(
-                modifier = positions.modifierFor("low_data_mode"),
-                title = stringResource(R.string.player),
+                modifier = positions.modifierFor("enable_video_playback"),
+                title = stringResource(R.string.video_playback),
             ) {
-                item {
-                    SwitchPreference(
-                        title = { Text(stringResource(R.string.low_data_mode_title)) },
-                        description = stringResource(R.string.low_data_mode_description),
-                        icon = { Icon(painterResource(R.drawable.android_cell), null) },
-                        checked = lowDataMode,
-                        onCheckedChange = onLowDataModeChange,
-                    )
-                }
-
                 item {
                     Column(modifier = positions.modifierFor("enable_video_playback")) {
                         SwitchPreference(
@@ -353,14 +297,16 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                             icon = { Icon(painterResource(R.drawable.player_pip), null) },
                             checked = enablePipMode,
                             onCheckedChange = onEnablePipModeChange,
-                            // PiP requires a video surface to float — disable the toggle
-                            // (and grey it out) when video playback is off, so the user
-                            // can't enable a setting that would have no effect.
                             isEnabled = enableVideoPlayback,
                         )
                     }
                 }
+            }
 
+            PreferenceGroup(
+                modifier = positions.modifierFor("low_data_mode"),
+                title = stringResource(R.string.player),
+            ) {
                 item {
                     Column(modifier = positions.modifierFor("history_duration")) {
                         SliderPreference(
@@ -575,47 +521,14 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    Column(modifier = positions.modifierFor("auto_download_like")) {
+                    Column(modifier = positions.modifierFor("swipe_to_song")) {
                         SwitchPreference(
-                            title = { Text(stringResource(R.string.auto_download_on_like)) },
-                            description = stringResource(R.string.auto_download_on_like_desc),
-                            icon = { Icon(painterResource(R.drawable.download), null) },
-                            checked = autoDownloadOnLike,
-                            onCheckedChange = onAutoDownloadOnLikeChange,
+                            title = { Text(stringResource(R.string.swipe_song_to_add)) },
+                            icon = { Icon(painterResource(R.drawable.swipe), null) },
+                            checked = swipeToSong,
+                            onCheckedChange = onSwipeToSongChange,
                         )
                     }
-                }
-
-                item {
-                    // Only expose AUTO and YOUTUBE_MUSIC in the picker.
-                    // Qobuz / Tidal / Deezer remain valid enum values (so
-                    // existing user preferences still deserialize) but are
-                    // no longer selectable from the UI — the AUTO chain
-                    // already picks them up automatically when their
-                    // accounts are configured in the Integration screen.
-                    val selectableSources = remember {
-                        listOf(DownloadSource.AUTO, DownloadSource.YOUTUBE_MUSIC)
-                    }
-                    ListPreference(
-                        modifier = positions.modifierFor("download_source"),
-                        title = { Text(stringResource(R.string.download_source_title)) },
-                        icon = { Icon(painterResource(R.drawable.download), null) },
-                        selectedValue =
-                            if (downloadSource in selectableSources) {
-                                downloadSource
-                            } else {
-                                DownloadSource.AUTO
-                            },
-                        values = selectableSources,
-                        valueText = {
-                            when (it) {
-                                DownloadSource.AUTO -> stringResource(R.string.download_source_auto)
-                                DownloadSource.YOUTUBE_MUSIC -> stringResource(R.string.download_source_youtube_music)
-                                else -> it.name
-                            }
-                        },
-                        onValueSelected = onDownloadSourceChange,
-                    )
                 }
 
                 item {
@@ -676,30 +589,6 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                             description = stringResource(R.string.manage_playlist_tags_desc),
                             icon = { Icon(painterResource(R.drawable.style), null) },
                             onClick = { showTagsManagementDialog = true },
-                        )
-                    }
-                }
-
-                item {
-                    Column(modifier = positions.modifierFor("external_downloader")) {
-                        SwitchPreference(
-                            title = { Text(stringResource(R.string.external_downloader)) },
-                            description = stringResource(R.string.external_downloader_desc),
-                            icon = { Icon(painterResource(R.drawable.download), null) },
-                            checked = externalDownloaderEnabled,
-                            onCheckedChange = onExternalDownloaderEnabledChange,
-                        )
-                    }
-                }
-
-                item {
-                    Column(modifier = positions.modifierFor("external_downloader_package")) {
-                        PreferenceEntry(
-                            title = { Text(stringResource(R.string.external_downloader_package)) },
-                            description = externalDownloaderPackage.ifEmpty { stringResource(R.string.external_downloader_package_desc) },
-                            icon = { Icon(painterResource(R.drawable.integration), null) },
-                            onClick = { showExternalDownloaderPackageDialog = true },
-                            isEnabled = externalDownloaderEnabled,
                         )
                     }
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
@@ -47,6 +47,8 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.DisableScreenshotKey
 import moe.rukamori.archivetune.constants.EnableHapticFeedbackKey
+import moe.rukamori.archivetune.constants.ForceHighRefreshRateKey
+import moe.rukamori.archivetune.constants.LowDataModeKey
 import moe.rukamori.archivetune.constants.PauseListenHistoryKey
 import moe.rukamori.archivetune.constants.PauseSearchHistoryKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
@@ -82,6 +84,16 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
         rememberPreference(
             key = EnableHapticFeedbackKey,
             defaultValue = true,
+        )
+    val (lowDataMode, onLowDataModeChange) =
+        rememberPreference(
+            key = LowDataModeKey,
+            defaultValue = true,
+        )
+    val (forceHighRefreshRate, onForceHighRefreshRateChange) =
+        rememberPreference(
+            key = ForceHighRefreshRateKey,
+            defaultValue = false,
         )
 
     var showClearListenHistoryDialog by remember {
@@ -237,6 +249,25 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
                 modifier = positions.modifierFor("haptics"),
                 title = stringResource(R.string.misc),
             ) {
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.low_data_mode_title)) },
+                        description = stringResource(R.string.low_data_mode_description),
+                        icon = { Icon(painterResource(R.drawable.android_cell), null) },
+                        checked = lowDataMode,
+                        onCheckedChange = onLowDataModeChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.force_high_refresh_rate)) },
+                        icon = { Icon(painterResource(R.drawable.speed), null) },
+                        checked = forceHighRefreshRate,
+                        onCheckedChange = onForceHighRefreshRateChange,
+                    )
+                }
+
                 item {
                     SwitchPreference(
                         title = { Text(stringResource(R.string.haptics)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -200,15 +200,11 @@ fun buildSettingsGroups(
                 SettingsChild("Tidal artwork fallback", "tidal_artwork_fallback", listOf("tidal artwork", "artwork fallback", "tidal cover", "hi-res artwork")) { SearchResultSwitch(TidalArtworkFallbackEnabledKey, true) },
                 SettingsChild("Persistent queue", "persistent_queue", listOf("queue", "persistent", "save queue", "resume")) { SearchResultSwitch(PersistentQueueKey, true) },
                 SettingsChild("Permanent shuffle", "permanent_shuffle", listOf("shuffle", "random", "permanent")) { SearchResultSwitch(PermanentShuffleKey, false) },
-                SettingsChild("Auto download on like", "auto_download_like", listOf("auto download", "like", "download liked")) { SearchResultSwitch(AutoDownloadOnLikeKey, false) },
-                SettingsChild("Download source", "download_source", listOf("download source", "qobuz download", "tidal download", "youtube music download")),
                 SettingsChild("Auto skip on error", "auto_skip_error", listOf("skip", "error", "auto skip", "failed")) { SearchResultSwitch(AutoSkipNextOnErrorKey, false) },
                 SettingsChild("Stop music on task clear", "stop_task_clear", listOf("stop", "task clear", "background", "close app")) { SearchResultSwitch(StopMusicOnTaskClearKey, false) },
                 SettingsChild("Wakelock", "wakelock", listOf("wakelock", "wake lock", "keep awake", "cpu")) { SearchResultSwitch(WakelockKey, false) },
                 SettingsChild("Artist separators", "artist_separators", listOf("artist", "separator", "split", "featuring")),
                 SettingsChild("Manage playlist tags", "manage_playlist_tags", listOf("playlist tags", "tag management", "organize playlists")),
-                SettingsChild("External downloader", "external_downloader", listOf("external downloader", "download app", "custom downloader")),
-                SettingsChild("External downloader package", "external_downloader_package", listOf("downloader package", "downloader app name")),
             ),
         )
     val sources =
@@ -441,8 +437,6 @@ fun buildSettingsGroups(
             onClick = { navController.navigate("settings/storage") },
             children = listOf(
                 SettingsChild("Downloaded songs", "downloaded_songs", listOf("downloaded", "offline songs", "saved songs")),
-                SettingsChild("Clear all downloads", "clear_all_downloads", listOf("clear downloads", "delete downloads", "remove downloads")),
-                SettingsChild("Export downloaded songs", "export_downloaded_songs", listOf("export", "export songs", "save songs", "local storage", "file")),
                 SettingsChild("Song cache size", "song_cache_size", listOf("cache size", "song cache", "memory", "download cache")),
                 SettingsChild("Clear song cache", "clear_song_cache", listOf("clear song cache", "delete song cache", "wipe song cache")),
                 SettingsChild("Image cache size", "image_cache_size", listOf("image cache", "thumbnail cache", "artwork cache")),
@@ -452,6 +446,22 @@ fun buildSettingsGroups(
                 SettingsChild("Storage folder", "storage_folder", listOf("storage path", "storage location", "storage directory")),
                 SettingsChild("Download location", "download_location", listOf("download path", "location", "folder", "directory", "save to")),
                 SettingsChild("Smart trimmer", "smart_trimmer", listOf("smart trimmer", "trim cache", "auto clean cache")) { SearchResultSwitch(SmartTrimmerKey, false) },
+            ),
+        )
+    val downloads =
+        SettingsItem(
+            key = "downloads",
+            icon = painterResource(R.drawable.download),
+            title = stringResource(R.string.downloads),
+            subtitle = stringResource(R.string.settings_downloads_subtitle),
+            accentColor = MaterialTheme.colorScheme.primary,
+            keywords = listOf("download", "downloader", "external downloader", "download source", "auto download", "export songs", "clear downloads", "offline"),
+            onClick = { navController.navigate("settings/downloads") },
+            children = listOf(
+                SettingsChild("Clear all downloads", "clear_all_downloads", listOf("clear downloads", "delete downloads", "remove downloads")),
+                SettingsChild("Export downloaded songs", "export_downloaded_songs", listOf("export", "export songs", "save songs", "local storage", "file")),
+                SettingsChild("Auto download on like", "auto_download_like", listOf("auto download", "like", "download liked")) { SearchResultSwitch(AutoDownloadOnLikeKey, false) },
+                SettingsChild("Download source", "download_source", listOf("download source", "qobuz download", "tidal download", "youtube music download")),
                 SettingsChild("External downloader", "external_downloader", listOf("external downloader", "download app", "custom downloader")) { SearchResultSwitch(ExternalDownloaderEnabledKey, false) },
                 SettingsChild("External downloader package", "external_downloader_package", listOf("downloader package", "downloader app name")),
             ),
@@ -608,7 +618,7 @@ fun buildSettingsGroups(
         ),
         SettingsGroup(
             title = stringResource(R.string.storage),
-            items = listOf(storage, backupRestore),
+            items = listOf(storage, downloads, backupRestore),
         ),
         SettingsGroup(
             title = stringResource(R.string.about),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -183,7 +183,6 @@ fun StorageSettings(
             defaultValue = 256,
         )
     var clearCacheDialog by remember { mutableStateOf(false) }
-    var clearDownloads by remember { mutableStateOf(false) }
     var clearImageCacheDialog by remember { mutableStateOf(false) }
     var clearCanvasCacheDialog by remember { mutableStateOf(false) }
     var clearLyricsCacheDialog by remember { mutableStateOf(false) }
@@ -353,53 +352,6 @@ fun StorageSettings(
                 onSelectFolder = viewModel::openStorageLocationPicker,
                 positions = positions,
             )
-
-            PreferenceGroup(
-                modifier = positions.modifierFor("downloaded_songs"),
-                title = stringResource(R.string.downloaded_songs),
-            ) {
-                item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.clear_all_downloads)) },
-                        description = stringResource(R.string.size_used, formatFileSize(downloadCacheSize)),
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_download),
-                                contentDescription = null,
-                            )
-                        },
-                        onClick = { clearDownloads = true },
-                    )
-                }
-                item {
-                    PreferenceEntry(
-                        title = { Text(stringResource(R.string.export_downloaded_songs)) },
-                        description = stringResource(R.string.export_downloaded_songs_description),
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.send),
-                                contentDescription = null,
-                            )
-                        },
-                        onClick = { navController.navigate("settings/storage/export_songs") },
-                    )
-                }
-            }
-
-            if (clearDownloads) {
-                ActionPromptDialog(
-                    title = stringResource(R.string.clear_all_downloads),
-                    onDismiss = { clearDownloads = false },
-                    onConfirm = {
-                        viewModel.clearDownloads()
-                        clearDownloads = false
-                    },
-                    onCancel = { clearDownloads = false },
-                    content = {
-                        Text(text = stringResource(R.string.clear_downloads_dialog))
-                    },
-                )
-            }
 
             PreferenceGroup(
                 modifier = positions.modifierFor("song_cache_size"),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -250,8 +250,10 @@ class LyricsMenuViewModel
             aiTranslationJob =
                 viewModelScope.launch(Dispatchers.IO) {
                     isAiTranslating.value = true
+                    var isAutomatic = false
                     try {
                         val prefs = context.dataStore.data.first()
+                        isAutomatic = prefs[AutoTranslateLyricsKey] ?: false
                         val translatedLyrics =
                             AiLyricsTranslator().translate(
                                 config =
@@ -276,11 +278,6 @@ class LyricsMenuViewModel
                                 source = LyricsEntity.Source.AI_TRANSLATION.value,
                             )
                         }
-                        // Suppress the success toast when the translation was triggered by the
-                        // "Automatic translation" preference — auto-translations happen on every
-                        // foreign-language lyrics load and would otherwise spam the user with a
-                        // toast per song. Failures are still surfaced so the user can debug.
-                        val isAutomatic = prefs[AutoTranslateLyricsKey] ?: false
                         if (!isAutomatic) {
                             val msg = context.getString(R.string.translation_success)
                             _aiTranslationEvents.emit(msg)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -288,8 +288,10 @@ class LyricsMenuViewModel
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
-                        val msg = context.getString(R.string.translation_failed) + ": " + (e.localizedMessage ?: e.toString())
-                        _aiTranslationEvents.emit(msg)
+                        if (!isAutomatic) {
+                            val msg = context.getString(R.string.translation_failed) + ": " + (e.localizedMessage ?: e.toString())
+                            _aiTranslationEvents.emit(msg)
+                        }
                     } finally {
                         isAiTranslating.value = false
                         aiTranslationJob = null

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -712,6 +712,10 @@
     <string name="update_never_show_again">Never show again</string>
     <string name="settings_lyrics_providers_subtitle">Choose which lyrics providers are active and set priority</string>
     <string name="settings_lyrics_romanisation_subtitle">Romanise foreign-language lyrics (Japanese, Korean, Chinese, Hindi, etc.)</string>
+    <string name="settings_downloads_subtitle">Manage downloaded songs, sources, and external downloaders</string>
+    <string name="video_playback">Video playback</string>
+    <string name="extras">Extras</string>
+    <string name="settings_extras_subtitle">Toggles for home chips, library tags, and library mix cards</string>
     <string name="hide_liked_songs_card">Hide Liked songs card</string>
     <string name="hide_liked_songs_card_desc">Hide the Liked songs quick-access card on the Library Mix screen</string>
     <string name="hide_offline_card">Hide Offline card</string>


### PR DESCRIPTION
## Summary

Settings reorganization + lyrics translation fixes + YIM share card fix. Built on top of PR #107.

### Settings reorg (from prior batch)

- **Downloads pill** on main settings → new `DownloadsSettings` sub-page housing: Clear All downloads, Export Downloaded songs, Auto download on Like, External downloader + package, Download source
- **Video playback** header in Playback settings — "Enable video playback" + "Enable PiP mode" moved out of the Player header
- **Queue** header in Playback settings — swipe-to-queue toggle moved under it
- **Low data mode** moved from Playback → Behaviour
- **Force high refresh rate** moved from Appearance → Behaviour

### Extras sub-page (NEW — user feedback)

User clarified the "Extras" section in Appearance should be a **separate sub-page** (matching the Lyrics Providers / Romanisation pattern), not an inline group.

- **New `AppearanceExtrasSettings.kt`** sub-page with all 7 toggles: Show home category chips, Show tags in library, Hide Liked/Offline/Cached/Local Files/Top50 cards
- `AppearanceSettings.kt` — inline Extras group replaced with a pill navigating to `settings/appearance/extras`
- `NavigationBuilder.kt` — new route registered

### Lyrics auto-translation fixes (NEW — user feedback)

**Problem:** Lyrics only got translated when the user opened the lyrics page, and failures spammed a toast saying "AI response changed the lyric segment count".

- **New `AutoLyricsTranslator`** (Hilt `@Inject`) — triggers AI translation from `MusicService` immediately after lyrics are fetched, so translation happens *before* the user opens the lyrics page. Reads `AutoTranslateLyricsKey` + AI config, applies foreign-script heuristic, saves as `AI_TRANSLATION`, logs failures silently.
- **`AiLyricsTranslator.translateBatchResilient`** — when a batch returns the wrong segment count, splits the batch in half and retries recursively. Single-segment failures fall back to original text. Eliminates the count-mismatch error toast.
- **`LyricsMenuViewModel`** — error toasts suppressed for auto-translations (manual translate still surfaces failures).

### YIM share card pill fix (NEW — user feedback)

**Problem:** The two bottom pills on the Year-in-Music Intro card ("Swipe to begin" + share) had unequal heights.

**Fix:** `Row` wrapped in `height(IntrinsicSize.Min)`, both pills get `fillMaxHeight()`, share pill gets matching `padding(vertical = 14.dp)`, swipe text centered. Both pills now guaranteed equal height.

## Files changed

- `ai/AiLyricsTranslator.kt` — resilient batch retry
- `ai/AutoLyricsTranslator.kt` (NEW) — MusicService-side auto-translate trigger
- `playback/MusicService.kt` — inject + call `AutoLyricsTranslator`
- `viewmodels/LyricsMenuViewModel.kt` — suppress auto-translate error toasts
- `ui/screens/settings/AppearanceExtrasSettings.kt` (NEW) — Extras sub-page
- `ui/screens/settings/AppearanceSettings.kt` — Extras group → pill
- `ui/screens/NavigationBuilder.kt` — extras route
- `ui/screens/YearInMusicScreen.kt` — equal-height share pills
- (prior batch) `ui/screens/settings/DownloadsSettings.kt`, `PlayerSettings.kt`, `PrivacySettings.kt`, `SettingsScreen.kt`, etc.

## Standing rules compliance

- No new comment blocks added (only mandatory GPL headers on new files)
- No local gradle compilation
- Commit on `dev`, PR `dev` → `main`
- Watching CI; will fix any failures
