### PR TITLE
feat: hide status bar + fixes (header collision, liquid glass pill fallback, playlist search position)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -72,6 +72,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -119,7 +119,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -1416,14 +1415,16 @@ class MainActivity : ComponentActivity() {
                     // By remembering the last non-zero top inset and substituting it for
                     // systemBars when the status bar is hidden, both the TopAppBar and the
                     // content use a consistent inset source and stay aligned.
+                    //
+                    // WindowInsets.statusBars is a @Composable property, so we read it in
+                    // the composable scope (not inside snapshotFlow) and update the cached
+                    // value via a simple LaunchedEffect keyed on the observed px value.
+                    val currentStatusBarTopPx = WindowInsets.statusBars.getTop(density)
                     var cachedStatusBarTop by remember { mutableStateOf(0.dp) }
-                    LaunchedEffect(Unit) {
-                        snapshotFlow { WindowInsets.statusBars.getTop(density) }
-                            .collect { px ->
-                                if (px > 0) {
-                                    cachedStatusBarTop = with(density) { px.toDp() }
-                                }
-                            }
+                    LaunchedEffect(currentStatusBarTopPx) {
+                        if (currentStatusBarTopPx > 0) {
+                            cachedStatusBarTop = with(density) { currentStatusBarTopPx.toDp() }
+                        }
                     }
                     val effectiveStatusBarTop =
                         if (shouldHideStatusBars && cachedStatusBarTop > 0.dp) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -118,6 +118,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -1029,7 +1030,6 @@ class MainActivity : ComponentActivity() {
                     val focusManager = LocalFocusManager.current
                     val density = LocalDensity.current
                     val windowsInsets = WindowInsets.systemBars
-                    val topInset = with(density) { windowsInsets.getTop(density).toDp() }
                     val bottomInset = with(density) { windowsInsets.getBottom(density).toDp() }
                     val bottomInsetDp = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
 
@@ -1404,6 +1404,39 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    // Cache the status bar top inset observed while the status bar is VISIBLE.
+                    // When shouldHideStatusBars becomes true, WindowInsets.statusBars reports 0
+                    // (the controller hides the bar), but the shared TopAppBar (further below)
+                    // uses WindowInsets.safeDrawing which still reports displayCutout top —
+                    // causing the TopAppBar and the content to drift apart by ~displayCutout
+                    // top, and the profile picture / "ArchiveTune" header collide with the
+                    // content beneath (album cards slide under the header).
+                    //
+                    // By remembering the last non-zero top inset and substituting it for
+                    // systemBars when the status bar is hidden, both the TopAppBar and the
+                    // content use a consistent inset source and stay aligned.
+                    var cachedStatusBarTop by remember { mutableStateOf(0.dp) }
+                    LaunchedEffect(Unit) {
+                        snapshotFlow { WindowInsets.statusBars.getTop(density) }
+                            .collect { px ->
+                                if (px > 0) {
+                                    cachedStatusBarTop = with(density) { px.toDp() }
+                                }
+                            }
+                    }
+                    val effectiveStatusBarTop =
+                        if (shouldHideStatusBars && cachedStatusBarTop > 0.dp) {
+                            cachedStatusBarTop
+                        } else {
+                            with(density) { WindowInsets.statusBars.getTop(density).toDp() }
+                        }
+                    val effectiveWindowsInsets =
+                        WindowInsets(
+                            top = effectiveStatusBarTop,
+                            bottom = with(density) { WindowInsets.systemBars.getBottom(density).toDp() },
+                        )
+                    val effectiveTopInset = effectiveStatusBarTop
+
                     LaunchedEffect(isYearInMusicScreen, playerConnection) {
                         val connection = playerConnection ?: return@LaunchedEffect
                         val player = connection.player
@@ -1446,6 +1479,7 @@ class MainActivity : ComponentActivity() {
                             shouldShowNavigationBar,
                             playerBottomSheetState.isDismissed,
                             navigationBarStyle,
+                            effectiveStatusBarTop,
                         ) {
                             var bottom = bottomInset
                             if (shouldShowNavigationBar && !useRail) {
@@ -1454,7 +1488,7 @@ class MainActivity : ComponentActivity() {
                             if (!playerBottomSheetState.isDismissed) {
                                 bottom += MiniPlayerHeight + MiniPlayerBottomSpacing
                             }
-                            windowsInsets
+                            effectiveWindowsInsets
                                 .only(
                                     (
                                         if (useRail) {
@@ -1993,7 +2027,7 @@ class MainActivity : ComponentActivity() {
 
                                             TopAppBar(
                                                 windowInsets =
-                                                    WindowInsets.safeDrawing.only(
+                                                    effectiveWindowsInsets.only(
                                                         (
                                                             if (useRail) {
                                                                 WindowInsetsSides.Right
@@ -2656,7 +2690,7 @@ class MainActivity : ComponentActivity() {
                                 Modifier
                                     .align(Alignment.TopCenter)
                                     .padding(
-                                        top = if (shouldShowTopBar) topInset + AppBarHeight + 8.dp else topInset + 8.dp,
+                                        top = if (shouldShowTopBar) effectiveTopInset + AppBarHeight + 8.dp else effectiveTopInset + 8.dp,
                                         start = 16.dp,
                                         end = 16.dp,
                                     ).zIndex(10f),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -236,6 +236,7 @@ import moe.rukamori.archivetune.constants.NavigationBarTintFrostedBlurKey
 import moe.rukamori.archivetune.constants.NavigationBarStyle
 import moe.rukamori.archivetune.constants.NavigationBarStyleKey
 import moe.rukamori.archivetune.constants.PureBlackKey
+import moe.rukamori.archivetune.constants.HideStatusBarKey
 import moe.rukamori.archivetune.constants.RemindAfterKey
 import moe.rukamori.archivetune.constants.SYSTEM_DEFAULT
 import moe.rukamori.archivetune.constants.SearchSource
@@ -864,6 +865,7 @@ class MainActivity : ComponentActivity() {
                 }
             val pureBlackEnabled by rememberPreference(PureBlackKey, defaultValue = false)
             val pureBlack = pureBlackEnabled && useDarkTheme
+            val hideStatusBar by rememberPreference(HideStatusBarKey, defaultValue = false)
             val navigationBarStyle by rememberEnumPreference(
                 NavigationBarStyleKey,
                 defaultValue = NavigationBarStyle.DEFAULT,
@@ -1380,7 +1382,8 @@ class MainActivity : ComponentActivity() {
                     var isPlayerLyricsFullScreen by remember { mutableStateOf(false) }
 
                     val shouldHideStatusBars =
-                        isYearInMusicScreen ||
+                        hideStatusBar ||
+                            isYearInMusicScreen ||
                             bottomSheetPageState.isVisible ||
                             (
                                 menuState.isVisible &&

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -23,6 +23,7 @@ val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")
 val DisableAnimationsKey = booleanPreferencesKey("disableAnimations")
 val ForceHighRefreshRateKey = booleanPreferencesKey("forceHighRefreshRate")
+val HideStatusBarKey = booleanPreferencesKey("hideStatusBar")
 
 // UI scale (DPI-like) multiplier applied via a LocalDensity override in MainActivity.
 // 1.0f = system default. Range clamped to [0.85f, 1.30f] in AppearanceSettings.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -876,6 +876,19 @@ fun FloatingNavigationToolbar(
                                 },
                                 onDrawBackdrop = { drawBackdrop -> drawBackdrop() },
                                 shape = { pillShape },
+                                // Fallback surface drawn UNDER the backdrop sample.
+                                // When the backdrop has content (album art, page content
+                                // behind the nav bar), the backdrop sample covers this
+                                // and you see the liquid glass refraction. When the
+                                // backdrop is EMPTY (e.g. bottom of a short page with
+                                // nothing behind the nav bar), the backdrop sample is
+                                // transparent and this opaque surface shows through —
+                                // matching the existing pattern used by the bar Surface
+                                // (baseColor = surfaceContainerHigh) and the Frosted nav
+                                // bar variant (opaque surface + 30% alpha overlay).
+                                onDrawBehind = {
+                                    drawRect(MaterialTheme.colorScheme.surfaceContainerHigh)
+                                },
                                 onDrawSurface = {
                                     val progress = dragAnim.pressProgress
                                     drawRect(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -821,6 +821,11 @@ fun FloatingNavigationToolbar(
                 val pillShape = RoundedCornerShape(percent = 50)
                 val isDark = isSystemInDarkTheme()
                 val primaryColor = MaterialTheme.colorScheme.primary
+                // Fallback surface drawn UNDER the backdrop sample. Hoisted to the
+                // composable scope because MaterialTheme.colorScheme is only
+                // accessible from a @Composable context (onDrawBehind is a plain
+                // DrawScope lambda).
+                val pillFallbackColor = MaterialTheme.colorScheme.surfaceContainerHigh
                 Box(
                     modifier =
                         Modifier
@@ -887,7 +892,7 @@ fun FloatingNavigationToolbar(
                                 // (baseColor = surfaceContainerHigh) and the Frosted nav
                                 // bar variant (opaque surface + 30% alpha overlay).
                                 onDrawBehind = {
-                                    drawRect(MaterialTheme.colorScheme.surfaceContainerHigh)
+                                    drawRect(pillFallbackColor)
                                 },
                                 onDrawSurface = {
                                     val progress = dragAnim.pressProgress

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryScreen.kt
@@ -28,9 +28,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -67,8 +65,8 @@ import androidx.core.graphics.toColorInt
 import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.LocalDatabase
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
-import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.ChipSortTypeKey
 import moe.rukamori.archivetune.constants.DisableBlurKey
 import moe.rukamori.archivetune.constants.LibraryFilter
@@ -162,8 +160,7 @@ fun LibraryScreen(navController: NavController) {
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .windowInsetsPadding(WindowInsets.statusBars)
-                    .padding(top = AppBarHeight),
+                    .padding(LocalPlayerAwareWindowInsets.current.asPaddingValues()),
         ) {
             val tabListState = rememberLazyListState()
             val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -233,17 +233,13 @@ fun LocalPlaylistScreen(
     // shifts all items below it. By saving firstVisibleItemIndex + scrollOffset
     // BEFORE the collapse and restoring them AFTER the expand, the visible
     // position is preserved across open/close search.
+    // (The LaunchedEffect that uses these is declared further below, AFTER
+    // lazyListState is created — Kotlin requires vals to be declared before use.)
     var savedScrollIndex by remember { mutableStateOf(0) }
     var savedScrollOffset by remember { mutableStateOf(0) }
     LaunchedEffect(isSearching) {
         if (isSearching) {
-            savedScrollIndex = lazyListState.firstVisibleItemIndex
-            savedScrollOffset = lazyListState.firstVisibleItemScrollOffset
             focusRequester.requestFocus()
-        } else {
-            // Wait one frame for the header to re-expand before restoring.
-            withFrameNanos {}
-            lazyListState.scrollToItem(savedScrollIndex, savedScrollOffset)
         }
     }
 
@@ -480,6 +476,22 @@ fun LocalPlaylistScreen(
                 mutableSongs.move(from.index - headerItems, to.index - headerItems)
             }
         }
+
+    // Save scroll position when entering search, restore when leaving.
+    // The header item collapses to height 0 when isSearching becomes true, which
+    // shifts all items below it. By saving firstVisibleItemIndex + scrollOffset
+    // BEFORE the collapse and restoring them AFTER the expand, the visible
+    // position is preserved across open/close search.
+    LaunchedEffect(isSearching) {
+        if (isSearching) {
+            savedScrollIndex = lazyListState.firstVisibleItemIndex
+            savedScrollOffset = lazyListState.firstVisibleItemScrollOffset
+        } else {
+            // Wait one frame for the header to re-expand before restoring.
+            withFrameNanos {}
+            lazyListState.scrollToItem(savedScrollIndex, savedScrollOffset)
+        }
+    }
 
     LaunchedEffect(reorderableState.isAnyItemDragging) {
         if (!reorderableState.isAnyItemDragging) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -568,8 +568,8 @@ fun LocalPlaylistScreen(
                         )
                     }
                 } else {
-                    if (!isSearching) {
-                        item(key = "header") {
+                    item(key = "header") {
+                        if (!isSearching) {
                             val songCount =
                                 if (
                                     playlist.songCount == 0 &&
@@ -722,9 +722,9 @@ fun LocalPlaylistScreen(
                         }
                     }
 
-                    if (!isSearching) {
-                        // Sort Header
-                        item(key = "sort_header") {
+                    // Sort Header
+                    item(key = "sort_header") {
+                        if (!isSearching) {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
                                 modifier = Modifier.padding(start = 16.dp),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -92,7 +93,6 @@ import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
-import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.constants.PlaylistEditLockKey
 import moe.rukamori.archivetune.constants.PlaylistSongSortType
@@ -227,9 +227,23 @@ fun LocalPlaylistScreen(
         }
 
     val focusRequester = remember { FocusRequester() }
+
+    // Save scroll position when entering search, restore when leaving.
+    // The header item collapses to height 0 when isSearching becomes true, which
+    // shifts all items below it. By saving firstVisibleItemIndex + scrollOffset
+    // BEFORE the collapse and restoring them AFTER the expand, the visible
+    // position is preserved across open/close search.
+    var savedScrollIndex by remember { mutableStateOf(0) }
+    var savedScrollOffset by remember { mutableStateOf(0) }
     LaunchedEffect(isSearching) {
         if (isSearching) {
+            savedScrollIndex = lazyListState.firstVisibleItemIndex
+            savedScrollOffset = lazyListState.firstVisibleItemScrollOffset
             focusRequester.requestFocus()
+        } else {
+            // Wait one frame for the header to re-expand before restoring.
+            withFrameNanos {}
+            lazyListState.scrollToItem(savedScrollIndex, savedScrollOffset)
         }
     }
 
@@ -546,9 +560,6 @@ fun LocalPlaylistScreen(
                         } else {
                             Modifier
                         },
-                    )
-                    .padding(
-                        top = if (isSearching) systemBarsTopPadding + AppBarHeight else 0.dp,
                     ),
             contentPadding =
                 PaddingValues(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.toMutableStateList
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -93,7 +94,6 @@ import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
-import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.HideExplicitKey
 import moe.rukamori.archivetune.db.entities.PlaylistEntity
 import moe.rukamori.archivetune.db.entities.PlaylistSongMap
@@ -219,9 +219,23 @@ fun OnlinePlaylistScreen(
         }
 
     val focusRequester = remember { FocusRequester() }
+
+    // Save scroll position when entering search, restore when leaving.
+    // The header item collapses to height 0 when isSearching becomes true, which
+    // shifts all items below it. By saving firstVisibleItemIndex + scrollOffset
+    // BEFORE the collapse and restoring them AFTER the expand, the visible
+    // position is preserved across open/close search.
+    var savedScrollIndex by remember { mutableStateOf(0) }
+    var savedScrollOffset by remember { mutableStateOf(0) }
     LaunchedEffect(isSearching) {
         if (isSearching) {
+            savedScrollIndex = lazyListState.firstVisibleItemIndex
+            savedScrollOffset = lazyListState.firstVisibleItemScrollOffset
             focusRequester.requestFocus()
+        } else {
+            // Wait one frame for the header to re-expand before restoring.
+            withFrameNanos {}
+            lazyListState.scrollToItem(savedScrollIndex, savedScrollOffset)
         }
     }
 
@@ -294,10 +308,7 @@ fun OnlinePlaylistScreen(
             state = lazyListState,
             modifier =
                 Modifier
-                    .fillMaxSize()
-                    .padding(
-                        top = if (isSearching) systemBarsTopPadding + AppBarHeight else 0.dp,
-                    ),
+                    .fillMaxSize(),
             contentPadding =
                 PaddingValues(
                     bottom =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -378,8 +378,8 @@ fun OnlinePlaylistScreen(
                         }
                     }
                 } else if (playlist != null) {
-                    if (!isSearching) {
-                        item(key = "header") {
+                    item(key = "header") {
+                        if (!isSearching) {
                             val author =
                                 playlist.author?.let { artist ->
                                     remember(artist) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -75,7 +76,6 @@ import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
-import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.spotify.SpotifyMapper
@@ -131,6 +131,26 @@ fun SpotifyPlaylistScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val downloadActionFailedMessage = stringResource(R.string.download_action_failed)
     val latestDownloads by rememberUpdatedState(downloads)
+
+    // Save scroll position when entering search, restore when leaving.
+    // The header item collapses to height 0 when isSearching becomes true, which
+    // shifts all items below it. By saving firstVisibleItemIndex + scrollOffset
+    // BEFORE the collapse and restoring them AFTER the expand, the visible
+    // position is preserved across open/close search.
+    var savedScrollIndex by remember { mutableStateOf(0) }
+    var savedScrollOffset by remember { mutableStateOf(0) }
+    LaunchedEffect(isSearching) {
+        if (isSearching) {
+            // Save BEFORE the header collapses (next frame).
+            savedScrollIndex = lazyListState.firstVisibleItemIndex
+            savedScrollOffset = lazyListState.firstVisibleItemScrollOffset
+        } else {
+            // Restore AFTER the header has expanded back. A single frame delay
+            // lets the LazyColumn re-measure with the header at full height.
+            withFrameNanos {}
+            lazyListState.scrollToItem(savedScrollIndex, savedScrollOffset)
+        }
+    }
 
     val downloadState =
         remember(state.downloadItems, downloads) {
@@ -340,10 +360,7 @@ fun SpotifyPlaylistScreen(
                 ),
             modifier =
                 Modifier
-                    .fillMaxSize()
-                    .padding(
-                        top = if (isSearching) systemBarsTopPadding + AppBarHeight else 0.dp,
-                    ),
+                    .fillMaxSize(),
         ) {
             playlist?.let { currentPlaylist ->
                 item(key = "header") {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -137,20 +137,10 @@ fun SpotifyPlaylistScreen(
     // shifts all items below it. By saving firstVisibleItemIndex + scrollOffset
     // BEFORE the collapse and restoring them AFTER the expand, the visible
     // position is preserved across open/close search.
+    // (The LaunchedEffect that uses these is declared further below, AFTER
+    // isSearching is created — Kotlin requires vals to be declared before use.)
     var savedScrollIndex by remember { mutableStateOf(0) }
     var savedScrollOffset by remember { mutableStateOf(0) }
-    LaunchedEffect(isSearching) {
-        if (isSearching) {
-            // Save BEFORE the header collapses (next frame).
-            savedScrollIndex = lazyListState.firstVisibleItemIndex
-            savedScrollOffset = lazyListState.firstVisibleItemScrollOffset
-        } else {
-            // Restore AFTER the header has expanded back. A single frame delay
-            // lets the LazyColumn re-measure with the header at full height.
-            withFrameNanos {}
-            lazyListState.scrollToItem(savedScrollIndex, savedScrollOffset)
-        }
-    }
 
     val downloadState =
         remember(state.downloadItems, downloads) {
@@ -283,7 +273,17 @@ fun SpotifyPlaylistScreen(
         }
 
     LaunchedEffect(isSearching) {
-        if (isSearching) focusRequester.requestFocus()
+        if (isSearching) {
+            // Save scroll position BEFORE the header collapses, then focus the search field.
+            savedScrollIndex = lazyListState.firstVisibleItemIndex
+            savedScrollOffset = lazyListState.firstVisibleItemScrollOffset
+            focusRequester.requestFocus()
+        } else {
+            // Restore scroll position AFTER the header has expanded back. A single
+            // frame delay lets the LazyColumn re-measure with the header at full height.
+            withFrameNanos {}
+            lazyListState.scrollToItem(savedScrollIndex, savedScrollOffset)
+        }
     }
 
     LaunchedEffect(viewModel) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -345,9 +345,9 @@ fun SpotifyPlaylistScreen(
                         top = if (isSearching) systemBarsTopPadding + AppBarHeight else 0.dp,
                     ),
         ) {
-            if (!isSearching) {
-                playlist?.let { currentPlaylist ->
-                    item(key = "header") {
+            playlist?.let { currentPlaylist ->
+                item(key = "header") {
+                    if (!isSearching) {
                         val trackCount = currentPlaylist.tracks?.total ?: tracks.size
                         val metadata =
                             listOfNotNull(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -82,6 +82,7 @@ import moe.rukamori.archivetune.constants.DisableBlurKey
 import moe.rukamori.archivetune.constants.DynamicThemeKey
 import moe.rukamori.archivetune.constants.FontPreferenceKey
 import moe.rukamori.archivetune.constants.ForceHighRefreshRateKey
+import moe.rukamori.archivetune.constants.HideStatusBarKey
 import moe.rukamori.archivetune.constants.GridItemSize
 import moe.rukamori.archivetune.constants.GridItemsSizeKey
 import moe.rukamori.archivetune.constants.HidePlayerThumbnailKey
@@ -198,6 +199,11 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
     val (forceHighRefreshRate, onForceHighRefreshRateChange) =
         rememberPreference(
             ForceHighRefreshRateKey,
+            defaultValue = false,
+        )
+    val (hideStatusBar, onHideStatusBarChange) =
+        rememberPreference(
+            HideStatusBarKey,
             defaultValue = false,
         )
     val (uiScale, onUiScaleChange) =
@@ -553,6 +559,18 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         checked = disableAnimations,
                         onCheckedChange = onDisableAnimationsChange,
                     )
+                }
+
+                item {
+                    Column(modifier = positions.modifierFor("hide_status_bar")) {
+                        SwitchPreference(
+                            title = { Text(stringResource(R.string.hide_status_bar)) },
+                            description = stringResource(R.string.hide_status_bar_desc),
+                            icon = { Icon(painterResource(R.drawable.visibility_off), null) },
+                            checked = hideStatusBar,
+                            onCheckedChange = onHideStatusBarChange,
+                        )
+                    }
                 }
 
                 item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -43,6 +43,7 @@ import moe.rukamori.archivetune.constants.EnableTranslatorKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderEnabledKey
 import moe.rukamori.archivetune.constants.ForceHighRefreshRateKey
 import moe.rukamori.archivetune.constants.HideAiMixKey
+import moe.rukamori.archivetune.constants.HideStatusBarKey
 import moe.rukamori.archivetune.constants.HideExplicitKey
 import moe.rukamori.archivetune.constants.HideNavigationBarLabelsKey
 import moe.rukamori.archivetune.constants.HidePlayerThumbnailKey
@@ -166,6 +167,7 @@ fun buildSettingsGroups(
                 SettingsChild("Swipe to song", "swipe_to_song", listOf("swipe to song", "swipe next", "swipe track")) { SearchResultSwitch(SwipeToSongKey, false) },
                 SettingsChild("Swipe sensitivity", "swipe_sensitivity", listOf("swipe", "gesture", "sensitivity")),
                 SettingsChild("Disable animations", "disable_animations", listOf("animation", "disable animations", "no animations", "performance")) { SearchResultSwitch(DisableAnimationsKey, false) },
+                SettingsChild("Hide status bar", "hide_status_bar", listOf("status bar", "hide status", "immersive", "fullscreen", "hide bar")) { SearchResultSwitch(HideStatusBarKey, false) },
                 SettingsChild("Force high refresh rate", "force_high_refresh_rate", listOf("refresh rate", "high refresh", "120hz", "90hz", "smooth")) { SearchResultSwitch(ForceHighRefreshRateKey, false) },
                 SettingsChild("Navigation bar style", "navigation_bar_style", listOf("navigation bar", "nav bar", "bottom bar")),
                 SettingsChild("Frosted navigation bar", "frosted_nav_bar", listOf("frosted nav", "frosted navigation", "frosted blur")) { SearchResultSwitch(NavigationBarFrostedBlurKey, false) },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,6 +508,8 @@
     <string name="disable_blur_desc">Disable blur effects throughout the app</string>
     <string name="disable_animations">Disable animations</string>
     <string name="disable_animations_desc">Disable most app animations. Recommended for low-end devices</string>
+    <string name="hide_status_bar">Hide status bar</string>
+    <string name="hide_status_bar_desc">Hide the system status bar on all screens. Swipe down from the top edge to reveal it temporarily</string>
     <string name="force_high_refresh_rate">Force high refresh rate</string>
     <string name="max_supported_refresh_rate">Max supported: %1$d Hz</string>
     <string name="blur_intensity">Blur intensity</string>


### PR DESCRIPTION
## Summary

This PR tracks `dev → main` and contains multiple feature/fix commits:

---

### Commit e8e3416 — feat: hide status bar option + fix search bar shifting playlist position

**1. Hide status bar (Appearance settings)**
New toggle in Appearance settings → "Hide status bar". When enabled, the system status bar is hidden across the entire app on all screens (immersive mode). Swipe down from the top edge to reveal it temporarily.

- New `HideStatusBarKey` (`booleanPreferencesKey`)
- Toggle UI in `AppearanceSettings.kt` with `visibility_off` icon
- Wired into `MainActivity`'s `shouldHideStatusBars` OR chain
- Indexed in `SettingsDataBuilders` search list
- Strings `hide_status_bar` + `hide_status_bar_desc`

**2. Fix: opening/closing search bar shifted playlist scroll position (first attempt)**
- Kept `item(key="header")` slots always present in the LazyColumn with empty content when `isSearching` — stable key sequence → stable index mapping.
- Applied to Local / Online / Spotify playlist screens.

---

### Commit 9f6b97c — fix: status bar header collision + liquid glass pill fallback + playlist search position

**3. Fix header / profile picture collision when status bar is hidden**
**Root cause:** when `shouldHideStatusBars` is true, `WindowInsets.statusBars` reports 0 (the controller hides the bar), but the shared TopAppBar used `WindowInsets.safeDrawing` which still reports `displayCutout` top. This caused the TopAppBar to sit at `displayCutout_top` while the content beneath used `systemBars` (top=0) — album cards slid under the header / profile picture.

**Fix:** cache the last non-zero status bar top inset via `snapshotFlow`, and substitute it for `systemBars` when `shouldHideStatusBars` is true. Both the TopAppBar and the content (via `playerAwareWindowInsets`) now use the same `effectiveWindowsInsets` source, staying aligned. LibraryScreen switched from `WindowInsets.statusBars + AppBarHeight` to `LocalPlayerAwareWindowInsets.current.asPaddingValues()`.

**4. Fix liquid glass nav bar pill invisible when nothing behind it**
**Root cause:** the pill's `drawBackdrop` call had no `onDrawBehind` callback, so when the backdrop was empty (e.g. bottom of a short page with no content behind the nav bar), the pill was ~10% alpha tint over a transparent surface → effectively invisible.

**Fix:** added `onDrawBehind` callback that draws an opaque `surfaceContainerHigh` fallback. When the backdrop has content (album art, page content), the backdrop sample covers this and you see the liquid glass refraction. When the backdrop is empty, the opaque surface shows through — matching the bar Surface's existing `baseColor` pattern and the Frosted nav bar variant.

**5. Fix playlist scroll position shifting when search bar opens/closes (definitive)**
**Root cause (1):** the LazyColumn had a conditional `top = if (isSearching) systemBarsTopPadding + AppBarHeight else 0.dp` padding — toggling `isSearching` shifted the LazyColumn's frame by ~88dp, shifting all visible items.

**Root cause (2):** the header item's content was wrapped in `if (!isSearching) { ... }` — collapsing the header from ~400dp to 0dp when searching shifted all items below it up by ~400dp.

**Fix (1):** removed the conditional `top` padding entirely. The TopAppBar (search bar) is rendered as a sibling overlay and covers the top of the LazyColumn when searching — no frame shift needed.

**Fix (2):** save `firstVisibleItemIndex + firstVisibleItemScrollOffset` BEFORE the header collapses (when `isSearching` becomes true), and restore them AFTER the header re-expands (when `isSearching` becomes false, with a one-frame delay for the LazyColumn to re-measure). Applied to LocalPlaylistScreen, OnlinePlaylistScreen, SpotifyPlaylistScreen.

---

## Test plan
- [ ] Enable Hide status bar → status bar disappears on all screens
- [ ] With Hide status bar ON → header and profile picture no longer collide with content on Home/Search/Library
- [ ] Swipe down from top edge while hidden → status bar temporarily shows
- [ ] Liquid glass nav bar visible on screens with no content behind it (e.g. short pages, solid dark backgrounds)
- [ ] Open a playlist, scroll to a song mid-list, open search bar, close it → scroll position unchanged
- [ ] Same test on Local / Online / Spotify playlists
