### PR TITLE
feat: UI scale + tablet mode + sleep timer + perf + dead code cleanup + APK size compression + Enhanced lyrics smoothness

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -387,6 +387,30 @@ android {
             excludes += "META-INF/LICENSE.md"
             // Installed on demand from Lyrics settings; saves roughly 13 MiB per APK.
             excludes += "com/atilika/kuromoji/ipadic/*.bin"
+            // Additional safe META-INF / metadata excludes — none of these are read at runtime by
+            // the app or any of its libraries (verified by checking for ServiceLoader / reflection
+            // usage on each). They are pure build-time / IDE metadata and just bloat every APK.
+            // - META-INF/DEPENDENCIES: Maven dependency manifest, only used by build tooling.
+            // - META-INF/INDEX.LIST: JAR index used by desktop ClassLoaders, never by Android.
+            // - META-INF/io.netty.versions.properties: Netty version manifest, runtime-irrelevant.
+            // - META-INF/*.version: per-library version files (e.g. kotlin-stdlib.version).
+            // - DebugProbesKt.bin: kotlinx.coroutines debug binary, only consulted by debugger.
+            // - kotlin-tooling-metadata.json: Kotlin tooling manifest, build-time only.
+            // - META-INF/buildinfo.properties / build.archives: Gradle/AGP build metadata.
+            // - META-INF/com.android.tools/**: AGP build-metadata, not consumed at runtime.
+            // - META-INF/proguard/**: bundled proguard configs, only needed at minify time.
+            // DO NOT add: META-INF/services/** (ServiceLoader), META-INF/MANIFEST.MF (signing +
+            // attributes), META-INF/*.kotlin_module (Kotlin reflection) — those are load-bearing.
+            excludes += "META-INF/DEPENDENCIES"
+            excludes += "META-INF/INDEX.LIST"
+            excludes += "META-INF/io.netty.versions.properties"
+            excludes += "META-INF/*.version"
+            excludes += "DebugProbesKt.bin"
+            excludes += "kotlin-tooling-metadata.json"
+            excludes += "META-INF/buildinfo.properties"
+            excludes += "META-INF/build.archives"
+            excludes += "META-INF/com.android.tools/**"
+            excludes += "META-INF/proguard/**"
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,6 +20,17 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
+# Move all classes that R8 is allowed to move into a single 'r8' package.
+# This shortens class name strings in the DEX constant pool and removes
+# per-package directory entries, reducing DEX size by ~1–3%. It does NOT
+# rename or move any class covered by a -keep rule (media3, tdlib, kuromoji,
+# jaudiotagger, newpipe.extractor, ktor, guava, Glance widgets, queue
+# persistence models, @Serializable companions). Reflection by system class
+# name (e.g. Class.forName("android.os.SystemProperties")) is unaffected.
+# Using a non-empty package name ('r8') avoids edge cases with the default
+# package that some class loaders trip over.
+-repackageclasses 'r8'
+
 ## Kotlin Serialization
 # Keep `Companion` object fields of serializable classes.
 # This avoids serializer lookup through `getDeclaredClasses` as done for named companion objects.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -149,6 +149,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -239,6 +240,8 @@ import moe.rukamori.archivetune.constants.SYSTEM_DEFAULT
 import moe.rukamori.archivetune.constants.SearchSource
 import moe.rukamori.archivetune.constants.SearchSourceKey
 import moe.rukamori.archivetune.constants.StopMusicOnTaskClearKey
+import moe.rukamori.archivetune.constants.TabletModeEnabledKey
+import moe.rukamori.archivetune.constants.UiScaleFactorKey
 import moe.rukamori.archivetune.constants.UpdateChannel
 import moe.rukamori.archivetune.constants.UpdateChannelKey
 import moe.rukamori.archivetune.constants.NeverShowUpdatePopupKey
@@ -1068,11 +1071,26 @@ class MainActivity : ComponentActivity() {
                     val bottomInsetDp = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
 
                     val isTvDevice = remember { applicationContext.isTvDevice() }
+                    val (tabletModeEnabled) = rememberPreference(TabletModeEnabledKey, defaultValue = false)
                     val useRail =
                         isTvDevice ||
+                            tabletModeEnabled ||
                             currentWindowAdaptiveInfo()
                                 .windowSizeClass
                                 .isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+
+                    // UI scale (DPI-like) — applied via a LocalDensity override so the entire
+                    // Compose tree scales together (text, icons, paddings, etc.). The slider in
+                    // Appearance Settings clamps to [0.85, 1.30]; we additionally guard here in
+                    // case a backup-restore injects an out-of-range value.
+                    val (uiScaleRaw) = rememberPreference(UiScaleFactorKey, defaultValue = 1.0f)
+                    val uiScale = uiScaleRaw.coerceIn(0.85f, 1.30f)
+                    val scaledDensity = remember(density, uiScale) {
+                        Density(
+                            density = density.density,
+                            fontScale = density.fontScale * uiScale,
+                        )
+                    }
 
                     val navController = rememberNavController()
                     DisposableEffect(navController) {
@@ -1863,6 +1881,7 @@ class MainActivity : ComponentActivity() {
                         LocalHapticFeedback provides customHaptic,
                         LocalAnimationsDisabled provides disableAnimations,
                         LocalDatabase provides database,
+                        LocalDensity provides scaledDensity,
                         LocalContentColor provides if (pureBlack) Color.White else contentColorFor(MaterialTheme.colorScheme.surface),
                         LocalPlayerConnection provides playerConnection,
                         LocalPlayerAwareWindowInsets provides playerAwareWindowInsets,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -23,6 +23,16 @@ val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")
 val DisableAnimationsKey = booleanPreferencesKey("disableAnimations")
 val ForceHighRefreshRateKey = booleanPreferencesKey("forceHighRefreshRate")
+
+// UI scale (DPI-like) multiplier applied via a LocalDensity override in MainActivity.
+// 1.0f = system default. Range clamped to [0.85f, 1.30f] in AppearanceSettings.
+// Stored as a float so the slider is continuous (1% steps via 46 discrete positions).
+val UiScaleFactorKey = floatPreferencesKey("uiScaleFactor")
+
+// When true, forces the two-pane NavigationRail layout (normally reserved for
+// tablet-width windows) on phone-sized windows too. Useful on landscape phones
+// and on tablets where the dp breakpoint misclassifies the window.
+val TabletModeEnabledKey = booleanPreferencesKey("tabletModeEnabled")
 val EnableHapticFeedbackKey = booleanPreferencesKey("enableHapticFeedback")
 val UseSystemFontKey = booleanPreferencesKey("useSystemFont")
 val FontPreferenceKey = stringPreferencesKey("fontPreference")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -29,7 +29,6 @@ import android.media.AudioDeviceCallback
 import android.media.AudioDeviceInfo
 import android.media.AudioFocusRequest
 import android.media.AudioManager
-import android.media.MediaCodecList
 import android.media.audiofx.AudioEffect
 import android.media.audiofx.BassBoost
 import android.media.audiofx.Equalizer
@@ -9293,14 +9292,6 @@ class MusicService :
             normalizedScheme == "android.resource" ||
             normalizedScheme == "telegram"
     }
-
-    private fun deviceSupportsMimeType(mimeType: String): Boolean =
-        runCatching {
-            val codecList = MediaCodecList(MediaCodecList.ALL_CODECS)
-            codecList.codecInfos.any { info ->
-                !info.isEncoder && info.supportedTypes.any { it.equals(mimeType, ignoreCase = true) }
-            }
-        }.getOrDefault(false)
 
     private fun createMediaSourceFactory() =
         DefaultMediaSourceFactory(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -151,8 +152,11 @@ private const val TTML_LEAD_MS = 0L
 private const val LYRIC_VISUAL_TUNING_OFFSET_MS = 150L
 private const val MANUAL_SCROLL_TIMEOUT_MS = 3000L
 private const val MANUAL_SCROLL_DEBOUNCE_MS = 50L
-private const val LYRIC_FOCUS_ANCHOR_RATIO = 0.42f
-private const val LYRIC_LINE_SYNC_TOP_ANCHOR_RATIO = 0.35f
+// Both word-synced (TTML) and line-synced (LRC) lyrics anchor the active line at the
+// same upper-third ratio. Previously TTML used 0.42f (middle) which pushed the active
+// line to the centre of the screen and felt laggy/awkward; users expect the active
+// line near the top so they can read ahead.
+private const val LYRIC_FOCUS_TOP_ANCHOR_RATIO = 0.30f
 private const val LYRIC_FOCUS_TOP_GUARD_RATIO = 0.18f
 private const val LYRIC_FOCUS_BOTTOM_GUARD_RATIO = 0.24f
 private const val LYRIC_FOCUS_MIN_SCROLL_PX = 6
@@ -338,6 +342,32 @@ fun LyricsEnhanced(
         remember(player) {
             mutableLongStateOf(player.currentPosition.coerceAtLeast(0L))
         }
+    val playbackSyncPosition: () -> Int =
+        remember {
+            {
+                (
+                    playbackPositionMs.longValue +
+                        latestLyricsSyncOffset.value.toLong() +
+                        latestLeadMs.value +
+                        LYRIC_VISUAL_TUNING_OFFSET_MS
+                ).coerceIn(0L, Int.MAX_VALUE.toLong())
+                    .toInt()
+            }
+        }
+    // The current line index is computed in the playback-position loop (below) and stored
+    // in this state. It ONLY changes when the active line actually changes — not on every
+    // 16 ms position tick. The auto-scroll LaunchedEffect reads this state via snapshotFlow,
+    // so its block re-evaluates only on line boundaries (every few seconds) instead of every
+    // frame. This eliminates per-frame work in the scroll trigger: previously the snapshotFlow
+    // read lineFocusPosition() → playbackPositionMs every frame, ran TWO binary searches
+    // (one in positionForStableLineFocus, one in the library's
+    // getCurrentFirstHighlightLineIndexByTime), and paid snapshot read-tracking overhead —
+    // all to produce a value that only changes a few times per song.
+    val currentLineIndexState = remember { mutableIntStateOf(-1) }
+    // rememberUpdatedState so the playback loop sees the latest syncedLyrics (which can be
+    // rebuilt when romanization finishes) without re-launching the loop and stuttering the
+    // 60 Hz position interpolation.
+    val latestSyncedLyrics = rememberUpdatedState(syncedLyrics)
     var isManualScrolling by remember { mutableStateOf(false) }
     var lastManualScrollTime by remember { mutableLongStateOf(0L) }
     val listState = key(lyricsSessionKey) { rememberLazyListState() }
@@ -348,6 +378,9 @@ fun LyricsEnhanced(
         lastManualScrollTime = 0L
         isSelectionModeActive = false
         selectedLineKeys.clear()
+        // Reset the cached line index so the auto-scroll effect force-scrolls to the
+        // new track's first active line instead of inheriting the previous track's index.
+        currentLineIndexState.intValue = -1
     }
 
     LaunchedEffect(player, lyricsSessionKey, animationsDisabled, playbackParameters.speed) {
@@ -406,27 +439,24 @@ fun LyricsEnhanced(
                     playbackPositionMs.longValue = nextPosition
                 }
             }
+
+            // Hoisted line-index computation: do the (cheap, O(log n)) binary search once
+            // per frame here, in the playback loop, and only publish to currentLineIndexState
+            // when the index actually changes. This replaces the previous design where the
+            // auto-scroll LaunchedEffect's snapshotFlow read lineFocusPosition() every frame,
+            // which (a) re-ran the snapshotFlow machinery per tick and (b) chained TWO binary
+            // searches (ours inside positionForStableLineFocus + the library's
+            // getCurrentFirstHighlightLineIndexByTime). Now the snapshotFlow only re-evaluates
+            // on line boundaries — every few seconds, not every 16 ms.
+            val syncedLyricsNow = latestSyncedLyrics.value
+            if (syncedLyricsNow.lines.isNotEmpty()) {
+                val newLineIdx = syncedLyricsNow.findLastStartedLineIndex(playbackSyncPosition())
+                if (newLineIdx != currentLineIndexState.intValue) {
+                    currentLineIndexState.intValue = newLineIdx
+                }
+            }
         }
     }
-
-    val playbackSyncPosition: () -> Int =
-        remember {
-            {
-                (
-                    playbackPositionMs.longValue +
-                        latestLyricsSyncOffset.value.toLong() +
-                        latestLeadMs.value +
-                        LYRIC_VISUAL_TUNING_OFFSET_MS
-                ).coerceIn(0L, Int.MAX_VALUE.toLong())
-                    .toInt()
-            }
-        }
-    val lineFocusPosition: () -> Int =
-        remember(syncedLyrics) {
-            {
-                syncedLyrics.positionForStableLineFocus(playbackSyncPosition())
-            }
-        }
 
     val nestedScrollConnection =
         remember {
@@ -477,12 +507,16 @@ fun LyricsEnhanced(
         }.first { it }
 
         var forceNextScroll = true
+        // Read currentLineIndexState (which only changes on line boundaries) instead of
+        // lineFocusPosition() (which read playbackPositionMs and thus re-evaluated every
+        // 16 ms). The snapshotFlow block now only re-runs when the active line actually
+        // changes — every few seconds — so the binary search + library lookup + snapshot
+        // read-tracking overhead disappear from the per-frame hot path.
         snapshotFlow {
             if (isManualScrolling || isSelectionModeActive) {
                 null
             } else {
-                syncedLyrics
-                    .getCurrentFirstHighlightLineIndexByTime(lineFocusPosition())
+                currentLineIndexState.intValue
                     .takeIf { index -> index in syncedLyrics.lines.indices }
             }
         }.distinctUntilChanged()
@@ -496,7 +530,6 @@ fun LyricsEnhanced(
                     index = index,
                     animateToNearbyItem = !forceNextScroll,
                     force = forceNextScroll,
-                    alignByItemCenter = isTtmlFormat,
                 )
                 forceNextScroll = false
             }
@@ -1132,7 +1165,6 @@ private suspend fun LazyListState.scrollLyricIntoFocus(
     index: Int,
     animateToNearbyItem: Boolean,
     force: Boolean,
-    alignByItemCenter: Boolean,
 ) {
     val itemCount = layoutInfo.totalItemsCount
     if (itemCount == 0) return
@@ -1157,23 +1189,15 @@ private suspend fun LazyListState.scrollLyricIntoFocus(
     val viewportHeight = viewportEnd - viewportStart
     if (viewportHeight <= 0) return
 
-    val itemFocusPoint =
-        if (alignByItemCenter) {
-            itemInfo.offset + itemInfo.size / 2
-        } else {
-            itemInfo.offset
-        }
+    // Anchor by the item's TOP edge (not its center) at LYRIC_FOCUS_TOP_ANCHOR_RATIO of the
+    // viewport. Both word-synced and line-synced lyrics use this — the active line stays
+    // in the upper third so users can read ahead.
+    val itemFocusPoint = itemInfo.offset
     val topGuard = viewportStart + (viewportHeight * LYRIC_FOCUS_TOP_GUARD_RATIO).roundToInt()
     val bottomGuard = viewportEnd - (viewportHeight * LYRIC_FOCUS_BOTTOM_GUARD_RATIO).roundToInt()
     if (!force && itemFocusPoint in topGuard..bottomGuard) return
 
-    val anchorRatio =
-        if (alignByItemCenter) {
-            LYRIC_FOCUS_ANCHOR_RATIO
-        } else {
-            LYRIC_LINE_SYNC_TOP_ANCHOR_RATIO
-        }
-    val targetFocusPoint = viewportStart + (viewportHeight * anchorRatio).roundToInt()
+    val targetFocusPoint = viewportStart + (viewportHeight * LYRIC_FOCUS_TOP_ANCHOR_RATIO).roundToInt()
     val scrollDelta = itemFocusPoint - targetFocusPoint
     if (abs(scrollDelta) > LYRIC_FOCUS_MIN_SCROLL_PX) {
         animateScrollBy(
@@ -1195,17 +1219,6 @@ private fun ISyncedLine.lineText(): String =
     }
 
 private fun ISyncedLine.selectionKey(text: String = lineText()): String = "$start:$end:${text.hashCode()}"
-
-private fun SyncedLyrics.positionForStableLineFocus(time: Int): Int {
-    if (lines.isEmpty()) return time
-    val index = findLastStartedLineIndex(time)
-    if (index < 0) return time
-
-    val line = lines[index]
-    if (time < line.end) return time
-
-    return (line.end - 1).coerceAtLeast(line.start)
-}
 
 private fun SyncedLyrics.findLastStartedLineIndex(time: Int): Int {
     var low = 0

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -152,13 +152,29 @@ private const val TTML_LEAD_MS = 0L
 private const val LYRIC_VISUAL_TUNING_OFFSET_MS = 150L
 private const val MANUAL_SCROLL_TIMEOUT_MS = 3000L
 private const val MANUAL_SCROLL_DEBOUNCE_MS = 50L
-// Both word-synced (TTML) and line-synced (LRC) lyrics anchor the active line at the
-// same upper-third ratio. Previously TTML used 0.42f (middle) which pushed the active
-// line to the centre of the screen and felt laggy/awkward; users expect the active
-// line near the top so they can read ahead.
-private const val LYRIC_FOCUS_TOP_ANCHOR_RATIO = 0.30f
-private const val LYRIC_FOCUS_TOP_GUARD_RATIO = 0.18f
-private const val LYRIC_FOCUS_BOTTOM_GUARD_RATIO = 0.24f
+// The active line is pinned close to the TOP of the lyrics pane — right below the
+// song title in the track header — instead of the middle of the screen. Both the
+// mocharealm karaoke library's `offset` parameter (which drives its internal
+// auto-scroll anchor AND the LazyColumn's top content padding) and our custom
+// `scrollLyricIntoFocus` target MUST agree on this ratio, otherwise the two scroll
+// systems fight every frame: the library re-pins the active line at `offset` while
+// our animateScrollBy tries to move it to LYRIC_FOCUS_TOP_ANCHOR_RATIO, producing
+// jitter. Keeping them in lockstep means our scroll only fires on line boundaries
+// to nudge the line into place; the library's per-frame auto-scroll then holds it
+// there.
+//
+// 0.08 ≈ 8% of the lyrics pane height. On a typical phone the pane starts ~132dp
+// below the top of the screen (status bar + grabber + track header), so 8% of a
+// ~668dp pane ≈ 53dp — the active line ends up ~185dp from the top of the screen,
+// i.e. directly under the song title. This matches Apple Music / Spotify / YouTube
+// Music's "read-ahead" layout.
+private const val LYRIC_FOCUS_TOP_ANCHOR_RATIO = 0.08f
+// Guards define the "close enough" zone inside which the custom scroll is skipped.
+// The top guard MUST be smaller than LYRIC_FOCUS_TOP_ANCHOR_RATIO so the resting
+// position (8%) is inside the zone — otherwise the custom scroll would re-fire on
+// every line change to "fix" a position that's already correct.
+private const val LYRIC_FOCUS_TOP_GUARD_RATIO = 0.04f
+private const val LYRIC_FOCUS_BOTTOM_GUARD_RATIO = 0.30f
 private const val LYRIC_FOCUS_MIN_SCROLL_PX = 6
 private const val LYRIC_FOCUS_ANIMATED_DISTANCE = 12
 private const val SMOOTH_PLAYBACK_MAX_FORWARD_DRIFT_MS = 80L
@@ -748,7 +764,15 @@ fun LyricsEnhanced(
                             .fillMaxSize()
                             .nestedScroll(nestedScrollConnection),
                 ) {
-                    val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.38f }
+                    // The karaoke library uses `offset` as BOTH the LazyColumn's top content
+                    // padding AND the anchor its internal auto-scroll pins the active line to.
+                    // 0.38 (the previous value) put the active line at ~38% of the pane —
+                    // visually the middle of the screen. Dropping it to 0.08 (matching
+                    // LYRIC_FOCUS_TOP_ANCHOR_RATIO) pins the active line just under the song
+                    // title, and — critically — keeps the library's per-frame auto-scroll
+                    // target aligned with our `scrollLyricIntoFocus` target so they don't
+                    // fight each other every frame.
+                    val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.08f }
 
                     // Keyed on the session only: romanization updates flow in as new state instead
                     // of disposing and rebuilding the whole karaoke view mid-playback.
@@ -1191,7 +1215,9 @@ private suspend fun LazyListState.scrollLyricIntoFocus(
 
     // Anchor by the item's TOP edge (not its center) at LYRIC_FOCUS_TOP_ANCHOR_RATIO of the
     // viewport. Both word-synced and line-synced lyrics use this — the active line stays
-    // in the upper third so users can read ahead.
+    // pinned near the top of the lyrics pane (right below the song title) so users can
+    // read ahead. This ratio MUST match the `offset` passed to KaraokeLyricsView, otherwise
+    // the library's internal auto-scroll and our animateScrollBy fight every frame.
     val itemFocusPoint = itemInfo.offset
     val topGuard = viewportStart + (viewportHeight * LYRIC_FOCUS_TOP_GUARD_RATIO).roundToInt()
     val bottomGuard = viewportEnd - (viewportHeight * LYRIC_FOCUS_BOTTOM_GUARD_RATIO).roundToInt()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -165,6 +165,27 @@ private const val MANUAL_SCROLL_TIMEOUT_MS = 3000L
 /** Sentinel entry prepended so auto-scroll has headroom above the first line. */
 private val HEAD_LYRICS_ENTRY = LyricsEntry(time = 0L, text = "")
 
+/**
+ * Per-Composable cache for [LyricsUtils.hasTrueWordSync] results. The check allocates
+ * several Lists (filter, map, distinct) per call and is pure — same entry → same result
+ * for the lifetime of the lyrics. Without this cache it was being recomputed for every
+ * visible word-synced line on every 16 ms position tick.
+ *
+ * Keyed by entry identity (LyricsEntry is a stable data class instance held in the
+ * parsed lyrics list). Cleared implicitly when the lyrics list changes because the
+ * entries themselves are GC'd, and the cache is held in `remember` so it dies with the
+ * LyricsV2 composable.
+ */
+private class WordSyncCache {
+    private val cache = HashMap<LyricsEntry, Boolean>()
+
+    fun getOrCompute(entry: LyricsEntry): Boolean =
+        cache.getOrPut(entry) { hasTrueWordSync(entry) }
+}
+
+@Composable
+private fun rememberWordSyncCache(): WordSyncCache = remember { WordSyncCache() }
+
 private fun isRtlText(text: String): Boolean {
     for (ch in text) {
         when (Character.getDirectionality(ch)) {
@@ -309,6 +330,10 @@ fun LyricsV2(
 
     val entriesWithWords: List<LyricsEntry> = lyricsEntries
 
+    // Per-entry cache for hasTrueWordSync() — avoids re-running the (allocating) word-sync
+    // detection on every 16 ms position tick for every visible line.
+    val wordSyncCache = rememberWordSyncCache()
+
     // ── Romanization ──
     LaunchedEffect(entriesWithWords, romanizationPreferences) {
         if (!romanizationPreferences.isEnabled) {
@@ -355,9 +380,17 @@ fun LyricsV2(
 
     // ── Playback position tracking ──
     val leadMs = if (isTtmlFormat) TTML_LEAD_MS else LRC_LEAD_MS
-    var currentPositionMs by remember { mutableLongStateOf(0L) }
+    // Hold the position in an explicit MutableState so we can expose a stable provider lambda
+    // that reads the current value. The lambda identity is stable across position updates, so
+    // passing it to child composables never by itself triggers their recomposition — only the
+    // composables that actually invoke the lambda (active / near-active lines) re-read it.
+    val currentPositionMsState = remember { mutableLongStateOf(0L) }
+    var currentPositionMs by currentPositionMsState
     var playbackPositionMs by remember { mutableLongStateOf(0L) }
     var currentLineIndex by remember { mutableIntStateOf(0) }
+
+    val currentPositionProvider: () -> Long =
+        remember { { currentPositionMsState.longValue } }
 
     LaunchedEffect(entriesWithWords, isSynced, leadMs, lyricsSyncOffset) {
         if (!isSynced || entriesWithWords.isEmpty()) return@LaunchedEffect
@@ -536,119 +569,20 @@ fun LyricsV2(
 
                 // ── Instrumental break icon ──
                 if (item.isInstrumental && isSynced) {
-                    val startTimeMs = item.time
-                    val endTimeMs = item.time + item.durationMs
-                    val isActive = playbackPositionMs in startTimeMs until endTimeMs
-                    val distanceFromActive = abs(index - currentLineIndex)
-                    val instrAlpha =
-                        when {
-                            isActive -> {
-                                1f
-                            }
-
-                            isManualScrolling -> {
-                                when {
-                                    distanceFromActive == 1 -> 0.72f
-                                    distanceFromActive == 2 -> 0.56f
-                                    distanceFromActive == 3 -> 0.40f
-                                    else -> 0.28f
-                                }
-                            }
-
-                            distanceFromActive == 1 -> {
-                                0.52f
-                            }
-
-                            distanceFromActive == 2 -> {
-                                0.30f
-                            }
-
-                            distanceFromActive == 3 -> {
-                                0.18f
-                            }
-
-                            else -> {
-                                inactiveAlpha
-                            }
-                        }
-                    val animatedInstrAlpha by androidx.compose.animation.core.animateFloatAsState(
-                        targetValue = instrAlpha,
-                        animationSpec =
-                            androidx.compose.animation.core.tween(
-                                durationMillis = if (isActive) 330 else 500,
-                                easing = androidx.compose.animation.core.FastOutSlowInEasing,
-                            ),
-                        label = "v2InstrumentalAlpha",
+                    InstrumentalBreakRow(
+                        item = item,
+                        index = index,
+                        hasHeadEntry = entriesWithWords.isNotEmpty() && entriesWithWords[0] === HEAD_LYRICS_ENTRY,
+                        currentLineIndex = currentLineIndex,
+                        isManualScrolling = isManualScrolling,
+                        lyricsLineSpacing = lyricsLineSpacing,
+                        lyricsLineBlur = lyricsLineBlur,
+                        lyricsClick = lyricsClick,
+                        textColor = textColor,
+                        inactiveAlpha = inactiveAlpha,
+                        playbackPositionProvider = { playbackPositionMs },
+                        onSeek = { time -> player.seekTo(time) },
                     )
-                    val animatedInstrScale by androidx.compose.animation.core.animateFloatAsState(
-                        targetValue = if (isActive) 1f else 0.95f,
-                        animationSpec =
-                            androidx.compose.animation.core.tween(
-                                durationMillis = 166,
-                                easing = androidx.compose.animation.core.FastOutSlowInEasing,
-                            ),
-                        label = "v2InstrumentalScale",
-                    )
-                    val targetInstrBlur =
-                        when {
-                            !isSynced || isActive || isManualScrolling -> 0f
-                            distanceFromActive == 1 -> 2f
-                            distanceFromActive == 2 -> 5f
-                            else -> 12f
-                        }
-                    val animatedInstrBlur by androidx.compose.animation.core.animateFloatAsState(
-                        targetValue = targetInstrBlur,
-                        animationSpec =
-                            androidx.compose.animation.core.tween(
-                                durationMillis = 300,
-                                easing = androidx.compose.animation.core.FastOutSlowInEasing,
-                            ),
-                        label = "v2InstrumentalBlur",
-                    )
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(
-                                    start = 12.dp,
-                                    end = 12.dp,
-                                    top =
-                                        if (index == 0 || (index == 1 && entriesWithWords[0] == HEAD_LYRICS_ENTRY)) {
-                                            0.dp
-                                        } else {
-                                            (lyricsLineSpacing * 8).dp
-                                        },
-                                    bottom = (lyricsLineSpacing * 8).dp,
-                                ).then(
-                                    if (lyricsLineBlur) {
-                                        Modifier.blur(
-                                            radiusX = animatedInstrBlur.dp,
-                                            radiusY = animatedInstrBlur.dp,
-                                            edgeTreatment = BlurredEdgeTreatment.Unbounded,
-                                        )
-                                    } else {
-                                        Modifier
-                                    },
-                                ).graphicsLayer {
-                                    scaleX = animatedInstrScale
-                                    scaleY = animatedInstrScale
-                                    alpha = animatedInstrAlpha
-                                }.then(
-                                    if (lyricsClick && item.time > 0) {
-                                        Modifier.clickable { player.seekTo(item.time) }
-                                    } else {
-                                        Modifier
-                                    },
-                                ),
-                    ) {
-                        InstrumentalBreakItem(
-                            durationMs = item.durationMs,
-                            currentPositionMs = playbackPositionMs,
-                            startTimeMs = startTimeMs,
-                            textColor = textColor,
-                            inactiveAlpha = inactiveAlpha,
-                        )
-                    }
                     return@itemsIndexed
                 }
 
@@ -889,12 +823,13 @@ fun LyricsV2(
                             )
                         }
 
-                        if (item.words != null && isSynced && hasTrueWordSync(item)) {
+                        if (item.words != null && isSynced && wordSyncCache.getOrCompute(item)) {
                             LyricsLineV2(
                                 words = item.words!!,
                                 isActive = isActive,
                                 isPast = isPast,
-                                currentPositionMs = currentPositionMs,
+                                distanceFromActive = distanceFromActive,
+                                currentPositionProvider = currentPositionProvider,
                                 textColor = textColor,
                                 inactiveAlpha = inactiveAlpha,
                                 baseFontSize = lyricsTextSize,
@@ -1188,7 +1123,8 @@ private fun LyricsLineV2(
     words: List<WordTimestamp>,
     isActive: Boolean,
     isPast: Boolean,
-    currentPositionMs: Long,
+    distanceFromActive: Int,
+    currentPositionProvider: () -> Long,
     textColor: Color,
     inactiveAlpha: Float,
     baseFontSize: Float,
@@ -1210,6 +1146,28 @@ private fun LyricsLineV2(
     // Split words into main and background
     val mainWords = words.filter { !it.isBackground }
     val bgWords = words.filter { it.isBackground }
+
+    // ── Position-read scoping (the key performance win) ──
+    // Only the active line and its immediate neighbours (distanceFromActive <= 1) need the
+    // live position so word fills can animate. Lines farther away have statically-known word
+    // progress (all-complete for past lines, all-pending for future lines), so we DON'T invoke
+    // the provider at all — we pass a stable sentinel down to AnimatedWordV2. Because the
+    // sentinel doesn't change between ticks, AnimatedWordV2 in far lines is skipped by
+    // Compose's positional equality check — no recomposition, no relayout, no redraw.
+    //
+    // distanceFromActive is computed by the parent from currentLineIndex (which changes only
+    // when the active line changes, ~once per few seconds), NOT from the 16 ms position tick.
+    // So this branch is stable across position ticks → LyricsLineV2 itself is skipped by
+    // Compose for far lines when only the position changes.
+    val isNearActive = isActive || distanceFromActive <= 1
+    val effectivePositionMs =
+        if (isNearActive) {
+            currentPositionProvider()
+        } else if (isPast) {
+            Long.MAX_VALUE
+        } else {
+            0L
+        }
 
     // 1. Render main words First (if any)
     if (mainWords.isNotEmpty()) {
@@ -1240,7 +1198,7 @@ private fun LyricsLineV2(
                     wordIndex = wordIndex,
                     isLineActive = isActive,
                     isLinePast = isPast,
-                    currentPositionMs = currentPositionMs,
+                    currentPositionMs = effectivePositionMs,
                     textColor = textColor,
                     inactiveAlpha = inactiveAlpha,
                     fontSize = if (isLineAllBackground) baseFontSize * 0.82f else baseFontSize,
@@ -1283,7 +1241,7 @@ private fun LyricsLineV2(
                     wordIndex = wordIndex + mainWords.size,
                     isLineActive = isActive,
                     isLinePast = isPast,
-                    currentPositionMs = currentPositionMs,
+                    currentPositionMs = effectivePositionMs,
                     textColor = textColor,
                     inactiveAlpha = inactiveAlpha,
                     fontSize = baseFontSize * 0.65f, // ~65% size of main text
@@ -1365,6 +1323,33 @@ private fun AnimatedWordV2(
     val fontWeight = if (isLineActive || isLinePast) FontWeight.ExtraBold else FontWeight.SemiBold
     val glowPadding = 10.dp
 
+    // ── Cached text style ──
+    // MaterialTheme.typography.headlineMedium.copy(...) was being rebuilt on every recomposition
+    // (every 16 ms tick for active words). The only field that changes per-frame for the overlay
+    // layer is `shadow` (glow), so we cache the base style here and only rebuild the overlay
+    // style when the glow is actually visible. The base (dim) layer style is fully cached.
+    val baseHeadlineStyle = MaterialTheme.typography.headlineMedium
+    val baseTextStyle =
+        remember(baseHeadlineStyle, actualFontSize, fontWeight, lyricsFontFamily) {
+            baseHeadlineStyle.copy(
+                fontSize = actualFontSize.sp,
+                fontWeight = fontWeight,
+                fontStyle = FontStyle.Normal,
+                lineHeight = (actualFontSize * 1.35f).sp,
+                fontFamily = lyricsFontFamily ?: baseHeadlineStyle.fontFamily,
+            )
+        }
+
+    // ── Cached gradient colors for the liquid-sweep mask ──
+    // listOf(Color.Transparent, Color.Black) was being allocated every frame for every active
+    // word inside drawWithContent. Precompute the two immutable color lists (LTR + RTL) once.
+    val sweepColors =
+        if (isRtl) {
+            remember { listOf(Color.Transparent, Color.Black) }
+        } else {
+            remember { listOf(Color.Black, Color.Transparent) }
+        }
+
     // ── Two-layer rendering: dim base + liquid fill overlay ──
     Box(
         modifier =
@@ -1396,40 +1381,33 @@ private fun AnimatedWordV2(
         // Layer 1: Base text (always dimmed)
         Text(
             text = word.text,
-            style =
-                MaterialTheme.typography.headlineMedium.copy(
-                    fontSize = actualFontSize.sp,
-                    fontWeight = fontWeight,
-                    fontStyle = FontStyle.Normal,
-                    lineHeight = (actualFontSize * 1.35f).sp,
-                    fontFamily = lyricsFontFamily ?: MaterialTheme.typography.headlineMedium.fontFamily,
-                ),
+            style = baseTextStyle,
             color = textColor.copy(alpha = if (isBackground) inactiveAlpha * 0.7f else inactiveAlpha),
             modifier = Modifier.padding(glowPadding),
         )
 
         // Layer 2: Filled overlay with liquid sweep mask + glow
         if (isWordComplete || isWordActive || isLinePast) {
-            Text(
-                text = word.text,
-                style =
-                    MaterialTheme.typography.headlineMedium.copy(
-                        fontSize = actualFontSize.sp,
-                        fontWeight = fontWeight,
-                        fontStyle = FontStyle.Normal,
-                        lineHeight = (actualFontSize * 1.35f).sp,
-                        fontFamily = lyricsFontFamily ?: MaterialTheme.typography.headlineMedium.fontFamily,
-                        shadow =
-                            if (glowAlpha > 0f) {
+            // Only rebuild the overlay style (with shadow) when glow is actually visible —
+            // avoids allocating a Shadow + copying the style on every frame for completed/past words.
+            val overlayTextStyle =
+                if (glowAlpha > 0f) {
+                    remember(baseTextStyle, glowAlpha, glowRadius, textColor) {
+                        baseTextStyle.copy(
+                            shadow =
                                 Shadow(
                                     color = textColor.copy(alpha = glowAlpha),
                                     offset = Offset.Zero,
                                     blurRadius = glowRadius.coerceAtLeast(1f),
-                                )
-                            } else {
-                                null
-                            },
-                    ),
+                                ),
+                        )
+                    }
+                } else {
+                    baseTextStyle
+                }
+            Text(
+                text = word.text,
+                style = overlayTextStyle,
                 color =
                     textColor.copy(
                         alpha = if (isBackground) 0.75f else 1f,
@@ -1450,12 +1428,7 @@ private fun AnimatedWordV2(
                                 drawRect(
                                     brush =
                                         androidx.compose.ui.graphics.Brush.horizontalGradient(
-                                            colors =
-                                                if (isRtl) {
-                                                    listOf(Color.Transparent, Color.Black)
-                                                } else {
-                                                    listOf(Color.Black, Color.Transparent)
-                                                },
+                                            colors = sweepColors,
                                             startX = center - edgeWidth,
                                             endX = center + edgeWidth,
                                         ),
@@ -1606,6 +1579,130 @@ private fun LrcBouncingWord(
 // ──────────────────────────────────────────────────────────────────────
 // Instrumental break icon: music-note filled bottom-to-top over the gap
 // ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Extracted wrapper for the instrumental-break row.
+ *
+ * Reads [playbackPositionProvider] internally so the parent `itemsIndexed` lambda doesn't
+ * subscribe to the 16 ms position tick. Without this extraction, every visible item (word-synced
+ * lines included) would recompose on every position update because Compose tracks snapshot-state
+ * reads at the composable-call scope, not per-control-flow branch.
+ */
+@Composable
+private fun InstrumentalBreakRow(
+    item: LyricsEntry,
+    index: Int,
+    hasHeadEntry: Boolean,
+    currentLineIndex: Int,
+    isManualScrolling: Boolean,
+    lyricsLineSpacing: Float,
+    lyricsLineBlur: Boolean,
+    lyricsClick: Boolean,
+    textColor: Color,
+    inactiveAlpha: Float,
+    playbackPositionProvider: () -> Long,
+    onSeek: (Long) -> Unit,
+) {
+    val startTimeMs = item.time
+    val endTimeMs = item.time + item.durationMs
+    val playbackPositionMs = playbackPositionProvider()
+    val isActive = playbackPositionMs in startTimeMs until endTimeMs
+    val distanceFromActive = abs(index - currentLineIndex)
+    val instrAlpha =
+        when {
+            isActive -> 1f
+            isManualScrolling -> {
+                when {
+                    distanceFromActive == 1 -> 0.72f
+                    distanceFromActive == 2 -> 0.56f
+                    distanceFromActive == 3 -> 0.40f
+                    else -> 0.28f
+                }
+            }
+            distanceFromActive == 1 -> 0.52f
+            distanceFromActive == 2 -> 0.30f
+            distanceFromActive == 3 -> 0.18f
+            else -> inactiveAlpha
+        }
+    val animatedInstrAlpha by androidx.compose.animation.core.animateFloatAsState(
+        targetValue = instrAlpha,
+        animationSpec =
+            androidx.compose.animation.core.tween(
+                durationMillis = if (isActive) 330 else 500,
+                easing = androidx.compose.animation.core.FastOutSlowInEasing,
+            ),
+        label = "v2InstrumentalAlpha",
+    )
+    val animatedInstrScale by androidx.compose.animation.core.animateFloatAsState(
+        targetValue = if (isActive) 1f else 0.95f,
+        animationSpec =
+            androidx.compose.animation.core.tween(
+                durationMillis = 166,
+                easing = androidx.compose.animation.core.FastOutSlowInEasing,
+            ),
+        label = "v2InstrumentalScale",
+    )
+    val targetInstrBlur =
+        when {
+            isActive || isManualScrolling -> 0f
+            distanceFromActive == 1 -> 2f
+            distanceFromActive == 2 -> 5f
+            else -> 12f
+        }
+    val animatedInstrBlur by androidx.compose.animation.core.animateFloatAsState(
+        targetValue = targetInstrBlur,
+        animationSpec =
+            androidx.compose.animation.core.tween(
+                durationMillis = 300,
+                easing = androidx.compose.animation.core.FastOutSlowInEasing,
+            ),
+        label = "v2InstrumentalBlur",
+    )
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = 12.dp,
+                    end = 12.dp,
+                    top =
+                        if (index == 0 || (index == 1 && hasHeadEntry)) {
+                            0.dp
+                        } else {
+                            (lyricsLineSpacing * 8).dp
+                        },
+                    bottom = (lyricsLineSpacing * 8).dp,
+                ).then(
+                    if (lyricsLineBlur) {
+                        Modifier.blur(
+                            radiusX = animatedInstrBlur.dp,
+                            radiusY = animatedInstrBlur.dp,
+                            edgeTreatment = BlurredEdgeTreatment.Unbounded,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ).graphicsLayer {
+                    scaleX = animatedInstrScale
+                    scaleY = animatedInstrScale
+                    alpha = animatedInstrAlpha
+                }.then(
+                    if (lyricsClick && item.time > 0) {
+                        Modifier.clickable { onSeek(item.time) }
+                    } else {
+                        Modifier
+                    },
+                ),
+    ) {
+        InstrumentalBreakItem(
+            durationMs = item.durationMs,
+            currentPositionMs = playbackPositionMs,
+            startTimeMs = startTimeMs,
+            textColor = textColor,
+            inactiveAlpha = inactiveAlpha,
+        )
+    }
+}
 
 @Composable
 private fun InstrumentalBreakItem(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/AppleMusicSleepTimerSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/AppleMusicSleepTimerSheet.kt
@@ -1,0 +1,267 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.menu
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.playback.SleepTimer
+import moe.rukamori.archivetune.utils.makeTimeString
+import kotlin.math.abs
+
+/**
+ * Apple Music–style sleep timer sheet.
+ *
+ * Renders as a compact modal sheet with:
+ *  - A header showing the current timer status (Off / End of song / m:ss remaining).
+ *  - A horizontal wrap of preset duration chips (5/10/15/20/30/45/60/90 min).
+ *  - An "End of current song" chip.
+ *  - A "Turn off timer" chip that only appears when the timer is active.
+ *
+ * Designed to be embedded inside the existing bottom-sheet menu container that
+ * PlayerMenu already lives in (so we don't introduce a second modal layer).
+ * The parent supplies the active [SleepTimer] instance so this composable can
+ * poll it for the live countdown and call [SleepTimer.start] / [SleepTimer.clear]
+ * directly — no extra callback wiring required.
+ */
+@Composable
+fun AppleMusicSleepTimerSheet(
+    sleepTimer: SleepTimer,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Poll the SleepTimer every 500ms for the live countdown. We deliberately
+    // don't read `triggerTime` as a Compose state here because the timer mutates
+    // it from a background coroutine — reading it once per recomposition via the
+    // published `var triggerTime` works fine, but a 500ms polling loop keeps the
+    // displayed countdown smooth without forcing a recomp on every millis tick.
+    var remainingMs by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(sleepTimer, sleepTimer.isActive) {
+        while (isActive) {
+            remainingMs =
+                when {
+                    sleepTimer.pauseWhenSongEnd -> -1L // sentinel: "end of song"
+                    sleepTimer.triggerTime > 0 -> sleepTimer.triggerTime - System.currentTimeMillis()
+                    else -> 0L
+                }
+            delay(500L)
+        }
+    }
+
+    val isEndOfSong = sleepTimer.pauseWhenSongEnd
+    val isTimed = sleepTimer.triggerTime > 0 && !isEndOfSong
+    val isActive = sleepTimer.isActive
+
+    Surface(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .wrapContentHeight(),
+        shape = RoundedCornerShape(28.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        tonalElevation = 3.dp,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 16.dp)
+                    .padding(bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()),
+        ) {
+            // Header row — icon + status text.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.secondaryContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.bedtime),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.sleep_timer),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    val statusText =
+                        when {
+                            isEndOfSong -> stringResource(R.string.sleep_timer_end_of_song)
+                            isTimed && remainingMs > 0 ->
+                                stringResource(
+                                    R.string.sleep_timer_remaining,
+                                    makeTimeString(remainingMs),
+                                )
+                            else -> stringResource(R.string.sleep_timer_pick_a_time)
+                        }
+                    Text(
+                        text = statusText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // Preset duration chips — Apple Music exposes a similar chip row.
+            val presets =
+                remember {
+                    listOf(5, 10, 15, 20, 30, 45, 60, 90)
+                }
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                presets.forEach { minutes ->
+                    val selected =
+                        isTimed &&
+                            abs(
+                                (sleepTimer.triggerTime - System.currentTimeMillis()) -
+                                    minutes.toLong() * 60_000L,
+                            ) < 30_000L // within 30s = same preset (handles small drift)
+                    FilterChip(
+                        selected = selected,
+                        onClick = {
+                            sleepTimer.start(minutes)
+                            onDismiss()
+                        },
+                        label = { Text("${minutes}m") },
+                        shape = RoundedCornerShape(20.dp),
+                        colors =
+                            FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = MaterialTheme.colorScheme.primary,
+                                selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                            ),
+                    )
+                }
+
+                // End of song chip.
+                FilterChip(
+                    selected = isEndOfSong,
+                    onClick = {
+                        sleepTimer.start(-1)
+                        onDismiss()
+                    },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.skip_next),
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                    label = { Text(stringResource(R.string.sleep_timer_end_of_song)) },
+                    shape = RoundedCornerShape(20.dp),
+                    colors =
+                        FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                            selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                )
+            }
+
+            // "Turn off timer" — only visible when the timer is active.
+            AnimatedVisibility(
+                visible = isActive,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                Spacer(Modifier.height(12.dp))
+            }
+            AnimatedVisibility(visible = isActive) {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(20.dp))
+                            .background(MaterialTheme.colorScheme.errorContainer)
+                            .clickable {
+                                sleepTimer.clear()
+                                onDismiss()
+                            }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.close),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.sleep_timer_cancel_timer),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -56,7 +56,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -156,13 +155,13 @@ fun PlayerMenu(
         }
     val activityResultLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { }
-    val librarySong by database.song(mediaMetadata.id).collectAsState(initial = null)
+    val librarySong by database.song(mediaMetadata.id).collectAsStateWithLifecycle(initialValue = null)
     val coroutineScope = rememberCoroutineScope()
 
     val downloadUtil = LocalDownloadUtil.current
     val download by downloadUtil
         .getDownload(mediaMetadata.id)
-        .collectAsState(initial = null)
+        .collectAsStateWithLifecycle(initialValue = null)
 
     val artists =
         remember(mediaMetadata.artists) {
@@ -449,6 +448,11 @@ fun PlayerMenu(
         )
     }
 
+    // Apple Music–style sleep timer sheet. Rendered as an extra item at the
+    // bottom of the same scrollable menu (no second modal layer) so the user
+    // can pick a duration without leaving the song's overflow menu.
+    var showSleepTimerSheet by rememberSaveable { mutableStateOf(false) }
+
     var showEqualizerDialog by rememberSaveable {
         mutableStateOf(false)
     }
@@ -573,6 +577,22 @@ fun PlayerMenu(
                 bottom = 8.dp + WindowInsets.systemBars.asPaddingValues().calculateBottomPadding(),
             ),
     ) {
+        // When the user taps "Sleep timer", replace the menu body with the
+        // Apple Music–style picker sheet. Keeping the surface header (album art
+        // + title) above gives the user context that this sheet still belongs
+        // to the current song, while the rest of the menu items are hidden so
+        // the sheet is immediately visible without scrolling.
+        if (showSleepTimerSheet) {
+            item {
+                AppleMusicSleepTimerSheet(
+                    sleepTimer = playerConnection.service.sleepTimer,
+                    onDismiss = {
+                        showSleepTimerSheet = false
+                        onDismiss()
+                    },
+                )
+            }
+        } else {
         item {
             MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
                 NewActionGrid(
@@ -1041,6 +1061,27 @@ fun PlayerMenu(
                             color = MaterialTheme.colorScheme.outlineVariant,
                         )
 
+                        // Sleep timer row — appears in the secondary list section alongside
+                        // Equalizer and Tempo & Pitch. Tapping it opens the inline Apple
+                        // Music–style sheet at the bottom of the menu.
+                        ListItem(
+                            headlineContent = { Text(text = stringResource(R.string.sleep_timer)) },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.bedtime),
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier =
+                                Modifier.clickable { showSleepTimerSheet = true },
+                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        )
+
+                        HorizontalDivider(
+                            modifier = Modifier.padding(start = 56.dp),
+                            color = MaterialTheme.colorScheme.outlineVariant,
+                        )
+
                         ListItem(
                             headlineContent = { Text(text = stringResource(R.string.equalizer)) },
                             leadingContent = {
@@ -1067,7 +1108,7 @@ fun PlayerMenu(
                                 )
                             },
                             supportingContent = {
-                                val playbackParameters by playerConnection.playbackParameters.collectAsState()
+                                val playbackParameters by playerConnection.playbackParameters.collectAsStateWithLifecycle()
                                 Text(
                                     text = "x${formatMultiplier(
                                         playbackParameters.speed,
@@ -1083,6 +1124,7 @@ fun PlayerMenu(
                 }
             }
         }
+        } // end else (menu body)
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2429,14 +2429,21 @@ private fun MikoLyricsTransition(
     }
     val progressState = progress.asState()
     val showContent by remember {
-        // Defer composing the heavy LyricsScreen tree until the sheet has crossed the halfway
-        // mark (progress > 0.5). On open, the slow spring takes ~250 ms to reach this point,
-        // which is enough time for the slide-up to visually "commit" before the lyrics tree is
-        // composed — this avoids jank on low-end devices and avoids the "blank panel then
-        // pop-in" artifact that immediate composition introduced on devices where the first
-        // frame of the lyrics tree takes longer than 16ms to compute. On close, the lyrics
-        // tree stays composed until progress drops back below 0.5, so the slide-down is smooth.
-        derivedStateOf { visible || progressState.value > 0.5f }
+        // Keep the heavy LyricsScreen tree composed for almost the entire close transition.
+        //
+        // The outer Box's graphicsLayer slides the whole sheet on/off screen via translationY
+        // = size.height * (1 - progress). The previous threshold of 0.5 unmounted the lyrics
+        // tree when the sheet was only halfway down — so for the last ~350 ms of the ~700 ms
+        // close spring the user saw an empty surface slide off-screen instead of the lyrics
+        // content, which read as the animation "ending abruptly".
+        //
+        // Dropping the threshold to 0.02 keeps the lyrics tree alive until the sheet is 98%
+        // off-screen (translationY ≈ 0.98 * height), at which point unmounting is invisible.
+        // The open path is unchanged: `visible` flips to true immediately on open, which
+        // short-circuits the `||` and composes the tree right away (no first-frame jank
+        // regression because the slide-up is already moving by the time the first frame of
+        // the lyrics tree is ready).
+        derivedStateOf { visible || progressState.value > 0.02f }
     }
 
     if (showContent) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2429,21 +2429,29 @@ private fun MikoLyricsTransition(
     }
     val progressState = progress.asState()
     val showContent by remember {
-        // Keep the heavy LyricsScreen tree composed for almost the entire close transition.
+        // Keep the heavy LyricsScreen tree composed for the ENTIRE close transition —
+        // the lyrics content must still be visible on the very last frame the sheet
+        // is on screen (progress → 0, translationY → height).
         //
-        // The outer Box's graphicsLayer slides the whole sheet on/off screen via translationY
-        // = size.height * (1 - progress). The previous threshold of 0.5 unmounted the lyrics
-        // tree when the sheet was only halfway down — so for the last ~350 ms of the ~700 ms
-        // close spring the user saw an empty surface slide off-screen instead of the lyrics
-        // content, which read as the animation "ending abruptly".
+        // The outer Box's graphicsLayer slides the whole sheet on/off screen via
+        // translationY = size.height * (1 - progress). Earlier thresholds (0.5, then
+        // 0.02) unmounted the lyrics tree before the slide-down finished, leaving an
+        // empty surface sliding off-screen — visible as the animation "ending
+        // abruptly" for the final frames.
         //
-        // Dropping the threshold to 0.02 keeps the lyrics tree alive until the sheet is 98%
-        // off-screen (translationY ≈ 0.98 * height), at which point unmounting is invisible.
-        // The open path is unchanged: `visible` flips to true immediately on open, which
-        // short-circuits the `||` and composes the tree right away (no first-frame jank
-        // regression because the slide-up is already moving by the time the first frame of
-        // the lyrics tree is ready).
-        derivedStateOf { visible || progressState.value > 0.02f }
+        // `progressState.value > 0f` keeps the tree composed for the whole spring
+        // glide. The close spring is critically damped (dampingRatio = 1f) so it
+        // approaches 0 monotonically with no overshoot; when the deviation drops
+        // below the visibilityThreshold (0.001f) Animatable snaps to exactly 0.0f,
+        // at which point `progress > 0f` flips false and the tree unmounts — by then
+        // translationY is exactly `height`, i.e. the sheet is 100% off-screen, so
+        // unmounting is invisible.
+        //
+        // Open path is unchanged: `visible` flips to true immediately on open,
+        // short-circuiting the `||` and composing the tree right away (no first-
+        // frame jank regression because the slide-up is already moving by the time
+        // the first frame of the lyrics tree is ready).
+        derivedStateOf { visible || progressState.value > 0f }
     }
 
     if (showContent) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -82,7 +82,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -456,19 +455,19 @@ fun BottomSheetPlayer(
             MaterialTheme.colorScheme.surfaceContainer.copy(alpha = progress)
         }
 
-    val playbackState by playerConnection.playbackState.collectAsState()
-    val isPlaying by playerConnection.isPlaying.collectAsState()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
-    val currentSong by playerConnection.currentSong.collectAsState(initial = null)
+    val playbackState by playerConnection.playbackState.collectAsStateWithLifecycle()
+    val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
+    val currentSong by playerConnection.currentSong.collectAsStateWithLifecycle(initialValue = null)
     val currentSongLiked = currentSong?.song?.liked == true
-    val queueTitle by playerConnection.queueTitle.collectAsState()
-    val currentFormat by playerConnection.currentFormat.collectAsState(initial = null)
+    val queueTitle by playerConnection.queueTitle.collectAsStateWithLifecycle()
+    val currentFormat by playerConnection.currentFormat.collectAsStateWithLifecycle(initialValue = null)
     // Snapshot the lyrics entity for the AOD screen — AOD shows only the current line, so we
     // pass the raw text down rather than the full Lyrics composable tree (cheaper to render,
     // and matches the "dim, low-power" goal of always-on display).
-    val currentLyricsEntity by playerConnection.currentLyrics.collectAsState(initial = null)
-    val queueWindows by playerConnection.queueWindows.collectAsState()
-    val currentWindowIndex by playerConnection.currentWindowIndex.collectAsState()
+    val currentLyricsEntity by playerConnection.currentLyrics.collectAsStateWithLifecycle(initialValue = null)
+    val queueWindows by playerConnection.queueWindows.collectAsStateWithLifecycle()
+    val currentWindowIndex by playerConnection.currentWindowIndex.collectAsStateWithLifecycle()
     val deviceMusicVolumeController = rememberDeviceMusicVolumeController()
     val onPlayerVolumeChange =
         remember(deviceMusicVolumeController) {
@@ -477,10 +476,10 @@ fun BottomSheetPlayer(
             }
         }
 
-    val repeatMode by playerConnection.repeatMode.collectAsState()
+    val repeatMode by playerConnection.repeatMode.collectAsStateWithLifecycle()
 
-    val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
-    val canSkipNext by playerConnection.canSkipNext.collectAsState()
+    val canSkipPrevious by playerConnection.canSkipPrevious.collectAsStateWithLifecycle()
+    val canSkipNext by playerConnection.canSkipNext.collectAsStateWithLifecycle()
 
     val aodModeEnabled by playerConnection.aodModeEnabled.collectAsStateWithLifecycle()
     val (thumbnailCornerRadius) = rememberPreference(ThumbnailCornerRadiusKey, defaultValue = 8f)
@@ -682,7 +681,7 @@ fun BottomSheetPlayer(
 
     val download by LocalDownloadUtil.current
         .getDownload(mediaMetadata?.id ?: "")
-        .collectAsState(initial = null)
+        .collectAsStateWithLifecycle(initialValue = null)
 
     val sleepTimerEnabled =
         remember(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -62,7 +62,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -153,16 +152,16 @@ fun Queue(
     val bottomSheetPageState = LocalBottomSheetPageState.current
 
     val playerConnection = LocalPlayerConnection.current ?: return
-    val isPlaying by playerConnection.isPlaying.collectAsState()
-    val repeatMode by playerConnection.repeatMode.collectAsState()
+    val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
+    val repeatMode by playerConnection.repeatMode.collectAsStateWithLifecycle()
 
-    val currentWindowIndex by playerConnection.currentWindowIndex.collectAsState()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
-    val currentSong by playerConnection.currentSong.collectAsState(initial = null)
+    val currentWindowIndex by playerConnection.currentWindowIndex.collectAsStateWithLifecycle()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
+    val currentSong by playerConnection.currentSong.collectAsStateWithLifecycle(initialValue = null)
     val currentSongLiked = currentSong?.song?.liked == true
 
-    val currentFormat by playerConnection.currentFormat.collectAsState(initial = null)
-    val queueTitle by playerConnection.queueTitle.collectAsState()
+    val currentFormat by playerConnection.currentFormat.collectAsStateWithLifecycle(initialValue = null)
+    val queueTitle by playerConnection.queueTitle.collectAsStateWithLifecycle()
 
     val selectedSongs = remember { mutableStateListOf<MediaMetadata>() }
     val selectedItems = remember { mutableStateListOf<Timeline.Window>() }
@@ -182,8 +181,8 @@ fun Queue(
 
     var locked by rememberPreference(QueueEditLockKey, defaultValue = true)
     var infiniteQueueEnabled by rememberPreference(AutoLoadMoreKey, defaultValue = true)
-    val infiniteQueueLoading by playerConnection.service.infiniteQueueLoading.collectAsState()
-    val togetherSessionState by playerConnection.service.togetherSessionState.collectAsState()
+    val infiniteQueueLoading by playerConnection.service.infiniteQueueLoading.collectAsStateWithLifecycle()
+    val togetherSessionState by playerConnection.service.togetherSessionState.collectAsStateWithLifecycle()
     val togetherForcesLock =
         togetherSessionState is moe.rukamori.archivetune.together.TogetherSessionState.Joined &&
             (togetherSessionState as moe.rukamori.archivetune.together.TogetherSessionState.Joined).role is moe.rukamori.archivetune.together.TogetherRole.Guest
@@ -296,7 +295,7 @@ fun Queue(
         )
     }
 
-    val queueWindows by playerConnection.queueWindows.collectAsState()
+    val queueWindows by playerConnection.queueWindows.collectAsStateWithLifecycle()
     val currentWindow =
         remember(currentWindowIndex, queueWindows) {
             queueWindows.getOrNull(currentWindowIndex)
@@ -573,7 +572,7 @@ fun Queue(
                 }
 
                 PlayerDesignStyle.V9 -> {
-                    val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
+                    val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsStateWithLifecycle()
                     QueueCollapsedContentV9(
                         showCodecOnPlayer = showCodecOnPlayer,
                         currentFormat = currentFormat,
@@ -665,7 +664,7 @@ fun Queue(
             }
         },
     ) {
-        val queueWindows by playerConnection.queueWindows.collectAsState()
+        val queueWindows by playerConnection.queueWindows.collectAsStateWithLifecycle()
         val mutableQueueWindows =
             remember {
                 mutableStateListOf<Timeline.Window>().apply {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/YearInMusicScreen.kt
@@ -1346,43 +1346,6 @@ private fun RecapCardContent(
 }
 
 @Composable
-private fun HeroMetricTile(
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier =
-            modifier
-                .clip(RoundedCornerShape(RecapTokens.SectionRadius))
-                .background(RecapCream.copy(alpha = 0.13f))
-                .border(
-                    width = 1.dp,
-                    color = RecapCream.copy(alpha = 0.14f),
-                    shape = RoundedCornerShape(RecapTokens.SectionRadius),
-                ).padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.SemiBold,
-            color = RecapCream.copy(alpha = 0.66f),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Black,
-            color = RecapCream,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-    }
-}
-
-@Composable
 private fun RankedArtistRow(
     rank: Int,
     artist: Artist,
@@ -1522,21 +1485,6 @@ private fun RankNumber(
             color = color,
         )
     }
-}
-
-@Composable
-private fun SummaryHighlightRow(
-    icon: Int,
-    label: String,
-    value: String,
-    color: Color,
-) {
-    RecapStatRow(
-        icon = icon,
-        label = label,
-        value = value,
-        color = color,
-    )
 }
 
 @Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
@@ -547,37 +547,6 @@ fun LocalSongScreen(
 }
 
 @Composable
-private fun LocalSongBadge(
-    iconRes: Int,
-    text: String,
-) {
-    Surface(
-        shape = RoundedCornerShape(20.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.92f),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-        ) {
-            Icon(
-                painter = painterResource(iconRes),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(18.dp),
-            )
-            Text(
-                text = text,
-                style = MaterialTheme.typography.labelLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
-}
-
-@Composable
 private fun LocalSongControlsCard(
     sortType: LocalSongSortType,
     sortDescending: Boolean,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
@@ -1324,11 +1324,3 @@ private fun TokenEditorDialog(
         },
     )
 }
-
-private fun previewSecureValue(value: String): String {
-    val normalized = value.replace("\n", " ").replace("\r", " ").trim()
-    if (normalized.length <= 76) {
-        return normalized
-    }
-    return normalized.take(52) + "\u2025" + normalized.takeLast(18)
-}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -109,7 +109,9 @@ import moe.rukamori.archivetune.constants.SliderStyle
 import moe.rukamori.archivetune.constants.SliderStyleKey
 import moe.rukamori.archivetune.constants.SwipeSensitivityKey
 import moe.rukamori.archivetune.constants.SwipeThumbnailKey
+import moe.rukamori.archivetune.constants.TabletModeEnabledKey
 import moe.rukamori.archivetune.constants.ThumbnailCornerRadiusKey
+import moe.rukamori.archivetune.constants.UiScaleFactorKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
 import moe.rukamori.archivetune.ui.component.IconButton
@@ -197,6 +199,16 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
     val (forceHighRefreshRate, onForceHighRefreshRateChange) =
         rememberPreference(
             ForceHighRefreshRateKey,
+            defaultValue = false,
+        )
+    val (uiScale, onUiScaleChange) =
+        rememberPreference(
+            UiScaleFactorKey,
+            defaultValue = 1.0f,
+        )
+    val (tabletModeEnabled, onTabletModeEnabledChange) =
+        rememberPreference(
+            TabletModeEnabledKey,
             defaultValue = false,
         )
     val (blurRadius, onBlurRadiusChange) = rememberPreference(BlurRadiusKey, defaultValue = 48f)
@@ -540,6 +552,37 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         checked = disableAnimations,
                         onCheckedChange = onDisableAnimationsChange,
                     )
+                }
+
+                item {
+                    Column(modifier = positions.modifierFor("ui_scale")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.ui_scale)) },
+                            description = stringResource(R.string.ui_scale_desc),
+                            icon = { Icon(painterResource(R.drawable.text_fields), null) },
+                            content = {
+                                Spacer(modifier = Modifier.height(10.dp))
+                                Slider(
+                                    value = uiScale,
+                                    onValueChange = { v ->
+                                        // Round to the nearest 1% so the displayed value and the
+                                        // stored value stay in sync (otherwise dragging produces
+                                        // long-tail floats like 0.92371 that look messy in backups).
+                                        onUiScaleChange((v * 100f).roundToInt() / 100f)
+                                    },
+                                    valueRange = 0.85f..1.30f,
+                                    steps = 44, // 45 discrete positions = 1% increments
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                Text(
+                                    text = stringResource(R.string.ui_scale_value, (uiScale * 100f).roundToInt()),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(start = 56.dp, top = 4.dp),
+                                )
+                            },
+                        )
+                    }
                 }
 
                 item {
@@ -959,6 +1002,16 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 modifier = positions.modifierFor("app_language"),
                 title = stringResource(R.string.misc),
             ) {
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.tablet_mode)) },
+                        description = stringResource(R.string.tablet_mode_desc),
+                        icon = { Icon(painterResource(R.drawable.desktop_windows), null) },
+                        checked = tabletModeEnabled,
+                        onCheckedChange = onTabletModeEnabledChange,
+                    )
+                }
+
                 item {
                     EnumListPreference(
                         title = { Text(stringResource(R.string.quick_picks_display_mode)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -572,37 +572,6 @@ private fun UserCard(
 }
 
 @Composable
-private fun DashboardSectionHeader(
-    text: String,
-    count: Int,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Surface(
-            modifier = Modifier.size(8.dp),
-            shape = CircleShape,
-            color = DashboardAccentColor,
-        ) {}
-        Spacer(Modifier.width(8.dp))
-        Text(
-            text = text,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-        )
-        Spacer(Modifier.weight(1f))
-        Text(
-            text = "$count ${stringResource(R.string.songs)}",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-@Composable
 private fun EmptyHint(text: String) {
     Text(
         text = text,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
@@ -1307,23 +1307,6 @@ object YTPlayerUtils {
             .onFailure { Timber.tag(logTag).e(it, "Failed to fetch metadata") }
     }
 
-    private fun findFormat(
-        playerResponse: PlayerResponse,
-        audioQuality: AudioQuality,
-        connectivityManager: ConnectivityManager,
-        // optional override from user preference; if non-null, use this instead of ConnectivityManager
-        networkMetered: Boolean? = null,
-        preferM4A: Boolean = false,
-    ): PlayerResponse.StreamingData.Format? {
-        val isMetered = networkMetered ?: connectivityManager.isActiveNetworkMetered
-        return selectAudioFormatCandidates(
-            playerResponse,
-            audioQuality,
-            isMetered,
-            preferM4A = preferM4A,
-        ).firstOrNull()
-    }
-
     private fun selectAudioFormatCandidates(
         playerResponse: PlayerResponse,
         audioQuality: AudioQuality,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -512,6 +512,17 @@
     <string name="max_supported_refresh_rate">Max supported: %1$d Hz</string>
     <string name="blur_intensity">Blur intensity</string>
     <string name="blur_intensity_value">%1$d dp</string>
+    <string name="ui_scale">UI scale</string>
+    <string name="ui_scale_desc">Adjust the size of all UI elements (smaller = more content, larger = easier to read)</string>
+    <string name="ui_scale_value">%1$d%%</string>
+    <string name="tablet_mode">Tablet mode</string>
+    <string name="tablet_mode_desc">Use the two-pane tablet layout (side navigation rail) on all screen sizes. Recommended for tablets and landscape phones.</string>
+    <string name="sleep_timer_off">Off</string>
+    <string name="sleep_timer_set_for">Sleep timer: %1$s</string>
+    <string name="sleep_timer_end_of_song">End of song</string>
+    <string name="sleep_timer_cancel_timer">Turn off timer</string>
+    <string name="sleep_timer_remaining">%1$s remaining</string>
+    <string name="sleep_timer_pick_a_time">Pick a time for the sleep timer</string>
     <string name="album_backdrop">Backdrop blur</string>
     <string name="album_backdrop_desc">Show artwork as blurred backdrop on the player</string>
     <string name="backdrop_blur_amount">Backdrop blur amount</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,12 @@ org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Djava.awt.headless=true -XX:
 kotlin.daemon.jvmargs=-Xmx4096M -Djava.awt.headless=true
 android.useAndroidX=true
 android.enableJetifier=false
+# R8 full mode is the default since AGP 8.0, but set it explicitly so the intent is
+# documented and to guard against any future AGP default change. Full mode enables more
+# aggressive shrinking (stricter type analysis, dead-code elimination, deeper inlining)
+# than the legacy compat mode — typically reduces DEX size by 5–10% on top of the existing
+# `-keep` rules. All reflection entry points are already covered by proguard-rules.pro.
+android.enableR8.fullMode=true
 org.gradle.configuration-cache=true
 org.gradle.unsafe.configuration-cache=true
 org.gradle.configuration-cache.problems=warn


### PR DESCRIPTION
## Summary

Seven-part feature/quality/size/perf pass — all in one PR per request:

### 1. DPI adjustment slider (Appearance → Theme)
New `UiScaleFactorKey` (0.85–1.30, 1% steps) applied via a `LocalDensity` override in `MainActivity`. The entire Compose tree (text, icons, paddings) scales together — effectively a DPI-like control that works on any device, including ones where the system DPI is locked.

### 2. Apple Music–style Sleep timer (songs overflow menu)
New `AppleMusicSleepTimerSheet.kt`. UI = header with live countdown + FlowRow of preset FilterChips (5/10/15/20/30/45/60/90 min) + End-of-song chip + Turn-off-timer row. Tapping **Sleep timer** in `PlayerMenu` replaces the menu body with the sheet so the picker is immediately visible without scrolling. Polls the existing `SleepTimer` every 500ms for the live countdown.

### 3. Tablet mode (Appearance → Misc)
New `TabletModeEnabledKey`. When ON, forces the side `NavigationRail` layout regardless of window dp width — useful on tablets where the dp breakpoint misclassifies the window, and on landscape phones.

### 4. Smoothness optimizations
Converted 22+ high-frequency `collectAsState()` calls to `collectAsStateWithLifecycle()` across `Player.kt`, `Queue.kt`, and `PlayerMenu.kt` so flows stop emitting while the app is backgrounded. **All animations and visual effects preserved** — no sacrifices.

### 5. Dead code removal (~134 lines, 7 functions)
All verified unused — `private` so no reflection possible, no `@Preview` annotation:
- `AccountSettings.previewSecureValue` (6 lines)
- `MusicService.deviceSupportsMimeType` + unused `MediaCodecList` import (7 lines)
- `YTPlayerUtils.findFormat` — thin wrapper around `selectAudioFormatCandidates(...).firstOrNull()` (14 lines)
- `YearInMusicScreen.HeroMetricTile` — orphaned composable (36 lines)
- `YearInMusicScreen.SummaryHighlightRow` — one-line wrapper around `RecapStatRow` (13 lines)
- `LocalSongScreen.LocalSongBadge` — orphaned composable (28 lines)
- `LastFmDashboardScreen.DashboardSectionHeader` — orphaned composable (30 lines)

### 6. APK size compression (commit `d17bb6754`)
Three safe, behavior-preserving size optimizations stacked on top of the existing minify/shrink/native-compress setup:

- **`gradle.properties`**: explicitly enable `android.enableR8.fullMode=true`. It's been the AGP default since 8.0, but setting it explicitly documents intent and guards against future default changes. Full mode does stricter type analysis, deeper dead-code elimination, and more aggressive inlining — typically 5–10% DEX reduction on top of the existing `-keep` rules.
- **`app/proguard-rules.pro`**: add `-repackageclasses 'r8'`. Moves every class R8 is allowed to move into a single `r8` package, shortening the class-name strings in the DEX constant pool and removing per-package directory entries (~1–3% additional DEX reduction). All reflection entry points already covered by existing `-keep` rules (media3, tdlib, kuromoji, jaudiotagger, newpipe.extractor, ktor, guava, Glance widgets, queue persistence, @Serializable companions). System-class reflection (`Class.forName("android.os.SystemProperties")`, `"miui.os.Build"`) is unaffected. ServiceLoader (`META-INF/services/**`) is unaffected. Non-empty package name avoids default-package edge cases.
- **`app/build.gradle.kts`**: add 10 safe META-INF / metadata excludes (DEPENDENCIES, INDEX.LIST, io.netty.versions.properties, *.version, DebugProbesKt.bin, kotlin-tooling-metadata.json, buildinfo.properties, build.archives, com.android.tools/**, proguard/**). None are read at runtime. Load-bearing files preserved: `META-INF/services/**` (ServiceLoader), `META-INF/MANIFEST.MF` (signing + attributes), `META-INF/*.kotlin_module` (Kotlin reflection).

**No source code changed. No `-keep` rules weakened. No dependencies removed. No animations/effects/features sacrificed.**

### 7. Enhanced (word-synced) lyrics smoothness + top-anchored active line (commit `a56c80433`)
Two changes to `LyricsEnhanced.kt` (the Enhanced Lyrics / word-synced karaoke view backed by the mocharealm accompanist library):

- **Hoisted line-index computation out of the per-frame snapshotFlow.** Previously the auto-scroll `LaunchedEffect`'s `snapshotFlow` read `lineFocusPosition()` every 16 ms tick, which chained TWO binary searches (ours inside `positionForStableLineFocus` + the library's `getCurrentFirstHighlightLineIndexByTime`) and re-ran the snapshotFlow machinery (state read-tracking, `distinctUntilChanged`) on every frame — all to produce a value that only changes a few times per song. Now the line index is computed once per frame in the existing playback-position loop (single O(log n) binary search) and stored in `currentLineIndexState`, which ONLY changes when the active line actually changes. The snapshotFlow reads `currentLineIndexState` instead, so its block re-evaluates only on line boundaries (every few seconds) instead of every 16 ms. `latestSyncedLyrics = rememberUpdatedState(syncedLyrics)` keeps the playback loop fed with the latest lyrics (e.g. when romanization finishes) without re-launching the loop and stuttering the 60 Hz position interpolation.
- **Anchored the active line near the top, not the middle.** Previously word-synced (TTML) lyrics passed `alignByItemCenter = true`, which positioned the active line's centre at 0.42 of the viewport — pushing it to the middle of the screen. Line-synced (LRC) lyrics used `alignByItemCenter = false` with anchor 0.35. Now both formats anchor by the item's TOP edge at `LYRIC_FOCUS_TOP_ANCHOR_RATIO = 0.30` (upper third), matching the conventional Apple Music / Spotify / YouTube Music layout so users can read ahead. The `alignByItemCenter` parameter, the duplicate `LYRIC_FOCUS_ANCHOR_RATIO` / `LYRIC_LINE_SYNC_TOP_ANCHOR_RATIO` constants, and the unused `positionForStableLineFocus` function are removed as dead code.

**No animations or visual effects removed.** The fill sweep, glow, blur, scale and alpha transitions in `KaraokeLyricsView` are all preserved exactly — they're driven by the library's own `currentPosition` read, which is unchanged. Only the per-frame overhead around the library call is reduced.

## Files changed
- **Added:** `app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/AppleMusicSleepTimerSheet.kt`
- **Modified (features/cleanup):** `PreferenceKeys.kt`, `strings.xml`, `MainActivity.kt`, `AppearanceSettings.kt`, `PlayerMenu.kt`, `Player.kt`, `Queue.kt`, `MusicService.kt`, `YTPlayerUtils.kt`, `YearInMusicScreen.kt`, `LocalSongScreen.kt`, `AccountSettings.kt`, `LastFmDashboardScreen.kt`
- **Modified (size compression, commit `d17bb6754`):** `app/build.gradle.kts`, `app/proguard-rules.pro`, `gradle.properties`
- **Modified (Enhanced lyrics perf + top anchor, commit `a56c80433`):** `app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt`

## Notes
- Local compile not attempted (sandbox has no Android SDK). CI on GitHub will validate.
- Brace balance verified on every modified Kotlin file via a Python script that strips strings/comments first.
- The `dev` branch had diverged from `main` (11 commits behind), so a new PR is opened rather than reusing #110.