### PR TITLE
perf(lyrics): fix Japanese word-synced lag + pin active line under title + smooth close transition

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
@@ -1546,6 +1546,137 @@ object LyricsUtils {
         return normalizeRomanizedText(word, romanized)
     }
 
+    /**
+     * Romanizes a list of words from a single line using ONE tokenization pass for Japanese.
+     *
+     * This is the critical performance fix for Japanese word-synced (TTML) lyrics.
+     * Previously, [romanizeLyricsWordWithLineContext] was called once per word, and each
+     * call ran Kuromoji's full Viterbi morphological analysis (trie traversal + lattice
+     * search over the entire IPADIC dictionary) on a single isolated word. For a typical
+     * 40-line song with 6 words per line, that's **240 tokenize calls** — each with
+     * non-trivial per-call overhead (dictionary loading is cached, but the Viterbi search
+     * is O(text × trie depth) per call).
+     *
+     * This function tokenizes the FULL LINE once (40 calls instead of 240 — a **6x
+     * reduction** in tokenize calls), then maps each token back to the original word
+     * boundaries by character position. Words that span multiple tokens get their
+     * romaji concatenated.
+     *
+     * Tokenizing the full line also gives **better romanization quality**: Kuromoji's
+     * morphological analyzer sees full context, so compounds like "日本語" tokenize as
+     * one token in context but may split into "日本" + "語" when isolated. The per-line
+     * path produces more accurate readings.
+     *
+     * For non-Japanese text, falls back to [romanizeLyricsWordWithLineContext] per word
+     * (character-by-character romanization for Korean/Hindi/Chinese is already cheap —
+     * no tokenizer involved).
+     */
+    suspend fun romanizeWordsForLine(
+        words: List<String>,
+        lineText: String,
+        preferences: LyricsRomanizationPreferences,
+    ): List<String?> {
+        if (words.isEmpty()) return emptyList()
+        // Japanese: single-pass line tokenization (Nx faster than per-word).
+        if (preferences.romanizeJapanese && looksJapanese(lineText)) {
+            return romanizeJapaneseWordsForLine(words, lineText)
+        }
+        // Other languages: per-word is cheap (character-by-character), keep as-is.
+        return words.map { word ->
+            romanizeLyricsWordWithLineContext(word, lineText, preferences)
+        }
+    }
+
+    /**
+     * Japanese-specific per-line tokenization. See [romanizeWordsForLine] for the
+     * rationale.
+     *
+     * Token-to-word mapping uses character positions: Kuromoji's [Token.getPosition]
+     * returns the character offset of each token in the input line. We find each word's
+     * start offset in the line (via [String.indexOf] with a running scan cursor to handle
+     * repeated words), then collect all tokens whose `[start, end)` range overlaps with
+     * the word's `[wordStart, wordEnd)` range. The romaji of overlapping tokens is
+     * concatenated to form the word's phonetic.
+     */
+    private suspend fun romanizeJapaneseWordsForLine(
+        words: List<String>,
+        lineText: String,
+    ): List<String?> = withContext(Dispatchers.Default) {
+        if (words.isEmpty()) return@withContext emptyList()
+        val tokenizer = JapaneseLanguagePackManager.tokenizerOrNull()
+            ?: return@withContext words.map { null }
+
+        val tokens = tokenizer.tokenize(lineText)
+        if (tokens.isEmpty()) return@withContext words.map { null }
+
+        // Pre-compute each token's [start, end) range and its romaji.
+        // The next token's reading is kept for sokuon-at-boundary gemination
+        // (same logic as romanizeJapanese, just vectorized).
+        val tokenCount = tokens.size
+        val tokenStarts = IntArray(tokenCount)
+        val tokenEnds = IntArray(tokenCount)
+        val tokenRomaji = ArrayList<String>(tokenCount)
+        for (i in 0 until tokenCount) {
+            val token = tokens[i]
+            val surface = token.surface
+            tokenStarts[i] = token.position
+            tokenEnds[i] = token.position + surface.length
+
+            val currentReading =
+                if (token.reading.isNullOrEmpty() || token.reading == "*") {
+                    surface
+                } else {
+                    token.reading
+                }
+            val katakanaReading = hiraganaToKatakana(currentReading)
+            val nextTokenReading =
+                if (i + 1 < tokenCount) {
+                    val nr = tokens[i + 1].reading
+                    val nextReading =
+                        if (nr.isNullOrEmpty() || nr == "*") tokens[i + 1].surface else nr
+                    hiraganaToKatakana(nextReading)
+                } else {
+                    null
+                }
+            tokenRomaji.add(katakanaToRomaji(katakanaReading, nextTokenReading))
+        }
+
+        // Walk through words and tokens in parallel (both are in text order).
+        // This is O(words + tokens) — no nested loops.
+        val result = ArrayList<String?>(words.size)
+        var scanOffset = 0
+        var tokenIdx = 0
+        for (word in words) {
+            val wordStart = lineText.indexOf(word, startIndex = scanOffset)
+            if (wordStart < 0) {
+                // Word not found in line text (malformed TTML or whitespace mismatch).
+                // Skip — the word will have no phonetic, which is a graceful degradation.
+                result.add(null)
+                continue
+            }
+            val wordEnd = wordStart + word.length
+
+            // Advance tokenIdx past tokens that end before this word starts.
+            while (tokenIdx < tokenCount && tokenEnds[tokenIdx] <= wordStart) {
+                tokenIdx++
+            }
+
+            // Collect all tokens that overlap [wordStart, wordEnd).
+            val romajiBuilder = StringBuilder()
+            var tIdx = tokenIdx
+            while (tIdx < tokenCount && tokenStarts[tIdx] < wordEnd) {
+                if (tokenEnds[tIdx] > wordStart) {
+                    romajiBuilder.append(tokenRomaji[tIdx])
+                }
+                tIdx++
+            }
+
+            result.add(romajiBuilder.toString().takeIf { it.isNotEmpty() })
+            scanOffset = wordEnd
+        }
+        result
+    }
+
     private suspend fun romanizeWithIcu(text: String): String =
         withContext(Dispatchers.Default) {
             genericRomanizationTransliterator.get().transliterate(text)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -133,7 +133,7 @@ import moe.rukamori.archivetune.lyrics.LyricsUtils.providedRomanizedTextForEntry
 import moe.rukamori.archivetune.lyrics.LyricsUtils.providedRomanizedWordsForEntry
 import moe.rukamori.archivetune.lyrics.LyricsUtils.providedTranslationTextForEntry
 import moe.rukamori.archivetune.lyrics.LyricsUtils.romanizeLyricsLine
-import moe.rukamori.archivetune.lyrics.LyricsUtils.romanizeLyricsWordWithLineContext
+import moe.rukamori.archivetune.lyrics.LyricsUtils.romanizeWordsForLine
 import moe.rukamori.archivetune.lyrics.LyricsUtils.shouldRomanizeLyricsLine
 import moe.rukamori.archivetune.lyrics.WordTimestamp
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
@@ -316,9 +316,14 @@ fun LyricsEnhanced(
                             if (isTtmlFormat && entry.words != null) {
                                 val mainWordCount = entry.words!!.count { !it.isBackground }
                                 providedRomanizedWordsForEntry(entry, mainWordCount, romanizationPreferences)
-                                    ?: entry.words!!.filter { !it.isBackground }.map { word ->
-                                        romanizeLyricsWordWithLineContext(word.text, entry.text, romanizationPreferences)
-                                    }
+                                    ?: romanizeWordsForLine(
+                                        // Japanese: single-pass line tokenization (6x fewer
+                                        // Kuromoji calls than per-word). Other languages:
+                                        // per-word character-by-character (already cheap).
+                                        words = entry.words!!.filter { !it.isBackground }.map { it.text },
+                                        lineText = entry.text,
+                                        preferences = romanizationPreferences,
+                                    )
                             } else {
                                 listOf(
                                     providedRomanizedTextForEntry(entry, romanizationPreferences)
@@ -810,7 +815,15 @@ fun LyricsEnhanced(
                             showTranslation = showTranslations,
                             showPhonetic = romanizationPreferences.isEnabled,
                             offset = lyricsViewportOffset,
-                            keepAliveZone = 72.dp,
+                            // keepAliveZone controls how many off-screen lines are kept composed
+                            // above/below the viewport. 72dp was too generous for Japanese/CJK
+                            // lyrics where every line carries per-word phonetic text (romaji) —
+                            // the extra composed-but-invisible lines multiplied text layout work
+                            // and memory pressure. 36dp still keeps 1-2 lines of read-ahead
+                            // composed for smooth auto-scroll, but halves the off-screen
+                            // composition cost. No visual difference — the lines outside the
+                            // viewport are not visible anyway.
+                            keepAliveZone = 36.dp,
                             modifier = Modifier.fillMaxSize(),
                         )
                     }


### PR DESCRIPTION
## Summary

Three follow-up fixes to the lyrics system, all addressing user-reported issues with Enhanced word-synced lyrics.

### 1. Fix Japanese word-synced lag — per-line tokenization (main fix)

Japanese word-synced (TTML) lyrics lagged significantly compared to other languages. Root cause: the romanization pipeline called **Kuromoji's full Viterbi morphological analyzer once per word**, even though the analyzer works on full lines. For a typical 40-line song with 6 words/line, that's **240 tokenize calls** when only **40** were needed — a 6x overhead specific to Japanese (Korean/Hindi/Chinese use cheap character-by-character romanization with no tokenizer).

**Fix:** New `romanizeWordsForLine()` dispatcher detects Japanese text and routes to `romanizeJapaneseWordsForLine()`, which:
- Tokenizes the **full line once** (40 calls instead of 240)
- Maps tokens back to original TTML word boundaries by **character position** (O(words + tokens), no nested loops)
- Words spanning multiple tokens get their romaji concatenated
- Also **improves romanization quality** — Kuromoji sees full line context, so compounds like "日本語" tokenize more accurately

Non-Japanese languages fall through to the existing per-word path (already cheap).

### 2. Pin active line under the song title

The active lyrics line was displaying at the **middle** of the screen. Root cause: the mocharealm karaoke library's `offset` parameter (which drives its internal per-frame auto-scroll anchor) was `maxHeight * 0.38f`, while our custom `scrollLyricIntoFocus` target was `0.30f`. The two scroll systems fought every frame — the library won, pinning the line at ~38% (middle).

**Fix:** Dropped both to **0.08** so they agree. The active line now pins at ~8% of the lyrics pane — right under the song title (Apple Music / Spotify / YouTube Music layout). Guards tightened accordingly.

### 3. Smooth lyrics UI close transition

Closing the lyrics UI ended abruptly. Root cause: `MikoLyricsTransition` unmounted the lyrics tree at `progress = 0.5` (halfway through the ~700ms close spring), leaving an empty surface sliding off-screen for the last ~350ms.

**Fix:** Dropped the threshold to **0f** — the lyrics tree stays composed for the **entire** slide-down, until the sheet is 100% off-screen.

### 4. Reduce keepAliveZone (secondary Japanese optimization)

Reduced karaoke library `keepAliveZone` from 72dp → 36dp. For Japanese/CJK lyrics where every line carries per-word phonetic text, the extra composed-but-invisible lines multiplied text layout work. 36dp still keeps 1-2 lines of read-ahead for smooth auto-scroll. No visual difference.

## No sacrifices

No animations, effects, features, or visual quality are removed. The karaoke fill sweep, glow, blur, scale, alpha transitions, and phonetic rendering are all preserved exactly. Only CPU work is reduced.

## Commits

- `a56c80433` perf(lyrics): make Enhanced word-synced lyrics smoother + anchor active line near top
- `7f9854460` fix(lyrics): pin Enhanced active line under the title + smooth close transition
- `342de0241` fix(lyrics): keep lyrics tree composed until sheet is 100% off-screen
- `c35f2ab9f` perf(lyrics): fix Japanese word-synced lag — per-line tokenization