### PR TITLE
fix(lyrics): stop line-synced lyrics flicker loop in LyricsScreen

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -139,7 +139,6 @@ import moe.rukamori.archivetune.constants.PlayerCustomImageUriKey
 import moe.rukamori.archivetune.constants.ShowLyricsPlayerControlsKey
 import moe.rukamori.archivetune.constants.AutoTranslateLyricsKey
 import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
-import moe.rukamori.archivetune.constants.PrioritizeWordSyncedLyricsKey
 import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.lyrics.LyricsUtils
@@ -283,26 +282,11 @@ fun LyricsScreen(
         }
 
     LaunchedEffect(mediaMetadata.id, currentLyrics?.lyrics, currentLyrics?.providerName) {
-
-        
-
-        
-
-        
-        
         val snapshot = currentLyrics
-        // Honor the "Prioritize Word Synced Lyrics" toggle even when the panel
-        // already has lyrics loaded: if the toggle is ON and the displayed lyrics
-        // are line-synced/plain, treat them as stale so the word-synced lookup
-        // below gets a chance to upgrade them.
-        val prioritizeWordSyncedSnapshot = context.dataStore[PrioritizeWordSyncedLyricsKey] ?: false
         val needsFetch =
             snapshot == null ||
                 snapshot.lyrics == LyricsEntity.LYRICS_NOT_FOUND ||
-                snapshot.providerName.isBlank() ||
-                (prioritizeWordSyncedSnapshot &&
-                    snapshot.lyrics != LyricsEntity.LYRICS_NOT_FOUND &&
-                    !LyricsUtils.hasWordSyncedLyrics(snapshot.lyrics))
+                snapshot.providerName.isBlank()
         if (!needsFetch) return@LaunchedEffect
         try {
             val existingLyrics =
@@ -313,16 +297,7 @@ fun LyricsScreen(
             val hasValidLyrics =
                 existingLyrics != null &&
                     existingLyrics.lyrics != LyricsEntity.LYRICS_NOT_FOUND
-            // When "Prioritize Word Synced Lyrics" is ON, don't short-circuit on
-            // stored lyrics unless they are word-synced — otherwise the word-synced
-            // priority lookup in LyricsHelper never gets a chance to run for songs
-            // that were previously cached with line-synced/plain lyrics.
-            val prioritizeWordSynced = context.dataStore[PrioritizeWordSyncedLyricsKey] ?: false
-            val storedIsWordSynced =
-                existingLyrics != null && LyricsUtils.hasWordSyncedLyrics(existingLyrics.lyrics)
-            if (hasValidLyrics && existingLyrics != null && existingLyrics.providerName.isNotBlank() &&
-                (!prioritizeWordSynced || storedIsWordSynced)
-            ) {
+            if (hasValidLyrics && existingLyrics != null && existingLyrics.providerName.isNotBlank()) {
                 return@LaunchedEffect
             }
 
@@ -332,20 +307,7 @@ fun LyricsScreen(
                 }
             withContext(Dispatchers.IO) {
                 database.query {
-                    val fetchedIsWordSynced = LyricsUtils.hasWordSyncedLyrics(lyricsResult.lyrics)
-                    if (hasValidLyrics && prioritizeWordSynced && fetchedIsWordSynced) {
-                        // Persist the word-synced upgrade over previously stored
-                        // line-synced/plain lyrics when the toggle is ON. Backfilling
-                        // only the provider name would keep the stale line-synced
-                        // text and make the toggle appear broken (see MusicService).
-                        upsert(
-                            LyricsEntity(
-                                id = mediaMetadata.id,
-                                lyrics = lyricsResult.lyrics,
-                                providerName = lyricsResult.providerName,
-                            ),
-                        )
-                    } else if (hasValidLyrics) {
+                    if (hasValidLyrics) {
                         backfillLyricsProviderName(
                             id = mediaMetadata.id,
                             providerName = lyricsResult.providerName,


### PR DESCRIPTION
## Problem

When the "Prioritize Word Synced Lyrics" toggle is ON and no word-synced lyrics are available (all word-sync providers fail), the lyrics panel flickers continuously — re-fetching lyrics ~5 times per second. Closing and reopening the lyrics page temporarily fixes it, but the flicker resumes after a few seconds.

## Root Cause

Commit `aeca55631` added a `prioritizeWordSyncedSnapshot` check to `LyricsScreen`'s `LaunchedEffect` that treats line-synced lyrics as stale when the toggle is ON, triggering a re-fetch. This created a feedback loop:

1. DB has line-synced lyrics (all word-sync providers failed).
2. `LaunchedEffect` sees line-synced + toggle ON → `needsFetch = true`.
3. `getLyricsWithProvider` returns cached lyrics (cache hit, ~0ms).
4. `upsert` writes to DB (changing `updatedAt`) or `backfillLyricsProviderName` writes (changing `providerName` from empty to non-empty).
5. `currentLyrics` re-emits → `LaunchedEffect` re-fires → back to step 2.

This caused ~5 `getLyricsWithProvider` calls per second (all cache hits), making the lyrics panel flicker continuously.

## Evidence from logs

```
[10:50:45.919] D/LyricsHelper: Found lyrics in cache for Good Time
[10:50:46.184] D/LyricsHelper: Found lyrics in cache for Good Time
[10:50:46.474] D/LyricsHelper: Found lyrics in cache for Good Time
[10:50:46.684] D/LyricsHelper: Found lyrics in cache for Good Time
[10:50:46.896] D/LyricsHelper: Found lyrics in cache for Good Time
... (continues for 40+ seconds)
```

~200ms intervals, 5 calls/second, all cache hits — no network calls, just the LaunchedEffect loop.

## Fix

Remove the `prioritizeWordSyncedSnapshot` check and the `upsert` path from `LyricsScreen` entirely. `MusicService`'s auto-fetch already handles the word-synced upgrade — including reacting to the `PrioritizeWordSynced` toggle being flipped while a song is playing (via the `combine` trigger added in the same commit `aeca55631`). `LyricsScreen` should only fetch when there are no valid lyrics at all (`null`, `LYRICS_NOT_FOUND`, or empty `providerName`), not when the toggle is on and the lyrics are line-synced.

## Changes

- `LyricsScreen.kt`: Reverted the `LaunchedEffect` to its pre-`aeca55631` behavior. Removed:
  - The `prioritizeWordSyncedSnapshot` check in `needsFetch`
  - The `prioritizeWordSynced` / `storedIsWordSynced` early-return check
  - The `upsert` path in the DB write (only `backfillLyricsProviderName` and `replaceLyricsIfAbsentOrNotFound` remain)
  - The unused `PrioritizeWordSyncedLyricsKey` import

Net: -41 lines, +3 lines.