### PR TITLE
fix(apple-music): eliminate inline lyrics auto-scroll lag after ~3s

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -188,7 +188,14 @@ fun AppleMusicPlayerContent(
     canSkipPrevious: Boolean,
     canSkipNext: Boolean,
     sliderPosition: Long?,
-    position: Long,
+    // Deferred position provider — reads the 100ms-polled playback position
+    // via a stable lambda so this composable does NOT recompose on every poll
+    // tick. Only AppleMusicControlsColumn reads it, and only when it's actually
+    // composed (visible). When lyrics is open and controls auto-hide after 3s,
+    // no recomposition happens at all — eliminating the wasted frame budget
+    // that caused the "smooth for first few seconds, then laggy" auto-scroll
+    // symptom in the inline Enhanced lyrics view.
+    positionProvider: () -> Long,
     duration: Long,
     playerConnection: PlayerConnection,
     navController: NavController,
@@ -763,7 +770,7 @@ fun AppleMusicPlayerContent(
                     canSkipPrevious = canSkipPrevious,
                     canSkipNext = canSkipNext,
                     sliderPosition = sliderPosition,
-                    position = position,
+                    positionProvider = positionProvider,
                     duration = duration,
                     playerConnection = playerConnection,
                     currentSongLiked = currentSongLiked,
@@ -1083,7 +1090,7 @@ fun AppleMusicPlayerContent(
                         canSkipPrevious = canSkipPrevious,
                         canSkipNext = canSkipNext,
                         sliderPosition = sliderPosition,
-                        position = position,
+                        positionProvider = positionProvider,
                         duration = duration,
                         playerConnection = playerConnection,
                         currentSongLiked = currentSongLiked,
@@ -1330,7 +1337,7 @@ private fun AppleMusicControlsColumn(
     canSkipPrevious: Boolean,
     canSkipNext: Boolean,
     sliderPosition: Long?,
-    position: Long,
+    positionProvider: () -> Long,
     duration: Long,
     playerConnection: PlayerConnection,
     currentSongLiked: Boolean,
@@ -1493,10 +1500,19 @@ private fun AppleMusicControlsColumn(
 
     Spacer(Modifier.height(titleToScrubberGap))
 
+    // Read the polled playback position through the deferred provider. This is
+    // the ONLY place in AppleMusicControlsColumn that reads the 100ms-polled
+    // position — by reading it here (inside the controls column that is only
+    // composed when visible), we ensure the parent AppleMusicPlayerContent
+    // does not recompose on every poll tick. When lyrics is open and controls
+    // are auto-hidden, this composable is not composed at all, so the state
+    // read never fires and no recomposition happens.
+    val currentPosition = positionProvider()
+
     // Thin scrubber + elapsed / -remaining.
     Column {
         AppleMusicSeekBar(
-            position = sliderPosition ?: position,
+            position = sliderPosition ?: currentPosition,
             duration = duration,
             onScrub = onSliderValueChange,
             onScrubFinished = onSliderValueChangeFinished,
@@ -1507,7 +1523,7 @@ private fun AppleMusicControlsColumn(
         // The chip is tappable and opens the song-detail bottom sheet.
         Box(Modifier.fillMaxWidth()) {
             Text(
-                text = makeTimeString(sliderPosition ?: position),
+                text = makeTimeString(sliderPosition ?: currentPosition),
                 style = MaterialTheme.typography.labelMedium,
                 color = Color.White.copy(alpha = 0.55f),
                 modifier = Modifier.align(Alignment.CenterStart),
@@ -1520,7 +1536,7 @@ private fun AppleMusicControlsColumn(
                 )
             }
             Text(
-                text = "-" + makeTimeString((duration - (sliderPosition ?: position)).coerceAtLeast(0L)),
+                text = "-" + makeTimeString((duration - (sliderPosition ?: currentPosition)).coerceAtLeast(0L)),
                 style = MaterialTheme.typography.labelMedium,
                 color = Color.White.copy(alpha = 0.55f),
                 modifier = Modifier.align(Alignment.CenterEnd),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -519,6 +519,15 @@ fun BottomSheetPlayer(
     var position by rememberSaveable(mediaMetadata?.id) {
         mutableLongStateOf(playerConnection.player.currentPosition)
     }
+    // Wrap `position` in a stable provider so AppleMusicPlayerContent does NOT
+    // recompose on every 100ms poll tick. The provider lambda is remembered
+    // (stable identity) and reads the latest position via the updated state.
+    // Only AppleMusicControlsColumn reads it — and only when it's actually
+    // composed (visible). When lyrics is open and controls auto-hide, no
+    // recomposition happens at all, freeing the frame budget for the karaoke
+    // syllable animation in the inline Enhanced lyrics view.
+    val positionUpdatedState = rememberUpdatedState(position)
+    val positionProvider = remember { { positionUpdatedState.value } }
     var duration by rememberSaveable(mediaMetadata?.id) {
         mutableLongStateOf(playerConnection.player.duration)
     }
@@ -1714,7 +1723,7 @@ fun BottomSheetPlayer(
                             canSkipPrevious = canSkipPrevious,
                             canSkipNext = canSkipNext,
                             sliderPosition = sliderPosition,
-                            position = position,
+                            positionProvider = positionProvider,
                             duration = duration,
                             playerConnection = playerConnection,
                             navController = navController,
@@ -2071,7 +2080,7 @@ fun BottomSheetPlayer(
                             canSkipPrevious = canSkipPrevious,
                             canSkipNext = canSkipNext,
                             sliderPosition = sliderPosition,
-                            position = position,
+                            positionProvider = positionProvider,
                             duration = duration,
                             playerConnection = playerConnection,
                             navController = navController,


### PR DESCRIPTION
## Problem

The inline word-synced Enhanced lyrics in the Apple Music player style started lagging after a few seconds of playback — smooth for the first ~3s, then progressively janky. This only happened in the Apple Music player style; the standalone LyricsScreen (used by other player styles) was smooth throughout.

## Root cause

The 100ms-polled `position: Long` was passed directly as a parameter to `AppleMusicPlayerContent`, causing the **entire** composable to recompose on every 100ms poll tick — even when lyrics was open and the bottom controls were auto-hidden (after the 3s auto-hide timer).

Each recomposition:
- Re-allocated `toggleQueue`/`toggleLyrics`/`restoreCover` lambdas
- Re-evaluated the `AnimatedContent(morphState)` content lambda
- Re-evaluated the `AnimatedVisibility(lyricsOpen)` content lambda
- Re-evaluated the `SharedTransitionLayout` content lambda

Even though Compose skipped the actual re-rendering of unchanged children, the parent recomposition itself stole frame budget from the 60Hz karaoke syllable animation. The lag appeared after ~3s because that is when the auto-hide timer fires — after that, the recomposition became pure waste with no visible benefit, and GC pressure from continuous lambda allocations compounded over time.

## Fix

Convert `position: Long` → `positionProvider: () -> Long` at the `AppleMusicPlayerContent` and `AppleMusicControlsColumn` level. In `Player.kt`, wrap `position` in `rememberUpdatedState` and pass a stable `remember`-ed lambda.

The state is now read **only** inside `AppleMusicControlsColumn` — which is only composed when controls are visible. When lyrics is open and controls auto-hide, no recomposition happens at all, freeing the full frame budget for the karaoke syllable sweep.

This mirrors how `sliderPosition` is already passed (as a nullable provider), and matches the standalone `LyricsScreen.kt` pattern where `position` is never passed to the lyrics composable.

## Testing

- Open Apple Music player style → play a song with word-synced lyrics (YouLyPlus/Apple Music TTML)
- Open the inline lyrics view
- Wait >3 seconds for controls to auto-hide
- Karaoke syllable fill should stay smooth indefinitely (previously: laggy after ~3s)
- Seekbar/time labels still update at 100ms when controls are visible
- Scrubbing still works