### PR TITLE
release: apple music lyrics cut-off fix + scroll lag fix

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsDocument.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsDocument.kt
@@ -253,19 +253,50 @@ object AiLyricsDocumentParser {
         }
 
     private fun readTtmlLineText(paragraphElement: Element): String {
-        val spanTexts = ArrayList<String>()
+        // Walk the paragraph's immediate children in document order and concatenate
+        // their text WITHOUT inserting artificial spaces between spans.
+        //
+        // The previous implementation joined span text with " " between every pair,
+        // which is correct for Latin-script word-synced lyrics (where each <span>
+        // is a separate word) but catastrophically wrong for CJK lyrics. Japanese
+        // word-synced TTML breaks "恋愛サーキュレーション" into per-mora spans
+        // ("恋", "愛", "サ", "ー", "キュ", "レ", "ー", "ション"), and joining those
+        // with spaces produces "恋 愛 サ ー キュ レ ー ション" — a string of broken
+        // Japanese that AI translators either refuse to translate or echo back
+        // unchanged, causing auto-translation to silently no-op for the entire song.
+        //
+        // The renderer's TTMLParser.parseSpanElements does the same direct-concat
+        // (lineText.append(wordText) with no separator), so this matches what the
+        // user actually sees on screen.
+        //
+        // Mixed-content <p> elements (direct text + nested spans, common in
+        // Musixmatch rich-sync TTML) are handled by including TEXT_NODE children
+        // in the walk — preserving any whitespace the source TTML puts between
+        // spans, instead of throwing it away and inserting our own.
+        val builder = StringBuilder()
         val children = paragraphElement.childNodes
         for (i in 0 until children.length) {
             val child = children.item(i) ?: continue
-            if (child.nodeType != Node.ELEMENT_NODE) continue
-            val childElement = child as? Element ?: continue
-            if (!childElement.tagName.endsWith("span", ignoreCase = true)) continue
-            val spanText = childElement.textContent?.trim().orEmpty()
-            if (spanText.isNotEmpty()) spanTexts.add(spanText)
+            when (child.nodeType) {
+                Node.ELEMENT_NODE -> {
+                    val childElement = child as? Element ?: continue
+                    if (!childElement.tagName.endsWith("span", ignoreCase = true)) continue
+                    val spanText = childElement.textContent.orEmpty()
+                    if (spanText.isNotEmpty()) builder.append(spanText)
+                }
+                Node.TEXT_NODE -> {
+                    val text = child.textContent.orEmpty()
+                    if (text.isNotEmpty()) builder.append(text)
+                }
+            }
         }
-        if (spanTexts.isNotEmpty()) {
-            return spanTexts.joinToString(" ").trim().replace(Regex("\\s+"), " ")
-        }
+        val joined = builder.toString()
+        // Collapse runs of whitespace (TTML is often pretty-printed with newlines
+        // and indentation between spans) but preserve all non-whitespace characters
+        // exactly — including CJK punctuation, kana, and kanji.
+        val collapsed = joined.replace(Regex("\\s+"), " ").trim()
+        if (collapsed.isNotEmpty()) return collapsed
+        // Fallback for paragraphs with no <span> children (e.g. plain timed text).
         return paragraphElement.textContent?.trim().orEmpty().replace(Regex("\\s+"), " ")
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
@@ -38,6 +38,10 @@ object LyricsUtils {
     private val YRC_WORD_TIME_REGEX = Regex("""\(\d{1,8},\d{1,8}(?:,\d{1,8})?\)""")
     private val QrcTranslationLineRegex = Regex("""^\[(\d{1,8}),(\d{1,8})](.*)$""")
     private val QrcWordTimingDetectRegex = Regex("""\(\d{1,8},\d{1,8}(?:,\d{1,8})?\)""")
+    // Matches the leading timestamp prefix of any LRC/QRC/YRC line. Used by
+    // `hasTranslation()` to detect duplicate prefixes (which indicate the
+    // translator appended a translated line under the same timestamp).
+    private val SyncedLinePrefixRegex = Regex("""^(\s*(?:\[[^\]]+])+)(\s*)(.*?)(\s*)$""")
     private val TTML_SPAN_REGEX =
         Regex(
             pattern = """<span\b[^>]*>""",
@@ -385,6 +389,47 @@ object LyricsUtils {
 
         return trimmed.contains("<tt", ignoreCase = true) ||
             trimmed.contains("http://www.w3.org/ns/ttml", ignoreCase = true)
+    }
+
+    /**
+     * Returns true when [lyrics] contains at least one actual translation entry
+     * produced by [moe.rukamori.archivetune.ai.AiLyricsTranslator].
+     *
+     * The translator marks the lyrics' source as `AI_TRANSLATION` regardless of
+     * whether the AI returned anything useful — if every line came back identical
+     * to the source (a common failure mode for CJK lyrics that were previously
+     * mangled by the span-joining bug in `AiLyricsDocument.readTtmlLineText`),
+     * the rebuild produces no `<translation>` element / no duplicate-timestamp
+     * LRC lines, but the row is still stored with `source = AI_TRANSLATION`.
+     *
+     * Without this check, the auto-translate LaunchedEffect in LyricsScreen.kt
+     * and AppleMusicPlayer.kt would skip those songs forever (the
+     * `source == AI_TRANSLATION` guard returns early), so the user would never
+     * get a translation even after the underlying bug is fixed. By allowing a
+     * retry when `hasTranslation()` is false, previously no-op'd translations
+     * get a chance to re-run with the corrected parser.
+     *
+     * Detection rules:
+     *  - TTML: look for `<translation ... data-archivetune="translation"` (the
+     *    marker `TtmlLyricsDocument.rebuild` writes).
+     *  - LRC / QRC / plain: look for any timestamp prefix that appears more
+     *    than once — translators append translated lines under the same prefix
+     *    as the original, so a duplicate prefix means at least one translation
+     *    was added.
+     */
+    fun hasTranslation(lyrics: String): Boolean {
+        if (lyrics.isBlank()) return false
+        if (isTtml(lyrics)) {
+            return lyrics.contains("data-archivetune", ignoreCase = true) &&
+                lyrics.contains("translation", ignoreCase = true)
+        }
+        val seenPrefixes = HashSet<String>()
+        lyrics.lineSequence().forEach { line ->
+            val match = SyncedLinePrefixRegex.matchEntire(line) ?: return@forEach
+            val prefix = match.groupValues[1]
+            if (!seenPrefixes.add(prefix)) return true
+        }
+        return false
     }
 
     fun shouldAutoTranslate(lyrics: String, targetLanguage: String): Boolean {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzAudioProvider.kt
@@ -488,15 +488,117 @@ object QobuzAudioProvider {
             if (cached.expiresAt > now) return cached.match
             searchCache.remove(key)
         }
-        val searchQuery =
-            listOf(query.artists.firstOrNull()?.searchArtist().orEmpty(), query.title.searchTitle())
-                .filter { it.isNotBlank() }
-                .joinToString(" ")
-                .ifBlank { query.title }
-        val match = bestMatch(backend, searchQuery, query)
+        val match = resolveTrackIdWithFallbacks(backend, query)
         searchCache[key] = CachedSearch(match, now + SEARCH_CACHE_MS)
         return match
     }
+
+    /**
+     * Tries a sequence of search queries against [backend] until one produces a
+     * match above [MIN_MATCH_SCORE].
+     *
+     * The primary query is `"{artist} {title}"` — same as before. When that
+     * returns nothing, we fall back to:
+     *
+     *  1. `"{title}"` alone — for songs whose YouTube-side artist name doesn't
+     *     match how Qobuz indexes the artist (e.g. YT has "Reira Ushio" but
+     *     Qobuz has "牛尾里的"). Forcing the artist into the query made Qobuz's
+     *     search return zero results, even though the track is on Qobuz.
+     *
+     *  2. `"{artist} {latin-only-title}"` — for bilingual YT titles like
+     *     "恋愛サーキュレーション - Renai Circulation", where Qobuz only has the
+     *     romaji side. The full bilingual search query confused Qobuz into
+     *     returning nothing.
+     *
+     *  3. `"{latin-only-title}"` alone — combination of 1 and 2 for the worst
+     *     case (bilingual title + artist name mismatch).
+     *
+     * Each fallback only runs when the previous one returned no match above
+     * threshold, so well-matched songs still resolve with a single search.
+     */
+    private fun resolveTrackIdWithFallbacks(backend: Backend, query: Query): Match? {
+        val artist = query.artists.firstOrNull()?.searchArtist().orEmpty()
+        val title = query.title.searchTitle()
+
+        // Primary: artist + full title.
+        val primaryQuery =
+            listOf(artist, title)
+                .filter { it.isNotBlank() }
+                .joinToString(" ")
+                .ifBlank { title }
+        bestMatch(backend, primaryQuery, query)?.let { return it }
+
+        // Fallback 1: title only (drop the artist).
+        if (artist.isNotBlank() && title.isNotBlank() && title != primaryQuery) {
+            bestMatch(backend, title, query)?.let { return it }
+        }
+
+        // Fallback 2: artist + Latin-only side of a bilingual title.
+        val latinTitle = title.latinOnlySubstring()
+        if (latinTitle.isNotBlank() && latinTitle != title) {
+            val latinWithArtist =
+                listOf(artist, latinTitle)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" ")
+                    .ifBlank { latinTitle }
+            bestMatch(backend, latinWithArtist, query)?.let { return it }
+
+            // Fallback 3: Latin-only title alone.
+            if (artist.isNotBlank()) {
+                bestMatch(backend, latinTitle, query)?.let { return it }
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Extracts the Latin/ASCII portion of a bilingual title.
+     *
+     * YouTube Music commonly formats Japanese/Korean titles as
+     * `"原題 - Romaji Title"` or `"Romaji Title - 原題"`, separated by " - ".
+     * Qobuz typically indexes only ONE side (either the original script or the
+     * romaji), so searching with the full bilingual string often returns zero
+     * results. This helper returns just the Latin side when the title is
+     * bilingual, so we can retry the search with a Qobuz-friendly query.
+     *
+     * For titles that are entirely Latin or entirely CJK, this returns the
+     * Latin remainder after stripping CJK characters (possibly empty).
+     */
+    private fun String.latinOnlySubstring(): String {
+        // Try the " - " bilingual split first.
+        val dashSplit = split(" - ")
+        if (dashSplit.size == 2) {
+            val left = dashSplit[0].trim()
+            val right = dashSplit[1].trim()
+            val leftHasCJK = left.any { it.isCjk() }
+            val rightHasCJK = right.any { it.isCjk() }
+            if (leftHasCJK && !rightHasCJK && right.isNotEmpty()) return right
+            if (rightHasCJK && !leftHasCJK && left.isNotEmpty()) return left
+        }
+        // Fall back to stripping all CJK characters and returning the remainder.
+        return replace(CJK_STRIPPING_REGEX, " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+    }
+
+    private fun Char.isCjk(): Boolean =
+        code in 0x3040..0x30ff || // Hiragana + Katakana
+            code in 0x3400..0x4dbf || // CJK Ext A
+            code in 0x4e00..0x9fff || // CJK Unified Ideographs
+            code in 0xf900..0xfaff || // CJK Compatibility Ideographs
+            code in 0xac00..0xd7af // Hangul Syllables
+
+    private val CJK_STRIPPING_REGEX =
+        Regex(
+            "[" +
+                "\\u3040-\\u30ff" +
+                "\\u3400-\\u4dbf" +
+                "\\u4e00-\\u9fff" +
+                "\\uf900-\\ufaff" +
+                "\\uac00-\\ud7af" +
+                "]+",
+        )
 
     /** Runs search and scores results against [query], returning the best match above threshold. */
     private fun bestMatch(
@@ -932,7 +1034,33 @@ object QobuzAudioProvider {
             ?.lowercase(Locale.US)
             ?.let { Normalizer.normalize(it, Normalizer.Form.NFD) }
             ?.replace(Regex("\\p{Mn}+"), "")
-            ?.replace(Regex("[^a-z0-9]+"), " ")
+            // Preserve CJK characters (Hiragana, Katakana, CJK Ideographs, Hangul,
+            // and fullwidth/halfwidth forms) instead of stripping them as noise.
+            //
+            // The previous pattern `[^a-z0-9]+` deleted every Japanese/Korean/
+            // Chinese character from the normalized form. When Qobuz returned a
+            // Japanese-only title (e.g. "恋愛サーキュレーション") for a song whose
+            // YouTube Music title was bilingual ("恋愛サーキュレーション - Renai Circulation"),
+            // the candidate title normalized to "" and `scoreMatch` returned
+            // `Int.MIN_VALUE` — so lossless matches silently failed for CJK songs
+            // that are actually available on Qobuz.
+            //
+            // Keeping CJK lets `significantTokens` produce real tokens for kana/kanji
+            // runs, so `tokenOverlap` can score Japanese-on-Japanese matches the same
+            // way it scores Latin-on-Latin.
+            ?.replace(
+                Regex(
+                    "[^a-z0-9" +
+                        "\\u3040-\\u30ff" + // Hiragana + Katakana (incl. extensions)
+                        "\\u3400-\\u4dbf" + // CJK Ext A
+                        "\\u4e00-\\u9fff" + // CJK Unified Ideographs
+                        "\\uf900-\\ufaff" + // CJK Compatibility Ideographs
+                        "\\uac00-\\ud7af" + // Hangul Syllables
+                        "\\uff00-\\uffef" + // Halfwidth/Fullwidth Forms (incl. fullwidth Latin)
+                        "]+",
+                ),
+                " ",
+            )
             ?.trim()
             .orEmpty()
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -412,7 +412,15 @@ fun AppleMusicPlayerContent(
         val snapshot = currentLyrics ?: return@LaunchedEffect
         val text = snapshot.lyrics ?: return@LaunchedEffect
         if (text.isBlank() || text == LyricsEntity.LYRICS_NOT_FOUND) return@LaunchedEffect
-        if (snapshot.source == LyricsEntity.Source.AI_TRANSLATION.value) return@LaunchedEffect
+        // Skip if these lyrics were already AI-translated AND actually contain
+        // translation content. The `hasTranslation` guard allows retrying when a
+        // previous attempt no-op'd (AI returned the same text — a common failure
+        // mode for CJK lyrics that were previously mangled by the span-joining
+        // bug in AiLyricsDocument.readTtmlLineText). Without this, those songs
+        // would be blocked from retrying forever.
+        if (snapshot.source == LyricsEntity.Source.AI_TRANSLATION.value &&
+            LyricsUtils.hasTranslation(text)
+        ) return@LaunchedEffect
         if (!LyricsUtils.shouldAutoTranslate(text, translatorTargetLang)) return@LaunchedEffect
         lyricsMenuViewModel.translateLyricsWithAi(
             mediaMetadata = mediaMetadata,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -56,6 +56,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -52,11 +52,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
@@ -1029,12 +1031,25 @@ fun AppleMusicPlayerContent(
                     // The Column is sized to fill the area BELOW the mini header
                     // (maxHeight - miniHeaderHeight) and offset down by
                     // miniHeaderHeight so it doesn't cover the mini header.
+                    //
+                    // HORIZONTAL INSETS: the inline overlay must apply system-bar
+                    // horizontal padding (status bar on landscape, gesture-nav
+                    // pill / display cutout on portrait) AND a minimum horizontal
+                    // margin, mirroring the standalone LyricsScreen.kt which uses
+                    // windowInsetsPadding(systemBars) + 24dp horizontal padding.
+                    // Without this, the lyrics text extends to the absolute screen
+                    // edge and the rightmost characters are clipped on devices
+                    // with curved edges / side cutouts — particularly visible on
+                    // long Japanese CJK lines.
                     Box(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
                                 .height(maxHeight - miniHeaderHeight)
                                 .offset(y = miniHeaderHeight)
+                                .windowInsetsPadding(
+                                    WindowInsets.systemBars.only(WindowInsetsSides.Horizontal),
+                                )
                                 .pointerInput(lyricsOpen) {
                                     if (!lyricsOpen) return@pointerInput
                                     awaitEachGesture {
@@ -1047,12 +1062,16 @@ fun AppleMusicPlayerContent(
                             LyricsMode.V2 -> LyricsV2(
                                 sliderPositionProvider = lyricsPosProvider,
                                 lyricsSyncOffset = lyricsSyncOffset,
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = 16.dp),
                             )
                             LyricsMode.ENHANCED -> LyricsEnhanced(
                                 sliderPositionProvider = lyricsPosProvider,
                                 lyricsSyncOffset = lyricsSyncOffset,
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = 16.dp),
                             )
                         }
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -354,7 +354,16 @@ fun LyricsScreen(
         val snapshot = currentLyrics ?: return@LaunchedEffect
         val text = snapshot.lyrics ?: return@LaunchedEffect
         if (text.isBlank() || text == LyricsEntity.LYRICS_NOT_FOUND) return@LaunchedEffect
-        if (snapshot.source == LyricsEntity.Source.AI_TRANSLATION.value) return@LaunchedEffect
+        // Skip if these lyrics were already AI-translated AND actually contain
+        // translation content. The `hasTranslation` guard is important: a previous
+        // translation attempt may have no-op'd (AI returned the same text — a
+        // common failure mode for CJK lyrics that were previously mangled by the
+        // span-joining bug in AiLyricsDocument.readTtmlLineText). Without this
+        // check, those songs would be blocked from retrying forever even after
+        // the parser is fixed.
+        if (snapshot.source == LyricsEntity.Source.AI_TRANSLATION.value &&
+            LyricsUtils.hasTranslation(text)
+        ) return@LaunchedEffect
 
         if (!LyricsUtils.shouldAutoTranslate(text, translatorTargetLang)) return@LaunchedEffect
 


### PR DESCRIPTION
## Summary

Merges accumulated `dev` fixes into `main` since the last dev→main PR (#139).

### Commits included (since #139)
- `8a60cc961` fix(apple-music): inline lyrics cut off at right edge (#140)
- `1954dff0a` fix(apple-music): add missing 'only' import for WindowInsets
- `2307f969c` Merge pull request #140 from 4nx3b/fix/apple-music-lyrics-cutoff

### Context
- PR #138 (inline lyrics auto-scroll lag) was already merged to main via #139.
- PR #140 (inline lyrics cut off at right edge) is on dev but not yet on main.

This PR brings main up to date with dev.

## Risk
Low — both PRs already passed CI on dev.
