### PR TITLE
fix(apple-music): word-synced Japanese lyrics cut off at right edge

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
@@ -1067,20 +1068,49 @@ fun AppleMusicPlayerContent(
                                     }
                                 },
                     ) {
+                        // HORIZONTAL PADDING + CLIP:
+                        //
+                        // 24dp horizontal padding matches the standalone LyricsScreen's
+                        // AppleMusicLyricsPane (LyricsScreen.kt:1215). The previous 16dp
+                        // value was chosen to "maximize the lyrics area", but the
+                        // mocharealm KaraokeLyricsView library renders the active
+                        // (currently-sung) line with a ~1.6-1.8x font-size emphasis
+                        // AND lays out each syllable as a separate Text in a
+                        // non-wrapping Row. For word-synced Japanese lyrics, this
+                        // means the active line's rendered width can exceed the
+                        // parent's max width — and without an explicit clip, the
+                        // overflow extends PAST the parent's padded bounds all the
+                        // way to the screen edge, making the cutoff look catastrophic
+                        // (last character sliced at the physical screen edge).
+                        //
+                        // 24dp padding gives the active-line emphasis scaling more
+                        // headroom so most lines fit, and clipToBounds() ensures any
+                        // residual overflow is clipped at the padded bounds (24dp
+                        // from the screen edge) — so even in the worst case the user
+                        // sees a clean cut with visible right margin, not text
+                        // running off the screen.
+                        //
+                        // This specifically fixes word-synced Japanese lyrics in
+                        // Apple Music style. Line-by-line lyrics (SyncedLine) wrap
+                        // naturally via Text's softWrap, so they never had this
+                        // issue. The cut-off was exclusive to the word-synced
+                        // (KaraokeLine) path.
                         when (lyricsMode) {
                             LyricsMode.V2 -> LyricsV2(
                                 sliderPositionProvider = lyricsPosProvider,
                                 lyricsSyncOffset = lyricsSyncOffset,
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .padding(horizontal = 16.dp),
+                                    .padding(horizontal = 24.dp)
+                                    .clipToBounds(),
                             )
                             LyricsMode.ENHANCED -> LyricsEnhanced(
                                 sliderPositionProvider = lyricsPosProvider,
                                 lyricsSyncOffset = lyricsSyncOffset,
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .padding(horizontal = 16.dp),
+                                    .padding(horizontal = 24.dp)
+                                    .clipToBounds(),
                             )
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes the word-synced Japanese lyrics cutoff at the right edge of the inline lyrics overlay in Apple Music player style.

## Root cause

Previous fix (PR #140, commit 8a60cc961) added 16dp horizontal padding + systemBars horizontal inset to the inline lyrics overlay. This resolved the cutoff for **line-by-line** lyrics (SyncedLine path — single Text composable with softWrap, wraps naturally) but NOT for **word-synced** lyrics (KaraokeLine path — Row of syllable Texts, does not wrap).

The mocharealm `KaraokeLyricsView` library renders the active (currently-sung) line with a ~1.6-1.8x font-size emphasis for visual prominence. For word-synced Japanese lyrics, each syllable is laid out as a separate Text in a non-wrapping Row. When the active line's scaled font makes the row wider than the parent's max width:
- The row overflows past the parent's bounds
- The parent Box had no `clipToBounds()`, so the overflow extended all the way to the physical screen edge
- Result: catastrophic cutoff (last character sliced at the screen edge with 0dp right margin)

## User-visible symptom

Verified from screenshot for song **"夢重力 - Dream Gravity"** by PIKASONIC, Nanatsukaze:
- Active line `飲み込んでしまう気が` (9 chars at ~45sp scaled font) was sliced at the right screen edge — the last `が` character was physically clipped by the screen edge with 0dp right margin
- Inactive gray lines (smaller font) fit fine
- English translation (Latin text, narrower per char) fit fine

## Fix

1. **Increase horizontal padding 16dp → 24dp**, matching the standalone `LyricsScreen`'s `AppleMusicLyricsPane` (LyricsScreen.kt:1215). This gives the active-line emphasis scaling more headroom so most lines fit entirely within the parent's bounds.

2. **Add `clipToBounds()` AFTER the padding.** This ensures any residual overflow (for very long lines that still don't fit at 24dp padding) is clipped at the padded bounds (24dp from the screen edge) instead of running off the screen edge. The user sees a clean cut with a visible right margin rather than text running off the screen.

## Why this is specific to word-synced Japanese lyrics in Apple Music style

- **Apple Music style** is the only place using the inline lyrics overlay in `AppleMusicPlayer.kt`. The standalone `LyricsScreen` already had 24dp padding.
- **Word-synced lyrics** use `KaraokeLine` (syllable Row, no wrap). Line-by-line lyrics use `SyncedLine` (single Text, wraps naturally) — unaffected by this bug.
- **Japanese CJK characters** are full-width (~1em per char), so a 9-char Japanese line is roughly 2-3x wider than a 9-char Latin line at the same font size, making the overflow much more likely.

## Files changed

- `app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt`
  - Added import: `androidx.compose.ui.draw.clipToBounds`
  - `LyricsV2` modifier: 16dp → 24dp horizontal padding + `clipToBounds()`
  - `LyricsEnhanced` modifier: 16dp → 24dp horizontal padding + `clipToBounds()`

## Test plan

- [ ] CI build passes
- [ ] Inline lyrics in Apple Music style with word-synced Japanese lyrics no longer cut off at the right edge
- [ ] Long Japanese lines (9+ chars) at default 26sp font size fit within the parent's bounds
- [ ] Even at user-increased font sizes, overflow is cleanly clipped at 24dp from the screen edge (visible right margin)
- [ ] Line-by-line lyrics (non-word-synced) still render correctly (no regression)
- [ ] Standalone LyricsScreen unaffected (no regression)
