### PR TITLE
fix(deezer): manual sign-in account bypassed by PoolAccountManager guard in MusicService

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -120,6 +120,9 @@ object DeezerAudioProvider {
         }
     }
 
+    /** True when at least one credential (manual or pooled) is available. Cheap: no network. */
+    fun hasAccounts(): Boolean = manualAccount != null || PoolAccountManager.deezerAccounts().isNotEmpty()
+
     /**
      * Every usable credential, manual first so a user's own (likely paid) account is tried before
      * shared pool entries.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -8560,19 +8560,17 @@ class MusicService :
      * only credential source and the whole source is a no-op until the pool has accounts.
      */
     private fun resolveDeezerStream(query: SourceQuery): DirectStream? {
-        val accounts = PoolAccountManager.deezerAccounts()
-        if (accounts.isEmpty()) {
-            Timber.tag("MusicService").d("Deezer skip: no pool accounts available")
+        // DeezerAudioProvider.accounts() merges the manually signed-in account (setManualArl) with
+        // PoolAccountManager.deezerAccounts(). Calling PoolAccountManager directly here bypassed the
+        // manual account entirely: a user who signed in through the Deezer login screen would see an
+        // empty list even though their ARL was registered, and every track would silently produce null.
+        // The guard now uses DeezerAudioProvider.hasAccounts() so both sources are considered.
+        if (!DeezerAudioProvider.hasAccounts()) {
+            Timber.tag("MusicService").d("Deezer skip: no manual or pooled accounts available")
             return null
         }
         val quality = parseDeezerAudioQuality()
-        Timber.tag("MusicService").d(
-            "Deezer resolve start | quality=%s accounts=%d",
-            quality.name,
-            accounts.size,
-        )
-        // No setAccounts equivalent to Qobuz's setTokens: Deezer credentials come only from the pool,
-        // so the provider reads PoolAccountManager itself. The count above is logged for diagnostics.
+        Timber.tag("MusicService").d("Deezer resolve start | quality=%s", quality.name)
         return runCatching {
             runBlocking(Dispatchers.IO) {
                 DeezerAudioProvider


### PR DESCRIPTION
## Summary

Manual Deezer sign-in (via the login screen) does not work — even when the account is correctly saved, `resolveDeezerStream` always returns `null` for users without a pool configured. This PR fixes that.

## Root Cause

`resolveDeezerStream` opens with a guard that calls `PoolAccountManager.deezerAccounts()` directly:

```kotlin
val accounts = PoolAccountManager.deezerAccounts()
if (accounts.isEmpty()) {
    Timber.tag("MusicService").d("Deezer skip: no pool accounts available")
    return null
}
```

`DeezerAudioProvider.accounts()` (private) is the function that merges both sources — it prepends the manually-registered ARL (`setManualArl`, called from `App` on cold start and from the login flow) before the pool accounts. Calling `PoolAccountManager` directly here bypasses that entirely. The result: a user who completed the Deezer login flow has their ARL stored in `DeezerAudioProvider.manualAccount`, but `MusicService` never reaches `DeezerAudioProvider.resolve()` — it bails before that with an empty list. The comment '// No setAccounts equivalent to Qobuz's setTokens: Deezer credentials come only from the pool' was accurate when manual sign-in did not exist; it became stale once `setManualArl` was added.

## Fix

Add `DeezerAudioProvider.hasAccounts()` — a cheap, no-network function that checks `manualAccount != null || PoolAccountManager.deezerAccounts().isNotEmpty()` — and use that as the guard instead. The resolve path already calls the correct private `accounts()`, so no further change is needed there.

```kotlin
fun hasAccounts(): Boolean = manualAccount != null || PoolAccountManager.deezerAccounts().isNotEmpty()
```

## Files Changed

| File | Change |
|---|---|
| `deezer/DeezerAudioProvider.kt` | Add `hasAccounts()` |
| `playback/MusicService.kt` | Replace `PoolAccountManager` guard with `DeezerAudioProvider.hasAccounts()` |

## Testing

- Sign in to Deezer manually (no pool configured) → tracks should now resolve
- Pool accounts only (no manual sign-in) → behaviour unchanged, pool still used
- Both manual + pool → manual account tried first, pool as fallback (existing `accounts()` ordering)