### PR TITLE
fix(apple-music): inline lyrics cut off at right edge

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -56,6 +56,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -52,11 +52,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
@@ -1029,12 +1031,25 @@ fun AppleMusicPlayerContent(
                     // The Column is sized to fill the area BELOW the mini header
                     // (maxHeight - miniHeaderHeight) and offset down by
                     // miniHeaderHeight so it doesn't cover the mini header.
+                    //
+                    // HORIZONTAL INSETS: the inline overlay must apply system-bar
+                    // horizontal padding (status bar on landscape, gesture-nav
+                    // pill / display cutout on portrait) AND a minimum horizontal
+                    // margin, mirroring the standalone LyricsScreen.kt which uses
+                    // windowInsetsPadding(systemBars) + 24dp horizontal padding.
+                    // Without this, the lyrics text extends to the absolute screen
+                    // edge and the rightmost characters are clipped on devices
+                    // with curved edges / side cutouts — particularly visible on
+                    // long Japanese CJK lines.
                     Box(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
                                 .height(maxHeight - miniHeaderHeight)
                                 .offset(y = miniHeaderHeight)
+                                .windowInsetsPadding(
+                                    WindowInsets.systemBars.only(WindowInsetsSides.Horizontal),
+                                )
                                 .pointerInput(lyricsOpen) {
                                     if (!lyricsOpen) return@pointerInput
                                     awaitEachGesture {
@@ -1047,12 +1062,16 @@ fun AppleMusicPlayerContent(
                             LyricsMode.V2 -> LyricsV2(
                                 sliderPositionProvider = lyricsPosProvider,
                                 lyricsSyncOffset = lyricsSyncOffset,
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = 16.dp),
                             )
                             LyricsMode.ENHANCED -> LyricsEnhanced(
                                 sliderPositionProvider = lyricsPosProvider,
                                 lyricsSyncOffset = lyricsSyncOffset,
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = 16.dp),
                             )
                         }
                     }


### PR DESCRIPTION
## Problem

In the Apple Music player style's inline lyrics view, some songs' lyrics get cut off on the right side — the last characters of each line are truncated/not visible. Particularly visible with long Japanese CJK lines like `まるでこの世界で二人た` and `硝子の上を裸足のまま歩`.

## Root cause

The inline lyrics overlay in `AppleMusicPlayer.kt` extended edge-to-edge horizontally with **no system-bar insets** and **no horizontal padding**. The `LyricsV2`/`LyricsEnhanced` composables were called with `modifier = Modifier.fillMaxSize()` (no horizontal padding).

On devices with curved displays, side display cutouts, or gesture-nav pill overlap, the rightmost characters were physically clipped by the screen edge.

The standalone `LyricsScreen.kt` already handles this correctly:
- `windowInsetsPadding(WindowInsets.systemBars)` (line 567)
- `.padding(horizontal = 24.dp)` (line 1206)

The inline overlay had neither → asymmetry between the two lyrics paths.

## Fix

Mirror the standalone screen by applying:
1. `WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)` on the overlay `Box` — handles status bar (landscape), gesture-nav pill, and display cutout.
2. `.padding(horizontal = 16.dp)` on the `LyricsV2`/`LyricsEnhanced` modifier — minimum margin on top of the system-bar inset.

16dp is slightly less than the standalone's 24dp because the inline view has less vertical space and we want to maximize the lyrics area; the system-bar inset handles the rest on devices that have one.

## Testing

- Open Apple Music player style → play a song with long Japanese lyrics
- Open the inline lyrics view
- Long CJK lines should now wrap correctly within the screen bounds
- Rightmost characters should be fully visible
- No clipping on devices with curved edges / cutouts