### PR TITLE
fix(lyrics): auto-translate word-by-word (QRC/YRC/TTML) + script-aware trigger

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsDocument.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsDocument.kt
@@ -7,9 +7,11 @@
 
 package moe.rukamori.archivetune.ai
 
+import moe.rukamori.archivetune.betterlyrics.QRCParser
 import moe.rukamori.archivetune.lyrics.LyricsUtils
 import org.w3c.dom.Document
 import org.w3c.dom.Element
+import org.w3c.dom.Node
 import org.xml.sax.InputSource
 import java.io.StringReader
 import java.io.StringWriter
@@ -36,6 +38,8 @@ object AiLyricsDocumentParser {
     fun parse(rawLyrics: String): AiLyricsDocument =
         if (LyricsUtils.isTtml(rawLyrics)) {
             parseTtml(rawLyrics).getOrElse { parseLineBased(rawLyrics, formatName = "TTML fallback") }
+        } else if (QRCParser.isQrc(rawLyrics)) {
+            parseQrc(rawLyrics)
         } else {
             parseLineBased(
                 rawLyrics = rawLyrics,
@@ -98,6 +102,100 @@ object AiLyricsDocumentParser {
         return LineBasedLyricsDocument(formatName = formatName, templates = templates, segments = segments)
     }
 
+    private fun parseQrc(rawLyrics: String): AiLyricsDocument {
+        val lines = rawLyrics.split('\n')
+        val entries = ArrayList<QrcLineEntry>(lines.size)
+        val segments = ArrayList<AiLyricsSegment>()
+        val seenTimingKeys = HashSet<String>()
+        lines.forEach { line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty() || QrcMetadataLineRegex.matches(trimmed)) {
+                entries.add(QrcLineEntry(raw = line, segmentId = -1, timingPrefix = "", cleanText = ""))
+                return@forEach
+            }
+            val qrcMatch = QrcLineRegex.matchEntire(trimmed)
+            if (qrcMatch != null) {
+                val startMs = qrcMatch.groupValues[1]
+                val durMs = qrcMatch.groupValues[2]
+                val content = qrcMatch.groupValues[3]
+                val timingKey = "$startMs,$durMs"
+                if (!seenTimingKeys.add(timingKey)) {
+                    entries.add(QrcLineEntry(raw = line, segmentId = -1, timingPrefix = "", cleanText = ""))
+                    return@forEach
+                }
+                val cleanText = extractQrcCleanText(content)
+                if (cleanText.isBlank()) {
+                    entries.add(QrcLineEntry(raw = line, segmentId = -1, timingPrefix = "", cleanText = ""))
+                    return@forEach
+                }
+                val segmentId = segments.size
+                segments.add(AiLyricsSegment(segmentId, cleanText))
+                entries.add(
+                    QrcLineEntry(
+                        raw = line,
+                        segmentId = segmentId,
+                        timingPrefix = "[$startMs,$durMs]",
+                        cleanText = cleanText,
+                    ),
+                )
+                return@forEach
+            }
+            val lrcMatch = SyncedLineRegex.matchEntire(line)
+            if (lrcMatch != null) {
+                val prefix = lrcMatch.groupValues[1]
+                val lrcTimingKey = prefix.filterNot { it.isWhitespace() }
+                if (!seenTimingKeys.add(lrcTimingKey)) {
+                    entries.add(QrcLineEntry(raw = line, segmentId = -1, timingPrefix = "", cleanText = ""))
+                    return@forEach
+                }
+                val content = lrcMatch.groupValues[3].trim()
+                if (content.isBlank()) {
+                    entries.add(QrcLineEntry(raw = line, segmentId = -1, timingPrefix = "", cleanText = ""))
+                    return@forEach
+                }
+                val segmentId = segments.size
+                segments.add(AiLyricsSegment(segmentId, content))
+                entries.add(
+                    QrcLineEntry(
+                        raw = line,
+                        segmentId = segmentId,
+                        timingPrefix = prefix,
+                        cleanText = content,
+                    ),
+                )
+                return@forEach
+            }
+            val plainMatch = PlainLineRegex.matchEntire(line)
+            val plainContent = plainMatch?.groupValues?.get(2).orEmpty().trim()
+            if (plainContent.isBlank()) {
+                entries.add(QrcLineEntry(raw = line, segmentId = -1, timingPrefix = "", cleanText = ""))
+                return@forEach
+            }
+            val segmentId = segments.size
+            segments.add(AiLyricsSegment(segmentId, plainContent))
+            entries.add(
+                QrcLineEntry(
+                    raw = line,
+                    segmentId = segmentId,
+                    timingPrefix = "",
+                    cleanText = plainContent,
+                ),
+            )
+        }
+        return QrcLyricsDocument(entries = entries, segments = segments)
+    }
+
+    private fun extractQrcCleanText(content: String): String {
+        if (content.isEmpty()) return ""
+        val words = ArrayList<String>()
+        QrcWordTimingRegex.findAll(content).forEach { match ->
+            val wordText = match.groupValues[1]
+            if (wordText.isNotEmpty()) words.add(wordText)
+        }
+        if (words.isEmpty()) return content.trim().replace(Regex("\\s+"), " ")
+        return words.joinToString("").trim().replace(Regex("\\s+"), " ")
+    }
+
     private fun parseTtml(rawLyrics: String): Result<AiLyricsDocument> =
         runCatching {
             val factory =
@@ -115,14 +213,14 @@ object AiLyricsDocumentParser {
             for (index in 0 until elements.length) {
                 val element = elements.item(index) as? Element ?: continue
                 if (!element.tagName.endsWith("p", ignoreCase = true)) continue
-                val text = element.textContent?.trim().orEmpty()
+                val text = readTtmlLineText(element)
                 if (text.isBlank()) continue
                 val segmentId = segments.size
                 val lineKey =
                     readAttributeBySuffix(element, "key")
                         ?: "archivetune-translation-$segmentId".also { key -> element.setAttribute("key", key) }
                 segments.add(AiLyricsSegment(segmentId, text))
-                paragraphs.add(TtmlParagraph(element = element, segmentId = segmentId, key = lineKey))
+                paragraphs.add(TtmlParagraph(element = element, segmentId = segmentId, key = lineKey, cleanText = text))
             }
             require(segments.isNotEmpty()) { "TTML has no translatable text" }
             TtmlLyricsDocument(
@@ -132,6 +230,23 @@ object AiLyricsDocumentParser {
                 segments = segments,
             )
         }
+
+    private fun readTtmlLineText(paragraphElement: Element): String {
+        val spanTexts = ArrayList<String>()
+        val children = paragraphElement.childNodes
+        for (i in 0 until children.length) {
+            val child = children.item(i) ?: continue
+            if (child.nodeType != Node.ELEMENT_NODE) continue
+            val childElement = child as? Element ?: continue
+            if (!childElement.tagName.endsWith("span", ignoreCase = true)) continue
+            val spanText = childElement.textContent?.trim().orEmpty()
+            if (spanText.isNotEmpty()) spanTexts.add(spanText)
+        }
+        if (spanTexts.isNotEmpty()) {
+            return spanTexts.joinToString(" ").trim().replace(Regex("\\s+"), " ")
+        }
+        return paragraphElement.textContent?.trim().orEmpty().replace(Regex("\\s+"), " ")
+    }
 
     private fun readAttributeBySuffix(
         element: Element,
@@ -154,6 +269,39 @@ object AiLyricsDocumentParser {
 
     private val SyncedLineRegex = Regex("""^(\s*(?:\[[^\]]+])+)(\s*)(.*?)(\s*)$""")
     private val PlainLineRegex = Regex("""^(\s*)(.*?)(\s*)$""")
+    private val QrcLineRegex = Regex("""^\[(\d{1,8}),(\d{1,8})](.*)$""")
+    private val QrcWordTimingRegex = Regex("""(.*?)\(\d{1,8},\d{1,8}(?:,\d{1,8})?\)""")
+    private val QrcMetadataLineRegex = Regex("""^\[[A-Za-z]+:.*]$""")
+}
+
+private data class QrcLineEntry(
+    val raw: String,
+    val segmentId: Int,
+    val timingPrefix: String,
+    val cleanText: String,
+)
+
+private data class QrcLyricsDocument(
+    private val entries: List<QrcLineEntry>,
+    override val segments: List<AiLyricsSegment>,
+) : AiLyricsDocument {
+    override val formatName: String = "QRC"
+
+    override fun rebuild(translations: Map<Int, String>): String =
+        entries.flatMap { entry ->
+            if (entry.segmentId < 0) {
+                listOf(entry.raw)
+            } else {
+                val translated = translations[entry.segmentId]?.trim().orEmpty()
+                if (translated.isBlank() || translated.equals(entry.cleanText, ignoreCase = true)) {
+                    listOf(entry.raw)
+                } else if (entry.timingPrefix.isEmpty()) {
+                    listOf(entry.raw, translated)
+                } else {
+                    listOf(entry.raw, "${entry.timingPrefix}${translated}")
+                }
+            }
+        }.joinToString("\n")
 }
 
 private data class LineTemplate(
@@ -187,6 +335,7 @@ private data class TtmlParagraph(
     val element: Element,
     val segmentId: Int,
     val key: String,
+    val cleanText: String,
 )
 
 private data class TtmlLyricsDocument(
@@ -207,12 +356,7 @@ private data class TtmlLyricsDocument(
                         ?.trim()
                         ?.takeIf {
                             it.isNotBlank() &&
-                                !it.equals(
-                                    paragraph.element.textContent
-                                        ?.trim()
-                                        .orEmpty(),
-                                    ignoreCase = true,
-                                )
+                                !it.equals(paragraph.cleanText, ignoreCase = true)
                         }
                         ?: return@mapNotNull null
                 paragraph to translated

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsDocument.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsDocument.kt
@@ -103,7 +103,8 @@ object AiLyricsDocumentParser {
     }
 
     private fun parseQrc(rawLyrics: String): AiLyricsDocument {
-        val lines = rawLyrics.split('\n')
+        val lyricContent = extractQrcLyricContent(rawLyrics)
+        val lines = lyricContent.split('\n')
         val entries = ArrayList<QrcLineEntry>(lines.size)
         val segments = ArrayList<AiLyricsSegment>()
         val seenTimingKeys = HashSet<String>()
@@ -188,12 +189,32 @@ object AiLyricsDocumentParser {
     private fun extractQrcCleanText(content: String): String {
         if (content.isEmpty()) return ""
         val words = ArrayList<String>()
+        var lastMatchEnd = 0
         QrcWordTimingRegex.findAll(content).forEach { match ->
             val wordText = match.groupValues[1]
             if (wordText.isNotEmpty()) words.add(wordText)
+            lastMatchEnd = match.range.last + 1
+        }
+        if (lastMatchEnd < content.length) {
+            val trailing = content.substring(lastMatchEnd).trim()
+            if (trailing.isNotEmpty()) words.add(trailing)
         }
         if (words.isEmpty()) return content.trim().replace(Regex("\\s+"), " ")
         return words.joinToString("").trim().replace(Regex("\\s+"), " ")
+    }
+
+    private fun extractQrcLyricContent(content: String): String {
+        val attributeMatch = QrcLyricContentAttributeRegex.find(content) ?: return content
+        val valueStart = attributeMatch.range.last + 1
+        val valueEnd = content.indexOf('"', startIndex = valueStart)
+        if (valueEnd < 0) return content
+        val raw = content.substring(valueStart, valueEnd)
+        return raw
+            .replace("&quot;", "\"")
+            .replace("&apos;", "'")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&amp;", "&")
     }
 
     private fun parseTtml(rawLyrics: String): Result<AiLyricsDocument> =
@@ -272,6 +293,7 @@ object AiLyricsDocumentParser {
     private val QrcLineRegex = Regex("""^\[(\d{1,8}),(\d{1,8})](.*)$""")
     private val QrcWordTimingRegex = Regex("""(.*?)\(\d{1,8},\d{1,8}(?:,\d{1,8})?\)""")
     private val QrcMetadataLineRegex = Regex("""^\[[A-Za-z]+:.*]$""")
+    private val QrcLyricContentAttributeRegex = Regex("""LyricContent\s*=\s*\"""", RegexOption.IGNORE_CASE)
 }
 
 private data class QrcLineEntry(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AutoLyricsTranslator.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AutoLyricsTranslator.kt
@@ -58,8 +58,7 @@ class AutoLyricsTranslator
                         val existing = database.lyrics(mediaMetadata.id).first()
                         if (existing != null && existing.source == LyricsEntity.Source.AI_TRANSLATION.value) return@launch
 
-                        val sample = lyricsText.take(1000)
-                        val nonAsciiCount = sample.count { it.code > 0x7F }
+                        val nonAsciiCount = lyricsText.asSequence().take(4000).count { it.code > 0x7F }
                         if (nonAsciiCount < 5) return@launch
 
                         val targetLanguage = prefs[TranslatorTargetLangKey].orEmpty()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AutoLyricsTranslator.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AutoLyricsTranslator.kt
@@ -28,6 +28,7 @@ import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
 import moe.rukamori.archivetune.db.MusicDatabase
 import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.extensions.toEnum
+import moe.rukamori.archivetune.lyrics.LyricsUtils
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.utils.dataStore
 import javax.inject.Inject
@@ -58,10 +59,9 @@ class AutoLyricsTranslator
                         val existing = database.lyrics(mediaMetadata.id).first()
                         if (existing != null && existing.source == LyricsEntity.Source.AI_TRANSLATION.value) return@launch
 
-                        val nonAsciiCount = lyricsText.asSequence().take(4000).count { it.code > 0x7F }
-                        if (nonAsciiCount < 5) return@launch
-
                         val targetLanguage = prefs[TranslatorTargetLangKey].orEmpty()
+                        if (!LyricsUtils.shouldAutoTranslate(lyricsText, targetLanguage)) return@launch
+
                         val config =
                             AiServiceConfig(
                                 provider = provider,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
@@ -36,6 +36,8 @@ object LyricsUtils {
     private val INLINE_MILLISECONDS_TIME_REGEX = Regex("""<\d{1,8}(?:,\d{1,8})?>""")
     private val YRC_LINE_REGEX = Regex("""\[(\d{1,8}),\d{1,8}\](.*)""")
     private val YRC_WORD_TIME_REGEX = Regex("""\(\d{1,8},\d{1,8}(?:,\d{1,8})?\)""")
+    private val QrcTranslationLineRegex = Regex("""^\[(\d{1,8}),(\d{1,8})](.*)$""")
+    private val QrcWordTimingDetectRegex = Regex("""\(\d{1,8},\d{1,8}(?:,\d{1,8})?\)""")
     private val TTML_SPAN_REGEX =
         Regex(
             pattern = """<span\b[^>]*>""",
@@ -441,9 +443,11 @@ object LyricsUtils {
     fun parseLyrics(lyrics: String): List<LyricsEntry> {
         val normalizedLyrics = normalizeLyricsText(lyrics)
         if (QRCParser.isQrc(normalizedLyrics)) {
+            val translationsByStartMs = extractQrcTranslations(normalizedLyrics)
             return QRCParser.parseQrc(normalizedLyrics).map { line ->
+                val startMs = (line.startTime * 1000.0).toLong()
                 LyricsEntry(
-                    time = (line.startTime * 1000.0).toLong(),
+                    time = startMs,
                     text = line.text,
                     words =
                         line.words
@@ -455,6 +459,7 @@ object LyricsUtils {
                                 )
                             }.takeIf { it.isNotEmpty() },
                     agent = line.agent,
+                    providerTranslationText = translationsByStartMs[startMs],
                     durationMs = ((line.endTime - line.startTime) * 1000.0).toLong().coerceAtLeast(0L),
                 )
             }
@@ -470,6 +475,29 @@ object LyricsUtils {
             }
         }
         return mergeLineSyncedTranslations(result).sorted()
+    }
+
+    private fun extractQrcTranslations(lyrics: String): Map<Long, String> {
+        val wordTimedStartMs = mutableSetOf<Long>()
+        val translationCandidates = mutableListOf<Pair<Long, String>>()
+        lyrics.lineSequence().forEach { line ->
+            val trimmed = line.trim()
+            val match = QrcTranslationLineRegex.matchEntire(trimmed) ?: return@forEach
+            val startMs = match.groupValues[1].toLongOrNull() ?: return@forEach
+            val content = match.groupValues[3]
+            if (QrcWordTimingDetectRegex.containsMatchIn(content)) {
+                wordTimedStartMs.add(startMs)
+            } else if (content.isNotBlank()) {
+                translationCandidates.add(startMs to content.trim())
+            }
+        }
+        val translations = mutableMapOf<Long, String>()
+        translationCandidates.forEach { (startMs, text) ->
+            if (startMs in wordTimedStartMs && startMs !in translations) {
+                translations[startMs] = text
+            }
+        }
+        return translations
     }
 
     fun normalizeLyricsText(lyrics: String): String {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
@@ -387,6 +387,110 @@ object LyricsUtils {
             trimmed.contains("http://www.w3.org/ns/ttml", ignoreCase = true)
     }
 
+    fun shouldAutoTranslate(lyrics: String, targetLanguage: String): Boolean {
+        if (lyrics.isBlank()) return false
+        val allowedScripts = allowedScriptsForLanguage(targetLanguage)
+        return lyrics.asSequence().any { char ->
+            if (!char.isLetter()) return@any false
+            val script = UnicodeScript.of(char.code)
+            script !in allowedScripts
+        }
+    }
+
+    private fun allowedScriptsForLanguage(language: String): Set<UnicodeScript> {
+        val normalized = language.trim().lowercase().replace('_', '-').substringBefore('-')
+        val code = when (normalized) {
+            "english", "en" -> "en"
+            "japanese", "ja" -> "ja"
+            "korean", "ko" -> "ko"
+            "chinese", "zh", "mandarin", "cmn", "cantonese", "yue" -> "zh"
+            "hindi", "hi", "sanskrit", "sa", "marathi", "mr", "nepali", "ne" -> "hi"
+            "arabic", "ar", "persian", "fa", "urdu", "ur" -> "ar"
+            "russian", "ru", "ukrainian", "uk", "belarusian", "be", "bulgarian", "bg" -> "ru"
+            "thai", "th" -> "th"
+            "hebrew", "he", "yiddish", "yi" -> "he"
+            "greek", "el" -> "el"
+            "armenian", "hy" -> "hy"
+            "georgian", "ka" -> "ka"
+            else -> normalized
+        }
+        return when (code) {
+            "ja" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.HAN,
+                UnicodeScript.HIRAGANA,
+                UnicodeScript.KATAKANA,
+            )
+            "ko" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.HANGUL,
+            )
+            "zh" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.HAN,
+            )
+            "hi" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.DEVANAGARI,
+            )
+            "ar" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.ARABIC,
+            )
+            "ru" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.CYRILLIC,
+            )
+            "th" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.THAI,
+            )
+            "he" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.HEBREW,
+            )
+            "el" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.GREEK,
+            )
+            "hy" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.ARMENIAN,
+            )
+            "ka" -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+                UnicodeScript.GEORGIAN,
+            )
+            else -> setOf(
+                UnicodeScript.LATIN,
+                UnicodeScript.COMMON,
+                UnicodeScript.INHERITED,
+            )
+        }
+    }
+
     fun isLineSyncedLrc(lyrics: String): Boolean =
         QRCParser.isQrc(normalizeLyricsText(lyrics)) ||
             lyrics.lineSequence().any { line ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -141,6 +141,7 @@ import moe.rukamori.archivetune.constants.AutoTranslateLyricsKey
 import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
 import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.extensions.togglePlayPause
+import moe.rukamori.archivetune.lyrics.LyricsUtils
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.LyricsEnhanced
@@ -357,12 +358,7 @@ fun LyricsScreen(
         if (text.isBlank() || text == LyricsEntity.LYRICS_NOT_FOUND) return@LaunchedEffect
         if (snapshot.source == LyricsEntity.Source.AI_TRANSLATION.value) return@LaunchedEffect
 
-        // Heuristic: at least 5 non-ASCII letters in the first ~1000 chars of lyrics →
-        // treat as foreign script. LRC tags ([00:12.34]) and timestamps are ASCII so
-        // they don't trip the detector.
-        val sample = text.take(1000)
-        val nonAsciiCount = sample.count { it.code > 0x7F }
-        if (nonAsciiCount < 5) return@LaunchedEffect
+        if (!LyricsUtils.shouldAutoTranslate(text, translatorTargetLang)) return@LaunchedEffect
 
         lyricsMenuViewModel.translateLyricsWithAi(
             mediaMetadata = mediaMetadata,


### PR DESCRIPTION
## What

Fix auto-translation for word-by-word lyrics (QRC/YRC/TTML formats) and replace the non-ASCII threshold with a script-aware check.

## Commit 1 (82da79bc9): QRC/YRC/TTML parsing fixes

Previously only line-synced LRC lyrics auto-translated correctly. QRC/YRC word-by-word lyrics fell through to `parseLineBased` which sent garbled `(start,dur)word` text to the AI.

- `AiLyricsDocumentParser`: new `parseQrc()` that strips word-timing parens before sending to AI
- `AiLyricsDocumentParser.parseTtml`: join `<span>` texts with single spaces instead of raw textContent
- `LyricsUtils.parseLyrics`: `extractQrcTranslations()` finds parallel translation lines and merges them as `providerTranslationText`
- `AutoLyricsTranslator`: increase non-ASCII sample from 1000 to 4000 chars

## Commit 2 (351545c70): XML-wrapped QRC + last-word + script-aware trigger

Word-by-word lyrics STILL weren't auto-translating for Japanese songs despite commit 1. Three more root causes:

### 1. XML-wrapped QRC not unwrapped

`AiLyricsDocumentParser.parseQrc` split the raw XML by newlines and tried to parse tag lines as lyrics. The `LyricContent` attribute (which holds the actual lyric text inside `<LyricInfo LyricContent="..."/>`) was never extracted.

Result: the AI received XML blobs, got confused, returned the wrong segment count, and `translateBatchResilient` silently fell back to the original text. The `translated == lyricsText` check then skipped the DB save.

**Fix**: new `extractQrcLyricContent()` that finds the `LyricContent` attribute via regex and unescapes its XML entities before line-splitting.

### 2. Last word of each QRC/YRC line was dropped

The word-timing regex `(.*?)(timing)` matches text BEFORE each timing pair. But QRC/YRC format is `(timing)word(timing)word...` — the last word has no trailing timing, so it was never captured.

For `[0,5000](0,1000)Hello(1000,1000) world`:
- Match 1: text="" (before `(0,1000)`)
- Match 2: text="Hello" (before `(1000,1000)`)
- ` world` — NOT matched (no trailing timing)

**Fix**: track the end of the last regex match and append any trailing text as a final word.

### 3. Non-ASCII threshold too strict

The old heuristic required `>=5 non-ASCII chars in first 1000/4000 chars`. Songs mostly in the device's preferred language but with a few foreign-script lines were skipped.

**Fix**: replaced with a script-aware check `shouldAutoTranslate(lyrics, targetLanguage)` that:
- Maps the target language to its allowed Unicode scripts (e.g. English → Latin only, Japanese → Latin + Han + Hiragana + Katakana, Korean → Latin + Hangul, etc.)
- Triggers translation if the lyrics contain ANY letter from a different script
- Correctly skips translating Japanese lyrics when the target language is already Japanese
- Correctly skips translating Spanish lyrics when target is Spanish (both Latin)
- Triggers for English-target + Japanese/CJK/Cyrillic/Arabic/Hebrew/etc. lyrics

## Files changed

- `app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsDocument.kt` (+160 lines commit 1, +20 lines commit 2)
- `app/src/main/kotlin/moe/rukamori/archivetune/ai/AutoLyricsTranslator.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt`
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt` (commit 2 only)

## Verification

- No comment blocks added (only existing GPL headers).
- No local gradle build (per standing rules) — relying on GitHub CI.