### PR TITLE
fix(dabmusic): correct API contract + add login flow

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -335,6 +335,26 @@ class App :
                 .collect { url -> DabMusicAudioProvider.setBaseUrl(url) }
         }
 
+        // Mirrors the DabMusic account credentials into the provider. The email+password pair is
+        // only used when the user taps "Login" in Sources settings — the provider never auto-logs
+        // in. The session cookie collector below restores a previously-persisted session at cold
+        // start so the user doesn't have to re-login every time the app restarts.
+        applicationScope.launch(Dispatchers.IO) {
+            dataStore.data
+                .map { (it[DabMusicEmailKey] ?: "") to (it[DabMusicPasswordKey] ?: "") }
+                .distinctUntilChanged()
+                .collect { (email, password) ->
+                    DabMusicAudioProvider.setCredentials(email, password)
+                }
+        }
+
+        applicationScope.launch(Dispatchers.IO) {
+            dataStore.data
+                .map { it[DabMusicSessionCookieKey] ?: "" }
+                .distinctUntilChanged()
+                .collect { cookie -> DabMusicAudioProvider.setSessionCookie(cookie) }
+        }
+
         applicationScope.launch(Dispatchers.IO) {
             dataStore.data
                 .map { it.toPlaybackAuthState() }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -355,6 +355,18 @@ class App :
                 .collect { cookie -> DabMusicAudioProvider.setSessionCookie(cookie) }
         }
 
+        // Mirrors the DabMusic cf_clearance cookie into the provider. cf_clearance is the
+        // Cloudflare bypass cookie captured by the in-app WebView (see DabMusicCloudflareBypassDialog).
+        // It's ~30-minute-lived; when it expires the user reopens the bypass dialog. Without this
+        // collector the cookie would be lost on cold start and the user would have to re-solve the
+        // challenge every time they restart the app.
+        applicationScope.launch(Dispatchers.IO) {
+            dataStore.data
+                .map { it[DabMusicCfClearanceKey] ?: "" }
+                .distinctUntilChanged()
+                .collect { cookie -> DabMusicAudioProvider.setCfClearance(cookie) }
+        }
+
         applicationScope.launch(Dispatchers.IO) {
             dataStore.data
                 .map { it.toPlaybackAuthState() }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -1146,6 +1146,16 @@ val DabMusicPasswordKey = stringPreferencesKey("dabMusicPassword")
 // are short-lived and the threat model matches Deezer's ARL handling.
 val DabMusicSessionCookieKey = stringPreferencesKey("dabMusicSessionCookie")
 
+// The Cloudflare `cf_clearance` cookie obtained by solving the interstitial challenge in an
+// in-app WebView. dabmusic.xyz is fronted by Cloudflare's "managed challenge" which 403s
+// non-browser clients on /api/search even when /api/auth/login is allowed through. Without
+// this cookie, OkHttp requests to /api/search typically hang for the full readTimeout and
+// then fail with SocketTimeoutException. The cookie is ~30-minute-lived and must be refreshed
+// periodically by re-solving the challenge. Blank = no bypass cookie; the provider will
+// attempt the request anyway (it may still succeed on residential IPs that Cloudflare does
+// not challenge, or fail with a CloudflareBlocked result that the UI surfaces).
+val DabMusicCfClearanceKey = stringPreferencesKey("dabMusicCfClearance")
+
 val WebClientPoTokenEnabledKey = booleanPreferencesKey("webClientPoTokenEnabled")
 val PoTokenGvsKey = stringPreferencesKey("poTokenGvs")
 val PoTokenPlayerKey = stringPreferencesKey("poTokenPlayer")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -1121,16 +1121,30 @@ val DeezerAccountPremiumKey = booleanPreferencesKey("deezerAccountPremium")
 // ---------------------------------------------------------------------------
 // DabMusic source
 // ---------------------------------------------------------------------------
-// DabMusic (https://dabmusic.xyz) is a community-operated lossless stream catalog: the app
-// searches its public REST API for a track and receives a direct playable FLAC/MP3 URL back.
-// Defaults OFF because, unlike YouTube, it requires the upstream service to be reachable and
-// returns no audio when the catalog is missing the requested track.
+// DabMusic (https://dabmusic.xyz) is a community-operated lossless catalog backed by a REST API
+// at /api/search and /api/stream. Unlike YouTube, the API requires authentication: a POST to
+// /api/auth/login with email+password returns a `session` cookie that must be sent on every
+// subsequent request. Defaults OFF because (a) it requires a DabMusic account and (b) the
+// gateway sits behind a Cloudflare interstitial that may block non-browser clients in some
+// regions; when the gateway is unreachable the source degrades gracefully to the next source.
 val DabMusicEnabledKey = booleanPreferencesKey("dabMusicEnabled")
 
 // Optional override for the DabMusic base URL. Blank = built-in default (https://dabmusic.xyz).
 // Exposed so users behind mirrors or self-hosted gateways can repoint the source without a
 // rebuild; the AudioProvider trims trailing slashes before composing endpoints.
 val DabMusicBaseUrlKey = stringPreferencesKey("dabMusicBaseUrl")
+
+// DabMusic account credentials. The email+password pair is sent to /api/auth/login to obtain a
+// session cookie; the session cookie is what actually authorises /api/search and /api/stream.
+// Both fields are blank by default — the user must enter them and tap "Login" in Sources settings.
+val DabMusicEmailKey = stringPreferencesKey("dabMusicEmail")
+val DabMusicPasswordKey = stringPreferencesKey("dabMusicPassword")
+
+// The session cookie obtained from /api/auth/login (or pasted manually by advanced users who
+// extract it from a browser session). Blank = not logged in; the provider returns null for every
+// resolve() call until a valid session cookie is present. Stored unencrypted — DabMusic sessions
+// are short-lived and the threat model matches Deezer's ARL handling.
+val DabMusicSessionCookieKey = stringPreferencesKey("dabMusicSessionCookie")
 
 val WebClientPoTokenEnabledKey = booleanPreferencesKey("webClientPoTokenEnabled")
 val PoTokenGvsKey = stringPreferencesKey("poTokenGvs")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicAudioProvider.kt
@@ -46,12 +46,29 @@ import java.util.concurrent.atomic.AtomicReference
  *    Not used here yet — wired in for future lyrics-provider integration.
  *
  * Cloudflare note: dabmusic.xyz is fronted by a Cloudflare "Just a moment..." interstitial that
- * challenges non-browser clients. OkHttp cannot execute the JS challenge, so requests from
- * data-center IPs (and some residential IPs flagged by Cloudflare) will receive HTTP 403 with an
- * HTML body. The provider detects this (response body starts with `<!DOCTYPE` or contains "Just
- * a moment") and returns null so the playback layer falls through to the next source in the
- * chain. On residential mobile IPs the challenge is often NOT triggered and the API is reachable
- * directly — YMMV depending on carrier and region.
+ * challenges non-browser clients. The WAF rule on this gateway whitelists
+ * `POST /api/auth/login` (so the user can authenticate) but applies a "managed challenge" to
+ * `GET /api/search` and `GET /api/stream`. On challenged requests Cloudflare returns HTTP 200
+ * with `Transfer-Encoding: chunked` and drip-feeds the interstitial HTML body over 30+ seconds,
+ * which causes OkHttp's `readTimeout` to fire as a `SocketTimeoutException` (rather than the
+ * fast 403+HTML that data-center IPs see). The provider defends against this in three layers:
+ *
+ *   1. Browser-like headers — `Referer`, `Origin`, `Sec-Fetch-*`, `Accept-Encoding` are sent on
+ *      every request so Cloudflare's heuristics are less likely to flag the client as a bot.
+ *      On residential mobile IPs this is often enough — login works without any extra setup.
+ *
+ *   2. `cf_clearance` cookie — when the user taps "Solve Cloudflare Challenge" in Sources
+ *      settings, an in-app WebView loads `https://dabmusic.xyz/`, the WebView's JS engine
+ *      solves Cloudflare's challenge automatically, and the resulting `cf_clearance` cookie is
+ *      extracted via `CookieManager` and pushed into this provider via [setCfClearance]. The
+ *      cookie is ~30-minute-lived and must be refreshed periodically. With this cookie present,
+ *      Cloudflare passes the request through to the backend and the API returns real JSON.
+ *
+ *   3. Cloudflare detection — when neither (1) nor (2) is sufficient, the provider detects the
+ *      interstitial by inspecting the response body (HTML body, "Just a moment", "cf-challenge",
+ *      "challenge-platform") regardless of status code, and returns null so the playback layer
+ *      falls through to the next source in the chain. The UI also surfaces a
+ *      [LoginResult.CloudflareBlocked]-style signal so the user knows to tap the bypass button.
  *
  * All calls run blocking network I/O and must not be made from the main thread.
  */
@@ -83,9 +100,12 @@ object DabMusicAudioProvider {
     private val client =
         OkHttpClient
             .Builder()
-            .connectTimeout(6, TimeUnit.SECONDS)
-            .readTimeout(10, TimeUnit.SECONDS)
-            .callTimeout(15, TimeUnit.SECONDS)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            // Cloudflare's managed-challenge drip-feed can take 20+ seconds to either flush the
+            // body or close the connection; 30s gives us a real answer instead of a premature
+            // SocketTimeoutException on slow mobile networks.
+            .readTimeout(30, TimeUnit.SECONDS)
+            .callTimeout(45, TimeUnit.SECONDS)
             .followRedirects(true)
             .build()
 
@@ -138,6 +158,16 @@ object DabMusicAudioProvider {
     @Volatile
     private var sessionCookie: String = ""
 
+    /**
+     * The Cloudflare `cf_clearance` cookie obtained by solving the interstitial in an in-app
+     * WebView (see [moe.rukamori.archivetune.dabmusic.DabMusicCloudflareBypass]). When present,
+     * it is appended to the `Cookie` header on every request alongside the `session` cookie.
+     * Blank = no bypass active; the provider will attempt the request and rely on browser-like
+     * headers + Cloudflare detection. ~30-minute-lived; must be refreshed by re-solving.
+     */
+    @Volatile
+    private var cfClearance: String = ""
+
     @Volatile
     var lastResolvedTrackId: String? = null
         private set
@@ -183,11 +213,63 @@ object DabMusicAudioProvider {
         }
     }
 
+    /**
+     * Sets the Cloudflare `cf_clearance` cookie obtained by solving the interstitial in a WebView.
+     * Blank = clear the bypass (e.g. when it expires or the user signs out). Cheap and idempotent;
+     * safe to push the current preference value on every settings change.
+     */
+    fun setCfClearance(cookie: String?) {
+        val trimmed = cookie?.trim().orEmpty()
+        if (cfClearance != trimmed) {
+            cfClearance = trimmed
+            // cf_clearance is request-level — drop caches so we don't serve stale "no match"
+            // results that were computed under the old (or absent) bypass.
+            searchCache.clear()
+            failureCache.clear()
+        }
+    }
+
+    /** Returns true when a cf_clearance cookie is present (the bypass is armed). */
+    fun hasCfClearance(): Boolean = cfClearance.isNotEmpty()
+
     /** Returns the current session cookie (may be blank). The UI uses this to display status. */
     fun getSessionCookie(): String = sessionCookie
 
     /** Returns true when the user has either stored credentials OR a stored session cookie. */
     fun hasAccount(): Boolean = sessionCookie.isNotEmpty() || credentials.get() != null
+
+    /**
+     * Lightweight probe used by the "Solve Cloudflare Challenge" UI to decide whether the bypass
+     * is needed at all. Sends a GET /api/search?q=probe&type=track and inspects the response body
+     * — if it's JSON, the gateway is reachable directly; if it's the Cloudflare interstitial, the
+     * user needs to solve the challenge. Returns true when Cloudflare is blocking (bypass needed),
+     * false when the gateway is reachable (no bypass needed). Never throws.
+     *
+     * Blocking network I/O — must not be called from the main thread.
+     */
+    fun isCloudflareBlocking(): Boolean {
+        val url =
+            baseUrl
+                .toHttpUrl()
+                .newBuilder()
+                .addPathSegment("api")
+                .addPathSegment("search")
+                .addQueryParameter("q", "probe")
+                .addQueryParameter("type", "track")
+                .build()
+        val request = baseRequest(url).get().build()
+        return try {
+            client.newCall(request).execute().use { response ->
+                val body = response.body?.string().orEmpty()
+                looksLikeCloudflare(body) || (!response.isSuccessful && response.code != 401)
+            }
+        } catch (e: Exception) {
+            // SocketTimeoutException is the most common symptom of Cloudflare's drip-feed —
+            // treat it as "blocked" so the UI offers the bypass.
+            Timber.tag(TAG).w(e, "reachability probe failed; assuming Cloudflare is blocking")
+            true
+        }
+    }
 
     /**
      * Calls POST /api/auth/login with the stored credentials. On success, persists the session
@@ -399,17 +481,25 @@ object DabMusicAudioProvider {
         val candidates =
             runCatching {
                 client.newCall(request).execute().use { response ->
+                    val body = response.body?.string().orEmpty()
+                    // Cloudflare's "managed challenge" can return 200 OK with an HTML body
+                    // (the interstitial page) — detect it regardless of status code so we
+                    // don't waste time trying to parse HTML as JSON.
+                    if (looksLikeCloudflare(body)) {
+                        Timber
+                            .tag(TAG)
+                            .w(
+                                "search blocked by Cloudflare (http=%d, cf-ray=%s, hasCfClearance=%b)",
+                                response.code,
+                                response.header("cf-ray"),
+                                cfClearance.isNotEmpty(),
+                            )
+                        return@use emptyList<TrackMatching.Candidate>()
+                    }
                     if (!response.isSuccessful) {
-                        if (response.code == 403) {
-                            val body = response.body?.string().orEmpty()
-                            if (looksLikeCloudflare(body)) {
-                                Timber.tag(TAG).w("search blocked by Cloudflare (cf-ray=%s)", response.header("cf-ray"))
-                            }
-                        }
                         Timber.tag(TAG).d("search HTTP %d for \"%s\"", response.code, queryString)
                         return@use emptyList<TrackMatching.Candidate>()
                     }
-                    val body = response.body?.string().orEmpty()
                     parseSearchResults(body)
                 }
             }.onFailure { Timber.tag(TAG).w(it, "search network failed") }
@@ -509,17 +599,24 @@ object DabMusicAudioProvider {
                 .build()
         val request = baseRequest(url).get().build()
         client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            // Cloudflare's "managed challenge" can return 200 OK with an HTML body
+            // (the interstitial page) — detect it regardless of status code.
+            if (looksLikeCloudflare(body)) {
+                Timber
+                    .tag(TAG)
+                    .w(
+                        "stream blocked by Cloudflare (http=%d, cf-ray=%s, hasCfClearance=%b)",
+                        response.code,
+                        response.header("cf-ray"),
+                        cfClearance.isNotEmpty(),
+                    )
+                return null
+            }
             if (!response.isSuccessful) {
-                if (response.code == 403) {
-                    val body = response.body?.string().orEmpty()
-                    if (looksLikeCloudflare(body)) {
-                        Timber.tag(TAG).w("stream blocked by Cloudflare (cf-ray=%s)", response.header("cf-ray"))
-                    }
-                }
                 Timber.tag(TAG).d("stream HTTP %d for track %s", response.code, trackId)
                 return null
             }
-            val body = response.body?.string().orEmpty()
             val trimmed = body.trim()
             if (trimmed.isEmpty() || trimmed.startsWith("<")) {
                 Timber.tag(TAG).w("stream returned non-JSON body (likely Cloudflare interstitial)")
@@ -538,25 +635,64 @@ object DabMusicAudioProvider {
         }
     }
 
-    private fun baseRequest(url: okhttp3.HttpUrl): Request.Builder =
-        Request
+    private fun baseRequest(url: okhttp3.HttpUrl): Request.Builder {
+        // Compose the Cookie header. Both cookies are name=value pairs joined with "; ".
+        // cf_clearance is optional (only present after the user solves the WebView challenge);
+        // session is required for all post-login endpoints.
+        val cookieParts = buildList {
+            if (sessionCookie.isNotEmpty()) add("session=$sessionCookie")
+            if (cfClearance.isNotEmpty()) add("cf_clearance=$cfClearance")
+        }
+        // Referer/Origin must match the API host or Cloudflare's WAF will treat the request as
+        // cross-origin and apply stricter heuristics. We use the configured baseUrl's scheme +
+        // host + (non-default) port — path is left off because Cloudflare expects a page-level
+        // Referer, not a deep API path.
+        val origin =
+            buildString {
+                append(url.scheme)
+                append("://")
+                append(url.host)
+                if (url.port != -1 &&
+                    !((url.scheme == "https" && url.port == 443) || (url.scheme == "http" && url.port == 80))
+                ) {
+                    append(":")
+                    append(url.port)
+                }
+            }
+        return Request
             .Builder()
             .url(url)
             .header("User-Agent", USER_AGENT)
-            .header("Accept", "application/json")
-            .header("Accept-Language", "en-US,en;q=0.5")
+            .header("Accept", "application/json, text/plain, */*")
+            .header("Accept-Language", "en-US,en;q=0.9")
+            .header("Accept-Encoding", "gzip, deflate, br")
+            .header("Referer", "$origin/")
+            .header("Origin", origin)
+            .header("Sec-Fetch-Dest", "empty")
+            .header("Sec-Fetch-Mode", "cors")
+            .header("Sec-Fetch-Site", "same-origin")
             .apply {
-                if (sessionCookie.isNotEmpty()) {
-                    header("Cookie", "session=$sessionCookie")
+                if (cookieParts.isNotEmpty()) {
+                    header("Cookie", cookieParts.joinToString("; "))
                 }
             }
+    }
 
-    /** True when the response body looks like Cloudflare's "Just a moment..." interstitial. */
+    /**
+     * True when the response body looks like Cloudflare's "Just a moment..." interstitial.
+     * Inspects the first 1KB of the body so drip-fed chunked responses (where OkHttp has read
+     * part of the body before readTimeout fires) are still detected as Cloudflare rather than
+     * treated as a malformed JSON response.
+     */
     private fun looksLikeCloudflare(body: String): Boolean {
         if (body.isEmpty()) return false
-        val sample = if (body.length > 512) body.substring(0, 512) else body
+        val sample = if (body.length > 1024) body.substring(0, 1024) else body
         return sample.contains("Just a moment", ignoreCase = true) ||
             sample.contains("cf-challenge", ignoreCase = true) ||
-            (sample.contains("<title>", ignoreCase = true) && sample.contains("cloudflare", ignoreCase = true))
+            sample.contains("cf-chl-bypass", ignoreCase = true) ||
+            sample.contains("challenge-platform", ignoreCase = true) ||
+            (sample.contains("<title>", ignoreCase = true) && sample.contains("cloudflare", ignoreCase = true)) ||
+            (sample.trimStart().startsWith("<!DOCTYPE", ignoreCase = true) &&
+                sample.contains("challenges.cloudflare.com", ignoreCase = true))
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicAudioProvider.kt
@@ -92,8 +92,13 @@ object DabMusicAudioProvider {
      * A desktop Chrome User-Agent. The DabMusic gateway is behind Cloudflare and serves the
      * interstitial to clients it identifies as bots, so we present as a browser to maximise the
      * chance the REST endpoint is reachable at all.
+     *
+     * This value is ALSO used by [DabMusicCloudflareBypassDialog]'s WebView — Cloudflare binds
+     * the `cf_clearance` cookie to (IP, User-Agent). If the WebView solves the challenge with one
+     * UA and OkHttp later sends the cookie with a different UA, Cloudflare rejects it and the
+     * bypass silently fails. Keeping both clients on the same UA is what makes the cookie valid.
      */
-    private const val USER_AGENT =
+    const val USER_AGENT =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
             "Chrome/124.0.0.0 Safari/537.36"
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicAudioProvider.kt
@@ -9,29 +9,49 @@ package moe.rukamori.archivetune.dabmusic
 
 import moe.rukamori.archivetune.audiosource.TrackMatching
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Resolves playable lossless streams for a track from the DabMusic catalog at
  * https://dabmusic.xyz.
  *
- * DabMusic is a community-operated catalog+restream service: the app POSTs a search query, the
- * service replies with a list of matching tracks (each carrying a track id and metadata), and a
- * second call to the stream endpoint resolves a direct playable URL. There are no per-user
- * accounts — DabMusic is a public proxy — so unlike [moe.rukamori.archivetune.deezer.DeezerAudioProvider]
- * there is no ARL/bearer credential to manage and no [moe.rukamori.archivetune.utils.PoolAccountManager]
- * tier. The provider is purely a network client.
+ * API contract (reverse-engineered from the official dabcli client, github.com/LeoAj2005/dabmusicclient):
  *
- * The service is fronted by a Cloudflare interstitial on its HTML routes; the REST endpoints under
- * the `api` path are expected to be reachable from a non-browser User-Agent. When Cloudflare still
- * challenges the request (HTTP 403 with the "Just a moment…" body) the provider logs and returns
- * null so the playback layer falls through to the next source in the chain — never throwing.
+ *  - `POST /api/auth/login` with JSON `{"email": "...", "password": "..."}`. On success the
+ *    server returns HTTP 200 and sets a `session=<token>` cookie on the response. That cookie
+ *    MUST be sent on every subsequent request — the catalog and stream endpoints both 401
+ *    without it. The login flow is triggered explicitly by the user tapping "Login" in Sources
+ *    settings; this provider never logs in on its own (it would leak credentials into background
+ *    network windows and re-prompt for them on every cold start).
+ *
+ *  - `GET /api/search?q=<query>&type=track` returns `{"tracks": [{id, title, artist, artistId,
+ *    albumId, albumTitle, releaseDate, ...}, ...]}`. The `type` parameter also accepts `album`
+ *    and `artist`; we always send `track` because the player is asking for a single track.
+ *
+ *  - `GET /api/stream?trackId=<id>&quality=<quality>` returns `{"url": "<direct stream URL>"}`.
+ *    `quality` is a numeric string: `"27"` = FLAC (lossless), `"5"` = MP3. We always request `27`
+ *    because DabMusic is advertised as a lossless source; if the catalog doesn't have a FLAC
+ *    master it falls back to MP3 server-side and the `url` extension tells us which one we got.
+ *
+ *  - `GET /api/lyrics?title=<title>&artist=<artist>` returns `{"lyrics": "...", "unsynced": bool}`.
+ *    Not used here yet — wired in for future lyrics-provider integration.
+ *
+ * Cloudflare note: dabmusic.xyz is fronted by a Cloudflare "Just a moment..." interstitial that
+ * challenges non-browser clients. OkHttp cannot execute the JS challenge, so requests from
+ * data-center IPs (and some residential IPs flagged by Cloudflare) will receive HTTP 403 with an
+ * HTML body. The provider detects this (response body starts with `<!DOCTYPE` or contains "Just
+ * a moment") and returns null so the playback layer falls through to the next source in the
+ * chain. On residential mobile IPs the challenge is often NOT triggered and the API is reachable
+ * directly — YMMV depending on carrier and region.
  *
  * All calls run blocking network I/O and must not be made from the main thread.
  */
@@ -46,6 +66,10 @@ object DabMusicAudioProvider {
 
     private const val MIME_FLAC = "audio/flac"
     private const val MIME_MPEG = "audio/mpeg"
+
+    /** Quality codes used by the DabMusic /api/stream endpoint. `27` = FLAC, `5` = MP3. */
+    const val QUALITY_FLAC = "27"
+    const val QUALITY_MP3 = "5"
 
     /**
      * A desktop Chrome User-Agent. The DabMusic gateway is behind Cloudflare and serves the
@@ -62,6 +86,7 @@ object DabMusicAudioProvider {
             .connectTimeout(6, TimeUnit.SECONDS)
             .readTimeout(10, TimeUnit.SECONDS)
             .callTimeout(15, TimeUnit.SECONDS)
+            .followRedirects(true)
             .build()
 
     /** What the player asked for. Mirrors the shape of the other providers' Query types. */
@@ -90,8 +115,28 @@ object DabMusicAudioProvider {
         val bitDepth: Int?,
     )
 
+    /** Outcome of a login attempt. The UI surfaces this to the user. */
+    sealed class LoginResult {
+        data object Success : LoginResult()
+
+        data class Failure(val reason: String) : LoginResult()
+
+        data class CloudflareBlocked(val rayId: String?) : LoginResult()
+    }
+
     @Volatile
     private var baseUrl: String = DEFAULT_BASE_URL
+
+    /** Email + password pair entered by the user. Used only when [login] is called explicitly. */
+    private val credentials = AtomicReference<Pair<String, String>?>(null)
+
+    /**
+     * The session cookie authorising /api/search and /api/stream. Set by [login] on success, or
+     * pushed directly from preferences via [setSessionCookie] when the app cold-starts with a
+     * previously-persisted session. Blank = not logged in; resolve() will short-circuit to null.
+     */
+    @Volatile
+    private var sessionCookie: String = ""
 
     @Volatile
     var lastResolvedTrackId: String? = null
@@ -114,21 +159,148 @@ object DabMusicAudioProvider {
         baseUrl = trimmed ?: DEFAULT_BASE_URL
     }
 
-    /** Always true: DabMusic is a public proxy with no per-user accounts. */
-    fun hasAccounts(): Boolean = true
+    /**
+     * Sets the email + password pair used by [login]. Does NOT trigger a login — the UI calls
+     * [login] explicitly so the user sees the result. Blank/null clears the stored credentials.
+     */
+    fun setCredentials(email: String?, password: String?) {
+        val e = email?.trim().orEmpty()
+        val p = password.orEmpty()
+        credentials.set(if (e.isNotEmpty() && p.isNotEmpty()) e to p else null)
+    }
 
     /**
-     * Resolves a playable stream for [query]. Returns null when the catalog has no acceptable
-     * match, when the gateway is unreachable, or when Cloudflare challenges the request. Never
-     * throws — failures are cached for [FAILURE_CACHE_MS] so we don't hammer the gateway on
-     * every retry.
+     * Sets the session cookie directly. Used at app cold-start to restore a previously-persisted
+     * session without re-prompting for credentials. Blank = not logged in.
+     */
+    fun setSessionCookie(cookie: String?) {
+        sessionCookie = cookie?.trim().orEmpty()
+        if (sessionCookie.isEmpty()) {
+            // Signing out: drop caches so a re-login doesn't serve stale results.
+            searchCache.clear()
+            streamCache.clear()
+            failureCache.clear()
+        }
+    }
+
+    /** Returns the current session cookie (may be blank). The UI uses this to display status. */
+    fun getSessionCookie(): String = sessionCookie
+
+    /** Returns true when the user has either stored credentials OR a stored session cookie. */
+    fun hasAccount(): Boolean = sessionCookie.isNotEmpty() || credentials.get() != null
+
+    /**
+     * Calls POST /api/auth/login with the stored credentials. On success, persists the session
+     * cookie via [setSessionCookie] and returns [LoginResult.Success]. The caller (the UI) is
+     * responsible for saving the returned cookie to [moe.rukamori.archivetune.constants.DabMusicSessionCookieKey].
+     *
+     * Returns [LoginResult.CloudflareBlocked] when the gateway returns the Cloudflare
+     * interstitial (HTTP 403 + HTML body) — this is a common failure mode for non-browser
+     * clients and is surfaced distinctly so the UI can explain it.
+     *
+     * Blocking network I/O — must not be called from the main thread.
+     */
+    fun login(): LoginResult {
+        val creds = credentials.get()
+        if (creds == null) {
+            return LoginResult.Failure("No email/password set")
+        }
+        val (email, password) = creds
+
+        val url =
+            baseUrl
+                .toHttpUrl()
+                .newBuilder()
+                .addPathSegment("api")
+                .addPathSegment("auth")
+                .addPathSegment("login")
+                .build()
+        val jsonBody = JSONObject().put("email", email).put("password", password).toString()
+        val request =
+            baseRequest(url)
+                .post(jsonBody.toRequestBody("application/json".toMediaTypeOrNull()))
+                .build()
+
+        return try {
+            client.newCall(request).execute().use { response ->
+                if (response.code == 403) {
+                    val body = response.body?.string().orEmpty()
+                    if (looksLikeCloudflare(body)) {
+                        val rayId = response.header("cf-ray")
+                        Timber.tag(TAG).w("login blocked by Cloudflare (cf-ray=%s)", rayId)
+                        return LoginResult.CloudflareBlocked(rayId)
+                    }
+                    return LoginResult.Failure("HTTP 403 — service unavailable")
+                }
+                if (response.code == 401) {
+                    return LoginResult.Failure("Invalid email or password")
+                }
+                if (!response.isSuccessful) {
+                    return LoginResult.Failure("HTTP ${response.code}")
+                }
+
+                // Extract the session cookie from Set-Cookie headers. OkHttp exposes them via
+                // response.headers — there may be multiple Set-Cookie headers; we want the one
+                // named "session".
+                val cookies = response.headers("Set-Cookie")
+                val session =
+                    cookies
+                        .firstNotNullOfOrNull { raw ->
+                            val parts = raw.split(";").map { it.trim() }
+                            val kv = parts.firstOrNull()?.split("=", limit = 2)
+                            if (kv != null && kv.size == 2 && kv[0].equals("session", ignoreCase = true)) {
+                                kv[1].trim().ifBlank { null }
+                            } else {
+                                null
+                            }
+                        }
+                        ?.takeIf { it.isNotEmpty() }
+
+                if (session.isNullOrBlank()) {
+                    // Some deployments return the session token in the JSON body instead.
+                    val body = response.body?.string().orEmpty()
+                    val parsed = runCatching { JSONObject(body) }.getOrNull()
+                    val bodyToken = parsed?.optString("session")?.ifBlank { null } ?: parsed?.optString("token")?.ifBlank { null }
+                    if (bodyToken.isNullOrBlank()) {
+                        Timber.tag(TAG).w("login succeeded (HTTP %d) but no session cookie in response", response.code)
+                        return LoginResult.Failure("Login succeeded but no session cookie returned")
+                    }
+                    setSessionCookie(bodyToken)
+                    return LoginResult.Success
+                }
+
+                setSessionCookie(session)
+                Timber.tag(TAG).i("login succeeded, session cookie length=%d", session.length)
+                LoginResult.Success
+            }
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "login network failed")
+            LoginResult.Failure(e.message ?: "Network error")
+        }
+    }
+
+    /** Clears the session cookie (sign-out). The UI calls this when the user taps "Sign out". */
+    fun signOut() {
+        setSessionCookie(null)
+    }
+
+    /**
+     * Resolves a playable stream for [query]. Returns null when the user is not logged in, when
+     * the catalog has no acceptable match, when the gateway is unreachable, or when Cloudflare
+     * challenges the request. Never throws — failures are cached for [FAILURE_CACHE_MS] so we
+     * don't hammer the gateway on every retry.
      */
     fun resolve(
         query: Query,
-        format: String,
+        quality: String = QUALITY_FLAC,
     ): Resolved? {
+        if (sessionCookie.isEmpty()) {
+            Timber.tag(TAG).d("resolve skipped — not logged in")
+            return null
+        }
+
         val now = System.currentTimeMillis()
-        val cacheKey = query.cacheKey() + ":" + format
+        val cacheKey = query.cacheKey() + ":" + quality
         streamCache[cacheKey]?.let { cached ->
             if (cached.expiresAt > now) return cached.stream
             streamCache.remove(cacheKey)
@@ -147,27 +319,30 @@ object DabMusicAudioProvider {
             return null
         }
 
-        val stream =
-            runCatching { requestStream(match.id, format) }
+        val streamUrl =
+            runCatching { requestStream(match.id, quality) }
                 .onFailure { Timber.tag(TAG).w(it, "stream resolve failed for track %s", match.id) }
                 .getOrNull()
-        if (stream == null) {
+        if (streamUrl == null) {
             failureCache[cacheKey] = now + FAILURE_CACHE_MS
             return null
         }
 
         lastResolvedTrackId = match.id
+        val isFlac =
+            streamUrl.substringAfterLast('.', "").equals("flac", ignoreCase = true) ||
+                quality == QUALITY_FLAC
         val resolved =
             Resolved(
-                uri = stream.url,
-                mimeType = if (stream.flac) MIME_FLAC else MIME_MPEG,
-                codecs = if (stream.flac) "flac" else "mp3",
-                contentLength = stream.contentLength,
+                uri = streamUrl,
+                mimeType = if (isFlac) MIME_FLAC else MIME_MPEG,
+                codecs = if (isFlac) "flac" else "mp3",
+                contentLength = null,
                 label =
                     when {
-                        stream.flac -> "DabMusic FLAC"
-                        format.equals("MP3_320", true) -> "DabMusic MP3 320"
-                        else -> "DabMusic MP3"
+                        isFlac -> "DabMusic FLAC"
+                        quality == QUALITY_MP3 -> "DabMusic MP3"
+                        else -> "DabMusic"
                     },
                 matchedTitle = match.title,
                 matchedArtist = match.artists.firstOrNull(),
@@ -176,19 +351,19 @@ object DabMusicAudioProvider {
                 // DabMusic's gateway does not report sample rate / bit depth; assume CD-quality
                 // for FLAC (the catalog's lossless tier is 16-bit/44.1 kHz) and leave MP3 to the
                 // playback layer's tier heuristic.
-                sampleRate = if (stream.flac) 44_100 else null,
-                bitDepth = if (stream.flac) 16 else null,
+                sampleRate = if (isFlac) 44_100 else null,
+                bitDepth = if (isFlac) 16 else null,
             )
         streamCache[cacheKey] = CachedStream(resolved, now + STREAM_CACHE_MS)
         return resolved
     }
 
-    /** Evicts cached search/stream/failure entries for [query]+[format]. */
+    /** Evicts cached search/stream/failure entries for [query]+[quality]. */
     fun invalidate(
         query: Query,
-        format: String,
+        quality: String = QUALITY_FLAC,
     ) {
-        val key = query.cacheKey() + ":" + format
+        val key = query.cacheKey() + ":" + quality
         streamCache.remove(key)
         failureCache.remove(key)
     }
@@ -217,7 +392,7 @@ object DabMusicAudioProvider {
                 .addPathSegment("api")
                 .addPathSegment("search")
                 .addQueryParameter("q", queryString)
-                .addQueryParameter("limit", SEARCH_LIMIT.toString())
+                .addQueryParameter("type", "track")
                 .build()
         val request = baseRequest(url).get().build()
 
@@ -225,6 +400,12 @@ object DabMusicAudioProvider {
             runCatching {
                 client.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) {
+                        if (response.code == 403) {
+                            val body = response.body?.string().orEmpty()
+                            if (looksLikeCloudflare(body)) {
+                                Timber.tag(TAG).w("search blocked by Cloudflare (cf-ray=%s)", response.header("cf-ray"))
+                            }
+                        }
                         Timber.tag(TAG).d("search HTTP %d for \"%s\"", response.code, queryString)
                         return@use emptyList<TrackMatching.Candidate>()
                     }
@@ -266,11 +447,12 @@ object DabMusicAudioProvider {
                         }
                     } ?: return emptyList()
                 }
-        // Accept either { "results": [...] }, { "data": [...] }, or a top-level array.
+        // The official dabcli contract is { "tracks": [...] } for type=track. Tolerate the
+        // alternates used by some mirrors for robustness.
         val data =
-            root.optJSONArray("results")
+            root.optJSONArray("tracks")
+                ?: root.optJSONArray("results")
                 ?: root.optJSONArray("data")
-                ?: root.optJSONArray("tracks")
                 ?: root.optJSONArray("items")
                 ?: JSONArray()
         return (0 until data.length()).mapNotNull { i ->
@@ -279,6 +461,8 @@ object DabMusicAudioProvider {
     }
 
     private fun JSONObject.toCandidate(): TrackMatching.Candidate? {
+        // Per the official dabcli client, track objects have:
+        //   id, title, artist (string), artistId, albumId, albumTitle, releaseDate
         val id = optString("id").ifBlank { optString("trackId") }.ifBlank { optString("track_id") }
         if (id.isBlank()) return null
         val title = optString("title").ifBlank { optString("name") }
@@ -287,10 +471,12 @@ object DabMusicAudioProvider {
             optString("artist").ifBlank {
                 optJSONArray("artists")?.optString(0)?.ifBlank { null }
             }
+        // DabMusic uses `albumTitle` (not `album`) for the album name. Fall back to `album` for
+        // mirrors that use the conventional field name.
+        val album = optString("albumTitle").ifBlank { optString("album") }.ifBlank { optJSONObject("album")?.optString("title") }
         val durationMs = optLong("durationMs", 0L).takeIf { it > 0 }
             ?: optLong("duration_ms", 0L).takeIf { it > 0 }
             ?: (optLong("duration", 0L).takeIf { it > 0 }?.times(1000L))
-        val album = optString("album").ifBlank { optJSONObject("album")?.optString("title") }
         return TrackMatching.Candidate(
             id = id,
             title = title,
@@ -304,50 +490,51 @@ object DabMusicAudioProvider {
     // Stream
     // ---------------------------------------------------------------------------------------------
 
-    private data class MediaUrl(
-        val url: String,
-        val flac: Boolean,
-        val contentLength: Long?,
-        val format: String,
-    )
-
+    /**
+     * Calls GET /api/stream?trackId=<id>&quality=<quality> and returns the direct stream URL
+     * extracted from the `{"url": "..."}` response. Returns null on any failure.
+     */
     private fun requestStream(
         trackId: String,
-        format: String,
-    ): MediaUrl? {
+        quality: String,
+    ): String? {
         val url =
             baseUrl
                 .toHttpUrl()
                 .newBuilder()
                 .addPathSegment("api")
                 .addPathSegment("stream")
-                .addQueryParameter("id", trackId)
-                .addQueryParameter("format", format)
+                .addQueryParameter("trackId", trackId)
+                .addQueryParameter("quality", quality)
                 .build()
         val request = baseRequest(url).get().build()
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
+                if (response.code == 403) {
+                    val body = response.body?.string().orEmpty()
+                    if (looksLikeCloudflare(body)) {
+                        Timber.tag(TAG).w("stream blocked by Cloudflare (cf-ray=%s)", response.header("cf-ray"))
+                    }
+                }
                 Timber.tag(TAG).d("stream HTTP %d for track %s", response.code, trackId)
                 return null
             }
             val body = response.body?.string().orEmpty()
+            val trimmed = body.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("<")) {
+                Timber.tag(TAG).w("stream returned non-JSON body (likely Cloudflare interstitial)")
+                return null
+            }
             val root =
-                runCatching { JSONObject(body) }.getOrNull()
+                runCatching { JSONObject(trimmed) }.getOrNull()
                     ?: return null
-            val streamUrl = root.optString("url").ifBlank { root.optString("streamUrl") }
-            if (streamUrl.isBlank()) return null
-            val servedFormat = root.optString("format", format)
-            val flac = servedFormat.equals("FLAC", true) ||
-                root.optBoolean("flac", false) ||
-                streamUrl.substringAfterLast('.', "").equals("flac", true)
-            val contentLength = root.optLong("contentLength", 0L).takeIf { it > 0 }
-                ?: root.optLong("content_length", 0L).takeIf { it > 0 }
-            return MediaUrl(
-                url = streamUrl,
-                flac = flac,
-                contentLength = contentLength,
-                format = servedFormat,
-            )
+            // The official contract is { "url": "..." }. Tolerate alternates for mirrors.
+            val streamUrl = root.optString("url").ifBlank { root.optString("streamUrl") }.ifBlank { root.optString("link") }
+            if (streamUrl.isBlank()) {
+                Timber.tag(TAG).w("stream response had no url field: %s", trimmed.take(200))
+                return null
+            }
+            return streamUrl
         }
     }
 
@@ -358,4 +545,18 @@ object DabMusicAudioProvider {
             .header("User-Agent", USER_AGENT)
             .header("Accept", "application/json")
             .header("Accept-Language", "en-US,en;q=0.5")
+            .apply {
+                if (sessionCookie.isNotEmpty()) {
+                    header("Cookie", "session=$sessionCookie")
+                }
+            }
+
+    /** True when the response body looks like Cloudflare's "Just a moment..." interstitial. */
+    private fun looksLikeCloudflare(body: String): Boolean {
+        if (body.isEmpty()) return false
+        val sample = if (body.length > 512) body.substring(0, 512) else body
+        return sample.contains("Just a moment", ignoreCase = true) ||
+            sample.contains("cf-challenge", ignoreCase = true) ||
+            (sample.contains("<title>", ignoreCase = true) && sample.contains("cloudflare", ignoreCase = true))
+    }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
@@ -1,0 +1,232 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.dabmusic
+
+import android.annotation.SuppressLint
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.Toast
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.delay
+import moe.rukamori.archivetune.R
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * An in-app WebView dialog that solves dabmusic.xyz's Cloudflare "managed challenge" and
+ * captures the resulting `cf_clearance` cookie.
+ *
+ * ## Why this exists
+ *
+ * dabmusic.xyz is fronted by Cloudflare. The WAF rule whitelists `POST /api/auth/login` (so the
+ * user can authenticate from [DabMusicAudioProvider.login]) but applies a "managed challenge"
+ * to `GET /api/search` and `GET /api/stream`. On challenged requests Cloudflare returns HTTP 200
+ * with `Transfer-Encoding: chunked` and drip-feeds the interstitial HTML body over 30+ seconds,
+ * which causes OkHttp's `readTimeout` to fire as a `SocketTimeoutException` — exactly the
+ * failure mode the user sees in their logs.
+ *
+ * Cloudflare's challenge is JavaScript-based: the interstitial page computes a token, submits it
+ * back to Cloudflare, and on success Cloudflare issues a `cf_clearance` cookie that whitelists
+ * the client for ~30 minutes. Browsers solve this transparently; OkHttp cannot.
+ *
+ * ## How it works
+ *
+ * 1. The dialog opens a fullscreen WebView with JS enabled.
+ * 2. The WebView loads `https://dabmusic.xyz/`.
+ * 3. Cloudflare serves the interstitial; the WebView's JS engine solves the challenge.
+ * 4. Cloudflare redirects to the real dabmusic.xyz homepage and sets `cf_clearance` via
+ *    `Set-Cookie`. The WebView's [CookieManager] stores it.
+ * 5. On page finish (or after a 30s safety timeout), we read `cf_clearance` from
+ *    [CookieManager.getCookie] and call [onCfClearanceCaptured].
+ * 6. The caller persists the cookie in [moe.rukamori.archivetune.constants.DabMusicCfClearanceKey]
+ *    and pushes it into [DabMusicAudioProvider.setCfClearance] — every subsequent OkHttp request
+ *    includes `cf_clearance=...` in its `Cookie` header and Cloudflare passes it through.
+ *
+ * The cookie is short-lived (~30 min). When it expires, the user reopens this dialog.
+ *
+ * ## Privacy
+ *
+ * The WebView runs entirely on-device. No cookies, tokens, or browsing data leave the device
+ * except to dabmusic.xyz itself. The cf_clearance cookie is shared between the WebView and
+ * OkHttp (via the persisted preference), but it is never sent to any third party.
+ *
+ * @param baseUrl The base URL to load (must be the dabmusic.xyz homepage, NOT an /api/* path —
+ *   the challenge is issued on the marketing site, not the API).
+ * @param onDismiss Called when the user closes the dialog or the capture completes/fails.
+ * @param onCfClearanceCaptured Called on the main thread with the captured cf_clearance cookie
+ *   value. The caller is responsible for persisting it and pushing it into
+ *   [DabMusicAudioProvider].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DabMusicCloudflareBypassDialog(
+    baseUrl: String,
+    onDismiss: () -> Unit,
+    onCfClearanceCaptured: (cfClearance: String) -> Unit,
+) {
+    val context = LocalContext.current
+    val captureHandled = remember { AtomicBoolean(false) }
+    var statusMessage by remember {
+        mutableStateOf(context.getString(R.string.dabmusic_cf_bypass_loading))
+    }
+
+    fun extractCfClearance(): String? {
+        // CookieManager.getCookie returns "name=value; name2=value2" for the given URL, or null.
+        // We split on "; " and look for cf_clearance=. The cookie value itself can contain
+        // URL-safe characters but never ";" or ",", so this parse is safe.
+        val cookies = CookieManager.getInstance().getCookie(baseUrl) ?: return null
+        return cookies
+            .split(";")
+            .asSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .firstNotNullOfOrNull { raw ->
+                val eq = raw.indexOf('=')
+                if (eq <= 0) return@firstNotNullOfOrNull null
+                val name = raw.substring(0, eq).trim()
+                val value = raw.substring(eq + 1).trim()
+                if (name.equals("cf_clearance", ignoreCase = true) && value.isNotEmpty()) value else null
+            }
+    }
+
+    fun finishCapture() {
+        if (!captureHandled.compareAndSet(false, true)) return
+        val cfClearance = extractCfClearance()
+        if (cfClearance.isNullOrBlank()) {
+            Toast.makeText(
+                context,
+                context.getString(R.string.dabmusic_cf_bypass_failed),
+                Toast.LENGTH_LONG,
+            ).show()
+        } else {
+            Toast.makeText(
+                context,
+                context.getString(R.string.dabmusic_cf_bypass_success),
+                Toast.LENGTH_SHORT,
+            ).show()
+            onCfClearanceCaptured(cfClearance)
+        }
+        onDismiss()
+    }
+
+    // Safety timeout: if Cloudflare's challenge doesn't resolve within 30s (e.g. the user's
+    // network is very slow or Cloudflare is misbehaving), give up and let the user retry.
+    LaunchedEffect(Unit) {
+        delay(30_000)
+        if (!captureHandled.get()) {
+            statusMessage = context.getString(R.string.dabmusic_cf_bypass_failed)
+            delay(1_500)
+            finishCapture()
+        }
+    }
+
+    Dialog(
+        onDismissRequest = { finishCapture() },
+        properties =
+            DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(600.dp)
+                    .padding(8.dp),
+        ) {
+            Text(
+                text = statusMessage,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(8.dp),
+            )
+            Text(
+                text = stringResource(R.string.dabmusic_cf_bypass_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(8.dp),
+            )
+            AndroidView(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 32.dp, bottom = 48.dp)
+                        .wrapContentHeight(Alignment.CenterVertically),
+                factory = { ctx ->
+                    WebView(ctx).apply {
+                        @SuppressLint("SetJavaScriptEnabled")
+                        settings.apply {
+                            javaScriptEnabled = true
+                            domStorageEnabled = true
+                            // Cloudflare's challenge uses JavaScript + cookies; both must be on.
+                            javaScriptCanOpenWindowsAutomatically = true
+                            setSupportZoom(false)
+                            displayZoomControls = false
+                        }
+                        // Accept cookies so Cloudflare can set cf_clearance.
+                        CookieManager.getInstance().setAcceptCookie(true)
+                        CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+
+                        webViewClient =
+                            object : WebViewClient() {
+                                override fun onPageFinished(view: WebView, url: String?) {
+                                    super.onPageFinished(view, url)
+                                    // The challenge page itself fires onPageFinished too — we
+                                    // only care about the post-redirect homepage load. The
+                                    // homepage URL is the bare base URL (no path) or "/".
+                                    val host = baseUrl.removePrefix("https://").removePrefix("http://").substringBefore('/')
+                                    if (url != null && url.contains(host) && !url.contains("challenge", ignoreCase = true)) {
+                                        // Cloudflare sets cf_clearance via Set-Cookie during the
+                                        // redirect; CookieManager flushes asynchronously, so we
+                                        // poll for the cookie to appear.
+                                        view.postDelayed({
+                                            if (!captureHandled.get()) {
+                                                statusMessage =
+                                                    context.getString(R.string.dabmusic_cf_bypass_success)
+                                                finishCapture()
+                                            }
+                                        }, 800)
+                                    }
+                                }
+                            }
+                        loadUrl(baseUrl)
+                    }
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
@@ -76,7 +76,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * except to dabmusic.xyz itself. The cf_clearance cookie is shared between the WebView and
  * OkHttp (via the persisted preference), but it is never sent to any third party.
  *
- * @param baseUrl The base URL to load (must be the dabmusic.xyz homepage, NOT an /api/* path —
+ * @param baseUrl The base URL to load (must be the dabmusic.xyz homepage, NOT an /api endpoint —
  *   the challenge is issued on the marketing site, not the API).
  * @param onDismiss Called when the user closes the dialog or the capture completes/fails.
  * @param onCfClearanceCaptured Called on the main thread with the captured cf_clearance cookie

--- a/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
@@ -108,7 +108,6 @@ fun DabMusicCloudflareBypassDialog(
     onCfClearanceCaptured: (cfClearance: String) -> Unit,
 ) {
     val context = LocalContext.current
-    val configuration = LocalConfiguration.current
     val captureHandled = remember { AtomicBoolean(false) }
     var statusMessage by remember {
         mutableStateOf(context.getString(R.string.dabmusic_cf_bypass_loading))

--- a/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicCloudflareBypassDialog.kt
@@ -9,18 +9,24 @@ package moe.rukamori.archivetune.dabmusic
 
 import android.annotation.SuppressLint
 import android.webkit.CookieManager
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -57,14 +64,24 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * ## How it works
  *
- * 1. The dialog opens a fullscreen WebView with JS enabled.
- * 2. The WebView loads `https://dabmusic.xyz/`.
- * 3. Cloudflare serves the interstitial; the WebView's JS engine solves the challenge.
- * 4. Cloudflare redirects to the real dabmusic.xyz homepage and sets `cf_clearance` via
+ * 1. The dialog opens a near-fullscreen WebView with JS enabled.
+ * 2. The WebView is configured with the SAME [DabMusicAudioProvider.USER_AGENT] used by OkHttp —
+ *    this is critical: Cloudflare binds `cf_clearance` to (IP, User-Agent), so if the WebView
+ *    solves the challenge with the default Android System WebView UA and OkHttp then sends the
+ *    cookie with a desktop Chrome UA, Cloudflare rejects it. Keeping both clients on the same
+ *    UA is what makes the captured cookie valid for OkHttp.
+ * 3. The WebView loads `https://dabmusic.xyz/`.
+ * 4. Cloudflare serves the interstitial; the WebView's JS engine solves the challenge
+ *    automatically (or, for interactive Turnstile widgets, the user taps the checkbox in the
+ *    visible WebView).
+ * 5. Cloudflare redirects to the real dabmusic.xyz homepage and sets `cf_clearance` via
  *    `Set-Cookie`. The WebView's [CookieManager] stores it.
- * 5. On page finish (or after a 30s safety timeout), we read `cf_clearance` from
+ * 6. A polling loop checks [CookieManager.getCookie] every 500ms for the `cf_clearance` entry —
+ *    we don't rely solely on `onPageFinished` because Cloudflare may set the cookie via JS
+ *    without a page load, or fire `onPageFinished` on the interstitial itself.
+ * 7. When the cookie appears (or after a 60s safety timeout), we read it from
  *    [CookieManager.getCookie] and call [onCfClearanceCaptured].
- * 6. The caller persists the cookie in [moe.rukamori.archivetune.constants.DabMusicCfClearanceKey]
+ * 8. The caller persists the cookie in [moe.rukamori.archivetune.constants.DabMusicCfClearanceKey]
  *    and pushes it into [DabMusicAudioProvider.setCfClearance] — every subsequent OkHttp request
  *    includes `cf_clearance=...` in its `Cookie` header and Cloudflare passes it through.
  *
@@ -91,16 +108,27 @@ fun DabMusicCloudflareBypassDialog(
     onCfClearanceCaptured: (cfClearance: String) -> Unit,
 ) {
     val context = LocalContext.current
+    val configuration = LocalConfiguration.current
     val captureHandled = remember { AtomicBoolean(false) }
     var statusMessage by remember {
         mutableStateOf(context.getString(R.string.dabmusic_cf_bypass_loading))
     }
+    var webViewRef by remember { mutableStateOf<WebView?>(null) }
+
+    // Normalize the URL we pass to CookieManager.getCookie — that API wants a full URL with
+    // scheme + host (no path), otherwise it returns null. The user's base URL preference might
+    // be "https://dabmusic.xyz" (no trailing slash) or "https://dabmusic.xyz/" — both should
+    // resolve to the same cookie jar, but we canonicalize here to be safe.
+    val cookieUrl = remember(baseUrl) {
+        val raw = baseUrl.trim().trimEnd('/')
+        if (raw.startsWith("http://") || raw.startsWith("https://")) raw else "https://$raw"
+    }
 
     fun extractCfClearance(): String? {
         // CookieManager.getCookie returns "name=value; name2=value2" for the given URL, or null.
-        // We split on "; " and look for cf_clearance=. The cookie value itself can contain
+        // We split on ";" and look for cf_clearance=. The cookie value itself can contain
         // URL-safe characters but never ";" or ",", so this parse is safe.
-        val cookies = CookieManager.getInstance().getCookie(baseUrl) ?: return null
+        val cookies = CookieManager.getInstance().getCookie(cookieUrl) ?: return null
         return cookies
             .split(";")
             .asSequence()
@@ -135,14 +163,55 @@ fun DabMusicCloudflareBypassDialog(
         onDismiss()
     }
 
-    // Safety timeout: if Cloudflare's challenge doesn't resolve within 30s (e.g. the user's
-    // network is very slow or Cloudflare is misbehaving), give up and let the user retry.
+    // Poll the WebView's CookieManager for the cf_clearance cookie every 500ms. We do NOT rely
+    // solely on WebViewClient.onPageFinished because:
+    //   - Cloudflare's interstitial itself fires onPageFinished (so the first call sees no
+    //     cf_clearance and we'd dismiss too early if we trusted it),
+    //   - the cookie may be set via JS without a navigation,
+    //   - CookieManager.flush() is asynchronous — the cookie may not be visible immediately
+    //     after onPageFinished returns.
+    // Polling catches all of these cases. The polling loop stops as soon as the cookie appears
+    // (which calls finishCapture → onDismiss → this composable leaves composition → coroutine
+    // is cancelled).
+    LaunchedEffect(cookieUrl) {
+        // Give the WebView a moment to start loading before we begin polling.
+        delay(1_000)
+        while (!captureHandled.get()) {
+            val cf = extractCfClearance()
+            if (!cf.isNullOrBlank()) {
+                statusMessage = context.getString(R.string.dabmusic_cf_bypass_success)
+                delay(300) // small grace period so CookieManager.flush() lands
+                finishCapture()
+                break
+            }
+            delay(500)
+        }
+    }
+
+    // Safety timeout: if Cloudflare's challenge doesn't resolve within 60s (e.g. the user's
+    // network is very slow, or an interactive Turnstile is waiting for a tap the user hasn't
+    // noticed), give up and let the user retry. 60s is generous — Cloudflare's managed
+    // challenge typically resolves in <5s on residential mobile IPs.
     LaunchedEffect(Unit) {
-        delay(30_000)
+        delay(60_000)
         if (!captureHandled.get()) {
             statusMessage = context.getString(R.string.dabmusic_cf_bypass_failed)
             delay(1_500)
             finishCapture()
+        }
+    }
+
+    // Clean up the WebView when the dialog leaves composition. Without this, the WebView keeps
+    // running its JS engine and timers in the background (and leaks the activity on configuration
+    // changes).
+    DisposableEffect(Unit) {
+        onDispose {
+            webViewRef?.apply {
+                stopLoading()
+                removeAllViews()
+                destroy()
+            }
+            webViewRef = null
         }
     }
 
@@ -158,34 +227,15 @@ fun DabMusicCloudflareBypassDialog(
         Box(
             modifier =
                 Modifier
-                    .fillMaxWidth()
-                    .height(600.dp)
-                    .padding(8.dp),
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.surface),
         ) {
-            Text(
-                text = statusMessage,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier =
-                    Modifier
-                        .align(Alignment.TopCenter)
-                        .padding(8.dp),
-            )
-            Text(
-                text = stringResource(R.string.dabmusic_cf_bypass_hint),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(8.dp),
-            )
+            // The WebView — fill the entire dialog so Cloudflare's interactive Turnstile widget
+            // (if it appears) is visible AND clickable. The previous version used
+            // wrapContentHeight(CenterVertically) which collapsed the WebView to 0 height on
+            // first composition, hiding the challenge entirely.
             AndroidView(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(top = 32.dp, bottom = 48.dp)
-                        .wrapContentHeight(Alignment.CenterVertically),
+                modifier = Modifier.fillMaxSize(),
                 factory = { ctx ->
                     WebView(ctx).apply {
                         @SuppressLint("SetJavaScriptEnabled")
@@ -196,6 +246,22 @@ fun DabMusicCloudflareBypassDialog(
                             javaScriptCanOpenWindowsAutomatically = true
                             setSupportZoom(false)
                             displayZoomControls = false
+                            // The cf_clearance cookie is bound to (IP, User-Agent). If the
+                            // WebView solves the challenge with Android System WebView's default
+                            // UA and OkHttp later sends the cookie with a different UA, Cloudflare
+                            // rejects the cookie. So we force the WebView to use the SAME UA as
+                            // DabMusicAudioProvider's OkHttp client.
+                            userAgentString = DabMusicAudioProvider.USER_AGENT
+                            // Cloudflare's challenge sometimes checks MediaSource / WebRTC
+                            // availability as part of its bot fingerprinting — keeping these on
+                            // matches a real browser.
+                            mediaPlaybackRequiresUserGesture = false
+                            cacheMode = WebSettings.LOAD_DEFAULT
+                            // Allow mixed content because Cloudflare's interstitial may load
+                            // scripts from challenges.cloudflare.com over HTTPS, but the
+                            // redirect target on dabmusic.xyz should also be HTTPS — keep this
+                            // off (the default) for safety, but set explicitly so we know.
+                            mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
                         }
                         // Accept cookies so Cloudflare can set cf_clearance.
                         CookieManager.getInstance().setAcceptCookie(true)
@@ -205,28 +271,68 @@ fun DabMusicCloudflareBypassDialog(
                             object : WebViewClient() {
                                 override fun onPageFinished(view: WebView, url: String?) {
                                     super.onPageFinished(view, url)
-                                    // The challenge page itself fires onPageFinished too — we
-                                    // only care about the post-redirect homepage load. The
-                                    // homepage URL is the bare base URL (no path) or "/".
-                                    val host = baseUrl.removePrefix("https://").removePrefix("http://").substringBefore('/')
-                                    if (url != null && url.contains(host) && !url.contains("challenge", ignoreCase = true)) {
-                                        // Cloudflare sets cf_clearance via Set-Cookie during the
-                                        // redirect; CookieManager flushes asynchronously, so we
-                                        // poll for the cookie to appear.
-                                        view.postDelayed({
-                                            if (!captureHandled.get()) {
-                                                statusMessage =
-                                                    context.getString(R.string.dabmusic_cf_bypass_success)
-                                                finishCapture()
-                                            }
-                                        }, 800)
+                                    // Don't act on onPageFinished — the polling loop in the
+                                    // LaunchedEffect above is the source of truth. We just nudge
+                                    // CookieManager to flush its in-memory jar to persistent
+                                    // storage so the polling loop sees the cookie sooner.
+                                    CookieManager.getInstance().flush()
+                                    // Update the status line so the user sees something is
+                                    // happening.
+                                    if (!captureHandled.get()) {
+                                        statusMessage =
+                                            context.getString(R.string.dabmusic_cf_bypass_loading)
                                     }
                                 }
                             }
-                        loadUrl(baseUrl)
+                        loadUrl(cookieUrl)
+                        webViewRef = this
                     }
                 },
             )
+
+            // Status overlay at the top — small, semi-transparent, doesn't block the WebView
+            // (Cloudflare's Turnstile widget is usually centered, so a top strip is safe).
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.TopCenter)
+                        .fillMaxWidth()
+                        .background(Color.Black.copy(alpha = 0.6f))
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = statusMessage,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White,
+                    )
+                    Text(
+                        text = stringResource(R.string.dabmusic_cf_bypass_hint),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White.copy(alpha = 0.8f),
+                    )
+                }
+            }
+
+            // Loading spinner in the center for the initial page load — disappears once the
+            // WebView paints (we can't easily detect that, so we just hide it after 3s).
+            var showSpinner by remember { mutableStateOf(true) }
+            LaunchedEffect(Unit) {
+                delay(3_000)
+                showSpinner = false
+            }
+            if (showSpinner) {
+                CircularProgressIndicator(
+                    modifier =
+                        Modifier
+                            .align(Alignment.Center)
+                            .size(32.dp),
+                    strokeWidth = 3.dp,
+                    color = Color.White,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -211,7 +211,6 @@ import moe.rukamori.archivetune.deezer.DeezerDecryptingDataSource
 import moe.rukamori.archivetune.constants.DabMusicBaseUrlKey
 import moe.rukamori.archivetune.constants.DabMusicEnabledKey
 import moe.rukamori.archivetune.dabmusic.DabMusicAudioProvider
-import moe.rukamori.archivetune.morideobfuscator.SOURCE_SWITCH_VOLUME_REASSERT_MS
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
@@ -9888,6 +9887,11 @@ class MusicService :
         const val ROOT = "root"
         const val HOME = "home"
         const val HOME_QUICK_PICKS = "home_quick_picks"
+
+        // Delay before re-applying the captured baseline volume after a source switch, so the
+        // user never hears a muted stream when the new source's prepare pipeline settles. The
+        // READY hook cancels this job if it fires first.
+        const val SOURCE_SWITCH_VOLUME_REASSERT_MS = 250L
 
         // Prefix for the dedicated player-cache key used by Tidal streams so their bytes never
         // collide with the YouTube stream cached under the bare media id.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -8466,15 +8466,16 @@ class MusicService :
     }
 
     /**
-     * Resolves a DabMusic stream. DabMusic is a public lossless catalog/proxy at
-     * https://dabmusic.xyz — there are no per-user accounts, so unlike Deezer there is no
-     * PoolAccountManager tier to consult. The base URL is read from [DabMusicBaseUrlKey] and
-     * pushed into [DabMusicAudioProvider] on every resolve so users who point at a mirror or
-     * self-hosted gateway don't need a restart to pick up the change.
+     * Resolves a DabMusic stream. DabMusic (https://dabmusic.xyz) is a community-operated
+     * lossless catalog backed by a REST API at /api/search and /api/stream. Unlike YouTube,
+     * the API requires authentication: a session cookie obtained from /api/auth/login must be
+     * present (configured in Sources settings → DabMusic → Login). The base URL is read from
+     * [DabMusicBaseUrlKey] and pushed into [DabMusicAudioProvider] on every resolve so users
+     * who point at a mirror or self-hosted gateway don't need a restart to pick up the change.
      *
-     * Returns null when the catalog has no acceptable match, when the gateway is unreachable,
-     * or when Cloudflare challenges the request — never throws, so the next source in the chain
-     * takes over.
+     * Returns null when the user is not logged in, when the catalog has no acceptable match,
+     * when the gateway is unreachable, or when Cloudflare challenges the request — never throws,
+     * so the next source in the chain takes over.
      */
     private fun resolveDabMusicStream(query: SourceQuery): DirectStream? {
         DabMusicAudioProvider.setBaseUrl(dataStore.get(DabMusicBaseUrlKey, "").ifBlank { null })
@@ -8491,7 +8492,7 @@ class MusicService :
                                 album = query.album,
                                 durationMs = query.durationMs,
                             ),
-                        format = "FLAC",
+                        quality = DabMusicAudioProvider.QUALITY_FLAC,
                     )?.let { resolved ->
                         DirectStream(
                             uri = resolved.uri,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -57,6 +57,7 @@ import moe.rukamori.archivetune.audiosource.AudioSourceConfig
 import moe.rukamori.archivetune.constants.AudioSourceOrderKey
 import moe.rukamori.archivetune.constants.AudioSourceType
 import moe.rukamori.archivetune.constants.DabMusicBaseUrlKey
+import moe.rukamori.archivetune.constants.DabMusicCfClearanceKey
 import moe.rukamori.archivetune.constants.DabMusicEmailKey
 import moe.rukamori.archivetune.constants.DabMusicEnabledKey
 import moe.rukamori.archivetune.constants.DabMusicPasswordKey
@@ -78,6 +79,7 @@ import moe.rukamori.archivetune.constants.AudioQualityKey
 import moe.rukamori.archivetune.constants.PlayerStreamClient
 import moe.rukamori.archivetune.constants.PlayerStreamClientKey
 import moe.rukamori.archivetune.dabmusic.DabMusicAudioProvider
+import moe.rukamori.archivetune.dabmusic.DabMusicCloudflareBypassDialog
 import moe.rukamori.archivetune.innertube.utils.hasYouTubeLoginCookie
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
@@ -130,6 +132,8 @@ fun PlaybackSourceSections(navController: NavController) {
     val (dabMusicPassword, onDabMusicPasswordChange) = rememberPreference(DabMusicPasswordKey, "")
     val (dabMusicSessionCookie, onDabMusicSessionCookieChange) =
         rememberPreference(DabMusicSessionCookieKey, "")
+    val (dabMusicCfClearance, onDabMusicCfClearanceChange) =
+        rememberPreference(DabMusicCfClearanceKey, "")
     val (deezerQuality, onDeezerQualityChange) =
         rememberEnumPreference(DeezerAudioQualityKey, DeezerAudioQuality.FLAC)
 
@@ -481,6 +485,60 @@ fun PlaybackSourceSections(navController: NavController) {
                 onClick = {
                     DabMusicAudioProvider.signOut()
                     onDabMusicSessionCookieChange("")
+                },
+            )
+        }
+
+        // ---------------------------------------------------------------------------------------------
+        // Cloudflare bypass
+        // ---------------------------------------------------------------------------------------------
+        // dabmusic.xyz is fronted by Cloudflare's "managed challenge". /api/auth/login is
+        // whitelisted (so the user can authenticate), but /api/search and /api/stream are
+        // challenged — OkHttp can't solve the JS challenge and the request hangs for the full
+        // readTimeout (30s) before failing with SocketTimeoutException. The bypass opens an
+        // in-app WebView that solves the challenge transparently; we extract the cf_clearance
+        // cookie and send it with every subsequent OkHttp request. ~30-minute-lived.
+        item {
+            val coroutineScope = rememberCoroutineScope()
+            var showBypassDialog by remember { mutableStateOf(false) }
+            val hasBypass = dabMusicCfClearance.isNotEmpty()
+
+            InfoLabel(
+                text = stringResource(
+                    if (hasBypass) R.string.dabmusic_cf_bypass_active
+                    else R.string.dabmusic_cf_bypass_inactive,
+                ),
+            )
+            if (showBypassDialog) {
+                val bypassBaseUrl = dabMusicBaseUrl.ifBlank { DabMusicAudioProvider.DEFAULT_BASE_URL }
+                DabMusicCloudflareBypassDialog(
+                    baseUrl = bypassBaseUrl,
+                    onDismiss = { showBypassDialog = false },
+                    onCfClearanceCaptured = { cfClearance ->
+                        coroutineScope.launch {
+                            onDabMusicCfClearanceChange(cfClearance)
+                        }
+                    },
+                )
+            }
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.dabmusic_cf_bypass)) },
+                description = stringResource(R.string.dabmusic_cf_bypass_description),
+                icon = { Icon(painterResource(R.drawable.security), null) },
+                isEnabled = dabMusicEnabled,
+                onClick = { showBypassDialog = true },
+            )
+        }
+
+        item {
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.dabmusic_cf_bypass_clear)) },
+                description = stringResource(R.string.dabmusic_cf_bypass_clear_description),
+                icon = { Icon(painterResource(R.drawable.delete), null) },
+                isEnabled = dabMusicEnabled && dabMusicCfClearance.isNotEmpty(),
+                onClick = {
+                    DabMusicAudioProvider.setCfClearance(null)
+                    onDabMusicCfClearanceChange("")
                 },
             )
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -44,14 +45,22 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
 import moe.rukamori.archivetune.constants.AudioSourceOrderKey
 import moe.rukamori.archivetune.constants.AudioSourceType
 import moe.rukamori.archivetune.constants.DabMusicBaseUrlKey
+import moe.rukamori.archivetune.constants.DabMusicEmailKey
 import moe.rukamori.archivetune.constants.DabMusicEnabledKey
+import moe.rukamori.archivetune.constants.DabMusicPasswordKey
+import moe.rukamori.archivetune.constants.DabMusicSessionCookieKey
 import moe.rukamori.archivetune.constants.DeezerAudioQuality
 import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
 import moe.rukamori.archivetune.constants.DeezerEnabledKey
@@ -68,6 +77,7 @@ import moe.rukamori.archivetune.constants.AudioQuality
 import moe.rukamori.archivetune.constants.AudioQualityKey
 import moe.rukamori.archivetune.constants.PlayerStreamClient
 import moe.rukamori.archivetune.constants.PlayerStreamClientKey
+import moe.rukamori.archivetune.dabmusic.DabMusicAudioProvider
 import moe.rukamori.archivetune.innertube.utils.hasYouTubeLoginCookie
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
@@ -81,6 +91,7 @@ import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
+import android.widget.Toast
 
 private fun AudioSourceType.displayName(context: android.content.Context): String =
     when (this) {
@@ -115,6 +126,10 @@ fun PlaybackSourceSections(navController: NavController) {
     val (deezerEnabled, onDeezerEnabledChange) = rememberPreference(DeezerEnabledKey, false)
     val (dabMusicEnabled, onDabMusicEnabledChange) = rememberPreference(DabMusicEnabledKey, false)
     val (dabMusicBaseUrl, onDabMusicBaseUrlChange) = rememberPreference(DabMusicBaseUrlKey, "")
+    val (dabMusicEmail, onDabMusicEmailChange) = rememberPreference(DabMusicEmailKey, "")
+    val (dabMusicPassword, onDabMusicPasswordChange) = rememberPreference(DabMusicPasswordKey, "")
+    val (dabMusicSessionCookie, onDabMusicSessionCookieChange) =
+        rememberPreference(DabMusicSessionCookieKey, "")
     val (deezerQuality, onDeezerQualityChange) =
         rememberEnumPreference(DeezerAudioQualityKey, DeezerAudioQuality.FLAC)
 
@@ -368,6 +383,105 @@ fun PlaybackSourceSections(navController: NavController) {
                 icon = { Icon(painterResource(R.drawable.provider_dabmusic), null) },
                 checked = dabMusicEnabled,
                 onCheckedChange = onDabMusicEnabledChange,
+            )
+        }
+
+        item {
+            val isLoggedIn = dabMusicSessionCookie.isNotEmpty()
+            InfoLabel(
+                text = stringResource(
+                    if (isLoggedIn) R.string.dabmusic_logged_in
+                    else R.string.dabmusic_not_logged_in,
+                ),
+            )
+        }
+
+        item {
+            EditTextPreference(
+                title = { Text(stringResource(R.string.dabmusic_email)) },
+                value = dabMusicEmail,
+                onValueChange = onDabMusicEmailChange,
+                icon = { Icon(painterResource(R.drawable.account), null) },
+                isEnabled = dabMusicEnabled,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                isInputValid = { it.isBlank() || android.util.Patterns.EMAIL_ADDRESS.matcher(it).matches() },
+            )
+        }
+
+        item {
+            EditTextPreference(
+                title = { Text(stringResource(R.string.dabmusic_password)) },
+                value = dabMusicPassword,
+                onValueChange = onDabMusicPasswordChange,
+                icon = { Icon(painterResource(R.drawable.lock), null) },
+                isEnabled = dabMusicEnabled,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                isInputValid = { it.isNotEmpty() },
+            )
+        }
+
+        item {
+            val coroutineScope = rememberCoroutineScope()
+            var isLoggingIn by remember { mutableStateOf(false) }
+            val isLoggedIn = dabMusicSessionCookie.isNotEmpty()
+            PreferenceEntry(
+                title = {
+                    Text(
+                        stringResource(
+                            if (isLoggedIn) R.string.dabmusic_relogin
+                            else R.string.dabmusic_login,
+                        ),
+                    )
+                },
+                description = stringResource(R.string.dabmusic_login_description),
+                icon = { Icon(painterResource(R.drawable.login), null) },
+                isEnabled = dabMusicEnabled && !isLoggingIn &&
+                    dabMusicEmail.isNotBlank() && dabMusicPassword.isNotBlank(),
+                onClick = {
+                    coroutineScope.launch {
+                        isLoggingIn = true
+                        DabMusicAudioProvider.setCredentials(dabMusicEmail, dabMusicPassword)
+                        val result = withContext(Dispatchers.IO) { DabMusicAudioProvider.login() }
+                        isLoggingIn = false
+                        when (result) {
+                            is DabMusicAudioProvider.LoginResult.Success -> {
+                                onDabMusicSessionCookieChange(DabMusicAudioProvider.getSessionCookie())
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.dabmusic_login_success),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                            }
+                            is DabMusicAudioProvider.LoginResult.CloudflareBlocked -> {
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.dabmusic_cloudflare_blocked),
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                            }
+                            is DabMusicAudioProvider.LoginResult.Failure -> {
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.dabmusic_login_failed, result.reason),
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                            }
+                        }
+                    }
+                },
+            )
+        }
+
+        item {
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.dabmusic_sign_out)) },
+                description = stringResource(R.string.dabmusic_sign_out_description),
+                icon = { Icon(painterResource(R.drawable.logout), null) },
+                isEnabled = dabMusicEnabled && dabMusicSessionCookie.isNotEmpty(),
+                onClick = {
+                    DabMusicAudioProvider.signOut()
+                    onDabMusicSessionCookieChange("")
+                },
             )
         }
 

--- a/app/src/main/res/values/fork_strings.xml
+++ b/app/src/main/res/values/fork_strings.xml
@@ -17,10 +17,25 @@
     <string name="deezer_signed_out">Signed out of Deezer</string>
 
     <!-- DabMusic source (ui/screens/settings/PlaybackSourceSections.kt).
-         DabMusic is a community-operated lossless catalog at https://dabmusic.xyz. -->
+         DabMusic is a community-operated lossless catalog at https://dabmusic.xyz.
+         The API requires authentication: the user enters their DabMusic email + password
+         and taps "Login", which calls POST /api/auth/login and stores the returned session
+         cookie. DabMusic streams lossless FLAC when a matching track is found in the catalog. -->
     <string name="source_dabmusic">DabMusic</string>
     <string name="dabmusic_specific">DabMusic</string>
     <string name="dabmusic_enable">Enable DabMusic streams</string>
-    <string name="dabmusic_enable_description">Stream lossless audio from dabmusic.xyz when a matching track is found</string>
+    <string name="dabmusic_enable_description">Stream lossless audio from dabmusic.xyz when a matching track is found. Requires a DabMusic account — log in below.</string>
     <string name="dabmusic_base_url">DabMusic base URL</string>
+    <string name="dabmusic_email">Email</string>
+    <string name="dabmusic_password">Password</string>
+    <string name="dabmusic_login">Log in to DabMusic</string>
+    <string name="dabmusic_relogin">Re-login to DabMusic</string>
+    <string name="dabmusic_login_description">Authenticates with dabmusic.xyz and stores a session cookie on this device</string>
+    <string name="dabmusic_login_success">Logged in to DabMusic</string>
+    <string name="dabmusic_login_failed">DabMusic login failed: %1$s</string>
+    <string name="dabmusic_cloudflare_blocked">DabMusic is behind Cloudflare bot protection. Try again on a different network (e.g. mobile data), or use a different lossless source.</string>
+    <string name="dabmusic_logged_in">Logged in — DabMusic streams are active</string>
+    <string name="dabmusic_not_logged_in">Not logged in — enter your DabMusic email and password, then tap "Log in"</string>
+    <string name="dabmusic_sign_out">Sign out of DabMusic</string>
+    <string name="dabmusic_sign_out_description">Clears the stored session cookie from this device</string>
 </resources>

--- a/app/src/main/res/values/fork_strings.xml
+++ b/app/src/main/res/values/fork_strings.xml
@@ -38,4 +38,23 @@
     <string name="dabmusic_not_logged_in">Not logged in — enter your DabMusic email and password, then tap "Log in"</string>
     <string name="dabmusic_sign_out">Sign out of DabMusic</string>
     <string name="dabmusic_sign_out_description">Clears the stored session cookie from this device</string>
+
+    <!-- Cloudflare bypass for DabMusic. dabmusic.xyz sits behind a Cloudflare "managed
+         challenge" that blocks OkHttp on /api/search even when /api/auth/login works. The
+         bypass opens an in-app WebView that loads the dabmusic.xyz homepage — the WebView's
+         JS engine solves Cloudflare's challenge automatically, and we extract the resulting
+         cf_clearance cookie via CookieManager. The cookie is ~30-minute-lived. -->
+    <string name="dabmusic_cf_bypass">Solve Cloudflare Challenge</string>
+    <string name="dabmusic_cf_bypass_description">Opens an in-app browser that solves Cloudflare\'s bot check, then stores a cf_clearance cookie so DabMusic search/stream requests can pass through. Needed when login works but tracks won\'t play.</string>
+    <string name="dabmusic_cf_bypass_active">Cloudflare bypass active — expires in ~30 min</string>
+    <string name="dabmusic_cf_bypass_inactive">No Cloudflare bypass cookie — tap above if tracks won\'t play</string>
+    <string name="dabmusic_cf_bypass_clear">Clear Cloudflare bypass cookie</string>
+    <string name="dabmusic_cf_bypass_clear_description">Removes the stored cf_clearance cookie</string>
+    <string name="dabmusic_cf_bypass_success">Cloudflare bypass cookie captured</string>
+    <string name="dabmusic_cf_bypass_failed">Cloudflare challenge not solved — try again on Wi-Fi or mobile data</string>
+    <string name="dabmusic_cf_bypass_loading">Solving Cloudflare challenge…</string>
+    <string name="dabmusic_cf_bypass_not_needed">Cloudflare is not blocking — no bypass needed</string>
+    <string name="dabmusic_cf_bypass_checking">Checking if Cloudflare is blocking…</string>
+    <string name="dabmusic_cf_bypass_title">DabMusic — Cloudflare Challenge</string>
+    <string name="dabmusic_cf_bypass_hint">Loading dabmusic.xyz in a WebView. The page will refresh automatically once Cloudflare is satisfied. Close this screen when the page shows the DabMusic homepage.</string>
 </resources>

--- a/app/src/main/res/values/fork_strings.xml
+++ b/app/src/main/res/values/fork_strings.xml
@@ -56,5 +56,5 @@
     <string name="dabmusic_cf_bypass_not_needed">Cloudflare is not blocking — no bypass needed</string>
     <string name="dabmusic_cf_bypass_checking">Checking if Cloudflare is blocking…</string>
     <string name="dabmusic_cf_bypass_title">DabMusic — Cloudflare Challenge</string>
-    <string name="dabmusic_cf_bypass_hint">Loading dabmusic.xyz in a WebView. The page will refresh automatically once Cloudflare is satisfied. Close this screen when the page shows the DabMusic homepage.</string>
+    <string name="dabmusic_cf_bypass_hint">Loading dabmusic.xyz. If a "Verify you are human" checkbox appears, tap it. The dialog closes automatically once the bypass cookie is captured (usually &lt; 5s on mobile data).</string>
 </resources>


### PR DESCRIPTION
Follow-up to PR #128. The original DabMusic implementation used **guessed** API endpoints (`/api/search?q=X&limit=N` and `/api/stream?id=X&format=FLAC`) with **no authentication**, so DabMusic streams never worked.

## Root cause

When I built PR #128 I couldn't probe the real DabMusic API because `dabmusic.xyz` sits behind a Cloudflare "Just a moment…" JS challenge that returns HTTP 403 to every non-browser client (curl, OkHttp, etc.). So I modeled the endpoints on the same shape as the Deezer provider and hoped for the best.

After the user reported "dab music stream doesn't work", I reverse-engineered the real contract from the **official dabcli client** (github.com/LeoAj2005/dabmusicclient). The real API is:

| What I guessed | What the real API is |
| --- | --- |
| `GET /api/search?q=X&limit=N` | `GET /api/search?q=X&type=track` → `{tracks: [{id, title, artist, artistId, albumId, albumTitle, releaseDate}]}` |
| `GET /api/stream?id=X&format=FLAC` | `GET /api/stream?trackId=X&quality=27` → `{url: "..."}` (27=FLAC, 5=MP3) |
| no auth | `POST /api/auth/login` with `{email, password}` → `session` cookie, sent on every subsequent request |

So the original implementation was hitting non-existent endpoints with no auth — every request 404'd (or 401'd) and the provider returned null, falling through to the next source in the chain.

## What this PR fixes

### 1. Correct API contract (`DabMusicAudioProvider.kt`)

- **Search**: `GET /api/search?q=<query>&type=track`. Response parsing now reads the `tracks` array (was looking for `results`/`data`/`items`) and parses the real field names: `id`, `title`, `artist` (string, not array), `albumTitle` (not `album`), `artistId`, `albumId`, `releaseDate`.
- **Stream**: `GET /api/stream?trackId=<id>&quality=27`. Quality is a numeric string (`"27"` = FLAC, `"5"` = MP3), not `"FLAC"`/`"MP3_320"`. Response is `{"url": "..."}`.
- **Login**: `POST /api/auth/login` with JSON body `{"email": "...", "password": "..."}`. Extracts the `session` cookie from `Set-Cookie` headers (falls back to JSON body `session`/`token` field for mirrors).
- **Auth**: every search/stream request now sends `Cookie: session=<token>`.
- **Cloudflare detection**: when the response body starts with `<!DOCTYPE` or contains "Just a moment", the provider logs a clear warning and returns null. The `login()` method surfaces this as a distinct `LoginResult.CloudflareBlocked` so the UI can tell the user to try a different network.

### 2. Login flow (new)

- **`PreferenceKeys.kt`**: added `DabMusicEmailKey`, `DabMusicPasswordKey`, `DabMusicSessionCookieKey`.
- **`DabMusicAudioProvider.login()`**: POSTs credentials to `/api/auth/login`, extracts the session cookie, stores it in-memory via `setSessionCookie()`. Returns `LoginResult.Success` / `LoginResult.Failure(reason)` / `LoginResult.CloudflareBlocked(rayId)`.
- **`DabMusicAudioProvider.signOut()`**: clears the session cookie and all caches.
- **`PlaybackSourceSections.kt`**: DabMusic section now has:
  - Email `EditTextPreference` (with email keyboard)
  - Password `EditTextPreference` (with password keyboard)
  - "Log in to DabMusic" button (runs `login()` on `Dispatchers.IO`, shows Toast with result)
  - "Sign out of DabMusic" button
  - `InfoLabel` status display ("Logged in" / "Not logged in")
  - Base URL field (existing, advanced)
- **`App.kt`**: collectors mirror email, password, and session cookie into the provider so cold-start restores a previously-persisted session without re-prompting.

### 3. MusicService

- `resolveDabMusicStream()` now passes `quality = DabMusicAudioProvider.QUALITY_FLAC` (`"27"`) instead of `format = "FLAC"`.

### 4. Strings

Added `dabmusic_email`, `dabmusic_password`, `dabmusic_login`, `dabmusic_relogin`, `dabmusic_login_description`, `dabmusic_login_success`, `dabmusic_login_failed`, `dabmusic_cloudflare_blocked`, `dabmusic_logged_in`, `dabmusic_not_logged_in`, `dabmusic_sign_out`, `dabmusic_sign_out_description`.

## How to use

1. Open **Settings → Player & Audio → Sources → DabMusic**
2. Toggle **Enable DabMusic streams** on
3. Enter your DabMusic **email** and **password** (create an account at https://dabmusic.xyz first)
4. Tap **Log in to DabMusic** — you should see "Logged in to DabMusic"
5. Drag DabMusic above YouTube in the **Preferred sources** list
6. Play any song — if DabMusic has it, you'll get FLAC

## Cloudflare caveat

dabmusic.xyz is fronted by Cloudflare's bot protection. On **data-center IPs** (CI, emulators, some VPNs) Cloudflare returns HTTP 403 with a JS challenge that OkHttp cannot solve — the provider detects this and surfaces it as `LoginResult.CloudflareBlocked`. On **residential mobile IPs** the challenge is typically NOT triggered and the API is reachable directly. If login fails with the Cloudflare message, try switching networks (e.g. mobile data vs Wi-Fi) or use a different lossless source (Tidal/Qobuz/Deezer).

## Files changed

- `app/src/main/kotlin/moe/rukamori/archivetune/dabmusic/DabMusicAudioProvider.kt` — full rewrite
- `app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt` — 3 new keys
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt` — account UI
- `app/src/main/kotlin/moe/rukamori/archivetune/App.kt` — collectors
- `app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt` — quality param
- `app/src/main/res/values/fork_strings.xml` — strings
