### PR TITLE
feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal, frosted headers

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1244,10 +1244,12 @@ class MainActivity : ComponentActivity() {
                     // (see [rememberPreSFrostedBitmap]). Both paths need the same GraphicsLayer,
                     // so we create it on every API level — `rememberGraphicsLayer` and
                     // `layer.record { ... }` work without RenderEffect.
+                    // Always capture the app content into a GraphicsLayer every frame so both
+                    // the frosted nav bar / mini player AND the frosted header pills can draw
+                    // it blurred. The recording cost is negligible (GPU layer copy) and the
+                    // layer is only read by consumers that opt into frosted blur.
                     val navBarFrostedBackdrop =
-                        if ((navigationBarFrostedBlur || miniPlayerBgStyle == MiniPlayerBackgroundStyle.FROSTED) &&
-                            !useRail
-                        ) {
+                        if (!useRail) {
                             val frostedLayer = rememberGraphicsLayer()
                             remember(frostedLayer) { NavigationBarBackdrop(frostedLayer) }
                         } else {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -23,16 +23,6 @@ val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")
 val DisableAnimationsKey = booleanPreferencesKey("disableAnimations")
 val ForceHighRefreshRateKey = booleanPreferencesKey("forceHighRefreshRate")
-
-// UI scale (DPI-like) multiplier applied via a LocalDensity override in MainActivity.
-// 1.0f = system default. Range clamped to [0.85f, 1.30f] in AppearanceSettings.
-// Stored as a float so the slider is continuous (1% steps via 46 discrete positions).
-val UiScaleFactorKey = floatPreferencesKey("uiScaleFactor")
-
-// When true, forces the two-pane NavigationRail layout (normally reserved for
-// tablet-width windows) on phone-sized windows too. Useful on landscape phones
-// and on tablets where the dp breakpoint misclassifies the window.
-val TabletModeEnabledKey = booleanPreferencesKey("tabletModeEnabled")
 val EnableHapticFeedbackKey = booleanPreferencesKey("enableHapticFeedback")
 val UseSystemFontKey = booleanPreferencesKey("useSystemFont")
 val FontPreferenceKey = stringPreferencesKey("fontPreference")
@@ -794,12 +784,9 @@ val NavigationBarStyleKey = stringPreferencesKey("navigationBarStyle")
 val NavigationBarFrostedBlurKey = booleanPreferencesKey("navigationBarFrostedBlur")
 val HideNavigationBarLabelsKey = booleanPreferencesKey("hideNavigationBarLabels")
 
-// ── Navigation bar customization (Task 6) ───────────────────────────────────
-// Advanced tuning knobs exposed in the new "Navigation bar" sub-page under
-// Appearance. Defaults preserve the pre-existing look: 80.dp width, 64.dp
-// height, 0.18 alpha for the floating surface, 4.dp label spacing, 28.dp
-// corner radius. The DEFAULT style is unaffected; these only meaningfully
-// change the FLOATING style (and provide a small radius tweak for DEFAULT).
+// ── Navigation bar dimension customization ──────────────────────────────────
+// Advanced tuning knobs for the FLOATING nav bar style (and corner radius for
+// DEFAULT). Defaults preserve the pre-existing look.
 val NavigationBarWidthKey = floatPreferencesKey("navigationBarWidth")
 const val NAVIGATION_BAR_WIDTH_DEFAULT = 0.8f // fraction of screen width when FLOATING
 
@@ -817,11 +804,6 @@ const val NAVIGATION_BAR_LABEL_SPACING_DEFAULT = 4f // dp between icon and label
 
 val NavigationBarCornerRadiusKey = floatPreferencesKey("navigationBarCornerRadius")
 const val NAVIGATION_BAR_CORNER_RADIUS_DEFAULT = 28f // dp
-
-// App-wide scrollbar toggle (Task 8). When false, all LazyColumn / LazyGrid /
-// ScrollState scrollbars in the app are suppressed. (Slider thumb tracks and
-// player position bars are not affected — those are not "scrollbars".)
-val HideScrollbarKey = booleanPreferencesKey("hideScrollbar")
 
 // Keys for customized background
 val PlayerCustomImageUriKey = stringPreferencesKey("playerCustomImageUri")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -169,8 +169,8 @@ fun FloatingNavigationToolbar(
     onSearchItemDoubleClick: (() -> Unit)? = null,
 ) {
     val isFloating = style == NavigationBarStyle.FLOATING
-    // Navigation bar customization (Task 6). Read directly here so the toolbar picks up
-    // the user's tuning without the call site needing to thread 6 extra params.
+    // Navigation bar customization. Read directly here so the toolbar picks up the user's
+    // tuning without the call site needing to thread 6 extra params.
     val (navBarWidthFraction) =
         rememberPreference(NavigationBarWidthKey, defaultValue = NAVIGATION_BAR_WIDTH_DEFAULT)
     val (navBarHeightMultiplier) =
@@ -504,7 +504,7 @@ fun FloatingNavigationToolbar(
                                     null
                                 } else {
                                     {
-                                        // User-configurable spacing between icon and label (Task 6).
+                                        // User-configurable spacing between icon and label.
                                         Spacer(Modifier.height(navBarLabelSpacing.dp))
                                         Text(
                                             text = stringResource(screen.titleId),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
@@ -1,0 +1,226 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.component
+
+import android.os.Build
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.utils.ImageBlurUtils
+
+private const val FrostedHeaderBlurRadiusPx = 40f
+private const val FrostedHeaderOverlayAlpha = 0.45f
+
+/**
+ * A frosted-glass pill that wraps header content (title text, icon buttons) so the header
+ * can be transparent while the content inside it stays legible against any background.
+ *
+ * Mirrors the frosted mechanism in [FloatingNavigationToolbar]: on Android 12+ it uses
+ * [BlurEffect] (hardware-accelerated, every frame) composited over the shared app-content
+ * [GraphicsLayer] from [LocalNavigationBarBackdrop]. On pre-S it falls back to a periodic
+ * CPU-blurred bitmap slice (same approach as the nav bar's pre-S path). If no backdrop
+ * layer is available (frosted blur disabled), it degrades to a semi-transparent
+ * `surfaceContainer` pill — still legible, just not blurred.
+ *
+ * Usage: wrap the title / actions of a `TopAppBar` (or any header) in this pill. The
+ * outer `TopAppBar` should have `containerColor = Color.Transparent`.
+ *
+ * @param modifier Modifier for the pill's outer layout.
+ * @param content The header content (text, icons) to display inside the pill.
+ */
+@Composable
+fun FrostedHeaderPill(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val backdrop = LocalNavigationBarBackdrop.current
+    val isPreS = Build.VERSION.SDK_INT < Build.VERSION_CODES.S
+    val canBlur = backdrop != null && !isPreS
+
+    val baseColor = MaterialTheme.colorScheme.surfaceContainer
+    val pillColor =
+        if (canBlur) {
+            // When blurring, the pill surface is mostly transparent so the blurred content
+            // shows through. A slight tint provides a frosted milkiness.
+            baseColor.copy(alpha = FrostedHeaderOverlayAlpha)
+        } else {
+            // No blur available: use a higher-alpha surface so the text stays legible.
+            baseColor.copy(alpha = 0.85f)
+        }
+
+    var pillPositionInRoot by remember { mutableStateOf(Offset.Zero) }
+    var pillSize by remember { mutableStateOf(IntSize.Zero) }
+
+    Surface(
+        modifier = modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .onGloballyPositioned {
+                pillPositionInRoot = it.positionInRoot()
+                pillSize = it.size
+            },
+        shape = RoundedCornerShape(percent = 50),
+        color = pillColor,
+    ) {
+        Box {
+            // Frosted backdrop: draw the blurred app-content slice behind the pill content.
+            if (canBlur && backdrop != null) {
+                if (isPreS) {
+                    val blurredBitmap = rememberPreSFrostedHeaderBitmap(
+                        backdrop = backdrop,
+                        barPositionInRoot = pillPositionInRoot,
+                        barSize = pillSize,
+                        blurRadiusPx = FrostedHeaderBlurRadiusPx,
+                    )
+                    if (blurredBitmap != null) {
+                        Box(
+                            modifier = Modifier
+                                .graphicsLayer {
+                                    alpha = FrostedHeaderOverlayAlpha
+                                    clip = true
+                                }
+                                .drawBehind { drawImage(blurredBitmap) },
+                        )
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .graphicsLayer {
+                                renderEffect = BlurEffect(
+                                    radiusX = FrostedHeaderBlurRadiusPx,
+                                    radiusY = FrostedHeaderBlurRadiusPx,
+                                    edgeTreatment = TileMode.Clamp,
+                                )
+                                alpha = FrostedHeaderOverlayAlpha
+                                clip = true
+                            }
+                            .drawBehind {
+                                val offset = backdrop.contentOffsetInRoot - pillPositionInRoot
+                                translate(offset.x, offset.y) {
+                                    drawLayer(backdrop.layer)
+                                }
+                            },
+                    )
+                }
+            }
+            // Actual content on top.
+            Row(modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)) {
+                content()
+            }
+        }
+    }
+}
+
+/**
+ * Pre-S fallback that captures a slice of the shared backdrop layer, blurs it on the CPU,
+ * and returns it for compositing. Mirrors [rememberPreSFrostedBitmap] in
+ * FloatingNavigationToolbar but is duplicated here to keep the header component
+ * self-contained (the nav bar version is `internal` to the component file).
+ */
+@Composable
+private fun rememberPreSFrostedHeaderBitmap(
+    backdrop: NavigationBarBackdrop?,
+    barPositionInRoot: Offset,
+    barSize: IntSize,
+    blurRadiusPx: Float,
+    updateIntervalMs: Long = 80L,
+): ImageBitmap? {
+    if (backdrop == null) return null
+    var blurred by remember(backdrop, blurRadiusPx, updateIntervalMs) {
+        mutableStateOf<ImageBitmap?>(null)
+    }
+    val barPositionState = rememberUpdatedState(barPositionInRoot)
+    val barSizeState = rememberUpdatedState(barSize)
+
+    androidx.compose.runtime.LaunchedEffect(backdrop, blurRadiusPx, updateIntervalMs) {
+        while (isActive) {
+            val layer = backdrop.layer
+            val layerW = layer.size.width
+            val layerH = layer.size.height
+            if (layerW > 0 && layerH > 0) {
+                try {
+                    val next = withContext(Dispatchers.Default) {
+                        val pos = barPositionState.value
+                        val size = barSizeState.value
+                        if (size.width <= 0 || size.height <= 0) return@withContext null
+
+                        val contentOffset = backdrop.contentOffsetInRoot
+                        val rawX = (pos.x - contentOffset.x).toInt()
+                        val rawY = (pos.y - contentOffset.y).toInt()
+                        val pad = blurRadiusPx.toInt().coerceIn(8, 64)
+                        val paddedX = rawX - pad
+                        val paddedY = rawY - pad
+                        val paddedW = size.width + 2 * pad
+                        val paddedH = size.height + 2 * pad
+                        val clampedX = paddedX.coerceIn(0, layerW - 1)
+                        val clampedY = paddedY.coerceIn(0, layerH - 1)
+                        val clampedRight = (paddedX + paddedW).coerceIn(1, layerW)
+                        val clampedBottom = (paddedY + paddedH).coerceIn(1, layerH)
+                        val clampedW = clampedRight - clampedX
+                        val clampedH = clampedBottom - clampedY
+                        if (clampedW <= 0 || clampedH <= 0) return@withContext null
+
+                        val imageBitmap = layer.toImageBitmap()
+                        val fullBitmap = imageBitmap.asAndroidBitmap()
+                        val sliceBitmap = android.graphics.Bitmap.createBitmap(
+                            fullBitmap, clampedX, clampedY, clampedW, clampedH,
+                        )
+                        val blurredSlice = ImageBlurUtils.blur(sliceBitmap, blurRadiusPx)
+                        val barXInSlice = (rawX - clampedX).coerceIn(0, blurredSlice.width - 1)
+                        val barYInSlice = (rawY - clampedY).coerceIn(0, blurredSlice.height - 1)
+                        val barW = size.width.coerceAtMost(blurredSlice.width - barXInSlice)
+                        val barH = size.height.coerceAtMost(blurredSlice.height - barYInSlice)
+                        if (barW <= 0 || barH <= 0) {
+                            blurredSlice.asImageBitmap()
+                        } else {
+                            android.graphics.Bitmap.createBitmap(
+                                blurredSlice, barXInSlice, barYInSlice, barW, barH,
+                            ).asImageBitmap()
+                        }
+                    }
+                    if (next != null) blurred = next
+                } catch (_: Throwable) {
+                    // Keep previous frame on failure.
+                }
+            }
+            delay(updateIntervalMs)
+        }
+    }
+    return blurred
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedTopAppBar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedTopAppBar.kt
@@ -1,0 +1,97 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import moe.rukamori.archivetune.R
+
+/**
+ * A [TopAppBar] variant with a fully transparent container and the title / navigation icon /
+ * actions each wrapped in a [FrostedHeaderPill] so the header content stays legible against
+ * any scrolling background (album art, gradient, etc.) without needing a solid bar.
+ *
+ * The pills use the shared [LocalNavigationBarBackdrop] GraphicsLayer for real backdrop blur
+ * on Android 12+, and degrade to a semi-transparent `surfaceContainer` on pre-S or when no
+ * backdrop is available.
+ *
+ * Usage: drop-in replacement for a standard `TopAppBar` that has a title string, a back
+ * arrow, and optional actions. For screens that need a more custom title (e.g. with an
+ * avatar or animated content), use [FrostedHeaderPill] directly.
+ *
+ * @param titleRes String resource for the title.
+ * @param onBack Click handler for the back arrow.
+ * @param onBackLongClick Optional long-click handler for the back arrow (typically
+ *   `navController::backToMain`).
+ * @param actions Optional composable for action buttons. Rendered inside a frosted pill.
+ */
+@Composable
+fun FrostedTopAppBar(
+    titleRes: Int,
+    onBack: () -> Unit,
+    onBackLongClick: () -> Unit = {},
+    actions: (@Composable () -> Unit)? = null,
+) {
+    TopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = Color.Transparent,
+            scrolledContainerColor = Color.Transparent,
+            titleContentColor = MaterialTheme.colorScheme.onSurface,
+            navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+            actionIconContentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        title = {
+            FrostedHeaderPill {
+                Text(
+                    text = stringResource(titleRes),
+                    style = MaterialTheme.typography.titleLarge,
+                    maxLines = 1,
+                )
+            }
+        },
+        navigationIcon = {
+            FrostedHeaderPill {
+                IconButton(
+                    onClick = onBack,
+                    onLongClick = onBackLongClick,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.arrow_back),
+                        contentDescription = null,
+                    )
+                }
+            }
+        },
+        actions = if (actions != null) {
+            {
+                FrostedHeaderPill(
+                    modifier = Modifier.padding(end = 8.dp),
+                ) {
+                    actions()
+                }
+            }
+        } else {
+            {}
+        },
+    )
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -261,8 +261,19 @@ internal class DeviceMusicVolumeController(
         val targetVolume =
             (minVolume + (safeFraction * volumeRange).roundToInt())
                 .coerceIn(minVolume, maxVolume)
+        // If the user dragged the slider above 0 but the rounded target is still at minVolume
+        // (happens for very small fractions on devices with many volume steps — e.g. 3% of a
+        // 15-step range rounds to 0), bump it up by one step so the volume actually changes.
+        // Without this, dragging from 0% would show the percentage increasing in the UI while
+        // the actual device volume stayed silent at 0.
+        val adjustedTarget =
+            if (safeFraction > 0f && targetVolume <= minVolume) {
+                (minVolume + 1).coerceAtMost(maxVolume)
+            } else {
+                targetVolume
+            }
 
-        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, targetVolume, 0)
+        audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, adjustedTarget, 0)
         refresh()
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/StatsScreen.kt
@@ -105,6 +105,7 @@ import moe.rukamori.archivetune.models.toMediaMetadata
 import moe.rukamori.archivetune.playback.queues.ListQueue
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
 import moe.rukamori.archivetune.ui.component.ChoiceChipsRow
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ItemThumbnail
 import moe.rukamori.archivetune.ui.component.LocalAlbumsGrid
@@ -247,37 +248,51 @@ fun StatsScreen(
                 .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
         topBar = {
             LargeFlexibleTopAppBar(
+                colors = TopAppBarDefaults.largeTopAppBarColors(
+                    containerColor = Color.Transparent,
+                    scrolledContainerColor = Color.Transparent,
+                ),
                 title = {
-                    Text(
-                        text = stringResource(R.string.stats),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.stats),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 },
                 subtitle = {
-                    Text(
-                        text = stringResource(R.string.settings_stats_subtitle),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.settings_stats_subtitle),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
                     }
                 },
                 actions = {
-                    IconButton(
-                        onClick = viewModel::showYearPicker,
-                        onLongClick = {},
+                    FrostedHeaderPill(
+                        modifier = Modifier.padding(end = 8.dp),
                     ) {
-                        Icon(
-                            painterResource(R.drawable.auto_awesome),
-                            contentDescription = stringResource(R.string.year_in_music),
-                        )
+                        IconButton(
+                            onClick = viewModel::showYearPicker,
+                            onLongClick = {},
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.auto_awesome),
+                                contentDescription = stringResource(R.string.year_in_music),
+                            )
+                        }
                     }
                 },
                 scrollBehavior = topAppBarScrollBehavior,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/StatsScreen.kt
@@ -271,15 +271,6 @@ fun StatsScreen(
                 },
                 actions = {
                     IconButton(
-                        onClick = viewModel::retry,
-                        onLongClick = {},
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.sync),
-                            contentDescription = stringResource(R.string.refresh),
-                        )
-                    }
-                    IconButton(
                         onClick = viewModel::showYearPicker,
                         onLongClick = {},
                     ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -35,6 +34,7 @@ import moe.rukamori.archivetune.constants.HideOfflineCardKey
 import moe.rukamori.archivetune.constants.HideTop50CardKey
 import moe.rukamori.archivetune.constants.ShowHomeCategoryChipsKey
 import moe.rukamori.archivetune.constants.ShowTagsInLibraryKey
+import moe.rukamori.archivetune.ui.component.FrostedTopAppBar
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
@@ -60,19 +60,10 @@ fun AppearanceExtrasSettings(navController: NavController) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.extras)) },
-                navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
-                        )
-                    }
-                },
+            FrostedTopAppBar(
+                titleRes = R.string.extras,
+                onBack = navController::navigateUp,
+                onBackLongClick = navController::backToMain,
             )
         },
     ) { innerPadding ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -915,6 +915,15 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
+                    PreferenceEntry(
+                        title = { Text(stringResource(R.string.navigation_bar_settings_title)) },
+                        description = stringResource(R.string.navigation_bar_settings_subtitle),
+                        icon = { Icon(painterResource(R.drawable.tune), null) },
+                        onClick = { navController.navigate("settings/appearance/navigation_bar") },
+                    )
+                }
+
+                item {
                     Column(modifier = positions.modifierFor("default_open_tab")) {
                         EnumListPreference(
                             title = { Text(stringResource(R.string.default_open_tab)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -9,22 +9,10 @@
 
 package moe.rukamori.archivetune.ui.screens.settings
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
-import android.os.Message
-import android.view.ViewGroup
-import android.webkit.CookieManager
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceRequest
-import android.webkit.WebSettings
-import android.webkit.WebView
-import android.webkit.WebViewClient
-import android.widget.FrameLayout
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -43,21 +31,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -66,9 +49,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -83,40 +64,31 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.backup.ScheduledBackupFrequency
 import moe.rukamori.archivetune.db.entities.Song
-import moe.rukamori.archivetune.spotify.SpotifyAccountUiState
-import moe.rukamori.archivetune.spotify.SpotifyAuth
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
-import moe.rukamori.archivetune.ui.component.PreferenceGroupScope
 import moe.rukamori.archivetune.ui.component.SwitchPreference
 import moe.rukamori.archivetune.ui.menu.AddToPlaylistDialogOnline
 import moe.rukamori.archivetune.ui.menu.LoadingScreen
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberPreference
-import moe.rukamori.archivetune.utils.resetAuthWebViewSession
 import moe.rukamori.archivetune.viewmodels.BackupCategory
 import moe.rukamori.archivetune.viewmodels.BackupRestoreViewModel
 import moe.rukamori.archivetune.viewmodels.GoogleDriveSyncScreenState
@@ -142,10 +114,6 @@ private val CSV_MIME_TYPES =
         "text/*",
         "application/octet-stream",
     )
-
-val SpotifyAccountIconSize = 44.dp
-const val SpotifyLoginUserAgent =
-    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36"
 
 @Composable
 fun BackupAndRestore(
@@ -448,6 +416,7 @@ fun BackupAndRestore(
                     )
                 }
             }
+
         }
     }
 
@@ -1024,512 +993,6 @@ private fun GoogleDriveSyncDatePickerDialog(
             modifier = Modifier.verticalScroll(rememberScrollState()),
             title = { Text(stringResource(R.string.scheduled_backup_custom_title)) },
             showModeToggle = false,
-        )
-    }
-}
-
-fun PreferenceGroupScope.spotifyAccountPreferences(
-    state: SpotifyAccountUiState,
-    showPlaylists: Boolean,
-    onConnectClick: () -> Unit,
-    onShowPlaylistsChange: (Boolean) -> Unit,
-    onReloadClick: () -> Unit,
-    onLogoutClick: () -> Unit,
-) {
-    if (!state.isAuthenticated) {
-        item {
-            PreferenceEntry(
-                title = { Text(stringResource(R.string.spotify_connect)) },
-                description = stringResource(R.string.spotify_not_connected),
-                icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
-                trailingContent = {
-                    AnimatedVisibility(visible = state.isLoading) {
-                        CircularWavyProgressIndicator(
-                            modifier = Modifier.size(28.dp),
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                },
-                onClick = onConnectClick,
-                isEnabled = !state.isLoading,
-            )
-        }
-        return
-    }
-
-    item {
-        PreferenceEntry(
-            title = {
-                Text(
-                    text =
-                        if (state.accountName.isNotBlank()) {
-                            stringResource(R.string.spotify_connected_as, state.accountName)
-                        } else {
-                            stringResource(R.string.spotify_account)
-                        },
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            },
-            description =
-                when {
-                    state.isLoading -> stringResource(R.string.spotify_loading_library)
-                    state.playlistCount > 0 -> stringResource(R.string.spotify_available_count, state.playlistCount)
-                    else -> stringResource(R.string.spotify_no_sources)
-                },
-            icon = { SpotifyAccountIcon(avatarUrl = state.accountAvatarUrl) },
-            trailingContent = {
-                AnimatedVisibility(visible = state.isLoading) {
-                    CircularWavyProgressIndicator(
-                        modifier = Modifier.size(28.dp),
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            },
-            isEnabled = false,
-        )
-    }
-
-    item {
-        SwitchPreference(
-            title = { Text(stringResource(R.string.spotify_show_playlist)) },
-            description = stringResource(R.string.spotify_show_playlist_desc),
-            icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
-            checked = showPlaylists,
-            onCheckedChange = onShowPlaylistsChange,
-            isEnabled = !state.isLoading,
-        )
-    }
-
-    item {
-        PreferenceEntry(
-            title = { Text(stringResource(R.string.spotify_reload_playlist)) },
-            description = stringResource(R.string.spotify_reload_playlist_desc),
-            icon = { Icon(painterResource(R.drawable.sync), null) },
-            onClick = onReloadClick,
-            isEnabled = !state.isLoading,
-        )
-    }
-
-    item {
-        PreferenceEntry(
-            title = { Text(stringResource(R.string.action_logout)) },
-            icon = { Icon(painterResource(R.drawable.logout), null) },
-            onClick = onLogoutClick,
-            isEnabled = !state.isLoading,
-        )
-    }
-}
-
-@Composable
-fun SpotifyAccountIcon(avatarUrl: String?) {
-    val context = LocalContext.current
-    val requestSize = with(LocalDensity.current) { SpotifyAccountIconSize.roundToPx() }
-    val accountIcon = painterResource(R.drawable.spotify_icon)
-    val imageRequest =
-        remember(context, avatarUrl, requestSize) {
-            avatarUrl
-                ?.takeIf(String::isNotBlank)
-                ?.let {
-                    ImageRequest
-                        .Builder(context)
-                        .data(it)
-                        .size(requestSize)
-                        .build()
-                }
-        }
-
-    Box(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primaryContainer),
-        contentAlignment = Alignment.Center,
-    ) {
-        if (imageRequest != null) {
-            AsyncImage(
-                model = imageRequest,
-                contentDescription = null,
-                placeholder = accountIcon,
-                error = accountIcon,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize(),
-            )
-        } else {
-            Icon(
-                painter = accountIcon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                modifier = Modifier.size(24.dp),
-            )
-        }
-    }
-}
-
-@SuppressLint("SetJavaScriptEnabled")
-@Composable
-fun SpotifyLoginSheet(
-    onDismiss: () -> Unit,
-    onCookiesCaptured: (spDc: String, spKey: String) -> Unit,
-) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var webView by remember { mutableStateOf<WebView?>(null) }
-    var mainWebView by remember { mutableStateOf<WebView?>(null) }
-    var captured by remember { mutableStateOf(false) }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            webView?.destroySpotifyLoginWebView()
-            mainWebView?.takeIf { it !== webView }?.destroySpotifyLoginWebView()
-            webView = null
-            mainWebView = null
-        }
-    }
-
-    BackHandler(enabled = webView != null) {
-        val activeWebView = webView
-        val rootWebView = mainWebView
-        when {
-            activeWebView?.canGoBack() == true -> {
-                activeWebView.goBack()
-            }
-
-            activeWebView != null && rootWebView != null && activeWebView !== rootWebView -> {
-                activeWebView.destroySpotifyLoginWebView()
-                webView = rootWebView
-            }
-
-            else -> {
-                onDismiss()
-            }
-        }
-    }
-
-    ModalBottomSheet(
-        modifier = Modifier.fillMaxHeight(),
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-        containerColor = MaterialTheme.colorScheme.surface,
-    ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .fillMaxHeight()
-                    .padding(horizontal = 20.dp)
-                    .padding(bottom = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.spotify_login_title),
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-            )
-            Text(
-                text = stringResource(R.string.spotify_waiting_for_login),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            AndroidView(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .clip(MaterialTheme.shapes.large),
-                factory = { context ->
-                    val container = FrameLayout(context)
-                    val spotifyWebView =
-                        WebView(context).apply {
-                            val cookieManager = CookieManager.getInstance()
-                            cookieManager.setAcceptCookie(true)
-                            cookieManager.setAcceptThirdPartyCookies(this, true)
-                            configureSpotifyLoginWebView()
-
-                            fun captureCookies(url: String?): Boolean {
-                                if (captured) return true
-                                val cookies = readSpotifyCookies(cookieManager, url)
-                                val spDc = cookies["sp_dc"].orEmpty()
-                                if (spDc.isBlank()) return false
-                                captured = true
-                                cookieManager.flush()
-                                onCookiesCaptured(spDc, cookies["sp_key"].orEmpty())
-                                return true
-                            }
-
-                            webViewClient =
-                                object : WebViewClient() {
-                                    override fun shouldOverrideUrlLoading(
-                                        view: WebView,
-                                        request: WebResourceRequest,
-                                    ): Boolean =
-                                        shouldOverrideSpotifyLoginUrl(
-                                            view = view,
-                                            url = request.url?.toString(),
-                                            captureCookies = { url -> captureCookies(url) },
-                                        )
-
-                                    @Deprecated("Deprecated in Java")
-                                    override fun shouldOverrideUrlLoading(
-                                        view: WebView,
-                                        url: String?,
-                                    ): Boolean =
-                                        shouldOverrideSpotifyLoginUrl(
-                                            view = view,
-                                            url = url,
-                                            captureCookies = { targetUrl -> captureCookies(targetUrl) },
-                                        )
-
-                                    override fun onPageStarted(
-                                        view: WebView,
-                                        url: String?,
-                                        favicon: android.graphics.Bitmap?,
-                                    ) {
-                                        captureCookies(url)
-                                    }
-
-                                    override fun onPageFinished(
-                                        view: WebView,
-                                        url: String?,
-                                    ) {
-                                        captureCookies(url)
-                                    }
-                                }
-                            webChromeClient =
-                                SpotifyLoginWebChromeClient(
-                                    container = container,
-                                    parentWebView = this,
-                                    captureCookies = { url -> captureCookies(url) },
-                                    onActiveWebViewChanged = { activeWebView -> webView = activeWebView },
-                                )
-                            webView = this
-                            mainWebView = this
-                            resetAuthWebViewSession(context, this) {
-                                loadUrl(SpotifyAuth.LOGIN_URL)
-                            }
-                        }
-                    container.addView(
-                        spotifyWebView,
-                        FrameLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                        ),
-                    )
-                    container
-                },
-                update = {
-                    webView = webView ?: mainWebView
-                },
-            )
-        }
-    }
-}
-
-private fun WebView.destroySpotifyLoginWebView() {
-    stopLoading()
-    loadUrl("about:blank")
-    (parent as? ViewGroup)?.removeView(this)
-    destroy()
-}
-
-@SuppressLint("SetJavaScriptEnabled")
-private fun WebView.configureSpotifyLoginWebView() {
-    settings.apply {
-        javaScriptEnabled = true
-        domStorageEnabled = true
-        javaScriptCanOpenWindowsAutomatically = true
-        setSupportMultipleWindows(true)
-        setSupportZoom(true)
-        builtInZoomControls = true
-        displayZoomControls = false
-        mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
-        userAgentString = SpotifyLoginUserAgent
-    }
-}
-
-private class SpotifyLoginWebChromeClient(
-    private val container: FrameLayout,
-    private val parentWebView: WebView,
-    private val captureCookies: (String?) -> Boolean,
-    private val onActiveWebViewChanged: (WebView) -> Unit,
-) : WebChromeClient() {
-    override fun onCreateWindow(
-        view: WebView,
-        isDialog: Boolean,
-        isUserGesture: Boolean,
-        resultMsg: Message,
-    ): Boolean {
-        closePopupWebViews()
-
-        val popupWebView =
-            WebView(view.context).apply {
-                val cookieManager = CookieManager.getInstance()
-                cookieManager.setAcceptCookie(true)
-                cookieManager.setAcceptThirdPartyCookies(this, true)
-                configureSpotifyLoginWebView()
-                webViewClient =
-                    object : WebViewClient() {
-                        override fun shouldOverrideUrlLoading(
-                            view: WebView,
-                            request: WebResourceRequest,
-                        ): Boolean =
-                            shouldOverrideSpotifyLoginUrl(
-                                view = view,
-                                url = request.url?.toString(),
-                                captureCookies = captureCookies,
-                            )
-
-                        @Deprecated("Deprecated in Java")
-                        override fun shouldOverrideUrlLoading(
-                            view: WebView,
-                            url: String?,
-                        ): Boolean =
-                            shouldOverrideSpotifyLoginUrl(
-                                view = view,
-                                url = url,
-                                captureCookies = captureCookies,
-                            )
-
-                        override fun onPageStarted(
-                            view: WebView,
-                            url: String?,
-                            favicon: android.graphics.Bitmap?,
-                        ) {
-                            captureCookies(url)
-                        }
-
-                        override fun onPageFinished(
-                            view: WebView,
-                            url: String?,
-                        ) {
-                            captureCookies(url)
-                        }
-                    }
-            }
-
-        val transport = resultMsg.obj as? WebView.WebViewTransport ?: return false
-        container.addView(
-            popupWebView,
-            FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-            ),
-        )
-        popupWebView.bringToFront()
-        popupWebView.requestFocus()
-        onActiveWebViewChanged(popupWebView)
-        transport.webView = popupWebView
-        resultMsg.sendToTarget()
-        return true
-    }
-
-    override fun onCloseWindow(window: WebView) {
-        window.destroySpotifyLoginWebView()
-        onActiveWebViewChanged(parentWebView)
-    }
-
-    private fun closePopupWebViews() {
-        for (index in container.childCount - 1 downTo 0) {
-            val child = container.getChildAt(index) as? WebView ?: continue
-            if (child !== parentWebView) {
-                child.destroySpotifyLoginWebView()
-            }
-        }
-        onActiveWebViewChanged(parentWebView)
-    }
-}
-
-private fun shouldOverrideSpotifyLoginUrl(
-    view: WebView,
-    url: String?,
-    captureCookies: (String?) -> Boolean,
-): Boolean {
-    if (captureCookies(url)) return true
-
-    val targetUrl = url?.takeIf(String::isNotBlank) ?: return false
-    if (targetUrl.isWebViewLoadableUrl()) return false
-
-    targetUrl.intentBrowserFallbackUrl()?.let { fallbackUrl -> view.loadUrl(fallbackUrl) }
-    return true
-}
-
-private fun String.isWebViewLoadableUrl(): Boolean {
-    val scheme = runCatching { Uri.parse(this).scheme?.lowercase() }.getOrNull()
-    return scheme == "http" ||
-        scheme == "https" ||
-        scheme == "javascript" ||
-        scheme == "data" ||
-        scheme == "blob"
-}
-
-private fun String.intentBrowserFallbackUrl(): String? =
-    runCatching { Intent.parseUri(this, Intent.URI_INTENT_SCHEME) }
-        .getOrNull()
-        ?.getStringExtra("browser_fallback_url")
-        ?.takeIf { it.isWebViewLoadableUrl() }
-
-private fun readSpotifyCookies(
-    cookieManager: CookieManager,
-    currentUrl: String?,
-): Map<String, String> {
-    val urls =
-        linkedSetOf(
-            "https://open.spotify.com",
-            "https://accounts.spotify.com",
-            "https://spotify.com",
-        )
-    currentUrl?.toSpotifyCookieOrigin()?.let(urls::add)
-    val cookies = linkedMapOf<String, String>()
-    cookieManager.flush()
-    urls.forEach { url ->
-        cookieManager
-            .getCookie(url)
-            ?.split(";")
-            ?.map(String::trim)
-            ?.filter(String::isNotBlank)
-            ?.forEach { part ->
-                val separator = part.indexOf('=')
-                if (separator <= 0) return@forEach
-                val key = part.substring(0, separator).trim()
-                val value = part.substring(separator + 1).trim()
-                if (key.isNotBlank()) {
-                    cookies[key] = value
-                }
-            }
-    }
-    return cookies
-}
-
-private fun String.toSpotifyCookieOrigin(): String? {
-    val uri = runCatching { Uri.parse(this) }.getOrNull() ?: return null
-    val host = uri.host?.lowercase() ?: return null
-    if (host != "spotify.com" && !host.endsWith(".spotify.com")) return null
-    val scheme =
-        uri.scheme
-            ?.takeIf { it.equals("https", ignoreCase = true) || it.equals("http", ignoreCase = true) }
-            ?: "https"
-    return "$scheme://$host"
-}
-
-@Composable
-fun SpotifyErrorDialog(
-    message: String,
-    onDismiss: () -> Unit,
-) {
-    DefaultDialog(
-        onDismiss = onDismiss,
-        title = { Text(stringResource(R.string.import_failed)) },
-        buttons = {
-            TextButton(onClick = onDismiss, shapes = ButtonDefaults.shapes()) {
-                Text(stringResource(android.R.string.ok))
-            }
-        },
-    ) {
-        Text(
-            text = message,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -81,6 +81,7 @@ import moe.rukamori.archivetune.backup.ScheduledBackupFrequency
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedTopAppBar
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -255,19 +256,10 @@ fun BackupAndRestore(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.backup_restore)) },
-                navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
-                        )
-                    }
-                },
+            FrostedTopAppBar(
+                titleRes = R.string.backup_restore,
+                onBack = navController::navigateUp,
+                onBackLongClick = navController::backToMain,
             )
         },
         snackbarHost = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,6 +38,7 @@ import moe.rukamori.archivetune.constants.ListenBrainzTokenKey
 import moe.rukamori.archivetune.constants.ManualSourceLoginEnabledKey
 import moe.rukamori.archivetune.constants.ShowSpotifyPlaylistsKey
 import moe.rukamori.archivetune.spotify.SpotifyAccountViewModel
+import moe.rukamori.archivetune.ui.component.FrostedTopAppBar
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -78,19 +78,10 @@ fun IntegrationScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.integration)) },
-                navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
-                        )
-                    }
-                },
+            FrostedTopAppBar(
+                titleRes = R.string.integration,
+                onBack = navController::navigateUp,
+                onBackLongClick = navController::backToMain,
             )
         },
     ) { innerPadding ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -29,9 +29,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.ListenBrainzEnabledKey
@@ -51,7 +51,11 @@ import moe.rukamori.archivetune.utils.rememberPreference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun IntegrationScreen(navController: NavController, scrollTo: String? = null) {
+fun IntegrationScreen(
+    navController: NavController,
+    scrollTo: String? = null,
+    spotifyAccountViewModel: SpotifyAccountViewModel = hiltViewModel(),
+) {
     val (listenBrainzEnabled, onListenBrainzEnabledChange) = rememberPreference(ListenBrainzEnabledKey, false)
     val (listenBrainzToken, onListenBrainzTokenChange) = rememberPreference(ListenBrainzTokenKey, "")
     // Manual Tidal/Qobuz instance & account management is an advanced flow gated behind the
@@ -59,22 +63,18 @@ fun IntegrationScreen(navController: NavController, scrollTo: String? = null) {
     // source pool, so most users never need to see raw instance/token fields.
     val (manualSourceLogin, _) = rememberPreference(ManualSourceLoginEnabledKey, false)
 
-    // Task 3: Spotify account management moved here from Backup & Restore. It's a music-source
-    // integration, not a backup/restore feature — co-locating it with Tidal/Qobuz/Deezer/Telegram
-    // makes the Integration page the single home for all streaming-service connections.
-    val spotifyAccountViewModel: SpotifyAccountViewModel = hiltViewModel()
     val spotifyState by spotifyAccountViewModel.uiState.collectAsStateWithLifecycle()
     val (showSpotifyPlaylists, onShowSpotifyPlaylistsChange) = rememberPreference(ShowSpotifyPlaylistsKey, false)
     var showSpotifyLogin by rememberSaveable { mutableStateOf(false) }
+
+    var showListenBrainzTokenEditor = remember { mutableStateOf(false) }
+    var showCrossServiceImport by remember { mutableStateOf(false) }
 
     LaunchedEffect(spotifyState.isAuthenticated) {
         if (spotifyState.isAuthenticated) {
             showSpotifyLogin = false
         }
     }
-
-    var showListenBrainzTokenEditor = remember { mutableStateOf(false) }
-    var showCrossServiceImport by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -150,19 +150,6 @@ fun IntegrationScreen(navController: NavController, scrollTo: String? = null) {
                 modifier = positions.modifierFor("music_sources"),
                 title = stringResource(R.string.music_sources),
             ) {
-                // Spotify lives at the top of Music Sources (Task 3). Moved here from
-                // Backup & Restore so all streaming-service integrations are co-located.
-                spotifyAccountPreferences(
-                    state = spotifyState,
-                    showPlaylists = showSpotifyPlaylists,
-                    onConnectClick = { showSpotifyLogin = true },
-                    onShowPlaylistsChange = onShowSpotifyPlaylistsChange,
-                    onReloadClick = spotifyAccountViewModel::reloadPlaylists,
-                    onLogoutClick = {
-                        spotifyAccountViewModel.logout()
-                    },
-                )
-
                 if (manualSourceLogin) {
                     item {
                         PreferenceEntry(
@@ -208,6 +195,24 @@ fun IntegrationScreen(navController: NavController, scrollTo: String? = null) {
                         },
                     )
                 }
+            }
+
+            // "External Sources" hosts Spotify — a read-only playlist import source, not a
+            // playback source like Tidal/Qobuz/Deezer/Telegram above. Separating it from
+            // "Music Sources" makes the distinction clear: Music Sources feed the player,
+            // External Sources feed the Library (playlist sync, scrobbling, etc.).
+            PreferenceGroup(
+                modifier = positions.modifierFor("external_sources"),
+                title = stringResource(R.string.external_sources),
+            ) {
+                spotifyAccountPreferences(
+                    state = spotifyState,
+                    showPlaylists = showSpotifyPlaylists,
+                    onConnectClick = { showSpotifyLogin = true },
+                    onShowPlaylistsChange = onShowSpotifyPlaylistsChange,
+                    onReloadClick = spotifyAccountViewModel::reloadPlaylists,
+                    onLogoutClick = { spotifyAccountViewModel.logout() },
+                )
             }
 
             PreferenceGroup(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
@@ -99,6 +99,7 @@ import moe.rukamori.archivetune.constants.NavigationBarTransparencyKey
 import moe.rukamori.archivetune.constants.NavigationBarWidthKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedTopAppBar
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -153,19 +154,10 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.navigation_bar_settings_title)) },
-                navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
-                        )
-                    }
-                },
+            FrostedTopAppBar(
+                titleRes = R.string.navigation_bar_settings_title,
+                onBack = navController::navigateUp,
+                onBackLongClick = navController::backToMain,
             )
         },
     ) { innerPadding ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
@@ -10,6 +10,7 @@
 package moe.rukamori.archivetune.ui.screens.settings
 
 import android.os.Build
+<<<<<<< HEAD
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,22 +19,36 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+=======
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
+<<<<<<< HEAD
 import androidx.compose.foundation.shape.RoundedCornerShape
+=======
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+<<<<<<< HEAD
 import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+=======
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -47,12 +62,17 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+<<<<<<< HEAD
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+=======
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
@@ -66,7 +86,10 @@ import moe.rukamori.archivetune.constants.NAVIGATION_BAR_TRANSPARENCY_DEFAULT
 import moe.rukamori.archivetune.constants.NAVIGATION_BAR_WIDTH_DEFAULT
 import moe.rukamori.archivetune.constants.NavigationBarCornerRadiusKey
 import moe.rukamori.archivetune.constants.NavigationBarFrostedBlurKey
+<<<<<<< HEAD
 import moe.rukamori.archivetune.constants.NavigationBarHeight
+=======
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
 import moe.rukamori.archivetune.constants.NavigationBarHeightKey
 import moe.rukamori.archivetune.constants.NavigationBarLabelSpacingKey
 import moe.rukamori.archivetune.constants.NavigationBarOpacityKey
@@ -80,7 +103,10 @@ import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
+<<<<<<< HEAD
 import moe.rukamori.archivetune.ui.screens.Screens
+=======
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
@@ -98,8 +124,11 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
     val (hideNavigationBarLabels, onHideNavigationBarLabelsChange) =
         rememberPreference(HideNavigationBarLabelsKey, defaultValue = false)
 
+<<<<<<< HEAD
     // Customization sliders (Task 6). Defaults are the constants defined alongside
     // their preference keys so the pre-existing look is preserved.
+=======
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
     val (navigationBarWidth, onNavigationBarWidthChange) =
         rememberPreference(NavigationBarWidthKey, defaultValue = NAVIGATION_BAR_WIDTH_DEFAULT)
     val (navigationBarHeight, onNavigationBarHeightChange) =
@@ -210,10 +239,14 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
 
             // Customization sliders: only meaningfully affect the FLOATING style (and the
             // corner radius for DEFAULT). They are shown unconditionally so the user can
+<<<<<<< HEAD
             // pre-configure the floating look before switching to it. Each slider opens a
             // dialog with a live preview that reflects the in-progress value (and the
             // committed values of the other dimensions) so the user can see exactly how
             // the bar will look before committing.
+=======
+            // pre-configure the floating look before switching to it.
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
             PreferenceGroup(title = stringResource(R.string.navigation_bar_dimensions)) {
                 item {
                     SliderPreferenceRow(
@@ -224,6 +257,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                         onValueChange = onNavigationBarWidthChange,
                         range = 0.5f..1.0f,
                         valueLabel = { "${(it * 100).roundToInt()}%" },
+<<<<<<< HEAD
                         preview = { tempWidth ->
                             NavBarPreview(
                                 widthFraction = tempWidth,
@@ -235,6 +269,9 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+=======
+                        default = NAVIGATION_BAR_WIDTH_DEFAULT,
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
                     )
                 }
 
@@ -247,6 +284,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                         onValueChange = onNavigationBarHeightChange,
                         range = 0.8f..1.4f,
                         valueLabel = { "${(it * 100).roundToInt()}%" },
+<<<<<<< HEAD
                         preview = { tempHeight ->
                             NavBarPreview(
                                 widthFraction = navigationBarWidth,
@@ -258,6 +296,9 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+=======
+                        default = NAVIGATION_BAR_HEIGHT_DEFAULT,
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
                     )
                 }
 
@@ -270,6 +311,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                         onValueChange = onNavigationBarOpacityChange,
                         range = 0.2f..1.0f,
                         valueLabel = { "${(it * 100).roundToInt()}%" },
+<<<<<<< HEAD
                         preview = { tempOpacity ->
                             NavBarPreview(
                                 widthFraction = navigationBarWidth,
@@ -281,6 +323,9 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+=======
+                        default = NAVIGATION_BAR_OPACITY_DEFAULT,
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
                     )
                 }
 
@@ -293,6 +338,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                         onValueChange = onNavigationBarTransparencyChange,
                         range = 0.0f..0.95f,
                         valueLabel = { "${(it * 100).roundToInt()}%" },
+<<<<<<< HEAD
                         preview = { tempTransparency ->
                             NavBarPreview(
                                 widthFraction = navigationBarWidth,
@@ -304,6 +350,9 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+=======
+                        default = NAVIGATION_BAR_TRANSPARENCY_DEFAULT,
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
                     )
                 }
 
@@ -316,6 +365,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                         onValueChange = onNavigationBarLabelSpacingChange,
                         range = 0f..16f,
                         valueLabel = { "${it.roundToInt()} dp" },
+<<<<<<< HEAD
                         preview = { tempSpacing ->
                             NavBarPreview(
                                 widthFraction = navigationBarWidth,
@@ -327,6 +377,9 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+=======
+                        default = NAVIGATION_BAR_LABEL_SPACING_DEFAULT,
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
                     )
                 }
 
@@ -339,6 +392,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                         onValueChange = onNavigationBarCornerRadiusChange,
                         range = 0f..48f,
                         valueLabel = { "${it.roundToInt()} dp" },
+<<<<<<< HEAD
                         preview = { tempRadius ->
                             NavBarPreview(
                                 widthFraction = navigationBarWidth,
@@ -352,6 +406,47 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                         },
                     )
                 }
+=======
+                        default = NAVIGATION_BAR_CORNER_RADIUS_DEFAULT,
+                    )
+                }
+
+                // Reset all six dimension values to their defaults in one tap. The button is
+                // disabled (greyed out) when every value is already at its default, so the
+                // user can see at a glance whether they have any unsaved customizations.
+                item {
+                    val allDefaults =
+                        navigationBarWidth == NAVIGATION_BAR_WIDTH_DEFAULT &&
+                            navigationBarHeight == NAVIGATION_BAR_HEIGHT_DEFAULT &&
+                            navigationBarOpacity == NAVIGATION_BAR_OPACITY_DEFAULT &&
+                            navigationBarTransparency == NAVIGATION_BAR_TRANSPARENCY_DEFAULT &&
+                            navigationBarLabelSpacing == NAVIGATION_BAR_LABEL_SPACING_DEFAULT &&
+                            navigationBarCornerRadius == NAVIGATION_BAR_CORNER_RADIUS_DEFAULT
+
+                    OutlinedButton(
+                        onClick = {
+                            onNavigationBarWidthChange(NAVIGATION_BAR_WIDTH_DEFAULT)
+                            onNavigationBarHeightChange(NAVIGATION_BAR_HEIGHT_DEFAULT)
+                            onNavigationBarOpacityChange(NAVIGATION_BAR_OPACITY_DEFAULT)
+                            onNavigationBarTransparencyChange(NAVIGATION_BAR_TRANSPARENCY_DEFAULT)
+                            onNavigationBarLabelSpacingChange(NAVIGATION_BAR_LABEL_SPACING_DEFAULT)
+                            onNavigationBarCornerRadiusChange(NAVIGATION_BAR_CORNER_RADIUS_DEFAULT)
+                        },
+                        enabled = !allDefaults,
+                        shapes = ButtonDefaults.shapes(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.restore),
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 8.dp),
+                        )
+                        Text(stringResource(R.string.navigation_bar_reset_dimensions))
+                    }
+                }
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
             }
         }
     }
@@ -360,11 +455,16 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
 /**
  * A preference row that opens a slider dialog when tapped. Mirrors the swipe-sensitivity
  * UX used in PlayerSettings / AppearanceSettings so all float-valued tuning knobs share
+<<<<<<< HEAD
  * the same interaction model.
  *
  * When [preview] is non-null, the dialog renders a live preview above the slider that
  * reflects the in-progress [tempValue] (passed to the preview lambda) so the user can
  * see exactly how the change will look before committing.
+=======
+ * the same interaction model. The dialog includes a "Reset" button that snaps the slider
+ * back to the default value before the user confirms.
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
  */
 @Composable
 private fun SliderPreferenceRow(
@@ -375,7 +475,11 @@ private fun SliderPreferenceRow(
     onValueChange: (Float) -> Unit,
     range: ClosedFloatingPointRange<Float>,
     valueLabel: (Float) -> String,
+<<<<<<< HEAD
     preview: (@Composable (Float) -> Unit)? = null,
+=======
+    default: Float? = null,
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -388,6 +492,20 @@ private fun SliderPreferenceRow(
                 showDialog = false
             },
             buttons = {
+<<<<<<< HEAD
+=======
+                // Reset button — snaps the slider to the default value (or the range start
+                // if no explicit default was supplied). Stays in the dialog so the user can
+                // preview the default and then either confirm or keep adjusting.
+                if (default != null) {
+                    TextButton(
+                        onClick = { tempValue = default },
+                        shapes = ButtonDefaults.shapes(),
+                    ) {
+                        Text(stringResource(R.string.reset))
+                    }
+                }
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
                 Spacer(modifier = Modifier.weight(1f))
                 TextButton(
                     onClick = {
@@ -416,6 +534,7 @@ private fun SliderPreferenceRow(
                 Text(
                     text = title,
                     style = MaterialTheme.typography.headlineSmall,
+<<<<<<< HEAD
                     modifier = Modifier.padding(bottom = 12.dp),
                 )
 
@@ -438,6 +557,15 @@ private fun SliderPreferenceRow(
                     text = valueLabel(tempValue),
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.padding(bottom = 12.dp),
+=======
+                    modifier = Modifier.padding(bottom = 16.dp),
+                )
+
+                Text(
+                    text = valueLabel(tempValue),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(bottom = 16.dp),
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)
                 )
 
                 Slider(
@@ -466,6 +594,7 @@ private fun SliderPreferenceRow(
         onClick = { showDialog = true },
     )
 }
+<<<<<<< HEAD
 
 /**
  * A miniature, self-contained mock of the floating / docked navigation bar used inside
@@ -601,3 +730,5 @@ private fun NavBarPreview(
         }
     }
 }
+=======
+>>>>>>> 61d35a52b (feat: Spotify move, nav bar dimensions+reset, volume fix, stats refresh removal)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SpotifyPreferences.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SpotifyPreferences.kt
@@ -1,0 +1,594 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.net.Uri
+import android.os.Message
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.spotify.SpotifyAccountUiState
+import moe.rukamori.archivetune.spotify.SpotifyAuth
+import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.PreferenceEntry
+import moe.rukamori.archivetune.ui.component.PreferenceGroupScope
+import moe.rukamori.archivetune.ui.component.SwitchPreference
+import moe.rukamori.archivetune.utils.resetAuthWebViewSession
+
+private val SpotifyAccountIconSize = 44.dp
+private const val SpotifyLoginUserAgent =
+    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36"
+
+/**
+ * Renders the Spotify account / playlist preferences inside a [PreferenceGroupScope].
+ *
+ * Extracted from `BackupAndRestore.kt` so that the Spotify block can be hosted under the
+ * "External Sources" header on the Integration page without dragging the rest of the
+ * backup/restore UI along with it. The host screen owns the [SpotifyAccountViewModel] and
+ * the `showSpotifyLogin` / error-dialog state; this function only renders the preference
+ * rows and invokes the supplied callbacks.
+ */
+@Composable
+internal fun PreferenceGroupScope.spotifyAccountPreferences(
+    state: SpotifyAccountUiState,
+    showPlaylists: Boolean,
+    onConnectClick: () -> Unit,
+    onShowPlaylistsChange: (Boolean) -> Unit,
+    onReloadClick: () -> Unit,
+    onLogoutClick: () -> Unit,
+) {
+    if (!state.isAuthenticated) {
+        item {
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.spotify_connect)) },
+                description = stringResource(R.string.spotify_not_connected),
+                icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
+                trailingContent = {
+                    AnimatedVisibility(visible = state.isLoading) {
+                        CircularWavyProgressIndicator(
+                            modifier = Modifier.size(28.dp),
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                },
+                onClick = onConnectClick,
+                isEnabled = !state.isLoading,
+            )
+        }
+        return
+    }
+
+    item {
+        PreferenceEntry(
+            title = {
+                Text(
+                    text =
+                        if (state.accountName.isNotBlank()) {
+                            stringResource(R.string.spotify_connected_as, state.accountName)
+                        } else {
+                            stringResource(R.string.spotify_account)
+                        },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+            description =
+                when {
+                    state.isLoading -> stringResource(R.string.spotify_loading_library)
+                    state.playlistCount > 0 -> stringResource(R.string.spotify_available_count, state.playlistCount)
+                    else -> stringResource(R.string.spotify_no_sources)
+                },
+            icon = { SpotifyAccountIcon(avatarUrl = state.accountAvatarUrl) },
+            trailingContent = {
+                AnimatedVisibility(visible = state.isLoading) {
+                    CircularWavyProgressIndicator(
+                        modifier = Modifier.size(28.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            },
+            isEnabled = false,
+        )
+    }
+
+    item {
+        SwitchPreference(
+            title = { Text(stringResource(R.string.spotify_show_playlist)) },
+            description = stringResource(R.string.spotify_show_playlist_desc),
+            icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
+            checked = showPlaylists,
+            onCheckedChange = onShowPlaylistsChange,
+            isEnabled = !state.isLoading,
+        )
+    }
+
+    item {
+        PreferenceEntry(
+            title = { Text(stringResource(R.string.spotify_reload_playlist)) },
+            description = stringResource(R.string.spotify_reload_playlist_desc),
+            icon = { Icon(painterResource(R.drawable.sync), null) },
+            onClick = onReloadClick,
+            isEnabled = !state.isLoading,
+        )
+    }
+
+    item {
+        PreferenceEntry(
+            title = { Text(stringResource(R.string.action_logout)) },
+            icon = { Icon(painterResource(R.drawable.logout), null) },
+            onClick = onLogoutClick,
+            isEnabled = !state.isLoading,
+        )
+    }
+}
+
+@Composable
+private fun SpotifyAccountIcon(avatarUrl: String?) {
+    val context = LocalContext.current
+    val requestSize = with(LocalDensity.current) { SpotifyAccountIconSize.roundToPx() }
+    val accountIcon = painterResource(R.drawable.spotify_icon)
+    val imageRequest =
+        remember(context, avatarUrl, requestSize) {
+            avatarUrl
+                ?.takeIf(String::isNotBlank)
+                ?.let {
+                    ImageRequest
+                        .Builder(context)
+                        .data(it)
+                        .size(requestSize)
+                        .build()
+                }
+        }
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (imageRequest != null) {
+            AsyncImage(
+                model = imageRequest,
+                contentDescription = null,
+                placeholder = accountIcon,
+                error = accountIcon,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            Icon(
+                painter = accountIcon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+internal fun SpotifyLoginSheet(
+    onDismiss: () -> Unit,
+    onCookiesCaptured: (spDc: String, spKey: String) -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var webView by remember { mutableStateOf<WebView?>(null) }
+    var mainWebView by remember { mutableStateOf<WebView?>(null) }
+    var captured by remember { mutableStateOf(false) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            webView?.destroySpotifyLoginWebView()
+            mainWebView?.takeIf { it !== webView }?.destroySpotifyLoginWebView()
+            webView = null
+            mainWebView = null
+        }
+    }
+
+    BackHandler(enabled = webView != null) {
+        val activeWebView = webView
+        val rootWebView = mainWebView
+        when {
+            activeWebView?.canGoBack() == true -> {
+                activeWebView.goBack()
+            }
+
+            activeWebView != null && rootWebView != null && activeWebView !== rootWebView -> {
+                activeWebView.destroySpotifyLoginWebView()
+                webView = rootWebView
+            }
+
+            else -> {
+                onDismiss()
+            }
+        }
+    }
+
+    ModalBottomSheet(
+        modifier = Modifier.fillMaxHeight(),
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.spotify_login_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = stringResource(R.string.spotify_waiting_for_login),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            AndroidView(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .clip(MaterialTheme.shapes.large),
+                factory = { context ->
+                    val container = FrameLayout(context)
+                    val spotifyWebView =
+                        WebView(context).apply {
+                            val cookieManager = CookieManager.getInstance()
+                            cookieManager.setAcceptCookie(true)
+                            cookieManager.setAcceptThirdPartyCookies(this, true)
+                            configureSpotifyLoginWebView()
+
+                            fun captureCookies(url: String?): Boolean {
+                                if (captured) return true
+                                val cookies = readSpotifyCookies(cookieManager, url)
+                                val spDc = cookies["sp_dc"].orEmpty()
+                                if (spDc.isBlank()) return false
+                                captured = true
+                                cookieManager.flush()
+                                onCookiesCaptured(spDc, cookies["sp_key"].orEmpty())
+                                return true
+                            }
+
+                            webViewClient =
+                                object : WebViewClient() {
+                                    override fun shouldOverrideUrlLoading(
+                                        view: WebView,
+                                        request: WebResourceRequest,
+                                    ): Boolean =
+                                        shouldOverrideSpotifyLoginUrl(
+                                            view = view,
+                                            url = request.url?.toString(),
+                                            captureCookies = { url -> captureCookies(url) },
+                                        )
+
+                                    @Deprecated("Deprecated in Java")
+                                    override fun shouldOverrideUrlLoading(
+                                        view: WebView,
+                                        url: String?,
+                                    ): Boolean =
+                                        shouldOverrideSpotifyLoginUrl(
+                                            view = view,
+                                            url = url,
+                                            captureCookies = { targetUrl -> captureCookies(targetUrl) },
+                                        )
+
+                                    override fun onPageStarted(
+                                        view: WebView,
+                                        url: String?,
+                                        favicon: android.graphics.Bitmap?,
+                                    ) {
+                                        captureCookies(url)
+                                    }
+
+                                    override fun onPageFinished(
+                                        view: WebView,
+                                        url: String?,
+                                    ) {
+                                        captureCookies(url)
+                                    }
+                                }
+                            webChromeClient =
+                                SpotifyLoginWebChromeClient(
+                                    container = container,
+                                    parentWebView = this,
+                                    captureCookies = { url -> captureCookies(url) },
+                                    onActiveWebViewChanged = { activeWebView -> webView = activeWebView },
+                                )
+                            webView = this
+                            mainWebView = this
+                            resetAuthWebViewSession(context, this) {
+                                loadUrl(SpotifyAuth.LOGIN_URL)
+                            }
+                        }
+                    container.addView(
+                        spotifyWebView,
+                        FrameLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        ),
+                    )
+                    container
+                },
+                update = {
+                    webView = webView ?: mainWebView
+                },
+            )
+        }
+    }
+}
+
+private fun WebView.destroySpotifyLoginWebView() {
+    stopLoading()
+    loadUrl("about:blank")
+    (parent as? ViewGroup)?.removeView(this)
+    destroy()
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun WebView.configureSpotifyLoginWebView() {
+    settings.apply {
+        javaScriptEnabled = true
+        domStorageEnabled = true
+        javaScriptCanOpenWindowsAutomatically = true
+        setSupportMultipleWindows(true)
+        setSupportZoom(true)
+        builtInZoomControls = true
+        displayZoomControls = false
+        mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+        userAgentString = SpotifyLoginUserAgent
+    }
+}
+
+private class SpotifyLoginWebChromeClient(
+    private val container: FrameLayout,
+    private val parentWebView: WebView,
+    private val captureCookies: (String?) -> Boolean,
+    private val onActiveWebViewChanged: (WebView) -> Unit,
+) : WebChromeClient() {
+    override fun onCreateWindow(
+        view: WebView,
+        isDialog: Boolean,
+        isUserGesture: Boolean,
+        resultMsg: Message,
+    ): Boolean {
+        closePopupWebViews()
+
+        val popupWebView =
+            WebView(view.context).apply {
+                val cookieManager = CookieManager.getInstance()
+                cookieManager.setAcceptCookie(true)
+                cookieManager.setAcceptThirdPartyCookies(this, true)
+                configureSpotifyLoginWebView()
+                webViewClient =
+                    object : WebViewClient() {
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView,
+                            request: WebResourceRequest,
+                        ): Boolean =
+                            shouldOverrideSpotifyLoginUrl(
+                                view = view,
+                                url = request.url?.toString(),
+                                captureCookies = captureCookies,
+                            )
+
+                        @Deprecated("Deprecated in Java")
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView,
+                            url: String?,
+                        ): Boolean =
+                            shouldOverrideSpotifyLoginUrl(
+                                view = view,
+                                url = url,
+                                captureCookies = captureCookies,
+                            )
+
+                        override fun onPageStarted(
+                            view: WebView,
+                            url: String?,
+                            favicon: android.graphics.Bitmap?,
+                        ) {
+                            captureCookies(url)
+                        }
+
+                        override fun onPageFinished(
+                            view: WebView,
+                            url: String?,
+                        ) {
+                            captureCookies(url)
+                        }
+                    }
+            }
+
+        val transport = resultMsg.obj as? WebView.WebViewTransport ?: return false
+        container.addView(
+            popupWebView,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+        popupWebView.bringToFront()
+        popupWebView.requestFocus()
+        onActiveWebViewChanged(popupWebView)
+        transport.webView = popupWebView
+        resultMsg.sendToTarget()
+        return true
+    }
+
+    override fun onCloseWindow(window: WebView) {
+        window.destroySpotifyLoginWebView()
+        onActiveWebViewChanged(parentWebView)
+    }
+
+    private fun closePopupWebViews() {
+        for (index in container.childCount - 1 downTo 0) {
+            val child = container.getChildAt(index) as? WebView ?: continue
+            if (child !== parentWebView) {
+                child.destroySpotifyLoginWebView()
+            }
+        }
+        onActiveWebViewChanged(parentWebView)
+    }
+}
+
+private fun shouldOverrideSpotifyLoginUrl(
+    view: WebView,
+    url: String?,
+    captureCookies: (String?) -> Boolean,
+): Boolean {
+    if (captureCookies(url)) return true
+
+    val targetUrl = url?.takeIf(String::isNotBlank) ?: return false
+    if (targetUrl.isWebViewLoadableUrl()) return false
+
+    targetUrl.intentBrowserFallbackUrl()?.let { fallbackUrl -> view.loadUrl(fallbackUrl) }
+    return true
+}
+
+private fun String.isWebViewLoadableUrl(): Boolean {
+    val scheme = runCatching { Uri.parse(this).scheme?.lowercase() }.getOrNull()
+    return scheme == "http" ||
+        scheme == "https" ||
+        scheme == "javascript" ||
+        scheme == "data" ||
+        scheme == "blob"
+}
+
+private fun String.intentBrowserFallbackUrl(): String? =
+    runCatching { Intent.parseUri(this, Intent.URI_INTENT_SCHEME) }
+        .getOrNull()
+        ?.getStringExtra("browser_fallback_url")
+        ?.takeIf { it.isWebViewLoadableUrl() }
+
+private fun readSpotifyCookies(
+    cookieManager: CookieManager,
+    currentUrl: String?,
+): Map<String, String> {
+    val urls =
+        linkedSetOf(
+            "https://open.spotify.com",
+            "https://accounts.spotify.com",
+            "https://spotify.com",
+        )
+    currentUrl?.toSpotifyCookieOrigin()?.let(urls::add)
+    val cookies = linkedMapOf<String, String>()
+    cookieManager.flush()
+    urls.forEach { url ->
+        cookieManager
+            .getCookie(url)
+            ?.split(";")
+            ?.map(String::trim)
+            ?.filter(String::isNotBlank)
+            ?.forEach { part ->
+                val separator = part.indexOf('=')
+                if (separator <= 0) return@forEach
+                val key = part.substring(0, separator).trim()
+                val value = part.substring(separator + 1).trim()
+                if (key.isNotBlank()) {
+                    cookies[key] = value
+                }
+            }
+    }
+    return cookies
+}
+
+private fun String.toSpotifyCookieOrigin(): String? {
+    val uri = runCatching { Uri.parse(this) }.getOrNull() ?: return null
+    val host = uri.host?.lowercase() ?: return null
+    if (host != "spotify.com" && !host.endsWith(".spotify.com")) return null
+    val scheme =
+        uri.scheme
+            ?.takeIf { it.equals("https", ignoreCase = true) || it.equals("http", ignoreCase = true) }
+            ?: "https"
+    return "$scheme://$host"
+}
+
+@Composable
+internal fun SpotifyErrorDialog(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    DefaultDialog(
+        onDismiss = onDismiss,
+        title = { Text(stringResource(R.string.import_failed)) },
+        buttons = {
+            TextButton(onClick = onDismiss, shapes = ButtonDefaults.shapes()) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,6 +569,7 @@
     <string name="navigation_bar_label_spacing_desc">Gap between icon and label (dp)</string>
     <string name="navigation_bar_corner_radius">Corner radius</string>
     <string name="navigation_bar_corner_radius_desc">Roundedness of the floating bar corners (dp)</string>
+    <string name="navigation_bar_reset_dimensions">Reset dimensions to default</string>
     <string name="hide_scrollbar">Hide scrollbar</string>
     <string name="hide_scrollbar_desc">Hide scrollbars across the whole app</string>
     <string name="fork_warning_unofficial">This is an unofficial Fork of Archivetune and is only made for my personal use. If you run into any issues i probably would never fix them unless it\'s serious</string>
@@ -841,6 +842,7 @@
 
     <!-- Tidal music source integration -->
     <string name="music_sources">Music Sources</string>
+    <string name="external_sources">External Sources</string>
     <string name="streaming_sources">Streaming sources</string>
     <string name="streaming_sources_description">Configure Tidal and Qobuz lossless sources and priority</string>
     <string name="tidal_integration">Tidal</string>


### PR DESCRIPTION
See commits for details. 5 changes: (1) Spotify moved to Integration > External Sources; (2) NavigationBarSettings with 6 dimension sliders + reset; (3) Volume slider from-0 fix; (4) Stats refresh button removed; (5) Frosted transparent headers (FrostedHeaderPill + FrostedTopAppBar) applied to Integration, Backup, NavBar, Extras, Stats.