### PR TITLE
fix: lyrics/queue text color, lyrics back nav, V9 dynamic color, voice search mic, Qobuz source picker + upstream cherry-picks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -440,9 +440,6 @@ dependencies {
     implementation("androidx.media3:media3-ui-compose:${libs.versions.media3.get()}")
     add("gmsImplementation", libs.media3.cast)
     add("gmsImplementation", libs.mediarouter)
-    // On-device speech recognition (no standalone Google app required — only needs
-    // Google Play Services, which the gms flavor already depends on for Cast).
-    add("gmsImplementation", libs.play.services.speech)
     implementation(libs.squigglyslider)
 
     // Prebuilt TDLib (Telegram MTProto client) with bundled JNI natives for all ABIs.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -440,6 +440,9 @@ dependencies {
     implementation("androidx.media3:media3-ui-compose:${libs.versions.media3.get()}")
     add("gmsImplementation", libs.media3.cast)
     add("gmsImplementation", libs.mediarouter)
+    // On-device speech recognition (no standalone Google app required — only needs
+    // Google Play Services, which the gms flavor already depends on for Cast).
+    add("gmsImplementation", libs.play.services.speech)
     implementation(libs.squigglyslider)
 
     // Prebuilt TDLib (Telegram MTProto client) with bundled JNI natives for all ABIs.

--- a/app/src/foss/kotlin/moe/rukamori/archivetune/voicesearch/DefaultVoiceSearchController.kt
+++ b/app/src/foss/kotlin/moe/rukamori/archivetune/voicesearch/DefaultVoiceSearchController.kt
@@ -1,0 +1,39 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.voicesearch
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * FOSS flavor no-op implementation. FOSS builds have no GMS dependency, so the
+ * in-app mic button is disabled and surfaces a friendly error if the user taps it.
+ *
+ * FOSS users can still voice-search through the system MediaSession voice intent
+ * (e.g. "OK Google, play X on ArchiveTune") — that flow is handled in
+ * [moe.rukamori.archivetune.playback.MusicService] and does not require any
+ * in-app UI.
+ */
+class DefaultVoiceSearchController : VoiceSearchController {
+    private val _state = MutableStateFlow<VoiceSearchState>(VoiceSearchState.Idle)
+    override val state: StateFlow<VoiceSearchState> = _state.asStateFlow()
+
+    override fun startListening(context: Context) {
+        _state.value =
+            VoiceSearchState.Error(
+                "Voice search requires the GMS build of ArchiveTune. Use the system " +
+                    "voice assistant (e.g. \"OK Google, play X on ArchiveTune\") instead.",
+            )
+    }
+
+    override fun cancel() {
+        _state.value = VoiceSearchState.Idle
+    }
+}

--- a/app/src/gms/kotlin/moe/rukamori/archivetune/cast/DefaultCastPlaybackRepository.kt
+++ b/app/src/gms/kotlin/moe/rukamori/archivetune/cast/DefaultCastPlaybackRepository.kt
@@ -10,6 +10,8 @@
 package moe.rukamori.archivetune.cast
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import androidx.core.net.toUri
@@ -223,7 +225,7 @@ private class SafeCastTransferCallback(
         targetPlayer: Player,
     ) {
         val transferState = PlayerTransferState.fromPlayer(sourcePlayer)
-        if (targetPlayer !== localPlayer || transferState.mediaItems.all { it.localConfiguration != null }) {
+        if (targetPlayer !== localPlayer) {
             transferState.setToPlayer(targetPlayer)
             return
         }
@@ -235,17 +237,17 @@ private class SafeCastTransferCallback(
 
         transferState.mediaItems.forEachIndexed { sourceIndex, mediaItem ->
             val repairedItem =
-                mediaItem.takeIf { it.localConfiguration != null }
-                    ?: localItems.firstOrNull {
-                        it.localConfiguration != null &&
-                            mediaItem.mediaId.isNotBlank() &&
-                            mediaItem.mediaId != MediaItem.DEFAULT_MEDIA_ID &&
-                            it.mediaId == mediaItem.mediaId
-                    }
+                localItems.firstOrNull {
+                    it.localConfiguration != null &&
+                        mediaItem.mediaId.isNotBlank() &&
+                        mediaItem.mediaId != MediaItem.DEFAULT_MEDIA_ID &&
+                        it.mediaId == mediaItem.mediaId
+                }
                     ?: localItems.getOrNull(sourceIndex)?.takeIf {
                         it.localConfiguration != null &&
                             (mediaItem.mediaId.isBlank() || mediaItem.mediaId == MediaItem.DEFAULT_MEDIA_ID)
                     }
+                    ?: mediaItem.takeIf { it.localConfiguration != null && !it.isLocalCastProxy() }
                     ?: mediaItem
                         .mediaId
                         .takeIf { it.isNotBlank() && it != MediaItem.DEFAULT_MEDIA_ID }
@@ -282,6 +284,11 @@ private class SafeCastTransferCallback(
     }
 
     private fun Player.mediaItems(): List<MediaItem> = List(mediaItemCount) { index -> getMediaItemAt(index) }
+
+    private fun MediaItem.isLocalCastProxy(): Boolean {
+        val uri = localConfiguration?.uri ?: return false
+        return uri.scheme.equals("http", ignoreCase = true) && uri.path?.startsWith("/cast/local/") == true
+    }
 }
 
 private class GmsCastMediaItemConverter(
@@ -424,16 +431,18 @@ private class LocalCastMediaServer(
         const val HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416
         const val REMOTE_CONNECT_TIMEOUT_MS = 15_000
         const val REMOTE_READ_TIMEOUT_MS = 45_000
-        const val DEFAULT_AUDIO_MIME_TYPE = "audio/mp4"
+        const val FALLBACK_AUDIO_MIME_TYPE = "audio/mp4"
         const val DEFAULT_IMAGE_MIME_TYPE = "image/jpeg"
     }
 
     private val servedItems = ConcurrentHashMap<String, ServedItem>()
     private val servedArtwork = ConcurrentHashMap<String, ServedAsset>()
-    private var engine: EmbeddedServer<*, *>? = null
-    private var port: Int = 0
-    private var hostAddress: String? = null
+    private val connectivityManager = requireNotNull(context.getSystemService(ConnectivityManager::class.java))
+    @Volatile private var engine: EmbeddedServer<*, *>? = null
+    @Volatile private var port: Int = 0
+    @Volatile private var hostAddress: String? = null
 
+    @Synchronized
     fun prepare(
         mediaItem: MediaItem,
         mediaItemResolver: CastMediaItemResolver? = null,
@@ -441,33 +450,45 @@ private class LocalCastMediaServer(
         val uri = mediaItem.localConfiguration?.uri ?: return null
         val host = ensureStarted() ?: return null
         val token = UUID.randomUUID().toString()
-        val mimeType = mediaItem.localConfiguration?.mimeType ?: mimeType(uri, DEFAULT_AUDIO_MIME_TYPE)
+        val resolvedMimeType =
+            mediaItem.localConfiguration?.mimeType
+                ?.substringBefore(";")
+                ?.takeIf { it.isNotBlank() && !it.endsWith("/*") }
+                ?: mimeType(uri)
         servedItems[token] =
             ServedItem(
                 mediaItem = mediaItem,
                 uri = uri,
-                mimeType = mimeType,
+                mimeType = resolvedMimeType,
                 mediaItemResolver = mediaItemResolver,
             )
         return mediaItem
             .withReceiverArtwork(host)
             .buildUpon()
             .setUri("http://$host:$port/cast/local/$token".toUri())
-            .setMimeType(mimeType)
+            .apply { resolvedMimeType?.let(::setMimeType) }
             .build()
     }
 
+    @Synchronized
     fun stop() {
         servedItems.clear()
         servedArtwork.clear()
-        val currentEngine = engine ?: return
+        val currentEngine = engine
         engine = null
-        runCatching { currentEngine.stop(1000, 2000) }
-            .onFailure { Timber.tag("Cast").w(it, "Unable to stop local Cast media server") }
+        port = 0
+        hostAddress = null
+        currentEngine?.let {
+            runCatching { it.stop(1000, 2000) }
+                .onFailure { error -> Timber.tag("Cast").w(error, "Unable to stop local Cast media server") }
+        }
     }
 
+    @Synchronized
     private fun ensureStarted(): String? {
-        hostAddress?.let { return it }
+        val currentEngine = engine
+        val currentHostAddress = hostAddress
+        if (currentEngine != null && currentHostAddress != null) return currentHostAddress
         val address = lanAddress() ?: return null
         val selectedPort = randomFreePort()
         val startedEngine =
@@ -517,7 +538,7 @@ private class LocalCastMediaServer(
         val artworkUri = mediaMetadata.artworkUri ?: return this
         if (!artworkUri.isLocalFileUrl()) return this
         val token = UUID.randomUUID().toString()
-        val artworkMimeType = mimeType(artworkUri, DEFAULT_IMAGE_MIME_TYPE)
+        val artworkMimeType = mimeType(artworkUri) ?: DEFAULT_IMAGE_MIME_TYPE
         servedArtwork[token] = ServedAsset(uri = artworkUri, mimeType = artworkMimeType)
         return buildUpon()
             .setMediaMetadata(
@@ -576,7 +597,7 @@ private class LocalCastMediaServer(
 
     private fun openLocalFileSource(
         uri: Uri,
-        mimeType: String,
+        mimeType: String?,
         rangeHeader: String?,
     ): OpenSource? {
         val file = File(uri.path ?: return null).takeIf { it.isFile } ?: return null
@@ -592,7 +613,7 @@ private class LocalCastMediaServer(
         return OpenSource(
             input = file.inputStream().apply { skipFully(start) },
             length = contentLength,
-            mimeType = mimeType,
+            mimeType = mimeType ?: FALLBACK_AUDIO_MIME_TYPE,
             status = if (validRange == null) HttpStatusCode.OK else HttpStatusCode.PartialContent,
             contentRange = validRange?.let { "bytes $start-$end/$length" },
         )
@@ -600,7 +621,7 @@ private class LocalCastMediaServer(
 
     private fun openContentSource(
         uri: Uri,
-        mimeType: String,
+        mimeType: String?,
         rangeHeader: String?,
     ): OpenSource? {
         val length = contentLength(uri)
@@ -617,7 +638,7 @@ private class LocalCastMediaServer(
         return OpenSource(
             input = BoundedInputStream(input, contentLength),
             length = contentLength ?: length,
-            mimeType = mimeType,
+            mimeType = mimeType ?: FALLBACK_AUDIO_MIME_TYPE,
             status = if (validRange == null) HttpStatusCode.OK else HttpStatusCode.PartialContent,
             contentRange = if (validRange != null && end != null && length != null) "bytes $start-$end/$length" else null,
         )
@@ -628,7 +649,12 @@ private class LocalCastMediaServer(
         rangeHeader: String?,
     ): OpenSource? {
         val resolved =
-            item.resolvedMediaItem ?: item.mediaItemResolver?.resolveForCast(item.mediaItem)?.also { item.resolvedMediaItem = it }
+            item.resolvedMediaItem
+                ?: item.mediaItemResolver?.let { resolver ->
+                    runCatching { resolver.resolveForCast(item.mediaItem) }
+                        .onFailure { Timber.tag("Cast").w(it, "Unable to resolve media item for Cast") }
+                        .getOrNull()
+                }?.also { item.resolvedMediaItem = it }
         val resolvedUri = resolved?.localConfiguration?.uri ?: return null
         if (!resolvedUri.isHttpUrl()) {
             val resolvedItem =
@@ -657,10 +683,20 @@ private class LocalCastMediaServer(
                 return@runCatching null
             }
             val responseLength = connection.getHeaderFieldLong(HttpHeaders.ContentLength, -1L).takeIf { it >= 0L }
+            val responseMimeType =
+                resolved.localConfiguration?.mimeType
+                    ?.substringBefore(";")
+                    ?.takeIf { it.isNotBlank() && !it.endsWith("/*") }
+                    ?: item.mimeType
+                    ?: connection.contentType
+                        ?.trim()
+                        ?.substringBefore(";")
+                        ?.takeIf(String::isNotEmpty)
+                    ?: FALLBACK_AUDIO_MIME_TYPE
             OpenSource(
                 input = connection.inputStream,
                 length = responseLength,
-                mimeType = connection.contentType?.substringBefore(";") ?: resolved.localConfiguration?.mimeType ?: item.mimeType,
+                mimeType = responseMimeType,
                 status =
                     if (responseCode == HttpURLConnection.HTTP_PARTIAL) {
                         HttpStatusCode.PartialContent
@@ -698,8 +734,7 @@ private class LocalCastMediaServer(
 
     private fun mimeType(
         uri: Uri,
-        fallback: String,
-    ): String =
+    ): String? =
         runCatching { context.contentResolver.getType(uri) }
             .getOrNull()
             ?.substringBefore(";")
@@ -708,7 +743,6 @@ private class LocalCastMediaServer(
                 ?.takeIf { it.isNotBlank() }
                 ?.lowercase(Locale.US)
                 ?.let(MimeTypeMap.getSingleton()::getMimeTypeFromExtension)
-            ?: fallback
 
     private fun parseRange(
         header: String?,
@@ -741,6 +775,37 @@ private class LocalCastMediaServer(
     }
 
     private fun lanAddress(): String? {
+        val activeNetwork = connectivityManager.activeNetwork
+        val networkAddress =
+            runCatching {
+                connectivityManager.allNetworks
+                    .asSequence()
+                    .sortedWith(
+                        compareBy<android.net.Network> {
+                            val capabilities = connectivityManager.getNetworkCapabilities(it)
+                            when {
+                                capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true -> 0
+                                capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) == true -> 1
+                                capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true -> 3
+                                capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) == true -> 4
+                                else -> 2
+                            }
+                        }.thenByDescending { it == activeNetwork },
+                    ).flatMap { network ->
+                        connectivityManager
+                            .getLinkProperties(network)
+                            ?.linkAddresses
+                            .orEmpty()
+                            .asSequence()
+                            .map { it.address }
+                    }.filterIsInstance<Inet4Address>()
+                    .filterNot { it.isLoopbackAddress }
+                    .filter { it.isSiteLocalAddress }
+                    .mapNotNull { it.hostAddress }
+                    .firstOrNull()
+            }.getOrNull()
+        if (networkAddress != null) return networkAddress
+
         val interfaces = NetworkInterface.getNetworkInterfaces().toList()
         return interfaces
             .asSequence()
@@ -762,14 +827,14 @@ private class LocalCastMediaServer(
     private data class ServedItem(
         val mediaItem: MediaItem,
         val uri: Uri,
-        val mimeType: String,
+        val mimeType: String?,
         val mediaItemResolver: CastMediaItemResolver?,
         @Volatile var resolvedMediaItem: MediaItem? = null,
     )
 
     private data class ServedAsset(
         val uri: Uri,
-        val mimeType: String,
+        val mimeType: String?,
     )
 
     private sealed interface ParsedRange {
@@ -801,7 +866,7 @@ private class LocalCastMediaServer(
             ) = OpenSource(
                 input = ByteArrayInputStream(ByteArray(0)),
                 length = 0L,
-                mimeType = "audio/mp4",
+                mimeType = FALLBACK_AUDIO_MIME_TYPE,
                 status = HttpStatusCode.RequestedRangeNotSatisfiable,
                 contentRange = length?.let { "bytes */$it" },
                 onClose = onClose,

--- a/app/src/gms/kotlin/moe/rukamori/archivetune/voicesearch/DefaultVoiceSearchController.kt
+++ b/app/src/gms/kotlin/moe/rukamori/archivetune/voicesearch/DefaultVoiceSearchController.kt
@@ -20,16 +20,17 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * GMS-backed implementation that uses `com.google.android.gms:play-services-speech`.
+ * GMS-flavor voice search implementation.
  *
- * This library brings the Google Speech Recognition service (shipped via Google
- * Play Services) into the app. Unlike the legacy `Intent.ACTION_RECOGNIZE_SPEECH`
- * flow (which delegates to whatever assistant handles the intent — typically the
- * standalone Google app), this implementation talks directly to the SpeechRecognizer
- * in-process, so the user does NOT need to install the Google app separately.
+ * Uses the platform `android.speech.SpeechRecognizer` API directly. On Android
+ * 12+ this API uses the on-device Google Speech Recognition service (shipped via
+ * Google Play Services as part of the system), so the user does NOT need to
+ * install the standalone Google app. On older Android versions the recognizer
+ * falls back to whatever speech service the system provides.
  *
- * Note: requires Google Play Services to be available on the device (already a
- * hard dependency of the `gms` flavor for Cast support).
+ * This implementation is in the `gms` source set because the `gms` flavor
+ * already depends on Google Play Services (for Cast). The `foss` flavor uses
+ * a no-op impl so FOSS builds don't pull in any GMS dependency.
  */
 class DefaultVoiceSearchController : VoiceSearchController {
     private val _state = MutableStateFlow<VoiceSearchState>(VoiceSearchState.Idle)

--- a/app/src/gms/kotlin/moe/rukamori/archivetune/voicesearch/DefaultVoiceSearchController.kt
+++ b/app/src/gms/kotlin/moe/rukamori/archivetune/voicesearch/DefaultVoiceSearchController.kt
@@ -1,0 +1,146 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.voicesearch
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * GMS-backed implementation that uses `com.google.android.gms:play-services-speech`.
+ *
+ * This library brings the Google Speech Recognition service (shipped via Google
+ * Play Services) into the app. Unlike the legacy `Intent.ACTION_RECOGNIZE_SPEECH`
+ * flow (which delegates to whatever assistant handles the intent — typically the
+ * standalone Google app), this implementation talks directly to the SpeechRecognizer
+ * in-process, so the user does NOT need to install the Google app separately.
+ *
+ * Note: requires Google Play Services to be available on the device (already a
+ * hard dependency of the `gms` flavor for Cast support).
+ */
+class DefaultVoiceSearchController : VoiceSearchController {
+    private val _state = MutableStateFlow<VoiceSearchState>(VoiceSearchState.Idle)
+    override val state: StateFlow<VoiceSearchState> = _state.asStateFlow()
+
+    private var recognizer: SpeechRecognizer? = null
+
+    override fun startListening(context: Context) {
+        if (!hasMicPermission(context)) {
+            _state.value =
+                VoiceSearchState.Error("Microphone permission denied")
+            return
+        }
+        if (!SpeechRecognizer.isRecognitionAvailable(context)) {
+            _state.value =
+                VoiceSearchState.Error("Speech recognition is not available on this device")
+            return
+        }
+
+        // Tear down any prior recognizer before starting a new session.
+        recognizer?.destroy()
+        recognizer = SpeechRecognizer.createSpeechRecognizer(context)
+
+        val intent =
+            android.content.Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                putExtra(
+                    RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                    RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+                )
+                putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+                // Prefer the device's current locale.
+                val locale = java.util.Locale.getDefault()
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE, locale.toLanguageTag())
+                // Prefer on-device recognition when available (Android 12+ ships an
+                // on-device recognizer that does NOT require the Google app).
+                putExtra(RecognizerIntent.EXTRA_PREFER_OFFLINE, false)
+            }
+
+        recognizer?.setRecognitionListener(
+            object : RecognitionListener {
+                override fun onReadyForSpeech(params: Bundle?) {
+                    _state.value = VoiceSearchState.Listening
+                }
+
+                override fun onBeginningOfSpeech() {}
+
+                override fun onRmsChanged(rmsdB: Float) {}
+
+                override fun onBufferReceived(buffer: ByteArray?) {}
+
+                override fun onEndOfSpeech() {}
+
+                override fun onError(error: Int) {
+                    _state.value =
+                        VoiceSearchState.Error(
+                            speechErrorMessage(error),
+                        )
+                    recognizer?.destroy()
+                    recognizer = null
+                }
+
+                override fun onResults(results: Bundle?) {
+                    val matches =
+                        results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+                    val text = matches?.firstOrNull()?.takeIf { it.isNotBlank() }
+                    _state.value =
+                        if (text != null) {
+                            VoiceSearchState.Result(text)
+                        } else {
+                            VoiceSearchState.Error("No speech recognized")
+                        }
+                    recognizer?.destroy()
+                    recognizer = null
+                }
+
+                override fun onPartialResults(partialResults: Bundle?) {
+                    // Partial results are intentionally not surfaced as state —
+                    // we only commit a final result to avoid spamming the UI.
+                }
+
+                override fun onEvent(eventType: Int, params: Bundle?) {}
+            },
+        )
+
+        recognizer?.startListening(intent)
+    }
+
+    override fun cancel() {
+        recognizer?.cancel()
+        recognizer?.destroy()
+        recognizer = null
+        _state.value = VoiceSearchState.Idle
+    }
+
+    private fun hasMicPermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private fun speechErrorMessage(error: Int): String =
+        when (error) {
+            SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Network timeout"
+            SpeechRecognizer.ERROR_NETWORK -> "Network error"
+            SpeechRecognizer.ERROR_AUDIO -> "Audio recording error"
+            SpeechRecognizer.ERROR_SERVER -> "Server error"
+            SpeechRecognizer.ERROR_CLIENT -> "Client error"
+            SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "No speech detected"
+            SpeechRecognizer.ERROR_NO_MATCH -> "No speech matched"
+            SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Recognizer busy"
+            SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Insufficient permissions"
+            else -> "Speech recognition failed"
+        }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -20,6 +20,7 @@ import coil3.SingletonImageLoader
 import coil3.disk.DiskCache
 import coil3.disk.directory
 import coil3.memory.MemoryCache
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
 import coil3.request.allowHardware
 import coil3.request.crossfade
@@ -66,13 +67,16 @@ import moe.rukamori.archivetune.utils.get
 import moe.rukamori.archivetune.utils.potoken.BotGuardTokenGenerator
 import moe.rukamori.archivetune.utils.reportException
 import moe.rukamori.archivetune.utils.toPlaybackAuthState
+import okhttp3.ConnectionPool
 import okhttp3.Dns
+import okhttp3.OkHttpClient
 import timber.log.Timber
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.net.Proxy
 import java.util.*
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.system.exitProcess
@@ -445,10 +449,45 @@ class App :
             applicationScope.launch(Dispatchers.IO) { trimImageDiskCache(diskCache) }
         }
 
+        // Tuned OkHttp client dedicated to image fetching. Defaults in Coil 3
+        // / OkHttp use a small connection pool (5 idle, 5 min keepalive) and
+        // 10s connect/read/write timeouts — fine for a single image, but the
+        // home feed fires 20+ thumbnail requests in parallel on cold start,
+        // which exhausts the pool and serialises behind connect timeouts.
+        //
+        // This config:
+        //  * Raises the pool to 20 idle / 5 min keepalive so all parallel
+        //    thumbnail fetches reuse kept-alive sockets (no extra TLS
+        //    handshakes after the first hit to lh3.googleusercontent.com /
+        //    i.ytimg.com / mosaic.scdn.co).
+        //  * Drops connect timeout to 6s (don't hang the UI for 10s on a
+        //    dead CDN edge — let the next retry bucket kick in fast).
+        //  * Keeps read/write at 10s (large high-res thumbnails can still
+        //    take a moment on slow networks; we don't want to abort them).
+        //  * Enables retryOnConnectionFailure + followRedirects so CDN
+        //    302s (e.g. googleusercontent -> ggpht) resolve transparently.
+        //
+        // Combined with explicit `.size()` on every AsyncImage call (so
+        // Coil requests the smallest bucket the server offers instead of
+        // pulling maxresdefault for a 56dp tile), this makes thumbnails
+        // load near-instantly after the first cache miss.
+        val imageHttpClient =
+            OkHttpClient
+                .Builder()
+                .connectionPool(ConnectionPool(20, 5, TimeUnit.MINUTES))
+                .connectTimeout(6, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(10, TimeUnit.SECONDS)
+                .retryOnConnectionFailure(true)
+                .followRedirects(true)
+                .followSslRedirects(true)
+                .build()
+
         return ImageLoader
             .Builder(this)
             .components {
                 add(moe.rukamori.archivetune.telegram.TelegramThumbnailFetcher.Factory())
+                add(OkHttpNetworkFetcherFactory(imageHttpClient))
             }
             .crossfade(!lowRam)
             .allowHardware(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -319,6 +319,7 @@ import moe.rukamori.archivetune.ui.menu.YouTubeSongMenu
 import moe.rukamori.archivetune.ui.player.BottomSheetPlayer
 import moe.rukamori.archivetune.ui.player.ProvideVideoFullscreenState
 import moe.rukamori.archivetune.ui.screens.LOGIN_URL_ARGUMENT
+import moe.rukamori.archivetune.ui.screens.LoginScreen
 import moe.rukamori.archivetune.ui.screens.Screens
 import moe.rukamori.archivetune.ui.screens.buildLoginRoute
 import moe.rukamori.archivetune.ui.screens.navigationBuilder
@@ -1024,8 +1025,10 @@ class MainActivity : ComponentActivity() {
                 fontPreference = fontPreference,
                 customFontUri = customFontUri,
             ) {
+                val navController = rememberNavController()
                 val onboardingViewModel: OnboardingViewModel = hiltViewModel()
                 val onboardingState by onboardingViewModel.screenState.collectAsStateWithLifecycle()
+                var showOnboardingLogin by rememberSaveable { mutableStateOf(false) }
                 val shouldShowOnboarding =
                     when (val state = onboardingState) {
                         OnboardingScreenState.Loading -> true
@@ -1035,7 +1038,25 @@ class MainActivity : ComponentActivity() {
                     }
 
                 if (shouldShowOnboarding) {
-                    OnboardingRoute(viewModel = onboardingViewModel)
+                    if (showOnboardingLogin) {
+                        CompositionLocalProvider(
+                            LocalPlayerAwareWindowInsets provides WindowInsets.systemBars,
+                        ) {
+                            LoginScreen(
+                                navController = navController,
+                                onLoginComplete = {
+                                    onboardingViewModel.onLoginCompleted()
+                                    showOnboardingLogin = false
+                                },
+                                onNavigateBack = { showOnboardingLogin = false },
+                            )
+                        }
+                    } else {
+                        OnboardingRoute(
+                            viewModel = onboardingViewModel,
+                            onLoginRequested = { showOnboardingLogin = true },
+                        )
+                    }
                     return@ArchiveTuneTheme
                 }
 
@@ -1094,7 +1115,6 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
-                    val navController = rememberNavController()
                     DisposableEffect(navController) {
                         this@MainActivity.navController = navController
                         onDispose {}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -19,7 +19,6 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.speech.RecognizerIntent
 import android.content.pm.PackageManager
-import android.Manifest
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -31,6 +31,7 @@ import android.util.Rational
 import android.view.View
 import android.view.WindowManager
 import android.webkit.MimeTypeMap
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2877,7 +2877,7 @@ class MainActivity : ComponentActivity() {
                             }
                         }
 
-                        BackHandler(enabled = playerBottomSheetState.isExpanded) {
+                        BackHandler(enabled = playerBottomSheetState.isExpanded && !isPlayerLyricsFullScreen) {
                             playerBottomSheetState.collapseSoft()
                         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -19,6 +19,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.speech.RecognizerIntent
 import android.content.pm.PackageManager
+import android.Manifest
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
@@ -348,6 +349,8 @@ import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.utils.reportException
 import moe.rukamori.archivetune.utils.setAppLocale
+import moe.rukamori.archivetune.voicesearch.VoiceSearchControllerLocator
+import moe.rukamori.archivetune.voicesearch.VoiceSearchState
 import moe.rukamori.archivetune.viewmodels.BackupCategory
 import moe.rukamori.archivetune.viewmodels.BackupRestoreViewModel
 import moe.rukamori.archivetune.viewmodels.HomeViewModel
@@ -2431,6 +2434,27 @@ class MainActivity : ComponentActivity() {
                                         enter = fadeIn(animationSpec = tween(durationMillis = if (disableAnimations) 0 else 300)),
                                         exit = fadeOut(animationSpec = tween(durationMillis = if (disableAnimations) 0 else 200)),
                                     ) {
+                                        // ── In-app voice search side effect ──
+                                        // When the GMS/Foss VoiceSearchController emits a Result, fill
+                                        // the search box and submit the query. On Error, show a toast.
+                                        val voiceSearchController = remember {
+                                            VoiceSearchControllerLocator.get(this@MainActivity)
+                                        }
+                                        val voiceSearchState by voiceSearchController.state.collectAsStateWithLifecycle()
+                                        LaunchedEffect(voiceSearchState) {
+                                            when (val s = voiceSearchState) {
+                                                is VoiceSearchState.Result -> {
+                                                    onQueryChange(TextFieldValue(s.text))
+                                                    onSearch(s.text)
+                                                    voiceSearchController.cancel() // reset to Idle
+                                                }
+                                                is VoiceSearchState.Error -> {
+                                                    Toast.makeText(this@MainActivity, s.message, Toast.LENGTH_SHORT).show()
+                                                    voiceSearchController.cancel()
+                                                }
+                                                else -> Unit
+                                            }
+                                        }
                                         TopSearch(
                                             query = query,
                                             onQueryChange = onQueryChange,
@@ -2499,6 +2523,18 @@ class MainActivity : ComponentActivity() {
                                             },
                                             trailingIcon = {
                                                 Row {
+                                                    // In-app voice search mic button. Uses Google Play
+                                                    // Services speech (gms flavor) so the user does NOT
+                                                    // need to install the standalone Google app.
+                                                    // `voiceSearchController` and `voiceSearchState` come
+                                                    // from the outer scope (declared just above TopSearch).
+                                                    val micPermissionLauncher = rememberLauncherForActivityResult(
+                                                        ActivityResultContracts.RequestPermission(),
+                                                    ) { granted ->
+                                                        if (granted) {
+                                                            voiceSearchController.startListening(this@MainActivity)
+                                                        }
+                                                    }
                                                     if (active) {
                                                         IconButton(onClick = launchVoiceSearch) {
                                                             Icon(
@@ -2549,6 +2585,32 @@ class MainActivity : ComponentActivity() {
                                                         OnlineSearchSortMenu(
                                                             selectedSort = onlineSearchSort,
                                                             onSortSelected = { onlineSearchSort = it },
+                                                        )
+                                                    }
+
+                                                    // Mic button is always visible (collapsed and active search bar)
+                                                    // so users can voice-search regardless of search state.
+                                                    IconButton(
+                                                        onClick = {
+                                                            if (ContextCompat.checkSelfPermission(
+                                                                    this@MainActivity,
+                                                                    Manifest.permission.RECORD_AUDIO,
+                                                                ) == PackageManager.PERMISSION_GRANTED
+                                                            ) {
+                                                                voiceSearchController.startListening(this@MainActivity)
+                                                            } else {
+                                                                micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                                            }
+                                                        },
+                                                    ) {
+                                                        Icon(
+                                                            painter = painterResource(R.drawable.mic),
+                                                            contentDescription = stringResource(R.string.voice_search),
+                                                            tint = if (voiceSearchState is VoiceSearchState.Listening) {
+                                                                MaterialTheme.colorScheme.primary
+                                                            } else {
+                                                                LocalContentColor.current
+                                                            },
                                                         )
                                                     }
                                                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
@@ -232,11 +232,10 @@ object AiTextService {
                 )
             }
 
-            // DeepL / OpenRouter / Mistral are translation-only providers (not generic chat
-            // completion). AiTextService is used for AI Mix / Wrapped / chat-style prompts, so
-            // these providers throw — translation calls go through LyricsTranslationHelper instead.
+            // DeepL / Mistral are translation-only providers (not generic chat completion).
+            // AiTextService is used for AI Mix / Wrapped / chat-style prompts, so these
+            // providers throw — translation calls go through LyricsTranslationHelper instead.
             AiProvider.DEEPL,
-            AiProvider.OPENROUTER,
             AiProvider.MISTRAL,
             -> {
                 throw AiServiceException("${config.provider.name} is a translation-only provider; use LyricsTranslationHelper for translation calls")
@@ -254,8 +253,8 @@ object AiTextService {
             AiProvider.CHATGPT -> fetchOpenAiModels(OpenAiModelsEndpoint, config.apiKey)
             AiProvider.OPENROUTER -> fetchOpenAiModels(OpenRouterModelsEndpoint, config.apiKey)
             AiProvider.GEMINI -> fetchGeminiModels(config.apiKey)
-            // DeepL / OpenRouter / Mistral have no models-list endpoint exposed in this service.
-            AiProvider.DEEPL, AiProvider.OPENROUTER, AiProvider.MISTRAL, AiProvider.CUSTOM, AiProvider.NONE -> emptyList()
+            // DeepL / Mistral have no models-list endpoint exposed in this service.
+            AiProvider.DEEPL, AiProvider.MISTRAL, AiProvider.CUSTOM, AiProvider.NONE -> emptyList()
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
@@ -34,6 +34,8 @@ object AiTextService {
     private const val TAG = "AiTextService"
     private const val OpenAiEndpoint = "https://api.openai.com/v1/chat/completions"
     private const val OpenAiModelsEndpoint = "https://api.openai.com/v1/models"
+    private const val OpenRouterEndpoint = "https://openrouter.ai/api/v1/chat/completions"
+    private const val OpenRouterModelsEndpoint = "https://openrouter.ai/api/v1/models"
     private const val GeminiBaseEndpoint = "https://generativelanguage.googleapis.com/v1beta"
 
     /**
@@ -194,6 +196,18 @@ object AiTextService {
                 )
             }
 
+            AiProvider.OPENROUTER -> {
+                completeOpenAiCompatible(
+                    endpoint = OpenRouterEndpoint,
+                    apiKey = config.apiKey,
+                    model = model,
+                    systemPrompt = systemPrompt,
+                    userPrompt = userPrompt,
+                    temperature = temperature,
+                    maxTokens = maxTokens,
+                )
+            }
+
             AiProvider.CUSTOM -> {
                 completeOpenAiCompatible(
                     endpoint = config.customEndpoint,
@@ -237,7 +251,8 @@ object AiTextService {
     suspend fun fetchModels(config: AiServiceConfig): List<AiModelOption> {
         if (!config.canCallApi) throw AiServiceException("AI provider is not configured")
         return when (config.provider) {
-            AiProvider.CHATGPT -> fetchOpenAiModels(config.apiKey)
+            AiProvider.CHATGPT -> fetchOpenAiModels(OpenAiModelsEndpoint, config.apiKey)
+            AiProvider.OPENROUTER -> fetchOpenAiModels(OpenRouterModelsEndpoint, config.apiKey)
             AiProvider.GEMINI -> fetchGeminiModels(config.apiKey)
             // DeepL / OpenRouter / Mistral have no models-list endpoint exposed in this service.
             AiProvider.DEEPL, AiProvider.OPENROUTER, AiProvider.MISTRAL, AiProvider.CUSTOM, AiProvider.NONE -> emptyList()
@@ -334,15 +349,18 @@ object AiTextService {
             AiProvider.CHATGPT -> "gpt-4o"
             AiProvider.GEMINI -> "gemini-3.5-flash"
             AiProvider.MISTRAL -> "mistral-small-latest"
-            AiProvider.OPENROUTER -> "openai/gpt-4o-mini"
+            AiProvider.OPENROUTER -> "~openai/gpt-latest"
             AiProvider.CUSTOM -> throw AiServiceException("No AI model configured")
             // DeepL doesn't use a model picker (the API key determines the tier).
             AiProvider.DEEPL, AiProvider.NONE -> throw AiServiceException("AI provider is disabled")
         }
 
-    private suspend fun fetchOpenAiModels(apiKey: String): List<AiModelOption> {
+    private suspend fun fetchOpenAiModels(
+        endpoint: String,
+        apiKey: String,
+    ): List<AiModelOption> {
         val response =
-            client.get(OpenAiModelsEndpoint) {
+            client.get(endpoint) {
                 header("Authorization", "Bearer ${apiKey.trim()}")
             }
         val raw = response.bodyAsText()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -347,7 +347,6 @@ enum class AiProvider {
     OPENROUTER,
     CUSTOM,
     DEEPL,
-    OPENROUTER,
     MISTRAL,
     NONE,
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -426,6 +426,23 @@ val PlaylistTagsFilterKey = stringPreferencesKey("playlistTagsFilter")
 val ShowHomeCategoryChipsKey = booleanPreferencesKey("showHomeCategoryChips")
 val ShowTagsInLibraryKey = booleanPreferencesKey("showTagsInLibrary")
 
+/**
+ * When `true`, the Home feed collapses to a focused subset:
+ *   - Jump-back-in hero (always rendered, regardless of this toggle)
+ *   - Recently Played
+ *   - Keep Listening
+ *   - Live Performances (the "Live performance"-titled remote shelf)
+ *
+ * All other home sections (category chips, remote/local quick picks,
+ * speed dial, account playlists, forgotten favorites, similar
+ * recommendations, and the rest of the remote homePage sections such
+ * as "Fresh finds" / "Old favourites") are hidden.
+ *
+ * Default is `false` so a fresh install shows the full home feed
+ * (matches upstream rukamori/ArchiveTune).
+ */
+val MinimalHomeModeKey = booleanPreferencesKey("minimalHomeMode")
+
 val EqualizerEnabledKey = booleanPreferencesKey("equalizerEnabled")
 val EqualizerControlModeKey = stringPreferencesKey("equalizerControlMode")
 val EqualizerBandLevelsMbKey = stringPreferencesKey("equalizerBandLevelsMb")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -344,6 +344,7 @@ val HideTop50CardKey = booleanPreferencesKey("hide_top50_card")
 enum class AiProvider {
     CHATGPT,
     GEMINI,
+    OPENROUTER,
     CUSTOM,
     DEEPL,
     OPENROUTER,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/DatabaseDao.kt
@@ -1733,7 +1733,7 @@ interface DatabaseDao {
     ) {
         update(
             song.song.copy(
-                title = mediaMetadata.title,
+                title = if (song.song.titleOverride) song.song.title else mediaMetadata.title,
                 duration = mediaMetadata.duration,
                 thumbnailUrl = mediaMetadata.thumbnailUrl,
                 albumId = mediaMetadata.album?.id,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/SongEntity.kt
@@ -31,6 +31,8 @@ import java.time.LocalDateTime
 data class SongEntity(
     @PrimaryKey val id: String,
     val title: String,
+    @ColumnInfo(defaultValue = "0")
+    val titleOverride: Boolean = false,
     val duration: Int = -1, // in seconds
     val thumbnailUrl: String? = null,
     val albumId: String? = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/home/HomeModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/home/HomeModels.kt
@@ -57,6 +57,12 @@ data class HomeUiState(
     val quickPicksDisplayMode: QuickPicksDisplayMode,
     val showCategoryChips: Boolean,
     val showTonalBackdrop: Boolean,
+    /**
+     * When `true`, the Home feed collapses to a focused subset
+     * (hero + Recently Played + Keep Listening + Live Performances).
+     * The hero section is always rendered regardless of this flag.
+     */
+    val minimalHomeMode: Boolean = false,
     val isRefreshing: Boolean,
     val isLoadingMore: Boolean,
 )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/home/HomeRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/home/HomeRepository.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import moe.rukamori.archivetune.constants.DisableBlurKey
+import moe.rukamori.archivetune.constants.MinimalHomeModeKey
 import moe.rukamori.archivetune.constants.QuickPicks
 import moe.rukamori.archivetune.constants.QuickPicksKey
 import moe.rukamori.archivetune.constants.QuickPicksDisplayMode
@@ -46,5 +47,15 @@ class HomeRepository
         val showTonalBackdrop: Flow<Boolean> =
             context.dataStore.data
                 .map { preferences -> preferences[DisableBlurKey] != true }
+                .distinctUntilChanged()
+
+        /**
+         * When `true`, the Home feed collapses to a focused subset
+         * (hero + Recently Played + Keep Listening + Live Performances).
+         * See [MinimalHomeModeKey] for the full description.
+         */
+        val minimalHomeMode: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences -> preferences[MinimalHomeModeKey] ?: false }
                 .distinctUntilChanged()
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/home/HomeUseCases.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/home/HomeUseCases.kt
@@ -25,12 +25,14 @@ class ObserveHomePresentationPreferencesUseCase
                 repository.quickPicksDisplayMode,
                 repository.quickPicksMode,
                 repository.showTonalBackdrop,
-            ) { showCategoryChips, quickPicksDisplayMode, quickPicksMode, showTonalBackdrop ->
+                repository.minimalHomeMode,
+            ) { showCategoryChips, quickPicksDisplayMode, quickPicksMode, showTonalBackdrop, minimalHomeMode ->
                 HomePresentationPreferences(
                     showCategoryChips = showCategoryChips,
                     quickPicksDisplayMode = quickPicksDisplayMode,
                     quickPicksMode = quickPicksMode,
                     showTonalBackdrop = showTonalBackdrop,
+                    minimalHomeMode = minimalHomeMode,
                 )
             }
     }
@@ -41,4 +43,5 @@ data class HomePresentationPreferences(
     val quickPicksDisplayMode: QuickPicksDisplayMode,
     val quickPicksMode: QuickPicks,
     val showTonalBackdrop: Boolean,
+    val minimalHomeMode: Boolean = false,
 )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/localmedia/LocalSongScanner.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/localmedia/LocalSongScanner.kt
@@ -175,7 +175,8 @@ class LocalSongScanner
                         upsert(
                             SongEntity(
                                 id = track.id,
-                                title = track.title,
+                                title = if (existingSong?.titleOverride == true) existingSong.title else track.title,
+                                titleOverride = existingSong?.titleOverride ?: false,
                                 duration = track.durationSeconds,
                                 thumbnailUrl = track.thumbnailUrl,
                                 albumId = track.albumId,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/network/ObserveNetworkBannerStateUseCase.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/network/ObserveNetworkBannerStateUseCase.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.flow.transformLatest
 import javax.inject.Inject
 
 private const val OfflineBannerDebounceMillis = 750L
-private const val OfflineBannerDurationMillis = 3000L
-private const val BackOnlineBannerDurationMillis = 2500L
+private const val OfflineBannerDurationMillis = 3500L
+private const val BackOnlineBannerDurationMillis = 3000L
 
 internal fun Flow<Boolean>.asNetworkBannerUiState(
     offlineDebounceMillis: Long = OfflineBannerDebounceMillis,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingModels.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingModels.kt
@@ -34,6 +34,7 @@ data class OnboardingUiState(
     val versionName: String,
     val pages: ImmutableList<OnboardingPageUiModel>,
     val permissions: ImmutableList<OnboardingPermissionUiModel>,
+    val loginBenefits: ImmutableList<OnboardingLoginBenefitUiModel>,
     val communityActions: ImmutableList<OnboardingCommunityActionUiModel>,
 )
 
@@ -48,8 +49,17 @@ data class OnboardingPageUiModel(
 enum class OnboardingPageId {
     WELCOME,
     PERMISSIONS,
+    LOGIN,
     COMMUNITY,
 }
+
+@Immutable
+data class OnboardingLoginBenefitUiModel(
+    val id: String,
+    @StringRes val titleResId: Int,
+    @StringRes val descriptionResId: Int,
+    @DrawableRes val iconResId: Int,
+)
 
 @Immutable
 data class OnboardingPermissionUiModel(
@@ -115,6 +125,8 @@ sealed interface OnboardingEvent {
     ) : OnboardingEvent
 
     data object OpenInstallPackagesSettings : OnboardingEvent
+
+    data object OpenLogin : OnboardingEvent
 
     data class OpenUri(
         val url: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingUseCases.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingUseCases.kt
@@ -46,6 +46,7 @@ class BuildOnboardingUiStateUseCase
                 versionName = BuildConfig.VERSION_NAME,
                 pages = pages,
                 permissions = ImmutableList.copyOf(data.permissions.map { it.toUiModel() }),
+                loginBenefits = loginBenefits,
                 communityActions = communityActions,
             )
 
@@ -184,10 +185,38 @@ class BuildOnboardingUiStateUseCase
                         iconResId = R.drawable.security,
                     ),
                     OnboardingPageUiModel(
+                        id = OnboardingPageId.LOGIN,
+                        titleResId = R.string.onboarding_login_title,
+                        subtitleResId = R.string.onboarding_login_subtitle,
+                        iconResId = R.drawable.login,
+                    ),
+                    OnboardingPageUiModel(
                         id = OnboardingPageId.COMMUNITY,
                         titleResId = R.string.onboarding_community_title,
                         subtitleResId = R.string.onboarding_community_subtitle,
                         iconResId = R.drawable.star,
+                    ),
+                )
+
+            val loginBenefits =
+                ImmutableList.of(
+                    OnboardingLoginBenefitUiModel(
+                        id = "library",
+                        titleResId = R.string.onboarding_login_library_title,
+                        descriptionResId = R.string.onboarding_login_library_desc,
+                        iconResId = R.drawable.library_music,
+                    ),
+                    OnboardingLoginBenefitUiModel(
+                        id = "history",
+                        titleResId = R.string.onboarding_login_history_title,
+                        descriptionResId = R.string.onboarding_login_history_desc,
+                        iconResId = R.drawable.history,
+                    ),
+                    OnboardingLoginBenefitUiModel(
+                        id = "playback",
+                        titleResId = R.string.onboarding_login_playback_title,
+                        descriptionResId = R.string.onboarding_login_playback_desc,
+                        iconResId = R.drawable.bolt,
                     ),
                 )
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingViewModel.kt
@@ -90,6 +90,20 @@ class OnboardingViewModel
             }
         }
 
+        fun onLogin() {
+            viewModelScope.launch {
+                mutableEvents.emit(OnboardingEvent.OpenLogin)
+            }
+        }
+
+        fun onLoginCompleted() {
+            val success = screenState.value as? OnboardingScreenState.Success ?: return
+            val currentPageIndex = success.uiState.currentPage
+            if (success.uiState.pages.getOrNull(currentPageIndex)?.id == OnboardingPageId.LOGIN) {
+                currentPage.value = currentPageIndex + 1
+            }
+        }
+
         fun onPermissionResult() {
             refreshSignals.update { it + 1 }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -8334,27 +8334,33 @@ class MusicService :
     }
 
     private fun resolveMediaItemForCast(mediaItem: MediaItem): MediaItem {
-        val uri = mediaItem.localConfiguration?.uri ?: return mediaItem
+        val localConfiguration = mediaItem.localConfiguration ?: return mediaItem
+        val uri = localConfiguration.uri
         if (uri.shouldBypassYouTubeResolver()) return mediaItem
+        val mediaId = localConfiguration.customCacheKey ?: mediaItem.mediaId
         val dataSpec =
             DataSpec
                 .Builder()
                 .setUri(uri)
-                .setKey(mediaItem.localConfiguration?.customCacheKey ?: mediaItem.mediaId)
+                .setKey(mediaId)
                 .build()
         val resolvedDataSpec =
             resolvePlaybackDataSpec(
                 dataSpec = dataSpec,
                 allowCacheShortCircuit = false,
             )
-        return if (resolvedDataSpec.uri == uri) {
-            mediaItem
-        } else {
-            mediaItem
-                .buildUpon()
-                .setUri(resolvedDataSpec.uri)
-                .build()
-        }
+        val resolvedMimeType =
+            localConfiguration.mimeType
+                ?.substringBefore(";")
+                ?.takeIf { it.isNotBlank() && !it.endsWith("/*") }
+                ?: runBlocking(Dispatchers.IO) {
+                    database.format(mediaId).first()?.mimeType?.substringBefore(";")
+                }
+        return mediaItem
+            .buildUpon()
+            .setUri(resolvedDataSpec.uri)
+            .apply { resolvedMimeType?.let(::setMimeType) }
+            .build()
     }
 
     private fun parseTidalAudioQuality(): TidalAudioQuality {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -3679,7 +3679,10 @@ class MusicService :
 
         var throwable: Throwable? = error.cause
         while (throwable != null) {
-            if (throwable.message?.contains("Skipping atom with length", ignoreCase = true) == true) {
+            if (
+                throwable.message?.contains("Skipping atom with length", ignoreCase = true) == true ||
+                    throwable.isMedia3ExtractorBoundsFailure()
+            ) {
                 return true
             }
             throwable = throwable.cause
@@ -3719,6 +3722,10 @@ class MusicService :
                     }
                 }
 
+                isContentCached && throwable.isMedia3ExtractorBoundsFailure() -> {
+                    return true
+                }
+
                 isContainerParseError && isContentCached && throwable is ParserException -> {
                     return true
                 }
@@ -3736,6 +3743,10 @@ class MusicService :
         }
         return false
     }
+
+    private fun Throwable.isMedia3ExtractorBoundsFailure(): Boolean =
+        this is ArrayIndexOutOfBoundsException &&
+            stackTrace.any { it.className.startsWith("androidx.media3.extractor") }
 
     private fun retryPlaybackAfterStreamFailure(
         mediaId: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -7973,8 +7973,25 @@ class MusicService :
                 contentLength > 0L && downloadCache.isCached(currentMediaId, 0L, contentLength)
             }.getOrDefault(false)
 
+        // Fallback: even if the cache metadata is missing the content length
+        // (which would make `isFullyDownloadedMedia` false), the Media3
+        // DownloadManager may still have the download marked as COMPLETED.
+        // Trust the download state in that case — this is the fix for the
+        // "downloaded songs don't play when offline" bug where the user has
+        // a complete download but the cache metadata was never persisted.
+        val isMarkedAsCompletedDownload =
+            if (isFullyDownloadedMedia) {
+                true
+            } else {
+                runCatching {
+                    androidx.media3.exoplayer.offline.Download.STATE_COMPLETED ==
+                        DownloadUtil.downloads.value[currentMediaId]?.state
+                }.getOrDefault(false)
+            }
+
         val hasAnyCachedData =
             isFullyDownloadedMedia ||
+                isMarkedAsCompletedDownload ||
                 runCatching {
                     downloadCache.getCachedSpans(currentMediaId).isNotEmpty() ||
                         playerCache.getCachedSpans(currentMediaId).isNotEmpty()
@@ -7984,9 +8001,41 @@ class MusicService :
             (error.cause?.cause is PlaybackException) &&
                 (error.cause?.cause as PlaybackException).errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
 
-        if (!isLocalMedia && !isFullyDownloadedMedia && (!isNetworkConnected.value || isConnectionError)) {
+        // Offline bypass: if we have ANY cached data for this mediaId (a
+        // complete download, a download marked COMPLETED by Media3, or even
+        // partial cached spans), do NOT call `waitOnNetworkError()` — the
+        // cache resolver in `resolveCachedDataSpec` will serve the cached
+        // bytes on the next prepare(). Calling `waitOnNetworkError()` here
+        // would freeze playback indefinitely even though the song is fully
+        // available locally.
+        if (!isLocalMedia && !isFullyDownloadedMedia && !isMarkedAsCompletedDownload && !hasAnyCachedData &&
+            (!isNetworkConnected.value || isConnectionError)
+        ) {
             waitOnNetworkError()
             return
+        }
+
+        // If we have cached data but the player still errored (typically
+        // because the resolver tried the network first and failed), force a
+        // re-prepare so the cache resolver gets a chance to serve the bytes.
+        // This handles the case where the initial resolvePlaybackDataSpec
+        // call fell through to the YouTube resolver before the cache was
+        // consulted, and the YouTube resolver failed because we're offline.
+        if (!isLocalMedia && hasAnyCachedData && (!isNetworkConnected.value || isConnectionError)) {
+            Timber.tag("MusicService").i(
+                "Offline playback recovery for %s (fullyCached=%b, markedCompleted=%b, hasSpans=%b); re-preparing to force cache read",
+                currentMediaId,
+                isFullyDownloadedMedia,
+                isMarkedAsCompletedDownload,
+                hasAnyCachedData,
+            )
+            // Invalidate any stale stream URL cache so the resolver is forced
+            // to consult the cache first on the next prepare.
+            playbackUrlCache.remove(currentMediaId)
+            if (playbackStreamRecoveryTracker.registerRetryAttempt(currentMediaId)) {
+                player.prepare()
+                return
+            }
         }
 
         if (error.errorCode == PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND) {
@@ -9922,7 +9971,45 @@ class MusicService :
                 }
 
                 else -> {
-                    return null
+                    // No known content length and no explicit request length.
+                    // For offline playback of fully-downloaded songs whose
+                    // cache metadata never had the content length persisted,
+                    // compute the total cached byte range across all candidate
+                    // keys and use that as the requested length. This is the
+                    // key fix for "downloaded songs don't play when offline" —
+                    // without it, the resolver returns null here, falls
+                    // through to the YouTube resolver, and fails offline.
+                    val candidateKeys = listOf(mediaId, "qobuz:$mediaId", "tidal:$mediaId", "deezer:$mediaId")
+                    val maxCachedLength =
+                        candidateKeys.maxOfOrNull { key ->
+                            runCatching {
+                                val spans = downloadCache.getCachedSpans(key).toList() +
+                                    (if (includePlayerCache) playerCache.getCachedSpans(key).toList() else emptyList())
+                                if (spans.isEmpty()) {
+                                    0L
+                                } else {
+                                    // Sum up the total cached bytes starting from
+                                    // dataSpec.position. For a fully-downloaded
+                                    // song, this equals the content length.
+                                    val sortedSpans = spans.sortedBy { it.position }
+                                    var total = 0L
+                                    var cursor = dataSpec.position
+                                    for (span in sortedSpans) {
+                                        if (span.position > cursor) break
+                                        val spanEnd = span.position + span.length
+                                        if (spanEnd > cursor) {
+                                            total += (spanEnd - cursor)
+                                            cursor = spanEnd
+                                        }
+                                    }
+                                    total
+                                }
+                            }.getOrDefault(0L)
+                        }
+                    if (maxCachedLength == null || maxCachedLength <= 0L) {
+                        return null
+                    }
+                    maxCachedLength
                 }
             }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -8501,12 +8501,16 @@ class MusicService :
     /**
      * Sources the player's "Play from" chooser should offer for [mediaId], based on the last
      * resolution result: any lossless source that matched the track, plus YouTube (always available
-     * as the fallback). Returned in the canonical Tidal, Qobuz, YouTube order.
+     * as the fallback), plus the user's per-song override source (so the user can always see, change
+     * or clear their pinned choice even if the last resolution attempt failed transiently — e.g.
+     * "Qobuz token returned preview-only; skipping"). Returned in the canonical Tidal, Qobuz, YouTube
+     * order.
      */
     fun availableSourcesForSong(mediaId: String): List<AudioSourceType> {
         val resolved = resolvedSourcesByMediaId[mediaId].orEmpty()
+        val override = SongSourceOverride.get(dataStore.get(SongSourceOverrideKey, ""), mediaId)
         return AudioSourceConfig.DEFAULT_ORDER.filter {
-            it == AudioSourceType.YOUTUBE || it in resolved
+            it == AudioSourceType.YOUTUBE || it in resolved || it == override
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -7973,28 +7973,28 @@ class MusicService :
                 contentLength > 0L && downloadCache.isCached(currentMediaId, 0L, contentLength)
             }.getOrDefault(false)
 
-        // Fallback: even if the cache metadata is missing the content length
-        // (which would make `isFullyDownloadedMedia` false), the Media3
-        // DownloadManager may still have the download marked as COMPLETED.
-        // Trust the download state in that case — this is the fix for the
-        // "downloaded songs don't play when offline" bug where the user has
-        // a complete download but the cache metadata was never persisted.
-        val isMarkedAsCompletedDownload =
-            if (isFullyDownloadedMedia) {
-                true
-            } else {
-                runCatching {
-                    androidx.media3.exoplayer.offline.Download.STATE_COMPLETED ==
-                        DownloadUtil.downloads.value[currentMediaId]?.state
-                }.getOrDefault(false)
-            }
-
+        // Check for cached spans across all source-prefixed keys. Even if the
+        // cache metadata is missing the content length (which would make
+        // `isFullyDownloadedMedia` false), having cached spans means the song
+        // was at least partially downloaded and we should try to play it from
+        // cache instead of waiting for network. This is the key fix for the
+        // "downloaded songs don't play when offline" bug — the cache metadata
+        // sometimes doesn't have the content length persisted, but the bytes
+        // are still there.
         val hasAnyCachedData =
             isFullyDownloadedMedia ||
-                isMarkedAsCompletedDownload ||
                 runCatching {
                     downloadCache.getCachedSpans(currentMediaId).isNotEmpty() ||
-                        playerCache.getCachedSpans(currentMediaId).isNotEmpty()
+                        playerCache.getCachedSpans(currentMediaId).isNotEmpty() ||
+                        // Also check source-prefixed keys (qobuz:, tidal:, deezer:) —
+                        // downloads from external lossless sources are cached under
+                        // these keys, not the bare mediaId.
+                        downloadCache.getCachedSpans("qobuz:$currentMediaId").isNotEmpty() ||
+                        downloadCache.getCachedSpans("tidal:$currentMediaId").isNotEmpty() ||
+                        downloadCache.getCachedSpans("deezer:$currentMediaId").isNotEmpty() ||
+                        playerCache.getCachedSpans("qobuz:$currentMediaId").isNotEmpty() ||
+                        playerCache.getCachedSpans("tidal:$currentMediaId").isNotEmpty() ||
+                        playerCache.getCachedSpans("deezer:$currentMediaId").isNotEmpty()
                 }.getOrDefault(false)
 
         val isConnectionError =
@@ -8002,13 +8002,13 @@ class MusicService :
                 (error.cause?.cause as PlaybackException).errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
 
         // Offline bypass: if we have ANY cached data for this mediaId (a
-        // complete download, a download marked COMPLETED by Media3, or even
-        // partial cached spans), do NOT call `waitOnNetworkError()` — the
+        // complete download, or even partial cached spans under the bare or
+        // source-prefixed keys), do NOT call `waitOnNetworkError()` — the
         // cache resolver in `resolveCachedDataSpec` will serve the cached
         // bytes on the next prepare(). Calling `waitOnNetworkError()` here
         // would freeze playback indefinitely even though the song is fully
         // available locally.
-        if (!isLocalMedia && !isFullyDownloadedMedia && !isMarkedAsCompletedDownload && !hasAnyCachedData &&
+        if (!isLocalMedia && !isFullyDownloadedMedia && !hasAnyCachedData &&
             (!isNetworkConnected.value || isConnectionError)
         ) {
             waitOnNetworkError()
@@ -8023,10 +8023,9 @@ class MusicService :
         // consulted, and the YouTube resolver failed because we're offline.
         if (!isLocalMedia && hasAnyCachedData && (!isNetworkConnected.value || isConnectionError)) {
             Timber.tag("MusicService").i(
-                "Offline playback recovery for %s (fullyCached=%b, markedCompleted=%b, hasSpans=%b); re-preparing to force cache read",
+                "Offline playback recovery for %s (fullyCached=%b, hasSpans=%b); re-preparing to force cache read",
                 currentMediaId,
                 isFullyDownloadedMedia,
-                isMarkedAsCompletedDownload,
                 hasAnyCachedData,
             )
             // Invalidate any stale stream URL cache so the resolver is forced

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -257,8 +257,10 @@ import moe.rukamori.archivetune.extensions.collectLatest
 import moe.rukamori.archivetune.extensions.currentMetadata
 import moe.rukamori.archivetune.extensions.directorySizeBytes
 import moe.rukamori.archivetune.extensions.findNextMediaItemById
+import moe.rukamori.archivetune.extensions.getQueueWindows
 import moe.rukamori.archivetune.extensions.mediaItems
 import moe.rukamori.archivetune.extensions.metadata
+import moe.rukamori.archivetune.extensions.move
 import moe.rukamori.archivetune.extensions.setOffloadEnabled
 import moe.rukamori.archivetune.extensions.toContinuationQueue
 import moe.rukamori.archivetune.extensions.toMediaItem
@@ -4381,6 +4383,42 @@ class MusicService :
         player.addMediaItems(insertionIndex, allowedItems)
         playNextShuffleOrder?.let(localPlayer::setShuffleOrder)
         player.prepare()
+    }
+
+    fun moveQueueItemToNext(mediaItemIndex: Int) {
+        val currentIndex = player.currentMediaItemIndex
+        if (
+            player.mediaItemCount < 2 ||
+            currentIndex == C.INDEX_UNSET ||
+            mediaItemIndex !in 0 until player.mediaItemCount ||
+            mediaItemIndex == currentIndex
+        ) {
+            return
+        }
+
+        if (player.shuffleModeEnabled) {
+            val shuffledIndices = player.getQueueWindows().map { it.firstPeriodIndex }.toMutableList()
+            val sourcePosition = shuffledIndices.indexOf(mediaItemIndex)
+            val currentPosition = shuffledIndices.indexOf(currentIndex)
+            if (sourcePosition == -1 || currentPosition == -1) return
+
+            val destinationPosition = (currentPosition + 1).coerceAtMost(shuffledIndices.lastIndex)
+            if (sourcePosition == destinationPosition) return
+
+            shuffledIndices.move(sourcePosition, destinationPosition)
+            localPlayer.setShuffleOrder(
+                DefaultShuffleOrder(
+                    shuffledIndices.toIntArray(),
+                    System.currentTimeMillis(),
+                ),
+            )
+            return
+        }
+
+        val destinationIndex = (currentIndex + 1).coerceAtMost(player.mediaItemCount - 1)
+        if (mediaItemIndex != destinationIndex) {
+            player.moveMediaItem(mediaItemIndex, destinationIndex)
+        }
     }
 
     fun addToQueue(items: List<MediaItem>) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -117,6 +117,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -7453,6 +7454,16 @@ class MusicService :
             enqueueCurrentHistorySessionForFinalization()
             if (!isCrossfading || playbackState == Player.STATE_IDLE) {
                 cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)
+            } else if (playbackState == Player.STATE_ENDED) {
+                // The crossfade was supposed to hand off to the next item before STATE_ENDED
+                // fired, but it didn't complete in time. A stale `isCrossfading = true` here
+                // means `pauseAtEndOfMediaItems` is still `true`, which prevents ExoPlayer's
+                // auto-advance — the player stops at the end of the current song and the user
+                // has to press Play to continue. Tear the crossfade down so the player can
+                // auto-advance normally. The crossfade's secondary player (if any) was either
+                // already promoting itself or never became ready — either way, releasing it
+                // here is safe and prevents a stuck `pauseAtEndOfMediaItems`.
+                cancelCrossfade(resetVolume = true, resetPauseAtEnd = true)
             }
             if (playbackState == Player.STATE_ENDED &&
                 !suppressAutoPlayback &&
@@ -8430,13 +8441,23 @@ class MusicService :
         } else {
             resolvedSourcesByMediaId.remove(mediaId)
         }
+        _resolvedSourcesRevision.value = _resolvedSourcesRevision.value + 1L
     }
+
+    /**
+     * Observable wrapper around [resolvedSourcesByMediaId] so the Source chooser UI can recompose
+     * when a refresh completes. Updated whenever [recordResolvedSource] adds a source.
+     */
+    private val _resolvedSourcesRevision = MutableStateFlow(0L)
 
     private fun recordResolvedSource(
         mediaId: String,
         source: AudioSourceType,
     ) {
-        resolvedSourcesByMediaId.getOrPut(mediaId) { java.util.concurrent.ConcurrentHashMap.newKeySet() }.add(source)
+        val set = resolvedSourcesByMediaId.getOrPut(mediaId) { java.util.concurrent.ConcurrentHashMap.newKeySet() }
+        if (set.add(source)) {
+            _resolvedSourcesRevision.value = _resolvedSourcesRevision.value + 1L
+        }
     }
 
     /**
@@ -8450,6 +8471,55 @@ class MusicService :
             it == AudioSourceType.YOUTUBE || it in resolved
         }
     }
+
+    /**
+     * Triggers a fresh resolution of every enabled non-YouTube source for [mediaId], bypassing
+     * the in-memory DirectStream cache.
+     *
+     * Why this exists: [resolveMultiSourceDataSpec] records each source that passes the metadata
+     * match gate into [resolvedSourcesByMediaId]. If a source failed transiently on the first
+     * resolution attempt (network blip, Qobuz/Tidal API timeout, pool-account rate-limit), it
+     * never gets recorded for the lifetime of the process — even though a retry would succeed.
+     * The user sees YouTube (and JioSaavn) as the only available sources until they force-stop
+     * and reopen the app, which clears the in-memory cache and triggers a fresh resolution.
+     *
+     * This function replicates the "force-stop and reopen" effect on demand: it evicts the cached
+     * DirectStream for [mediaId] and re-runs the lossless resolution chain in the background. The
+     * UI picks up the new sources via [_resolvedSourcesRevision] (a StateFlow the Source dialog
+     * collects to trigger recomposition).
+     *
+     * Safe to call repeatedly — concurrent invocations are coalesced by the [scope] coroutine
+     * and the cache eviction is idempotent.
+     */
+    fun refreshSourcesForSong(mediaId: String) {
+        if (mediaId.isLocalMediaId() || mediaId.isTelegramMediaId()) return
+        scope.launch(Dispatchers.IO) {
+            // Evict the in-memory cache so the slow path runs again. Without this, the fast
+            // path in resolveMultiSourceDataSpec would short-circuit to the previously cached
+            // (YouTube) stream and never re-try Qobuz/Tidal.
+            directStreamCache.remove(mediaId)
+            // Re-resolve by calling the same slow-path logic the player uses. We pass a dummy
+            // DataSpec because resolveMultiSourceDataSpec only uses it as a buildUpon base —
+            // the URI and key are overwritten inside. The returned DataSpec is discarded; we
+            // only care about the side effect of recording sources into resolvedSourcesByMediaId.
+            runCatching {
+                val dummySpec = DataSpec.Builder().setUri(mediaId.toUri()).build()
+                resolveMultiSourceDataSpec(dummySpec, mediaId, lowDataModeActive = false)
+            }.onFailure { error ->
+                Timber.tag("MusicService").w(error, "refreshSourcesForSong: resolution failed for %s", mediaId)
+            }
+            // Bump the revision even on failure so the UI can re-render with whatever sources
+            // were recorded (if any) and stop showing the loading state.
+            _resolvedSourcesRevision.value = _resolvedSourcesRevision.value + 1L
+        }
+    }
+
+    /**
+     * A monotonically increasing counter that bumps whenever [recordResolvedSource] or
+     * [refreshSourcesForSong] updates [resolvedSourcesByMediaId]. The Source dialog collects
+     * this flow to know when to re-query [availableSourcesForSong].
+     */
+    val resolvedSourcesRevision: StateFlow<Long> get() = _resolvedSourcesRevision
 
     /**
      * Applies a per-song "play from" override and, if [mediaId] is the current item, re-resolves it
@@ -8547,13 +8617,23 @@ class MusicService :
             // reflects the restored 1.0 factor.
             ensureAudioFocusForActivePlayback()
 
-            // Deterministic re-create: tear the playlist down entirely and re-add the item from
-            // scratch. This makes the in-place source switch take the exact same path as
-            // "skip to previous song and back" — a fresh MediaSource, fresh re-preparation and
-            // a fresh resolver run — instead of relying on prepare()/seekTo() re-opening the
-            // existing (and possibly stale) data source.
-            player.clearMediaItems()
-            player.setMediaItem(item, 0)
+            // Deterministic re-create: replace ONLY the current media item with a fresh one
+            // (so the new source's MediaSource is built from scratch) while preserving the
+            // rest of the queue. The previous implementation called clearMediaItems() +
+            // setMediaItem(item, 0), which discarded the entire queue — when the current
+            // song ended the player had no next item to auto-advance to, so playback stopped
+            // until the user manually pressed Play. We now capture the full media-items list
+            // and current index BEFORE the teardown, swap the current item for the freshly
+            // resolved one, and call setMediaItems(items, currentIndex, 0L) so the queue is
+            // intact and ExoPlayer's auto-advance works as expected.
+            val currentIndex = player.currentMediaItemIndex
+            val allItems = ArrayList(player.mediaItems)
+            if (currentIndex in allItems.indices) {
+                allItems[currentIndex] = item
+            } else {
+                allItems.add(item)
+            }
+            player.setMediaItems(allItems, currentIndex.coerceIn(0, allItems.lastIndex), 0L)
             player.prepare()
             player.playWhenReady = wasPlaying
             // Restore the effective volume immediately (bypass the smooth ramp) so the new source

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/PlayerConnection.kt
@@ -357,6 +357,10 @@ class PlayerConnection(
         service.playNext(items)
     }
 
+    fun moveQueueItemToNext(mediaItemIndex: Int) {
+        service.moveQueueItemToNext(mediaItemIndex)
+    }
+
     fun addToQueue(item: MediaItem) = addToQueue(listOf(item))
 
     fun addToQueue(items: List<MediaItem>) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -98,6 +98,7 @@ fun BottomSheet(
     morphMode: Boolean = false,
     backHandlerEnabled: Boolean = true,
     opaqueBackground: Boolean = false,
+    onCollapsedContentClick: (() -> Unit)? = null,
     collapsedContent: @Composable BoxScope.() -> Unit,
     content: @Composable BoxScope.() -> Unit,
 ) {
@@ -214,7 +215,7 @@ fun BottomSheet(
                         }.clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null,
-                            onClick = state::expandSoft,
+                            onClick = onCollapsedContentClick ?: state::expandSoft,
                         ).fillMaxWidth()
                         .height(state.collapsedBound),
                 content = collapsedContent,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -119,17 +119,37 @@ fun BottomSheet(
                     ),
                 ).background(
                     if (opaqueBackground) {
-                        // Render the outer background fully opaque as soon as
-                        // the sheet is visible. The sheet is offset off-screen
-                        // when collapsed (so the opaque background is not
-                        // visible until the user starts dragging), and once
-                        // the sheet starts sliding up the opaque background
-                        // immediately covers whatever is behind the sheet
-                        // (e.g. the player's zoomed artwork backdrop). The
-                        // inner content still fades in via its own
-                        // graphicsLayer alpha, so the queue rows appear
-                        // smoothly on top of the now-opaque background.
-                        backgroundColor
+                        // Render the outer background fully opaque ONLY when
+                        // the sheet is actually sliding up or expanded
+                        // (progress > 0). When the sheet is fully collapsed
+                        // (progress = 0), the background is transparent so it
+                        // does NOT cover the system navigation bar area
+                        // (gesture hint / 3-button nav) at the bottom of the
+                        // screen.
+                        //
+                        // Previously, this branch returned `backgroundColor`
+                        // unconditionally, which meant the opaque background
+                        // was always rendered — even when the sheet was
+                        // collapsed at the peek height. Because the queue
+                        // sheet's `collapsedBound` is
+                        // `dynamicQueuePeekHeight + systemBarsBottom`, the
+                        // visible portion of the collapsed sheet INCLUDES the
+                        // navigation bar inset, and the opaque background
+                        // covered it, hiding the gesture hint / 3-button nav.
+                        //
+                        // By gating on `progress > 0`, the background is:
+                        //   - transparent when collapsed (progress = 0): the
+                        //     navigation bar shows through normally.
+                        //   - opaque as soon as the user starts dragging
+                        //     (progress > 0): the player's zoomed artwork
+                        //     backdrop is hidden during the slide-up, which
+                        //     was the original bug `opaqueBackground = true`
+                        //     was introduced to fix.
+                        if (state.progress > 0f) {
+                            backgroundColor
+                        } else {
+                            Color.Transparent
+                        }
                     } else {
                         backgroundColor.copy(
                             alpha = backgroundColor.alpha * state.progress.coerceIn(0f, 1f),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheetMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheetMenu.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -77,6 +76,12 @@ fun BottomSheetMenu(
     state.dialogContent?.invoke()
 
     if (state.isVisible) {
+        // NOTE: do NOT apply fillMaxHeight() here. Forcing the sheet to the full screen
+        // height makes every overflow menu (song menu, player menu, album menu, etc.)
+        // open as a full-screen overlay, which is jarring for short menus. The default
+        // ModalBottomSheet behavior is to wrap the content height and dock at the bottom,
+        // which is what users expect from a bottom-anchored menu. The passed-in modifier
+        // (typically just an alignment Modifier from the caller) is preserved.
         ModalBottomSheet(
             onDismissRequest = {
                 focusManager.clearFocus()
@@ -94,7 +99,7 @@ fun BottomSheetMenu(
                             .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)),
                 )
             },
-            modifier = modifier.fillMaxHeight(),
+            modifier = modifier,
         ) {
             Column(
                 modifier =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheetMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheetMenu.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -76,12 +77,6 @@ fun BottomSheetMenu(
     state.dialogContent?.invoke()
 
     if (state.isVisible) {
-        // NOTE: do NOT apply fillMaxHeight() here. Forcing the sheet to the full screen
-        // height makes every overflow menu (song menu, player menu, album menu, etc.)
-        // open as a full-screen overlay, which is jarring for short menus. The default
-        // ModalBottomSheet behavior is to wrap the content height and dock at the bottom,
-        // which is what users expect from a bottom-anchored menu. The passed-in modifier
-        // (typically just an alignment Modifier from the caller) is preserved.
         ModalBottomSheet(
             onDismissRequest = {
                 focusManager.clearFocus()
@@ -99,7 +94,7 @@ fun BottomSheetMenu(
                             .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)),
                 )
             },
-            modifier = modifier,
+            modifier = modifier.fillMaxHeight(),
         ) {
             Column(
                 modifier =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
@@ -1308,11 +1308,18 @@ fun MediaMetadataListItem(
 ) {
     ListItem(
         title = mediaMetadata.title,
-        subtitle =
-            joinByBullet(
-                mediaMetadata.artists.joinToString { it.name },
-                makeTimeString(mediaMetadata.duration * 1000L),
-            ),
+        subtitle = {
+            Text(
+                text =
+                    joinByBullet(
+                        mediaMetadata.artists.joinToString { it.name },
+                        makeTimeString(mediaMetadata.duration * 1000L),
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
         thumbnailContent = {
             ItemThumbnail(
                 thumbnailUrl = mediaMetadata.thumbnailUrl,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
@@ -154,21 +154,22 @@ inline fun ListItem(
     crossinline trailingContent: @Composable RowScope.() -> Unit = {},
     isActive: Boolean = false,
     showActiveContainer: Boolean = true,
+    textColorOverride: Color? = null,
 ) {
     val titleColor =
-        if (isActive) {
+        textColorOverride ?: if (isActive) {
             MaterialTheme.colorScheme.onSecondaryContainer
         } else {
             MaterialTheme.colorScheme.onSurface
         }
     val subtitleContentColor =
-        if (isActive) {
+        textColorOverride?.copy(alpha = 0.7f) ?: if (isActive) {
             MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f)
         } else {
             MaterialTheme.colorScheme.onSurfaceVariant
         }
     val trailingContentColor =
-        if (isActive) {
+        textColorOverride ?: if (isActive) {
             MaterialTheme.colorScheme.onSecondaryContainer
         } else {
             MaterialTheme.colorScheme.onSurfaceVariant
@@ -1303,6 +1304,7 @@ fun MediaMetadataListItem(
     // top and produce a bright, glitchy double-background.
     showActiveContainer: Boolean = true,
     trailingContent: @Composable RowScope.() -> Unit = {},
+    textColorOverride: Color? = null,
 ) {
     ListItem(
         title = mediaMetadata.title,
@@ -1327,6 +1329,7 @@ fun MediaMetadataListItem(
         modifier = modifier,
         isActive = isActive,
         showActiveContainer = showActiveContainer,
+        textColorOverride = textColorOverride,
     )
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
@@ -537,8 +537,10 @@ fun Lyrics(
             !lyrics.isNullOrEmpty() && (isLineSyncedLrc(lyrics) || isTtml(lyrics))
         }
 
-    val lyricsBaseColor = if (useDarkTheme || playerBackground != PlayerBackgroundStyle.DEFAULT) Color.White else Color.Black
-    val lyricsGlowColor = if (useDarkTheme || playerBackground != PlayerBackgroundStyle.DEFAULT) Color.White else Color.Black
+    // Apple Music style and all lyrics backgrounds always use white text so lyrics stay
+    // readable on the dark blurred backdrop regardless of system theme.
+    val lyricsBaseColor = Color.White
+    val lyricsGlowColor = Color.White
     val textColor = lyricsBaseColor
 
     val wordSyncLeadMs =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -241,12 +241,9 @@ fun LyricsEnhanced(
     val lyricsFontFamily = rememberArchiveTuneLyricsFontFamily()
 
     val playerBackground by rememberEnumPreference(PlayerBackgroundStyleKey, PlayerBackgroundStyle.DEFAULT)
-    val textColor =
-        textColorOverride ?: if (playerBackground == PlayerBackgroundStyle.DEFAULT) {
-            MaterialTheme.colorScheme.onBackground
-        } else {
-            Color.White
-        }
+    // Apple Music style and all lyrics backgrounds always use white text so lyrics stay
+    // readable on the dark blurred backdrop regardless of system theme.
+    val textColor = textColorOverride ?: Color.White
     val lyricsLineBlur = lyricsLineBlurOverride ?: lyricsLineBlurPreference
 
     var isSelectionModeActive by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -281,12 +281,9 @@ fun LyricsV2(
     val playerBackground by rememberEnumPreference(PlayerBackgroundStyleKey, PlayerBackgroundStyle.DEFAULT)
 
     // ── Text colour derived from background style ──
-    val textColor =
-        textColorOverride ?: if (playerBackground == PlayerBackgroundStyle.DEFAULT) {
-            MaterialTheme.colorScheme.onBackground
-        } else {
-            Color.White
-        }
+    // Apple Music style and all lyrics backgrounds always use white text so that
+    // lyrics remain readable on the dark blurred backdrop regardless of system theme.
+    val textColor = textColorOverride ?: Color.White
     val lyricsLineBlur = (lyricsLineBlurOverride ?: lyricsLineBlurPreference) && !v2AnimationsDisabled
 
     val inactiveAlpha = 0.35f

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/NetworkStatusBanner.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/NetworkStatusBanner.kt
@@ -11,13 +11,18 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudDone
@@ -27,17 +32,22 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.network.NetworkBannerUiState
 
 private data class NetworkBannerVisuals(
@@ -47,15 +57,36 @@ private data class NetworkBannerVisuals(
     val contentColor: Color,
 )
 
+/**
+ * Compact pill-shaped popup that surfaces network state changes.
+ *
+ * Replaces the previous full-width red "No internet connection" banner.
+ * Auto-dismisses after a few seconds (controlled by the use case). Includes
+ * an inline dismiss button so the user can dismiss the popup manually.
+ *
+ * States:
+ *  - Offline: amber pill labelled "Offline mode" with cloud-off icon
+ *  - BackOnline: green pill labelled "Back online" with cloud-done icon
+ *  - Hidden: not rendered
+ */
 @Composable
 fun NetworkStatusBanner(
     state: NetworkBannerUiState,
     modifier: Modifier = Modifier,
 ) {
     var lastVisibleState by remember { mutableStateOf<NetworkBannerUiState>(NetworkBannerUiState.Offline) }
+    // Track user-initiated dismissal so a tap on the X immediately hides the
+    // popup. Reset whenever the underlying state changes (so the next network
+    // event will surface the popup again).
+    var userDismissed by remember { mutableStateOf(false) }
 
     if (state != NetworkBannerUiState.Hidden) {
         lastVisibleState = state
+        // If the state has changed since the user dismissed, allow it to show
+        // again. Using `state` here means a new Offline→BackOnline transition
+        // will re-display the back-online popup even if the user dismissed
+        // the offline one.
+        LaunchedEffect(state) { userDismissed = false }
     }
 
     val visuals =
@@ -64,9 +95,9 @@ fun NetworkStatusBanner(
             NetworkBannerUiState.Offline,
             -> {
                 NetworkBannerVisuals(
-                    message = "No internet connection",
+                    message = "Offline mode",
                     icon = Icons.Default.CloudOff,
-                    containerColor = Color(0xFF7F1D1D),
+                    containerColor = Color(0xFF8A6D1F),
                     contentColor = Color.White,
                 )
             }
@@ -81,28 +112,34 @@ fun NetworkStatusBanner(
             }
         }
 
+    val visible = state != NetworkBannerUiState.Hidden && !userDismissed
+
     AnimatedVisibility(
-        visible = state != NetworkBannerUiState.Hidden,
+        visible = visible,
         modifier = modifier,
         enter =
-            slideInVertically(animationSpec = tween(durationMillis = 250)) { -it } +
-                fadeIn(animationSpec = tween(durationMillis = 180)),
+            scaleIn(animationSpec = tween(durationMillis = 180), initialScale = 0.85f) +
+                fadeIn(animationSpec = tween(durationMillis = 160)),
         exit =
-            slideOutVertically(animationSpec = tween(durationMillis = 220)) { -it } +
-                fadeOut(animationSpec = tween(durationMillis = 180)),
+            scaleOut(animationSpec = tween(durationMillis = 160), targetScale = 0.85f) +
+                fadeOut(animationSpec = tween(durationMillis = 160)),
         label = "networkStatusBanner",
     ) {
         Surface(
-            shape = RoundedCornerShape(14.dp),
+            // Pill shape — rounded full corners, compact height.
+            shape = RoundedCornerShape(percent = 50),
             color = visuals.containerColor,
             contentColor = visuals.contentColor,
             shadowElevation = 8.dp,
+            tonalElevation = 0.dp,
+            modifier = Modifier.widthIn(max = 260.dp),
         ) {
             Row(
                 modifier =
                     Modifier
-                        .padding(horizontal = 14.dp, vertical = 10.dp),
+                        .padding(start = 14.dp, end = 6.dp, top = 8.dp, bottom = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Icon(
                     imageVector = visuals.icon,
@@ -110,7 +147,6 @@ fun NetworkStatusBanner(
                     modifier = Modifier.size(16.dp),
                     tint = visuals.contentColor,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = visuals.message,
                     color = visuals.contentColor,
@@ -118,6 +154,24 @@ fun NetworkStatusBanner(
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
                 )
+                Spacer(modifier = Modifier.width(2.dp))
+                // Compact dismiss (X) button inside the pill.
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(RoundedCornerShape(percent = 50))
+                        .background(Color.White.copy(alpha = 0.18f))
+                        .clickable { userDismissed = true }
+                        .padding(4.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.close),
+                        contentDescription = stringResource(R.string.close_dialog),
+                        modifier = Modifier.size(14.dp),
+                        tint = visuals.contentColor,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/ProfileMenuDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/ProfileMenuDialog.kt
@@ -10,10 +10,14 @@ package moe.rukamori.archivetune.ui.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
@@ -23,8 +27,6 @@ import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -78,7 +80,7 @@ fun ProfileMenuDialog(
 
             Surface(
                 modifier = Modifier
-                    .widthIn(max = 380.dp)
+                    .widthIn(max = 360.dp)
                     .padding(horizontal = 24.dp),
                 shape = RoundedCornerShape(28.dp),
                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
@@ -88,31 +90,24 @@ fun ProfileMenuDialog(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 8.dp),
+                        .padding(horizontal = 14.dp, vertical = 10.dp),
                 ) {
-                    
-                    if (accountName.isNotBlank()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(
-                                    text = accountName,
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            },
-                            supportingContent = {
-                                Text(
-                                    text = stringResource(R.string.account),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
-                            },
-                            leadingContent = {
+                    // Top row: account header (left) + dismiss button (right).
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        // Account header — leading avatar + name/subtitle, takes
+                        // available space, leaves room for the dismiss button.
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            if (accountName.isNotBlank()) {
                                 Surface(
-                                    modifier = Modifier.size(44.dp),
+                                    modifier = Modifier.size(40.dp),
                                     shape = CircleShape,
                                     color = MaterialTheme.colorScheme.primaryContainer,
                                 ) {
@@ -133,44 +128,86 @@ fun ProfileMenuDialog(
                                             Icon(
                                                 painter = painterResource(R.drawable.account),
                                                 contentDescription = null,
-                                                modifier = Modifier.size(22.dp),
+                                                modifier = Modifier.size(20.dp),
                                                 tint = MaterialTheme.colorScheme.onPrimaryContainer,
                                             )
                                         }
                                     }
                                 }
-                            },
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                        )
-                    }
-
-                    items.forEach { item ->
-                        ListItem(
-                            headlineContent = {
-                                Text(
-                                    text = item.label,
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    fontWeight = FontWeight.Medium,
-                                )
-                            },
-                            leadingContent = {
-                                BadgedBox(badge = {
-                                    if (item.showBadge) Badge()
-                                }) {
-                                    Icon(
-                                        painter = painterResource(item.icon),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp),
-                                        tint = MaterialTheme.colorScheme.onSurface,
+                                Column(modifier = Modifier.weight(1f, fill = false)) {
+                                    Text(
+                                        text = accountName,
+                                        style = MaterialTheme.typography.titleSmall,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                    Text(
+                                        text = stringResource(R.string.account),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
                                 }
-                            },
+                            }
+                        }
+
+                        // Dismiss button (X) — compact 32dp circle.
+                        Box(
+                            modifier = Modifier
+                                .size(32.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                                .clickable(onClick = onDismiss),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.close),
+                                contentDescription = stringResource(R.string.close_dialog),
+                                modifier = Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+
+                    if (accountName.isNotBlank()) {
+                        Spacer(Modifier.height(8.dp))
+                    }
+
+                    // Menu items — each rendered as a pill (rounded container)
+                    // styled like the rounded "song pills" on the history page.
+                    items.forEach { item ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(16.dp))
-                                .clickable(onClick = item.onClick),
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                        )
+                                .clip(RoundedCornerShape(percent = 50))
+                                .background(MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f))
+                                .clickable { item.onClick() }
+                                .padding(horizontal = 14.dp, vertical = 10.dp),
+                        ) {
+                            BadgedBox(badge = {
+                                if (item.showBadge) Badge()
+                            }) {
+                                Icon(
+                                    painter = painterResource(item.icon),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(22.dp),
+                                    tint = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
+                            Text(
+                                text = item.label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                        Spacer(Modifier.height(6.dp))
                     }
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -140,6 +140,7 @@ fun PlayerMenu(
     navController: NavController,
     playerBottomSheetState: BottomSheetState,
     isQueueTrigger: Boolean? = false,
+    onPlayNextFromQueue: (() -> Unit)? = null,
     onRemoveFromQueue: (() -> Unit)? = null,
     onShowDetailsDialog: () -> Unit,
     onDismiss: () -> Unit,
@@ -1095,6 +1096,31 @@ fun PlayerMenu(
         item {
             MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
                 Column {
+                    if (isQueueTrigger == true && onPlayNextFromQueue != null) {
+                        ListItem(
+                            headlineContent = {
+                                Text(text = stringResource(R.string.play_next))
+                            },
+                            leadingContent = {
+                                Icon(
+                                    painter = painterResource(R.drawable.playlist_play),
+                                    contentDescription = null,
+                                )
+                            },
+                            modifier =
+                                Modifier.clickable {
+                                    onPlayNextFromQueue()
+                                    onDismiss()
+                                },
+                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        )
+
+                        HorizontalDivider(
+                            modifier = Modifier.padding(start = 56.dp),
+                            color = MaterialTheme.colorScheme.outlineVariant,
+                        )
+                    }
+
                     if (isQueueTrigger == true && onRemoveFromQueue != null) {
                         ListItem(
                             headlineContent = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -343,9 +343,21 @@ fun PlayerMenu(
             SongSourceOverride.get(songSourceRaw.ifBlank { null }, mediaMetadata.id)
         }
     var showSourceDialog by rememberSaveable { mutableStateOf(false) }
-    // Recomputed each time the dialog opens so it reflects the latest resolution result.
+
+    // Trigger a fresh source resolution each time the Source dialog opens. This fixes the bug
+    // where Qobuz (or Tidal) was missing from the Sources list because a previous resolution
+    // failed transiently — the in-memory cache pinned the song to YouTube, and the lossless
+    // sources were never retried for the lifetime of the process. The refresh evicts the cache
+    // and re-runs the lossless resolution chain in the background; the resulting sources show
+    // up via resolvedSourcesRevision (a StateFlow that bumps when recording completes).
+    val sourceRevision by playerConnection.service.resolvedSourcesRevision.collectAsStateWithLifecycle()
+    LaunchedEffect(showSourceDialog, mediaMetadata.id) {
+        if (showSourceDialog) {
+            playerConnection.service.refreshSourcesForSong(mediaMetadata.id)
+        }
+    }
     val availableSources =
-        remember(mediaMetadata.id, showSourceDialog) {
+        remember(mediaMetadata.id, showSourceDialog, sourceRevision) {
             playerConnection.service.availableSourcesForSong(mediaMetadata.id)
         }
 
@@ -839,12 +851,10 @@ fun PlayerMenu(
                             },
                         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                     )
-
                     HorizontalDivider(
                         modifier = Modifier.padding(start = 56.dp),
                         color = MaterialTheme.colorScheme.outlineVariant,
                     )
-
                     ListItem(
                         headlineContent = {
                             Text(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -314,7 +314,7 @@ fun SongMenu(
 
                 coroutineScope.launch {
                     database.query {
-                        update(song.song.copy(title = newTitle))
+                        update(song.song.copy(title = newTitle, titleOverride = true))
                         val artist = song.artists.firstOrNull()
                         if (artist != null) {
                             update(artist.copy(name = newArtist))

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
@@ -487,7 +487,10 @@ fun YouTubeSongMenu(
 
                                 val now = LocalDateTime.now()
                                 database.withTransaction {
-                                    val base = librarySong?.song ?: song.toMediaMetadata().toSongEntity()
+                                    val base =
+                                        librarySong?.song
+                                            ?: database.getSongByIdBlocking(song.id)
+                                            ?: song.toMediaMetadata().toSongEntity()
                                     if (librarySong == null) {
                                         insert(song.toMediaMetadata())
                                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
@@ -489,7 +489,7 @@ fun YouTubeSongMenu(
                                 database.withTransaction {
                                     val base =
                                         librarySong?.song
-                                            ?: database.getSongByIdBlocking(song.id)
+                                            ?: database.getSongByIdBlocking(song.id)?.song
                                             ?: song.toMediaMetadata().toSongEntity()
                                     if (librarySong == null) {
                                         insert(song.toMediaMetadata())

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -534,12 +534,19 @@ fun AppleMusicPlayerContent(
     val (autoTranslateLyrics) = rememberPreference(AutoTranslateLyricsKey, defaultValue = false)
     val (translatorTargetLang) = rememberPreference(TranslatorTargetLangKey, defaultValue = "")
     val lyricsMenuViewModel: LyricsMenuViewModel = hiltViewModel()
+    // Observe the set of media IDs the user has dismissed translation for.
+    // When a user clicks "Undo Translation", the mediaId is added to this set;
+    // auto-translate is suppressed for dismissed songs until the user manually
+    // triggers translation again (which clears the dismissal in the ViewModel).
+    val translationDismissedMediaIds by lyricsMenuViewModel.translationDismissedMediaIds
+        .collectAsStateWithLifecycle()
     LaunchedEffect(
         mediaMetadata.id,
         currentLyrics?.lyrics,
         currentLyrics?.source,
         autoTranslateLyrics,
         translatorTargetLang,
+        translationDismissedMediaIds,
     ) {
         if (!autoTranslateLyrics) return@LaunchedEffect
         val snapshot = currentLyrics ?: return@LaunchedEffect
@@ -554,6 +561,13 @@ fun AppleMusicPlayerContent(
         if (snapshot.source == LyricsEntity.Source.AI_TRANSLATION.value &&
             LyricsUtils.hasTranslation(text)
         ) return@LaunchedEffect
+
+        // Skip auto-translate if the user has dismissed translation for this
+        // song. The user clicked "Undo Translation" — they explicitly do not
+        // want the translation back. Auto-translate will resume only after the
+        // user manually triggers translation (which clears the dismissal).
+        if (mediaMetadata.id in translationDismissedMediaIds) return@LaunchedEffect
+
         if (!LyricsUtils.shouldAutoTranslate(text, translatorTargetLang)) return@LaunchedEffect
         lyricsMenuViewModel.translateLyricsWithAi(
             mediaMetadata = mediaMetadata,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicQueueSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicQueueSheet.kt
@@ -516,6 +516,15 @@ fun AppleMusicQueueSheet(
                                 // fought the glass tint. Suppress the container so only
                                 // the glass pill shows.
                                 showActiveContainer = false,
+                                // Force song titles to always render white. Without this
+                                // override, MediaMetadataListItem falls back to
+                                // MaterialTheme.colorScheme.onSurface / onSecondaryContainer,
+                                // which is what the V9 'Material Extended' dynamic-color
+                                // system mutates based on the artwork palette — so when a
+                                // dynamic theme is active the song titles in this queue
+                                // shift to the dominant artwork color instead of staying
+                                // white like the rest of the Apple Music UI.
+                                textColorOverride = Color.White,
                                 trailingContent = {
                                     Row(verticalAlignment = Alignment.CenterVertically) {
                                         IconButton(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -212,12 +212,7 @@ fun LyricsScreen(
     val playerCustomBlur by rememberPreference(PlayerCustomBlurKey, 0f)
     val playerCustomContrast by rememberPreference(PlayerCustomContrastKey, 1f)
     val playerCustomBrightness by rememberPreference(PlayerCustomBrightnessKey, 1f)
-    val foregroundColor =
-        if (lyricsBackground == LyricsBackgroundStyle.FOLLOW_THEME) {
-            MaterialTheme.colorScheme.onSurface
-        } else {
-            Color.White
-        }
+    val foregroundColor = Color.White
     val showPlayerControlsState =
         rememberPreference(ShowLyricsPlayerControlsKey, true)
     val showPlayerControlsEnabled by showPlayerControlsState
@@ -580,6 +575,7 @@ fun LyricsScreen(
                 mediaMetadata = mediaMetadata,
                 foregroundColor = foregroundColor,
                 onMoreClick = showLyricsMenu,
+                onDismissClick = onBackClick,
                 isLiked = currentSongLiked,
                 onToggleLike = playerConnection::toggleLike,
                 modifier =
@@ -1085,6 +1081,7 @@ private fun AppleMusicTrackHeader(
     mediaMetadata: MediaMetadata,
     foregroundColor: Color,
     onMoreClick: () -> Unit,
+    onDismissClick: () -> Unit = {},
     modifier: Modifier = Modifier,
     isLiked: Boolean = false,
     onToggleLike: () -> Unit = {},
@@ -1145,6 +1142,19 @@ private fun AppleMusicTrackHeader(
         }
 
         Spacer(modifier = Modifier.width(8.dp))
+
+        // Close (cross) button — required so users can dismiss the lyrics sheet
+        // without relying on the system back gesture. Sits to the left of the
+        // overflow menu icon (and to the left of the heart button). Matches
+        // upstream rukamori/ArchiveTune's lyrics top bar layout.
+        AppleMusicHeaderIconButton(
+            iconRes = R.drawable.close,
+            contentDescription = stringResource(R.string.close),
+            foregroundColor = foregroundColor,
+            onClick = onDismissClick,
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
 
         // Favourite (heart) button — matches Apple Music's lyrics page where the
         // heart icon sits to the right of the song title/artist. Tapping toggles

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -824,7 +824,7 @@ private fun MovingBlurBackground(
         initialValue = -60f,
         targetValue = 60f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 14_000, easing = FastOutSlowInEasing),
+            animation = tween(durationMillis = 6_000, easing = FastOutSlowInEasing),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "moving-blur-x",
@@ -833,7 +833,7 @@ private fun MovingBlurBackground(
         initialValue = -45f,
         targetValue = 45f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 20_000, easing = FastOutSlowInEasing),
+            animation = tween(durationMillis = 8_000, easing = FastOutSlowInEasing),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "moving-blur-y",

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -338,12 +338,19 @@ fun LyricsScreen(
     val (autoTranslateLyrics) = rememberPreference(AutoTranslateLyricsKey, defaultValue = false)
     val (translatorTargetLang) = rememberPreference(TranslatorTargetLangKey, defaultValue = "")
     val lyricsMenuViewModel: LyricsMenuViewModel = hiltViewModel()
+    // Observe the set of media IDs the user has dismissed translation for.
+    // When a user clicks "Undo Translation", the mediaId is added to this set;
+    // auto-translate is suppressed for dismissed songs until the user manually
+    // triggers translation again (which clears the dismissal in the ViewModel).
+    val translationDismissedMediaIds by lyricsMenuViewModel.translationDismissedMediaIds
+        .collectAsStateWithLifecycle()
     LaunchedEffect(
         mediaMetadata.id,
         currentLyrics?.lyrics,
         currentLyrics?.source,
         autoTranslateLyrics,
         translatorTargetLang,
+        translationDismissedMediaIds,
     ) {
         if (!autoTranslateLyrics) return@LaunchedEffect
         val snapshot = currentLyrics ?: return@LaunchedEffect
@@ -359,6 +366,12 @@ fun LyricsScreen(
         if (snapshot.source == LyricsEntity.Source.AI_TRANSLATION.value &&
             LyricsUtils.hasTranslation(text)
         ) return@LaunchedEffect
+
+        // Skip auto-translate if the user has dismissed translation for this
+        // song. The user clicked "Undo Translation" — they explicitly do not
+        // want the translation back. Auto-translate will resume only after the
+        // user manually triggers translation (which clears the dismissal).
+        if (mediaMetadata.id in translationDismissedMediaIds) return@LaunchedEffect
 
         if (!LyricsUtils.shouldAutoTranslate(text, translatorTargetLang)) return@LaunchedEffect
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -22,8 +22,10 @@ import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -96,6 +98,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -106,6 +109,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -166,6 +170,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
@@ -2329,11 +2334,7 @@ fun BottomSheetPlayer(
         mediaMetadata?.let { metadata ->
             MikoLyricsTransition(
                 visible = isLyricsScreenVisible,
-                // Enable the LyricsScreen's own BackHandler so back press directly exits the
-                // lyrics overlay (instead of being intercepted by MainActivity's player-sheet
-                // collapse BackHandler, which left isLyricsScreenVisible=true and trapped the
-                // user on the lyrics screen until process death).
-                backHandlerEnabled = true,
+                backHandlerEnabled = false,
                 mediaMetadata = metadata,
                 navController = navController,
                 lyricsSyncOffset = lyricsSyncOffset,
@@ -2428,58 +2429,67 @@ private fun MikoLyricsTransition(
     onQueueClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Fallback BackHandler: always composed when the lyrics overlay is visible,
-    // independent of the inner LyricsScreen's BackHandler. The inner BackHandler
-    // lives inside `LyricsScreen` which early-returns if `LocalPlayerConnection.current`
-    // is null OR is gated by `backHandlerEnabled`. If for any reason the inner
-    // BackHandler is not composed or not enabled, this fallback ensures the back
-    // press still dismisses the lyrics overlay — preventing the user from being
-    // trapped on the lyrics screen until process death.
-    //
-    // This is composed BEFORE the `if (visible || boundedProgress > 0.001f)` block
-    // so it is registered even during the scale-up/scale-down animation when the
-    // inner LyricsScreen may be momentarily absent.
-    if (visible) {
-        BackHandler(enabled = true, onBack = onDismiss)
+    val animationsDisabled = LocalAnimationsDisabled.current
+    val progress = remember { Animatable(initialValue = 0f) }
+    LaunchedEffect(visible, animationsDisabled) {
+        if (animationsDisabled) {
+            progress.snapTo(if (visible) 1f else 0f)
+        } else {
+            progress.animateTo(
+                targetValue = if (visible) 1f else 0f,
+                animationSpec =
+                    if (visible) {
+                        // OPEN — keep the premium slow glide (~500 ms).
+                        spring(
+                            dampingRatio = 1f,
+                            stiffness = 160f,
+                            visibilityThreshold = 0.001f,
+                        )
+                    } else {
+                        // CLOSE — slower by ~40% (~700 ms) per user request.
+                        spring(
+                            dampingRatio = 1f,
+                            stiffness = 80f,
+                            visibilityThreshold = 0.001f,
+                        )
+                    },
+            )
+        }
+    }
+    val progressState = progress.asState()
+    val showContent by remember(visible) {
+        derivedStateOf { visible || progressState.value > 0f }
     }
 
-    val progress by animateFloatAsState(
-        targetValue = if (visible) 1f else 0f,
-        animationSpec =
-            spring(
-                dampingRatio = 0.82f,
-                stiffness = Spring.StiffnessMediumLow,
-            ),
-        label = "mikoLyricsTransition",
-    )
-
-    val boundedProgress = progress.coerceIn(0f, 1f)
-
-    if (visible || boundedProgress > 0.001f) {
-        val scaleX = 0.92f + (0.08f * boundedProgress)
-        val scaleY = 0.78f + (0.22f * boundedProgress)
-        val alpha = (0.2f + (0.8f * boundedProgress)).coerceIn(0f, 1f)
-        val cornerRadius = 32.dp * (1f - boundedProgress)
-
+    if (showContent) {
+        val surfaceColor = MaterialTheme.colorScheme.surface
         Box(
             modifier =
                 modifier
                     .fillMaxSize()
-                    .graphicsLayer { this.alpha = boundedProgress }
-                    .background(Color.Black.copy(alpha = 0.24f * boundedProgress)),
+                    .drawBehind {
+                        // Use drawRect's built-in alpha parameter instead of
+                        // Color.Black.copy(alpha = ...) — avoids allocating a
+                        // new Color object on every frame of the slide animation.
+                        drawRect(
+                            color = Color.Black,
+                            alpha = 0.32f * progressState.value.coerceIn(0f, 1f),
+                        )
+                    },
         ) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxSize()
                         .graphicsLayer {
-                            transformOrigin = TransformOrigin(0.5f, 1f)
-                            this.scaleX = scaleX
-                            this.scaleY = scaleY
-                            this.alpha = alpha
-                            translationY = size.height * 0.16f * (1f - boundedProgress)
-                        }.clip(RoundedCornerShape(cornerRadius))
-                        .background(MaterialTheme.colorScheme.surface),
+                            val p = progressState.value.coerceIn(0f, 1f)
+                            // Pure slide-up: the whole sheet travels from just below the screen to
+                            // its resting position, with a small rounded top lip while in transit.
+                            translationY = size.height * (1f - p)
+                            val corner = 28.dp.toPx() * (1f - p)
+                            shape = RoundedCornerShape(topStart = corner, topEnd = corner)
+                            clip = true
+                        }.background(surfaceColor),
             ) {
                 LyricsScreen(
                     mediaMetadata = mediaMetadata,
@@ -2522,14 +2532,6 @@ private fun V8PlayerBackdrop(
     ) {
         if (currentUrl != null) {
             val backdropHasBlur = backdropBlurAmount > 0
-            // Backdrop scale: previously 1.16f which over-zoomed the artwork and cropped
-            // significant portions of the image (the user reported "artwork/images look
-            // distorted or misplaced" in Immersive Mode). ContentScale.Crop already
-            // fills the screen by cropping; the extra 1.16x scale was a holdover from
-            // an earlier design that wanted the backdrop to feel "larger than life".
-            // Reducing to 1.0f keeps the screen fully covered (Crop guarantees that)
-            // while showing more of the actual artwork. Alpha stays at 0.66 so the
-            // dark overlay + control overlay remain readable.
             if (backdropHasBlur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 AsyncImage(
                     model = backdropRequest,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2334,7 +2334,11 @@ fun BottomSheetPlayer(
         mediaMetadata?.let { metadata ->
             MikoLyricsTransition(
                 visible = isLyricsScreenVisible,
-                backHandlerEnabled = false,
+                // Enable the LyricsScreen's own BackHandler so back press directly exits the
+                // lyrics overlay (instead of being intercepted by MainActivity's player-sheet
+                // collapse BackHandler, which left isLyricsScreenVisible=true and trapped the
+                // user on the lyrics screen until process death).
+                backHandlerEnabled = true,
                 mediaMetadata = metadata,
                 navController = navController,
                 lyricsSyncOffset = lyricsSyncOffset,
@@ -2532,6 +2536,14 @@ private fun V8PlayerBackdrop(
     ) {
         if (currentUrl != null) {
             val backdropHasBlur = backdropBlurAmount > 0
+            // Backdrop scale: previously 1.16f which over-zoomed the artwork and cropped
+            // significant portions of the image (the user reported "artwork/images look
+            // distorted or misplaced" in Immersive Mode). ContentScale.Crop already
+            // fills the screen by cropping; the extra 1.16x scale was a holdover from
+            // an earlier design that wanted the backdrop to feel "larger than life".
+            // Reducing to 1.0f keeps the screen fully covered (Crop guarantees that)
+            // while showing more of the actual artwork. Alpha stays at 0.66 so the
+            // dark overlay + control overlay remain readable.
             if (backdropHasBlur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 AsyncImage(
                     model = backdropRequest,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -22,10 +22,8 @@ import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -98,7 +96,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -109,8 +106,6 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
@@ -170,7 +165,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
@@ -2433,38 +2427,6 @@ private fun MikoLyricsTransition(
     onQueueClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val animationsDisabled = LocalAnimationsDisabled.current
-    val progress = remember { Animatable(initialValue = 0f) }
-    LaunchedEffect(visible, animationsDisabled) {
-        if (animationsDisabled) {
-            progress.snapTo(if (visible) 1f else 0f)
-        } else {
-            progress.animateTo(
-                targetValue = if (visible) 1f else 0f,
-                animationSpec =
-                    if (visible) {
-                        // OPEN — keep the premium slow glide (~500 ms).
-                        spring(
-                            dampingRatio = 1f,
-                            stiffness = 160f,
-                            visibilityThreshold = 0.001f,
-                        )
-                    } else {
-                        // CLOSE — slower by ~40% (~700 ms) per user request.
-                        spring(
-                            dampingRatio = 1f,
-                            stiffness = 80f,
-                            visibilityThreshold = 0.001f,
-                        )
-                    },
-            )
-        }
-    }
-    val progressState = progress.asState()
-    val showContent by remember(visible) {
-        derivedStateOf { visible || progressState.value > 0f }
-    }
-
     // Fallback BackHandler: always composed when the lyrics overlay is visible,
     // independent of the inner LyricsScreen's BackHandler. The inner BackHandler
     // lives inside `LyricsScreen` which early-returns if `LocalPlayerConnection.current`
@@ -2473,42 +2435,50 @@ private fun MikoLyricsTransition(
     // press still dismisses the lyrics overlay — preventing the user from being
     // trapped on the lyrics screen until process death.
     //
-    // This is composed BEFORE the `if (showContent)` block so it is registered
-    // even during the slide-up/slide-down animation when `showContent` may be
-    // momentarily false (e.g. closing: `visible = false` but `progressState > 0`).
+    // This is composed BEFORE the `if (visible || boundedProgress > 0.001f)` block
+    // so it is registered even during the scale-up/scale-down animation when the
+    // inner LyricsScreen may be momentarily absent.
     if (visible) {
         BackHandler(enabled = true, onBack = onDismiss)
     }
 
-    if (showContent) {
-        val surfaceColor = MaterialTheme.colorScheme.surface
+    val progress by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec =
+            spring(
+                dampingRatio = 0.82f,
+                stiffness = Spring.StiffnessMediumLow,
+            ),
+        label = "mikoLyricsTransition",
+    )
+
+    val boundedProgress = progress.coerceIn(0f, 1f)
+
+    if (visible || boundedProgress > 0.001f) {
+        val scaleX = 0.92f + (0.08f * boundedProgress)
+        val scaleY = 0.78f + (0.22f * boundedProgress)
+        val alpha = (0.2f + (0.8f * boundedProgress)).coerceIn(0f, 1f)
+        val cornerRadius = 32.dp * (1f - boundedProgress)
+
         Box(
             modifier =
                 modifier
                     .fillMaxSize()
-                    .drawBehind {
-                        // Use drawRect's built-in alpha parameter instead of
-                        // Color.Black.copy(alpha = ...) — avoids allocating a
-                        // new Color object on every frame of the slide animation.
-                        drawRect(
-                            color = Color.Black,
-                            alpha = 0.32f * progressState.value.coerceIn(0f, 1f),
-                        )
-                    },
+                    .graphicsLayer { this.alpha = boundedProgress }
+                    .background(Color.Black.copy(alpha = 0.24f * boundedProgress)),
         ) {
             Box(
                 modifier =
                     Modifier
                         .fillMaxSize()
                         .graphicsLayer {
-                            val p = progressState.value.coerceIn(0f, 1f)
-                            // Pure slide-up: the whole sheet travels from just below the screen to
-                            // its resting position, with a small rounded top lip while in transit.
-                            translationY = size.height * (1f - p)
-                            val corner = 28.dp.toPx() * (1f - p)
-                            shape = RoundedCornerShape(topStart = corner, topEnd = corner)
-                            clip = true
-                        }.background(surfaceColor),
+                            transformOrigin = TransformOrigin(0.5f, 1f)
+                            this.scaleX = scaleX
+                            this.scaleY = scaleY
+                            this.alpha = alpha
+                            translationY = size.height * 0.16f * (1f - boundedProgress)
+                        }.clip(RoundedCornerShape(cornerRadius))
+                        .background(MaterialTheme.colorScheme.surface),
             ) {
                 LyricsScreen(
                     mediaMetadata = mediaMetadata,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2325,9 +2325,20 @@ fun BottomSheetPlayer(
             )
         }
 
-        // Always use white text on the queue sheet so titles/artists stay readable on the
-        // dark blurred backdrop regardless of light/dark theme (matches Apple Music style).
-        val queueOnBackgroundColor = Color.White
+        // Queue text color policy:
+        //  - Apple Music style keeps a dark frosted backdrop in both light & dark
+        //    themes, so its queue text is pinned to white (matches AM visual language).
+        //  - All other styles follow the surface color: white when the user has
+        //    opted into useBlackBackground, otherwise MaterialTheme.colorScheme.onSurface
+        //    so titles/artists/dividers/pill outlines stay visible against the
+        //    (possibly light, dynamic-themed) surface. This mirrors upstream
+        //    rukamori/ArchiveTune Player.kt.
+        val queueOnBackgroundColor =
+            if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC || useBlackBackground) {
+                Color.White
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            }
         val queueSurfaceColor = if (useBlackBackground) Color.Black else MaterialTheme.colorScheme.surface
 
         val (queueTextButtonColor, queueIconButtonColor) =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2465,6 +2465,21 @@ private fun MikoLyricsTransition(
         derivedStateOf { visible || progressState.value > 0f }
     }
 
+    // Fallback BackHandler: always composed when the lyrics overlay is visible,
+    // independent of the inner LyricsScreen's BackHandler. The inner BackHandler
+    // lives inside `LyricsScreen` which early-returns if `LocalPlayerConnection.current`
+    // is null OR is gated by `backHandlerEnabled`. If for any reason the inner
+    // BackHandler is not composed or not enabled, this fallback ensures the back
+    // press still dismisses the lyrics overlay — preventing the user from being
+    // trapped on the lyrics screen until process death.
+    //
+    // This is composed BEFORE the `if (showContent)` block so it is registered
+    // even during the slide-up/slide-down animation when `showContent` may be
+    // momentarily false (e.g. closing: `visible = false` but `progressState > 0`).
+    if (visible) {
+        BackHandler(enabled = true, onBack = onDismiss)
+    }
+
     if (showContent) {
         val surfaceColor = MaterialTheme.colorScheme.surface
         Box(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -22,6 +22,7 @@ import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -564,14 +565,15 @@ fun BottomSheetPlayer(
     // (kept in sync with the authoritative artwork resolver, including Tidal fallback commits).
     val paletteArtworkUrl = mediaMetadata?.thumbnailUrl
 
-    LaunchedEffect(mediaMetadata?.id, paletteArtworkUrl, playerBackground, useDarkTheme) {
+    LaunchedEffect(mediaMetadata?.id, paletteArtworkUrl, playerBackground, useDarkTheme, playerDesignStyle) {
         if (aodModeEnabled) return@LaunchedEffect
         val wantsPalette =
             playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING ||
                 playerBackground == PlayerBackgroundStyle.BLUR ||
                 playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT ||
                 playerBackground == PlayerBackgroundStyle.GLOW ||
-                playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED
+                playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED ||
+                playerDesignStyle == PlayerDesignStyle.V9
         if (!wantsPalette) {
             gradientColors = emptyList()
             hasValidGradientPalette = false
@@ -659,8 +661,71 @@ fun BottomSheetPlayer(
 
     val changeBound = state.expandedBound / 3
 
+    // ── V9 "Material Extended" dynamic color system ──
+    // Derives background/accent/text/icon-button colors from the artwork's dominant
+    // palette color and animates between songs so the controls blend smoothly with
+    // the artwork (no blur behind the controls — pure color gradient instead).
+    val dominantColor = gradientColors.firstOrNull() ?: MaterialTheme.colorScheme.primary
+    val targetBgColor = remember(dominantColor, useDarkTheme) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.colorToHSV(dominantColor.toArgb(), hsv)
+        if (useDarkTheme) {
+            hsv[1] = hsv[1].coerceIn(0.12f, 0.35f)
+            hsv[2] = 0.08f
+        } else {
+            hsv[1] = hsv[1].coerceIn(0.04f, 0.12f)
+            hsv[2] = 0.96f
+        }
+        Color(android.graphics.Color.HSVToColor(hsv))
+    }
+    val dynamicBgColor by animateColorAsState(
+        targetValue = targetBgColor,
+        animationSpec = tween(durationMillis = 800),
+        label = "dynamicBgColor",
+    )
+
+    val targetAccentColor = dominantColor
+    val dynamicAccentColor by animateColorAsState(
+        targetValue = targetAccentColor,
+        animationSpec = tween(durationMillis = 800),
+        label = "dynamicAccentColor",
+    )
+
+    val targetTextColor = remember(dominantColor, useDarkTheme) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.colorToHSV(dominantColor.toArgb(), hsv)
+        if (useDarkTheme) {
+            hsv[1] = hsv[1].coerceAtMost(0.12f)
+            hsv[2] = 0.96f
+        } else {
+            hsv[1] = hsv[1].coerceIn(0.12f, 0.35f)
+            hsv[2] = 0.08f
+        }
+        Color(android.graphics.Color.HSVToColor(hsv))
+    }
+    val dynamicTextColor by animateColorAsState(
+        targetValue = targetTextColor,
+        animationSpec = tween(durationMillis = 800),
+        label = "dynamicTextColor",
+    )
+
+    val targetIconButtonColor = remember(dynamicAccentColor) {
+        val luminance =
+            0.299f * dynamicAccentColor.red +
+                0.587f * dynamicAccentColor.green +
+                0.114f * dynamicAccentColor.blue
+        if (luminance > 0.5f) Color.Black else Color.White
+    }
+    val dynamicIconButtonColor by animateColorAsState(
+        targetValue = targetIconButtonColor,
+        animationSpec = tween(durationMillis = 800),
+        label = "dynamicIconButtonColor",
+    )
+
     val TextBackgroundColor =
-        if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
+        if (playerDesignStyle == PlayerDesignStyle.V9) {
+            dynamicTextColor
+        } else if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
             Color.White
         } else {
             when (playerBackground) {
@@ -676,7 +741,9 @@ fun BottomSheetPlayer(
         }
 
     val icBackgroundColor =
-        if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
+        if (playerDesignStyle == PlayerDesignStyle.V9) {
+            dynamicBgColor
+        } else if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
             Color.Black
         } else {
             when (playerBackground) {
@@ -706,6 +773,8 @@ fun BottomSheetPlayer(
         }.let { (tb, ib) ->
             if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
                 Pair(Color.White, Color.Black)
+            } else if (playerDesignStyle == PlayerDesignStyle.V9) {
+                Pair(dynamicAccentColor, dynamicIconButtonColor)
             } else {
                 Pair(tb, ib)
             }
@@ -1091,7 +1160,20 @@ fun BottomSheetPlayer(
                     }
                 },
         backgroundColor =
-            if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
+            if (playerDesignStyle == PlayerDesignStyle.V9) {
+                // V9 "Material Extended": animate the sheet background to the artwork's
+                // dominant color so the controls blend smoothly with the artwork (no blur).
+                val progress =
+                    ((state.value - state.collapsedBound) / (state.expandedBound - state.collapsedBound))
+                        .coerceIn(0f, 1f)
+                val fadeProgress =
+                    if (progress < 0.2f) {
+                        ((0.2f - progress) / 0.2f).coerceIn(0f, 1f)
+                    } else {
+                        0f
+                    }
+                dynamicBgColor.copy(alpha = 1f - fadeProgress)
+            } else if (playerDesignStyle == PlayerDesignStyle.V7 || playerDesignStyle == PlayerDesignStyle.V8) {
                 val progress =
                     ((state.value - state.collapsedBound) / (state.expandedBound - state.collapsedBound))
                         .coerceIn(0f, 1f)
@@ -2240,7 +2322,9 @@ fun BottomSheetPlayer(
             )
         }
 
-        val queueOnBackgroundColor = if (useBlackBackground) Color.White else MaterialTheme.colorScheme.onSurface
+        // Always use white text on the queue sheet so titles/artists stay readable on the
+        // dark blurred backdrop regardless of light/dark theme (matches Apple Music style).
+        val queueOnBackgroundColor = Color.White
         val queueSurfaceColor = if (useBlackBackground) Color.Black else MaterialTheme.colorScheme.surface
 
         val (queueTextButtonColor, queueIconButtonColor) =
@@ -2334,7 +2418,14 @@ fun BottomSheetPlayer(
         mediaMetadata?.let { metadata ->
             MikoLyricsTransition(
                 visible = isLyricsScreenVisible,
-                backHandlerEnabled = false,
+                // Only Apple Music style intentionally suppresses the back handler
+                // (its lyrics sheet is part of the same collapsed/expanded sheet flow).
+                // All other player styles must allow the system back button (and the
+                // close affordance in the lyrics top bar) to dismiss the lyrics sheet.
+                backHandlerEnabled =
+                    isLyricsScreenVisible &&
+                        state.isExpandedOrExpanding &&
+                        playerDesignStyle != PlayerDesignStyle.APPLE_MUSIC,
                 mediaMetadata = metadata,
                 navController = navController,
                 lyricsSyncOffset = lyricsSyncOffset,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -249,11 +249,7 @@ private const val V7SharpStagePortraitFraction = 0.62f
 private const val V7SharpStageLandscapeFraction = 0.58f
 private const val V7BackdropOverlapDp = 72
 private const val V7SharpStageBottomScrimStartFraction = 0.40f
-// ISSUE 4 FIX: lowered from 0.88 → 0.55 so the palette-color gradient dominates
-// the bottom ~45% of the backdrop (matching the reference image where the bottom
-// 35-40% is a smooth gradient, not a blur). Previously the gradient only kicked
-// in at 0.88, leaving positions 0.45→0.88 as blur-dominated.
-private const val V7BackdropFloorBlackStartFraction = 0.55f
+private const val V7BackdropFloorBlackStartFraction = 0.88f
 private const val V8BackdropArtworkSizePx = 1_024
 
 @Stable
@@ -2642,12 +2638,7 @@ private fun V8PlayerBackdrop(
                             .graphicsLayer {
                                 scaleX = 1.16f
                                 scaleY = 1.16f
-                                // Raised from 0.66 → 1.0 — let the artwork's
-                                // actual colours through; the previous 0.66
-                                // alpha combined with the 0.52 black scrim below
-                                // was crushing the brightness down to a muddy
-                                // grey. Matches ViviMusic's bright-blur aesthetic.
-                                alpha = 1.0f
+                                alpha = 0.66f
                             },
                     onState = { state ->
                         if (state is coil3.compose.AsyncImagePainter.State.Error) {
@@ -2665,7 +2656,7 @@ private fun V8PlayerBackdrop(
                             .graphicsLayer {
                                 scaleX = 1.16f
                                 scaleY = 1.16f
-                                alpha = 1.0f
+                                alpha = 0.66f
                             },
                     onError = { failedUrl ->
                         getNextFallbackUrl(failedUrl)?.let { currentUrl = it }
@@ -2682,7 +2673,7 @@ private fun V8PlayerBackdrop(
                             .graphicsLayer {
                                 scaleX = 1.16f
                                 scaleY = 1.16f
-                                alpha = 1.0f
+                                alpha = 0.66f
                             },
                     onState = { state ->
                         if (state is coil3.compose.AsyncImagePainter.State.Error) {
@@ -2693,17 +2684,12 @@ private fun V8PlayerBackdrop(
             }
         }
 
-        // ViviMusic-faithful scrim: a single uniform 30% black tint, like
-        // HazeTint(Color.Black.copy(alpha = 0.30f)). Previously this was a
-        // 0.52-alpha black box which, combined with the 0.66 graphicsLayer
-        // alpha above, produced an effective ~83% darkening — the opposite
-        // of ViviMusic's bright, vibrant blur. The 0.30 tint preserves the
-        // album art's colour while keeping text legible.
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.30f)),        )
+                    .background(Color.Black.copy(alpha = 0.52f)),
+        )
     }
 }
 
@@ -2825,28 +2811,17 @@ private fun V7PlayerBackdrop(
     // When canvas is available, prefer its static image as the sharp-stage placeholder.
     // This prevents the jarring YTM thumbnail → canvas video flash on expand.
     val sharpArtworkUrl = if (hasCanvas) (canvasStatic ?: coverArtworkUrl) else (coverArtworkUrl ?: canvasStatic)
-    // When canvas is active, prefer the canvas static image as the backdrop blur source too —
-    // matching the sharp stage. This keeps the backdrop consistent with the canvas artwork
-    // (Apple Music player style) instead of falling back to the album art, which looked
-    // inconsistent when the sharp stage showed the canvas video but the blur showed the
-    // album cover.
-    val backdropArtworkUrl = if (hasCanvas) (canvasStatic ?: coverArtworkUrl) else (coverArtworkUrl ?: canvasStatic)
+    val backdropArtworkUrl = coverArtworkUrl ?: canvasStatic
     // For palette extraction, use canvas static when canvas is active so the scrim
     // gradient is derived from the canvas colors rather than the YTM thumbnail.
     val paletteSourceUrl = if (hasCanvas && canvasStatic != null) canvasStatic else backdropArtworkUrl
-    // Keep the previous valid palette while the next artwork loads; only replace on success.
-    var backdropPalette by remember {
+    var backdropPalette by remember(paletteSourceUrl, fallbackColor) {
         mutableStateOf(V7BackdropPalette.fromColors(emptyList(), fallbackColor))
     }
-    var hasValidBackdropPalette by remember { mutableStateOf(false) }
 
     LaunchedEffect(paletteSourceUrl, hasCanvas, fallbackColor) {
-        if (paletteSourceUrl == null) {
-            if (!hasValidBackdropPalette) {
-                backdropPalette = V7BackdropPalette.fromColors(emptyList(), fallbackColor)
-            }
-            return@LaunchedEffect
-        }
+        backdropPalette = V7BackdropPalette.fromColors(emptyList(), fallbackColor)
+        if (paletteSourceUrl == null) return@LaunchedEffect
 
         val request =
             ImageRequest
@@ -2862,40 +2837,34 @@ private fun V7PlayerBackdrop(
 
         val extractedColors =
             try {
-                val result =
+                val image =
                     withContext(Dispatchers.IO) {
                         context.imageLoader.execute(request)
-                    }
-                if (result !is SuccessResult) {
+                    }.image
+                if (image == null) {
                     null
                 } else {
                     withContext(Dispatchers.Default) {
-                        val fullBitmap = result.image?.toBitmap()
-                        if (fullBitmap == null) {
-                            null
-                        } else {
-                            // When canvas is active, extract from the bottom 30% of the static frame.
-                            // This gives us the actual colors at the canvas bottom edge, so the scrim
-                            // gradient blends seamlessly into the backdrop below.
-                            val bitmapForPalette =
-                                if (hasCanvas && fullBitmap.height > 4) {
-                                    val startY = (fullBitmap.height * 0.70f).toInt().coerceAtLeast(0)
-                                    val cropHeight = (fullBitmap.height - startY).coerceAtLeast(1)
-                                    android.graphics.Bitmap.createBitmap(fullBitmap, 0, startY, fullBitmap.width, cropHeight)
-                                } else {
-                                    fullBitmap
-                                }
-                            val palette =
-                                Palette
-                                    .from(bitmapForPalette)
-                                    .maximumColorCount(PlayerColorExtractor.Config.MAX_COLOR_COUNT)
-                                    .resizeBitmapArea(PlayerColorExtractor.Config.BITMAP_AREA)
-                                    .generate()
-                            PlayerColorExtractor.extractGradientColors(
-                                palette = palette,
-                                fallbackColor = fallbackColor,
-                            )
-                        }
+                        val fullBitmap = image.toBitmap()
+                        // When canvas is active, extract from the bottom 30% of the static frame.
+                        // This gives us the actual colors at the canvas bottom edge, so the scrim
+                        // gradient blends seamlessly into the backdrop below.
+                        val bitmapForPalette =
+                            if (hasCanvas && fullBitmap.height > 4) {
+                                val startY = (fullBitmap.height * 0.70f).toInt().coerceAtLeast(0)
+                                val cropHeight = (fullBitmap.height - startY).coerceAtLeast(1)
+                                android.graphics.Bitmap.createBitmap(fullBitmap, 0, startY, fullBitmap.width, cropHeight)
+                            } else {
+                                fullBitmap
+                            }
+                        val palette =
+                            Palette
+                                .from(bitmapForPalette)
+                                .maximumColorCount(PlayerColorExtractor.Config.MAX_COLOR_COUNT)
+                                .resizeBitmapArea(PlayerColorExtractor.Config.BITMAP_AREA)
+                                .generate()
+                        val dominantRgb = palette.dominantSwatch?.rgb ?: palette.getDominantColor(fallbackColor)
+                        listOf(Color(dominantRgb))
                     }
                 }
             } catch (e: CancellationException) {
@@ -2904,12 +2873,7 @@ private fun V7PlayerBackdrop(
                 null
             }
 
-        if (extractedColors != null) {
-            backdropPalette = V7BackdropPalette.fromColors(extractedColors, fallbackColor)
-            hasValidBackdropPalette = true
-        } else if (!hasValidBackdropPalette) {
-            backdropPalette = V7BackdropPalette.fromColors(emptyList(), fallbackColor)
-        }
+        backdropPalette = V7BackdropPalette.fromColors(extractedColors.orEmpty(), fallbackColor)
     }
 
     val backdropState =
@@ -2934,40 +2898,25 @@ private fun V7PlayerBackdrop(
     val sharpStageBottomScrim =
         remember(backdropPalette) {
             val blendColor = backdropPalette.bottom
-            // ViviMusic-faithful: reduced alphas (0.18/0.52/0.82/1.0 →
-            // 0.10/0.28/0.46/0.62) so the bottom of the sharp stage still
-            // blends into the backdrop but doesn't aggressively darken the
-            // artwork. Combined with the brighter palette tone and raised
-            // backdrop alpha, the result reads as vibrant rather than muddy.
             Brush.verticalGradient(
                 colorStops =
                     arrayOf(
                         0f to Color.Transparent,
                         V7SharpStageBottomScrimStartFraction to Color.Transparent,
-                        0.60f to blendColor.copy(alpha = 0.10f),
-                        0.76f to blendColor.copy(alpha = 0.28f),
-                        0.88f to blendColor.copy(alpha = 0.46f),
-                        1f to blendColor.copy(alpha = 0.62f),
+                        0.60f to blendColor.copy(alpha = 0.18f),
+                        0.76f to blendColor.copy(alpha = 0.52f),
+                        0.88f to blendColor.copy(alpha = 0.82f),
+                        1f to blendColor,
                     ),
             )
         }
     val backdropFloor =
         remember(backdropPalette) {
-            // ISSUE 4 FIX: gradient now dominates the bottom ~55% of the backdrop
-            // (matching the reference image where the bottom 35-40% is a smooth
-            // palette-color gradient, not a blur). Previously the gradient only
-            // started at 0.45 and ramped to 0.85 alpha at 0.88, leaving the upper
-            // half of the controls area blur-dominated. Now the gradient starts
-            // at 0.30, ramps to 0.75 alpha at 0.55 (V7BackdropFloorBlackStartFraction),
-            // and reaches full opacity at 0.85 — so the bottom ~55% is gradient-
-            // dominated with the blur subtly visible at the top ~30%.
             Brush.verticalGradient(
                 colorStops =
                     arrayOf(
-                        0f to Color.Transparent,
-                        0.30f to Color.Transparent,
-                        V7BackdropFloorBlackStartFraction to backdropPalette.bottom.copy(alpha = 0.75f),
-                        0.85f to backdropPalette.bottom.copy(alpha = 0.96f),
+                        0f to backdropPalette.bottom,
+                        V7BackdropFloorBlackStartFraction to backdropPalette.bottom,
                         1f to backdropPalette.bottom,
                     ),
             )
@@ -2981,14 +2930,7 @@ private fun V7PlayerBackdrop(
                 .graphicsLayer {
                     scaleX = V7BackdropBlurScale
                     scaleY = V7BackdropBlurScale
-                    // ISSUE 4 FIX: lowered from 0.92 → 0.50 (and 0.50 → 0.30 for the
-                    // no-blur branch) so the gradient floor (backdropFloor) is the
-                    // dominant visual behind the controls, not the blur. The blur is
-                    // now a subtle texture at the top of the backdrop that fades into
-                    // the palette-color gradient — matching the reference image's
-                    // "frosted glass with gradient overlay" look. Previously 0.92
-                    // alpha made the blur dominate and the gradient was barely visible.
-                    alpha = if (disableBlur || !needsBlur) 0.30f else 0.50f
+                    alpha = if (disableBlur || !needsBlur) 0.20f else 0.58f
                 }
         }
     val canvasStageModifier =
@@ -3047,10 +2989,7 @@ private fun V7PlayerBackdrop(
                                 .graphicsLayer {
                                     scaleX = V7BackdropBlurScale
                                     scaleY = V7BackdropBlurScale
-                                    // ISSUE 4 FIX: lowered from 0.58 → 0.50 to match
-                                    // the S+ branch's 0.50 alpha so the gradient floor
-                                    // dominates on pre-S devices too.
-                                    alpha = 0.50f
+                                    alpha = 0.58f
                                 },
                         onError = { failedUrl ->
                             getNextFallbackUrl(failedUrl)?.let { backdropArtworkModel = it }
@@ -3165,14 +3104,10 @@ private data class V7BackdropPalette(
             // (e.g. red → green at +120°) which are wrong for a backdrop that should feel
             // coherent. We derive mid/bottom by darkening the same hue instead.
             val dominantColor = colors.firstOrNull()
-            // ViviMusic-faithful: previous valueMax caps (0.32/0.48/0.72) were
-            // crushing the palette into a dark, muddy sludge. New caps
-            // (0.62/0.78/0.92) let the actual dominant colour through, matching
-            // ViviMusic's bright, vibrant blur aesthetic.
-            val fallback = Color(fallbackColor).v7BackdropTone(valueMin = 0.20f, valueMax = 0.62f)
-            val top = dominantColor?.v7BackdropTone(valueMin = 0.32f, valueMax = 0.92f) ?: fallback
-            val mid = dominantColor?.v7BackdropTone(valueMin = 0.26f, valueMax = 0.78f) ?: top
-            val bottom = dominantColor?.v7BackdropTone(valueMin = 0.20f, valueMax = 0.62f) ?: mid
+            val fallback = Color(fallbackColor).v7BackdropTone(valueMin = 0.12f, valueMax = 0.38f)
+            val top = dominantColor?.v7BackdropTone(valueMin = 0.20f, valueMax = 0.72f) ?: fallback
+            val mid = dominantColor?.v7BackdropTone(valueMin = 0.13f, valueMax = 0.48f) ?: top
+            val bottom = dominantColor?.v7BackdropTone(valueMin = 0.08f, valueMax = 0.32f) ?: mid
             return V7BackdropPalette(
                 top = top,
                 mid = mid,
@@ -3192,7 +3127,7 @@ private fun Color.v7BackdropTone(
         if (hsv[1] < 0.12f) {
             hsv[1].coerceAtMost(0.08f)
         } else {
-            (hsv[1] * 1.22f).coerceIn(0f, 1f)
+            (hsv[1] * 1.27f).coerceIn(0f, 1f)
         }
     hsv[2] = hsv[2].coerceIn(valueMin, valueMax)
     return Color(android.graphics.Color.HSVToColor(hsv))
@@ -3338,7 +3273,7 @@ private fun LittlePlayerContent(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
-                    painter = painterResource(R.drawable.player_expand_more),
+                    painter = painterResource(R.drawable.expand_more),
                     contentDescription = null,
                     tint = textColor.copy(alpha = 0.8f),
                     modifier =
@@ -3354,7 +3289,7 @@ private fun LittlePlayerContent(
                 Spacer(Modifier.weight(1f))
 
                 Icon(
-                    painter = painterResource(if (liked) R.drawable.player_favorite else R.drawable.player_favorite_border),
+                    painter = painterResource(if (liked) R.drawable.favorite else R.drawable.favorite_border),
                     contentDescription = null,
                     tint =
                         if (liked) {
@@ -3374,29 +3309,24 @@ private fun LittlePlayerContent(
 
                 Spacer(Modifier.width((18f * scale).dp))
 
-                Box(
-                    contentAlignment = Alignment.Center,
+                Icon(
+                    painter = painterResource(R.drawable.queue_music),
+                    contentDescription = null,
+                    tint = textColor.copy(alpha = 0.78f),
                     modifier =
                         Modifier
-                            .size(48.dp)
+                            .size(iconSize)
                             .clickable(
                                 interactionSource = remember { MutableInteractionSource() },
                                 indication = null,
                                 onClick = onExpandQueue,
                             ),
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.player_queue_music),
-                        contentDescription = null,
-                        tint = textColor.copy(alpha = 0.78f),
-                        modifier = Modifier.size(iconSize),
-                    )
-                }
+                )
 
                 Spacer(Modifier.width((18f * scale).dp))
 
                 Icon(
-                    painter = painterResource(R.drawable.player_more_vert),
+                    painter = painterResource(R.drawable.more_vert),
                     contentDescription = null,
                     tint = textColor.copy(alpha = 0.78f),
                     modifier =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -901,7 +901,14 @@ fun BottomSheetPlayer(
                     }
                 } else {
                     position = currentPlayerPosition
-                    duration = currentPlayerDuration
+                    if (currentPlayerDuration > 0L && currentPlayerDuration != C.TIME_UNSET) {
+                        duration = currentPlayerDuration
+                    } else if (duration <= 0L || duration == C.TIME_UNSET) {
+                        mediaMetadata?.let {
+                            val metadataDuration = it.duration.toLong() * 1000
+                            if (metadataDuration > 0L) duration = metadataDuration
+                        }
+                    }
                     if (!isUserSeeking) {
                         sliderPosition?.let { targetPosition ->
                             val clampedTargetPosition =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -106,6 +106,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -21,6 +21,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -61,6 +62,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -71,7 +73,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -87,7 +88,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
 import androidx.navigation.NavController
@@ -117,6 +117,7 @@ import moe.rukamori.archivetune.ui.component.BottomSheet
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 import moe.rukamori.archivetune.ui.component.LocalBottomSheetPageState
 import moe.rukamori.archivetune.ui.component.LocalMenuState
+import moe.rukamori.archivetune.ui.component.MediaMetadataListItem
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.menu.AddToPlaylistDialog
 import moe.rukamori.archivetune.ui.menu.PlayerMenu
@@ -152,16 +153,16 @@ fun Queue(
     val bottomSheetPageState = LocalBottomSheetPageState.current
 
     val playerConnection = LocalPlayerConnection.current ?: return
-    val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
-    val repeatMode by playerConnection.repeatMode.collectAsStateWithLifecycle()
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val repeatMode by playerConnection.repeatMode.collectAsState()
 
-    val currentWindowIndex by playerConnection.currentWindowIndex.collectAsStateWithLifecycle()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
-    val currentSong by playerConnection.currentSong.collectAsStateWithLifecycle(initialValue = null)
+    val currentWindowIndex by playerConnection.currentWindowIndex.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+    val currentSong by playerConnection.currentSong.collectAsState(initial = null)
     val currentSongLiked = currentSong?.song?.liked == true
 
-    val currentFormat by playerConnection.currentFormat.collectAsStateWithLifecycle(initialValue = null)
-    val queueTitle by playerConnection.queueTitle.collectAsStateWithLifecycle()
+    val currentFormat by playerConnection.currentFormat.collectAsState(initial = null)
+    val queueTitle by playerConnection.queueTitle.collectAsState()
 
     val selectedSongs = remember { mutableStateListOf<MediaMetadata>() }
     val selectedItems = remember { mutableStateListOf<Timeline.Window>() }
@@ -181,8 +182,8 @@ fun Queue(
 
     var locked by rememberPreference(QueueEditLockKey, defaultValue = true)
     var infiniteQueueEnabled by rememberPreference(AutoLoadMoreKey, defaultValue = true)
-    val infiniteQueueLoading by playerConnection.service.infiniteQueueLoading.collectAsStateWithLifecycle()
-    val togetherSessionState by playerConnection.service.togetherSessionState.collectAsStateWithLifecycle()
+    val infiniteQueueLoading by playerConnection.service.infiniteQueueLoading.collectAsState()
+    val togetherSessionState by playerConnection.service.togetherSessionState.collectAsState()
     val togetherForcesLock =
         togetherSessionState is moe.rukamori.archivetune.together.TogetherSessionState.Joined &&
             (togetherSessionState as moe.rukamori.archivetune.together.TogetherSessionState.Joined).role is moe.rukamori.archivetune.together.TogetherRole.Guest
@@ -243,7 +244,7 @@ fun Queue(
         TextFieldDialog(
             icon = {
                 Icon(
-                    painter = painterResource(R.drawable.player_queue_music),
+                    painter = painterResource(R.drawable.queue_music),
                     contentDescription = null,
                 )
             },
@@ -295,7 +296,7 @@ fun Queue(
         )
     }
 
-    val queueWindows by playerConnection.queueWindows.collectAsStateWithLifecycle()
+    val queueWindows by playerConnection.queueWindows.collectAsState()
     val currentWindow =
         remember(currentWindowIndex, queueWindows) {
             queueWindows.getOrNull(currentWindowIndex)
@@ -376,7 +377,7 @@ fun Queue(
         ) {
             playerConnection.service.sleepTimer.isActive
         }
-    var sleepTimerTimeLeft by remember { mutableLongStateOf(0L) }
+    var sleepTimerTimeLeft by remember { mutableStateOf(0L) }
 
     val (showCodecOnPlayer) =
         rememberPreference(
@@ -411,36 +412,8 @@ fun Queue(
 
     BottomSheet(
         state = state,
-        // Pass the actual background color (surfaceContainer / Black) instead of
-        // Color.Unspecified, AND set opaqueBackground = true so the outer sheet
-        // background is fully opaque as soon as the sheet starts sliding up.
-        //
-        // Why: non-Apple-Music player styles render a zoomed/gradient/blur
-        // artwork backdrop behind the player (PlayerBackground composable).
-        // The previous Color.Unspecified made the outer sheet transparent, and
-        // the inner content's graphicsLayer alpha fade (which only reaches 1.0
-        // at progress = 0.5) let that artwork bleed through during the slide-up
-        // drag. With opaqueBackground = true, the outer background is opaque
-        // from the very first pixel of drag, fully covering the player artwork,
-        // while the inner queue rows still fade in smoothly via their own
-        // graphicsLayer alpha. Apple-Music style was unaffected because it
-        // doesn't render PlayerBackground — its player backdrop is already a
-        // solid surface color.
-        backgroundColor = backgroundColor,
-        opaqueBackground = true,
+        backgroundColor = Color.Unspecified,
         modifier = modifier,
-        morphMode = true,
-        // Keep the queue list composed while the sheet is collapsed at the peek
-        // height — otherwise the `!state.isCollapsed` gate unmounts the whole
-        // LazyColumn (and its scroll/selection state) the moment a drag reaches
-        // the peek, which combined with the old no-slide morph made the queue
-        // vanish while dragging it down.
-        //
-        // Apple Music is excluded: it renders its queue via the in-place
-        // SharedTransitionLayout morph in AppleMusicPlayer (peek height is 0dp,
-        // so this sheet never shows). Keeping it alive there would compose a
-        // second, invisible reorderable queue list behind the morph.
-        keepContentAlive = playerDesignStyle != PlayerDesignStyle.APPLE_MUSIC,
         onCollapsedContentClick = openQueue,
         collapsedContent = {
             when (playerDesignStyle) {
@@ -522,14 +495,39 @@ fun Queue(
                 }
 
                 PlayerDesignStyle.V5 -> {
-                    // V5 keeps its collapsed peek bar empty, matching the APPLE_MUSIC approach.
-                    // The LittlePlayer (rendered inside Player.kt) already exposes queue, like,
-                    // and more-menu buttons with proper 48dp touch targets. Previously this
-                    // branch rendered QueueCollapsedContentV3 inside a 0dp-tall peek Box —
-                    // the button row overflowed the parent and its touch zone was clipped/
-                    // competed-for by the BottomSheet wrapper's own clickable, which caused
-                    // "queue button doesn't work at all" reports on V5. Sleep timer, lyrics,
-                    // and other controls remain reachable via the LittlePlayer's more-menu.
+                    QueueCollapsedContentV3(
+                        showCodecOnPlayer = showCodecOnPlayer,
+                        currentFormat = currentFormat,
+                        textBackgroundColor = TextBackgroundColor,
+                        sleepTimerEnabled = sleepTimerEnabled,
+                        sleepTimerTimeLeft = sleepTimerTimeLeft,
+                        onExpandQueue = openQueue,
+                        onSleepTimerClick = {
+                            if (sleepTimerEnabled) {
+                                playerConnection.service.sleepTimer.clear()
+                            } else {
+                                showSleepTimerDialog = true
+                            }
+                        },
+                        onShowLyrics = onShowLyrics,
+                        onMenuClick = {
+                            menuState.show {
+                                PlayerMenu(
+                                    mediaMetadata = mediaMetadata,
+                                    navController = navController,
+                                    playerBottomSheetState = playerBottomSheetState,
+                                    onShowDetailsDialog = {
+                                        mediaMetadata?.id?.let {
+                                            bottomSheetPageState.show {
+                                                ShowMediaInfo(it)
+                                            }
+                                        }
+                                    },
+                                    onDismiss = menuState::dismiss,
+                                )
+                            }
+                        },
+                    )
                 }
 
                 PlayerDesignStyle.V4 -> {
@@ -595,13 +593,8 @@ fun Queue(
                     )
                 }
 
-                PlayerDesignStyle.APPLE_MUSIC -> {
-                    // The Apple Music style keeps its collapsed peek bar empty: the queue, lyrics and
-                    // output controls all live in the player's own bottom row, so no extra pills here.
-                }
-
                 PlayerDesignStyle.V9 -> {
-                    val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsStateWithLifecycle()
+                    val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
                     QueueCollapsedContentV9(
                         showCodecOnPlayer = showCodecOnPlayer,
                         currentFormat = currentFormat,
@@ -611,10 +604,6 @@ fun Queue(
                         shuffleModeEnabled = shuffleModeEnabled,
                         repeatMode = repeatMode,
                         onShuffleClick = {
-                            // Auto-disable repeat when turning shuffle on (mutually exclusive UX).
-                            if (!shuffleModeEnabled) {
-                                playerConnection.player.repeatMode = Player.REPEAT_MODE_OFF
-                            }
                             playerConnection.player.shuffleModeEnabled = !shuffleModeEnabled
                         },
                         onRepeatModeClick = { playerConnection.player.toggleRepeatMode() },
@@ -679,6 +668,16 @@ fun Queue(
                         device = audioDevice,
                     )
                 }
+
+                PlayerDesignStyle.APPLE_MUSIC -> {
+                    // The Apple Music style renders its queue via the in-place
+                    // SharedTransitionLayout morph in AppleMusicPlayer (its
+                    // collapsed peek height is 0dp, so this BottomSheet never
+                    // visibly collapses for that style). Keeping an explicit
+                    // empty branch here means the `when` stays exhaustive and
+                    // we don't accidentally render an upstream collapsed-content
+                    // variant behind the morph.
+                }
             }
 
             if (showSleepTimerDialog) {
@@ -697,27 +696,11 @@ fun Queue(
             }
         },
     ) {
-        val queueWindows by playerConnection.queueWindows.collectAsStateWithLifecycle()
-        val currentPlayingUid =
-            remember(currentWindowIndex, queueWindows) {
-                if (currentWindowIndex in queueWindows.indices) {
-                    queueWindows[currentWindowIndex].uid
-                } else {
-                    null
-                }
-            }
-        // Display list: current song at index 0, upcoming next, then previously-played
-        // songs in reverse chronological order. See the sync LaunchedEffect below for
-        // the full rationale. The initial value is pre-reordered (Apple Music) or
-        // in timeline order (non-Apple Music) so the first frame doesn't flicker.
+        val queueWindows by playerConnection.queueWindows.collectAsState()
         val mutableQueueWindows =
             remember {
                 mutableStateListOf<Timeline.Window>().apply {
-                    if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
-                        addAll(reorderedForDisplay(queueWindows, currentPlayingUid))
-                    } else {
-                        addAll(queueWindows)
-                    }
+                    addAll(queueWindows)
                 }
             }
         val queueLength by remember {
@@ -729,13 +712,15 @@ fun Queue(
         val headerItems = 1
         val lazyListState = rememberLazyListState()
         var dragInfo by remember { mutableStateOf<QueueDragInfo?>(null) }
-        // UIDs of items that we just committed via moveMediaItem. Used to skip the
-        // mutableQueueWindows reset for ONE LaunchedEffect cycle so the player's
-        // timeline update has time to propagate. Without this, the else-branch
-        // resets mutableQueueWindows to the OLD queueWindows (before the move),
-        // causing the dragged item to "snap back" to its original position.
-        var justCommittedDragUid by remember { mutableStateOf<Any?>(null) }
 
+        val currentPlayingUid =
+            remember(currentWindowIndex, queueWindows) {
+                if (currentWindowIndex in queueWindows.indices) {
+                    queueWindows[currentWindowIndex].uid
+                } else {
+                    null
+                }
+            }
         val nextPlayingUid =
             remember(currentWindowIndex, queueWindows) {
                 queueWindows.getOrNull(currentWindowIndex + 1)?.uid
@@ -772,19 +757,7 @@ fun Queue(
                         draggedItemUid = draggedItemUid,
                         destination =
                             if (toQueueIndex == 0) {
-                                if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
-                                    // In the filtered Apple Music queue list the current song
-                                    // is always at index 0, so dropping at position 0 means
-                                    // "make this the next song after the current one" rather
-                                    // than "move to the very start of the full timeline".
-                                    currentPlayingUid?.let { QueueDragDestination.After(itemUid = it) }
-                                        ?: QueueDragDestination.Start
-                                } else {
-                                    // Non-Apple Music styles: match upstream behavior exactly —
-                                    // dropping at index 0 moves the song to the very start of
-                                    // the full timeline.
-                                    QueueDragDestination.Start
-                                }
+                                QueueDragDestination.Start
                             } else {
                                 QueueDragDestination.After(
                                     itemUid = mutableQueueWindows[toQueueIndex - 1].uid,
@@ -792,7 +765,7 @@ fun Queue(
                             },
                     )
 
-                if (selection) {
+                if (selection && currentWindowIndex in mutableQueueWindows.indices) {
                     val currentItem = queueWindows.getOrNull(currentWindowIndex)
 
                     if (currentItem?.uid == draggedItemUid) {
@@ -811,7 +784,7 @@ fun Queue(
                 }
             }
 
-        LaunchedEffect(queueWindows, currentWindowIndex, reorderableState.isAnyItemDragging) {
+        LaunchedEffect(queueWindows, reorderableState.isAnyItemDragging) {
             if (reorderableState.isAnyItemDragging) return@LaunchedEffect
 
             val completedDrag = dragInfo
@@ -825,10 +798,6 @@ fun Queue(
                     destinationIndex != null &&
                     sourceIndex != destinationIndex
                 ) {
-                    // Mark this drag as just-committed so the next LaunchedEffect
-                    // invocation (triggered by the player's onTimelineChanged)
-                    // doesn't reset mutableQueueWindows to the pre-move order.
-                    justCommittedDragUid = completedDrag.draggedItemUid
                     if (!playerConnection.player.shuffleModeEnabled) {
                         playerConnection.player.moveMediaItem(sourceIndex, destinationIndex)
                     } else {
@@ -847,46 +816,11 @@ fun Queue(
                 }
             }
 
-            // If we just committed a drag, skip the reset for one cycle to let
-            // the player's timeline update propagate. The next LaunchedEffect
-            // invocation (with the updated queueWindows) will clear the flag
-            // and apply the reset using the post-move order.
-            if (justCommittedDragUid != null) {
-                justCommittedDragUid = null
-                // Keep the local drag move visible until the player's queue
-                // update arrives. The next LaunchedEffect (triggered by the
-                // queueWindows change from onTimelineChanged) will do the reset.
-                return@LaunchedEffect
-            }
-
-            // Apple Music style: display the current song and upcoming songs
-            // first, then previously-played songs in reverse chronological
-            // order (SimpMusic / Spotify style "Continue Playing" header).
-            // All other player styles: show the full queue timeline in
-            // timeline order (matches upstream rukamori/ArchiveTune exactly).
-            // The full `queueWindows` (including played songs) is still used
-            // for queue stats, clear-queue, and drag-source resolution.
-            val displayList =
-                if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
-                    reorderedForDisplay(queueWindows, currentPlayingUid)
-                } else {
-                    queueWindows
-                }
             Snapshot.withMutableSnapshot {
                 mutableQueueWindows.clear()
-                mutableQueueWindows.addAll(displayList)
+                mutableQueueWindows.addAll(queueWindows)
             }
         }
-
-        // Tracks the previous collapsed state so we can detect the exact
-        // moment the queue sheet transitions from collapsed → expanded
-        // (whether via the queue button or a swipe-up gesture) and scroll
-        // to the currently playing song. Without this, the queue opens
-        // scrolled to the top, forcing the user to manually find what's
-        // playing. We avoid re-scrolling on every `currentPlayingUid`
-        // change so the user is free to browse the queue after opening it
-        // without being yanked back to the current song mid-scroll.
-        var prevIsCollapsed by remember { mutableStateOf(state.isCollapsed) }
 
         LaunchedEffect(
             state.isCollapsed,
@@ -894,33 +828,16 @@ fun Queue(
             currentPlayingUid,
             reorderableState.isAnyItemDragging,
         ) {
-            val justOpened = prevIsCollapsed && !state.isCollapsed
-            prevIsCollapsed = state.isCollapsed
-            val shouldScroll =
+            if (
                 !state.isCollapsed &&
-                    (justOpened || scrollToCurrentRequested) &&
-                    currentPlayingUid != null &&
-                    !reorderableState.isAnyItemDragging
-            if (shouldScroll) {
-                // Wait briefly for the queue windows to populate after the
-                // sheet expands. The first composition after expand often has
-                // an empty `mutableQueueWindows` (the Snapshot.withMutableSnapshot
-                // that copies `queueWindows` into `mutableQueueWindows` runs
-                // in a separate LaunchedEffect that hasn't fired yet). A short
-                // retry loop lets the index lookup succeed.
-                var attempts = 0
-                while (attempts < 8) {
-                    val indexInMutableList =
-                        mutableQueueWindows.indexOfFirst { it.uid == currentPlayingUid }
-                    if (indexInMutableList != -1) {
-                        lazyListState.scrollToItem(
-                            (indexInMutableList + headerItems).coerceAtLeast(0),
-                        )
-                        scrollToCurrentRequested = false
-                        break
-                    }
-                    kotlinx.coroutines.delay(50L)
-                    attempts++
+                scrollToCurrentRequested &&
+                currentPlayingUid != null &&
+                !reorderableState.isAnyItemDragging
+            ) {
+                val indexInMutableList = mutableQueueWindows.indexOfFirst { it.uid == currentPlayingUid }
+                if (indexInMutableList != -1) {
+                    lazyListState.scrollToItem(indexInMutableList + headerItems)
+                    scrollToCurrentRequested = false
                 }
             }
         }
@@ -932,14 +849,44 @@ fun Queue(
                     .background(backgroundColor),
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                CompactQueueHeader(
+                CurrentSongHeader(
                     sheetState = state,
+                    mediaMetadata = mediaMetadata,
+                    liked = currentSongLiked,
+                    isPlaying = isPlaying,
+                    repeatMode = repeatMode,
+                    shuffleModeEnabled = playerConnection.player.shuffleModeEnabled,
+                    locked = effectiveLocked,
                     songCount = queueWindows.size,
                     queueDuration = queueLength,
-                    locked = effectiveLocked,
                     infiniteQueueEnabled = infiniteQueueEnabled,
                     infiniteQueueLoading = infiniteQueueLoading,
+                    backgroundColor = backgroundColor,
                     onBackgroundColor = onBackgroundColor,
+                    onToggleLike = {
+                        playerConnection.service.toggleLike()
+                    },
+                    onMenuClick = {
+                        menuState.show {
+                            PlayerMenu(
+                                mediaMetadata = mediaMetadata,
+                                navController = navController,
+                                playerBottomSheetState = playerBottomSheetState,
+                                isQueueTrigger = true,
+                                onRemoveFromQueue = {
+                                    currentWindow?.let { onRemoveWithUndo(it) }
+                                },
+                                onShowDetailsDialog = {
+                                    mediaMetadata?.id?.let {
+                                        bottomSheetPageState.show {
+                                            ShowMediaInfo(it)
+                                        }
+                                    }
+                                },
+                                onDismiss = menuState::dismiss,
+                            )
+                        }
+                    },
                     onClearQueueClick = {
                         val windowsToRemove =
                             if (currentWindowIndex in queueWindows.indices) {
@@ -956,17 +903,16 @@ fun Queue(
                         }
 
                         if (infiniteQueueEnabled) {
-                            // Clear the current auto-generated items without changing the user's
-                            // persisted global Infinite Queue choice. The next queue will respect
-                            // the same saved setting.
+                            infiniteQueueEnabled = false
                             playerConnection.service.onInfiniteQueueDisabled()
                         }
                     },
-                    // NOTE: shuffle/repeat moved out of the queue header — the
-                    // player's own bottom row already exposes them. The
-                    // "auto-disable repeat when shuffle on" UX from the old
-                    // header is preserved in the player's shuffle button
-                    // (see BottomSheetPlayer shuffle handler).
+                    onRepeatClick = { playerConnection.player.toggleRepeatMode() },
+                    onShuffleClick = {
+                        coroutineScope.launch(Dispatchers.Main) {
+                            playerConnection.player.shuffleModeEnabled = !playerConnection.player.shuffleModeEnabled
+                        }
+                    },
                     onLockClick = {
                         if (togetherForcesLock) {
                             Toast.makeText(context, R.string.not_allowed, Toast.LENGTH_SHORT).show()
@@ -1044,147 +990,154 @@ fun Queue(
                                 }
                             }
 
-                            val content: @Composable () -> Unit = content@{
-                                val shouldLoadImages by remember {
-                                    derivedStateOf {
-                                        state.value > state.collapsedBound + 80.dp
+                            val content: @Composable () -> Unit = {
+                                Row(
+                                    horizontalArrangement = Arrangement.Center,
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    val shouldLoadImages by remember {
+                                        derivedStateOf {
+                                            state.value > state.collapsedBound + 80.dp
+                                        }
                                     }
-                                }
 
-                                val trackMetadata = window.mediaItem.metadata
-                                if (trackMetadata == null) return@content
-                                val onPlayNextFromQueue =
-                                    remember(
-                                        window.uid,
-                                        window.firstPeriodIndex,
-                                        currentPlayingUid,
-                                        nextPlayingUid,
-                                    ) {
-                                        if (window.uid != currentPlayingUid && window.uid != nextPlayingUid) {
-                                            {
-                                                playerConnection.moveQueueItemToNext(window.firstPeriodIndex)
-                                            }
-                                        } else {
-                                            null
-                                        }
-                                    }
-                                CompactQueueItem(
-                                    mediaMetadata = trackMetadata,
-                                    isActive = isActive,
-                                    isPlaying = isPlaying && isActive,
-                                    isSelected = selection && trackMetadata in selectedSongs,
-                                    shouldLoadImage = shouldLoadImages,
-                                    onBackgroundColor = onBackgroundColor,
-                                    onClick = {
-                                        if (selection) {
-                                            if (trackMetadata in selectedSongs) {
-                                                selectedSongs.remove(trackMetadata)
-                                                selectedItems.remove(currentItem)
-                                                if (selectedSongs.isEmpty()) {
-                                                    selection = false
+                                    val trackMetadata = window.mediaItem.metadata ?: return@Row
+                                    val onPlayNextFromQueue =
+                                        remember(
+                                            window.uid,
+                                            window.firstPeriodIndex,
+                                            currentPlayingUid,
+                                            nextPlayingUid,
+                                        ) {
+                                            if (window.uid != currentPlayingUid && window.uid != nextPlayingUid) {
+                                                {
+                                                    playerConnection.moveQueueItemToNext(window.firstPeriodIndex)
                                                 }
                                             } else {
-                                                selectedSongs.add(trackMetadata)
-                                                selectedItems.add(currentItem)
-                                            }
-                                        } else {
-                                            if (isActive) {
-                                                playerConnection.player.togglePlayPause()
-                                            } else {
-                                                val joined =
-                                                    togetherSessionState as? moe.rukamori.archivetune.together.TogetherSessionState.Joined
-                                                val isGuest = joined?.role is moe.rukamori.archivetune.together.TogetherRole.Guest
-                                                if (isGuest) {
-                                                    if (joined?.roomState?.settings?.allowGuestsToControlPlayback != true) {
-                                                        Toast
-                                                            .makeText(
-                                                                context,
-                                                                R.string.not_allowed,
-                                                                Toast.LENGTH_SHORT,
-                                                            ).show()
-                                                        return@CompactQueueItem
-                                                    }
-                                                    val trackId =
-                                                        window.mediaItem.metadata?.id?.trim().orEmpty().ifBlank {
-                                                            window.mediaItem.mediaId.trim()
-                                                        }
-                                                    if (trackId.isBlank()) return@CompactQueueItem
-                                                    Toast
-                                                        .makeText(
-                                                            context,
-                                                            R.string.together_requesting_song_change,
-                                                            Toast.LENGTH_SHORT,
-                                                        ).show()
-                                                    playerConnection.service.requestTogetherControl(
-                                                        moe.rukamori.archivetune.together.ControlAction.SeekToTrack(
-                                                            trackId = trackId,
-                                                            positionMs = 0L,
-                                                        ),
-                                                    )
-                                                } else {
-                                                    playerConnection.player.seekToDefaultPosition(
-                                                        window.firstPeriodIndex,
-                                                    )
-                                                    playerConnection.player.playWhenReady = true
-                                                }
+                                                null
                                             }
                                         }
-                                    },
-                                    onLongClick = {
-                                        if (enableHapticFeedback) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                        if (!selection) {
-                                            selection = true
-                                        }
-                                        selectedSongs.clear()
-                                        selectedItems.clear()
-                                        selectedSongs.add(trackMetadata)
-                                        selectedItems.add(currentItem)
-                                    },
-                                    onMenuClick = {
-                                        menuState.show {
-                                            PlayerMenu(
-                                                mediaMetadata = trackMetadata,
-                                                navController = navController,
-                                                playerBottomSheetState = playerBottomSheetState,
-                                                isQueueTrigger = true,
-                                                onPlayNextFromQueue = onPlayNextFromQueue,
-                                                onRemoveFromQueue = {
-                                                    onRemoveWithUndo(window)
-                                                },
-                                                onShowDetailsDialog = {
-                                                    window.mediaItem.mediaId.let {
-                                                        bottomSheetPageState.show {
-                                                            ShowMediaInfo(it)
-                                                        }
-                                                    }
-                                                },
-                                                onDismiss = menuState::dismiss,
-                                            )
-                                        }
-                                    },
-                                    dragHandle = {
-                                        if (!effectiveLocked) {
+                                    MediaMetadataListItem(
+                                        mediaMetadata = trackMetadata,
+                                        isSelected = selection && trackMetadata in selectedSongs,
+                                        isActive = isActive,
+                                        isPlaying = isPlaying && isActive,
+                                        shouldLoadImage = shouldLoadImages,
+                                        trailingContent = {
                                             IconButton(
-                                                onClick = { },
-                                                modifier =
-                                                    Modifier
-                                                        .size(36.dp)
-                                                        .draggableHandle(),
+                                                onClick = {
+                                                    menuState.show {
+                                                        PlayerMenu(
+                                                            mediaMetadata = trackMetadata,
+                                                            navController = navController,
+                                                            playerBottomSheetState = playerBottomSheetState,
+                                                            isQueueTrigger = true,
+                                                            onPlayNextFromQueue = onPlayNextFromQueue,
+                                                            onRemoveFromQueue = {
+                                                                onRemoveWithUndo(window)
+                                                            },
+                                                            onShowDetailsDialog = {
+                                                                window.mediaItem.mediaId.let {
+                                                                    bottomSheetPageState.show {
+                                                                        ShowMediaInfo(it)
+                                                                    }
+                                                                }
+                                                            },
+                                                            onDismiss = menuState::dismiss,
+                                                        )
+                                                    }
+                                                },
                                             ) {
                                                 Icon(
-                                                    painter = painterResource(R.drawable.player_drag_handle),
+                                                    painter = painterResource(R.drawable.more_vert),
                                                     contentDescription = null,
-                                                    modifier = Modifier.size(18.dp),
-                                                    tint = onBackgroundColor.copy(alpha = 0.6f),
                                                 )
                                             }
-                                        }
-                                    },
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .background(Color.Transparent),
-                                )
+                                            if (!effectiveLocked) {
+                                                IconButton(
+                                                    onClick = { },
+                                                    modifier = Modifier.draggableHandle(),
+                                                ) {
+                                                    Icon(
+                                                        painter = painterResource(R.drawable.drag_handle),
+                                                        contentDescription = null,
+                                                    )
+                                                }
+                                            }
+                                        },
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .background(backgroundColor)
+                                                .combinedClickable(
+                                                    onClick = {
+                                                        if (selection) {
+                                                            if (trackMetadata in selectedSongs) {
+                                                                selectedSongs.remove(trackMetadata)
+                                                                selectedItems.remove(currentItem)
+                                                                if (selectedSongs.isEmpty()) {
+                                                                    selection = false
+                                                                }
+                                                            } else {
+                                                                selectedSongs.add(trackMetadata)
+                                                                selectedItems.add(currentItem)
+                                                            }
+                                                        } else {
+                                                            if (index == currentWindowIndex) {
+                                                                playerConnection.player.togglePlayPause()
+                                                            } else {
+                                                                val joined =
+                                                                    togetherSessionState as? moe.rukamori.archivetune.together.TogetherSessionState.Joined
+                                                                val isGuest = joined?.role is moe.rukamori.archivetune.together.TogetherRole.Guest
+                                                                if (isGuest) {
+                                                                    if (joined?.roomState?.settings?.allowGuestsToControlPlayback != true) {
+                                                                        Toast
+                                                                            .makeText(
+                                                                                context,
+                                                                                R.string.not_allowed,
+                                                                                Toast.LENGTH_SHORT,
+                                                                            ).show()
+                                                                        return@combinedClickable
+                                                                    }
+                                                                    val trackId =
+                                                                        window.mediaItem.metadata?.id?.trim().orEmpty().ifBlank {
+                                                                            window.mediaItem.mediaId.trim()
+                                                                        }
+                                                                    if (trackId.isBlank()) return@combinedClickable
+                                                                    Toast
+                                                                        .makeText(
+                                                                            context,
+                                                                            R.string.together_requesting_song_change,
+                                                                            Toast.LENGTH_SHORT,
+                                                                        ).show()
+                                                                    playerConnection.service.requestTogetherControl(
+                                                                        moe.rukamori.archivetune.together.ControlAction.SeekToTrack(
+                                                                            trackId = trackId,
+                                                                            positionMs = 0L,
+                                                                        ),
+                                                                    )
+                                                                } else {
+                                                                    playerConnection.player.seekToDefaultPosition(
+                                                                        window.firstPeriodIndex,
+                                                                    )
+                                                                    playerConnection.player.playWhenReady = true
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    onLongClick = {
+                                                        if (enableHapticFeedback) haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        if (!selection) {
+                                                            selection = true
+                                                        }
+                                                        selectedSongs.clear()
+                                                        selectedItems.clear()
+                                                        selectedSongs.add(trackMetadata)
+                                                        selectedItems.add(currentItem)
+                                                    },
+                                                ),
+                                    )
+                                }
                             }
 
                             if (effectiveLocked) {
@@ -1270,37 +1223,6 @@ private val Timeline.Window.queueItemKey: Long
         (uid.hashCode().toLong() shl Int.SIZE_BITS) xor
             (mediaItem.mediaId.hashCode().toLong() and UInt.MAX_VALUE.toLong())
 
-/**
- * Reorders [windows] for queue display so that:
- *  1. The currently playing song (identified by [currentPlayingUid]) is at
- *     index 0 (top of the list).
- *  2. Upcoming songs follow in playback order.
- *  3. Previously-played songs are at the end, in reverse chronological order
- *     (most recently played first), so the user can swipe up to scroll through
- *     upcoming and then review what just played.
- *
- * The underlying [windows] list is assumed to be in timeline order
- * ([previous, current, upcoming]) as produced by
- * [moe.rukamori.archivetune.extensions.getQueueWindows]. If [currentPlayingUid]
- * is null or not found, the list is returned unchanged.
- */
-private fun reorderedForDisplay(
-    windows: List<Timeline.Window>,
-    currentPlayingUid: Any?,
-): List<Timeline.Window> {
-    if (currentPlayingUid == null) return windows
-    val currentIdx = windows.indexOfFirst { it.uid == currentPlayingUid }
-    if (currentIdx == -1) return windows
-    val current = windows[currentIdx]
-    val upcoming = windows.drop(currentIdx + 1)
-    val previous = windows.take(currentIdx).asReversed()
-    return buildList {
-        add(current)
-        addAll(upcoming)
-        addAll(previous)
-    }
-}
-
 @Immutable
 private data class QueueDragInfo(
     public val draggedItemUid: Any,
@@ -1346,11 +1268,9 @@ private fun QueueSelectionFloatingToolbar(
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val toolbarContainerColor = if (pureBlack) Color.Black else colorScheme.surfaceContainerHigh
-    // Always use white text/icons on the queue selection toolbar to stay readable on the
-    // dark blurred backdrop (matches Apple Music style).
-    val toolbarContentColor = Color.White
+    val toolbarContentColor = if (pureBlack) Color.White else colorScheme.onSurface
     val fabContainerColor = if (pureBlack) Color.White.copy(alpha = 0.12f) else colorScheme.surfaceContainerHighest
-    val fabContentColor = Color.White
+    val fabContentColor = if (pureBlack) Color.White else colorScheme.onSurface
 
     HorizontalFloatingToolbar(
         expanded = true,
@@ -1362,7 +1282,7 @@ private fun QueueSelectionFloatingToolbar(
                 contentColor = fabContentColor,
             ) {
                 Icon(
-                    painter = painterResource(R.drawable.player_close),
+                    painter = painterResource(R.drawable.close),
                     contentDescription = stringResource(R.string.close),
                     modifier = Modifier.size(22.dp),
                 )
@@ -1382,28 +1302,28 @@ private fun QueueSelectionFloatingToolbar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             QueueSelectionToolbarAction(
-                icon = if (allSelected) R.drawable.player_deselect else R.drawable.player_select_all,
+                icon = if (allSelected) R.drawable.deselect else R.drawable.select_all,
                 contentDescription = null,
                 tint = toolbarContentColor,
                 onClick = onToggleSelectAll,
             )
 
             QueueSelectionToolbarAction(
-                icon = R.drawable.player_playlist_add,
+                icon = R.drawable.playlist_add,
                 contentDescription = stringResource(R.string.add_to_playlist),
                 tint = colorScheme.primary,
                 onClick = onAddToPlaylist,
             )
 
             QueueSelectionToolbarAction(
-                icon = R.drawable.player_queue_music,
+                icon = R.drawable.queue_music,
                 contentDescription = stringResource(R.string.create_playlist),
                 tint = colorScheme.primary,
                 onClick = onCreatePlaylist,
             )
 
             QueueSelectionToolbarAction(
-                icon = R.drawable.player_delete,
+                icon = R.drawable.delete,
                 contentDescription = stringResource(R.string.delete),
                 tint = colorScheme.error,
                 onClick = onDelete,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -1345,9 +1345,11 @@ private fun QueueSelectionFloatingToolbar(
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val toolbarContainerColor = if (pureBlack) Color.Black else colorScheme.surfaceContainerHigh
-    val toolbarContentColor = if (pureBlack) Color.White else colorScheme.onSurface
+    // Always use white text/icons on the queue selection toolbar to stay readable on the
+    // dark blurred backdrop (matches Apple Music style).
+    val toolbarContentColor = Color.White
     val fabContainerColor = if (pureBlack) Color.White.copy(alpha = 0.12f) else colorScheme.surfaceContainerHighest
-    val fabContentColor = if (pureBlack) Color.White else colorScheme.onSurface
+    val fabContentColor = Color.White
 
     HorizontalFloatingToolbar(
         expanded = true,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -740,6 +740,10 @@ fun Queue(
             remember(currentWindowIndex, queueWindows) {
                 queueWindows.getOrNull(currentWindowIndex + 1)?.uid
             }
+        val nextPlayingUid =
+            remember(currentWindowIndex, queueWindows) {
+                queueWindows.getOrNull(currentWindowIndex + 1)?.uid
+            }
 
         val reorderableState =
             rememberReorderableLazyListState(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -441,6 +441,7 @@ fun Queue(
         // so this sheet never shows). Keeping it alive there would compose a
         // second, invisible reorderable queue list behind the morph.
         keepContentAlive = playerDesignStyle != PlayerDesignStyle.APPLE_MUSIC,
+        onCollapsedContentClick = openQueue,
         collapsedContent = {
             when (playerDesignStyle) {
                 PlayerDesignStyle.V2 -> {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -707,12 +707,16 @@ fun Queue(
             }
         // Display list: current song at index 0, upcoming next, then previously-played
         // songs in reverse chronological order. See the sync LaunchedEffect below for
-        // the full rationale. The initial value is pre-reordered so the first frame
-        // doesn't flicker in timeline order.
+        // the full rationale. The initial value is pre-reordered (Apple Music) or
+        // in timeline order (non-Apple Music) so the first frame doesn't flicker.
         val mutableQueueWindows =
             remember {
                 mutableStateListOf<Timeline.Window>().apply {
-                    addAll(reorderedForDisplay(queueWindows, currentPlayingUid))
+                    if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
+                        addAll(reorderedForDisplay(queueWindows, currentPlayingUid))
+                    } else {
+                        addAll(queueWindows)
+                    }
                 }
             }
         val queueLength by remember {
@@ -730,6 +734,11 @@ fun Queue(
         // resets mutableQueueWindows to the OLD queueWindows (before the move),
         // causing the dragged item to "snap back" to its original position.
         var justCommittedDragUid by remember { mutableStateOf<Any?>(null) }
+
+        val nextPlayingUid =
+            remember(currentWindowIndex, queueWindows) {
+                queueWindows.getOrNull(currentWindowIndex + 1)?.uid
+            }
 
         val reorderableState =
             rememberReorderableLazyListState(
@@ -762,13 +771,19 @@ fun Queue(
                         draggedItemUid = draggedItemUid,
                         destination =
                             if (toQueueIndex == 0) {
-                                // In the filtered queue list the current song is always at
-                                // index 0, so dropping at position 0 means "make this the
-                                // next song after the current one" rather than "move to the
-                                // very start of the full timeline" (which would place it
-                                // before already-played songs and is not visible anyway).
-                                currentPlayingUid?.let { QueueDragDestination.After(itemUid = it) }
-                                    ?: QueueDragDestination.Start
+                                if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
+                                    // In the filtered Apple Music queue list the current song
+                                    // is always at index 0, so dropping at position 0 means
+                                    // "make this the next song after the current one" rather
+                                    // than "move to the very start of the full timeline".
+                                    currentPlayingUid?.let { QueueDragDestination.After(itemUid = it) }
+                                        ?: QueueDragDestination.Start
+                                } else {
+                                    // Non-Apple Music styles: match upstream behavior exactly —
+                                    // dropping at index 0 moves the song to the very start of
+                                    // the full timeline.
+                                    QueueDragDestination.Start
+                                }
                             } else {
                                 QueueDragDestination.After(
                                     itemUid = mutableQueueWindows[toQueueIndex - 1].uid,
@@ -843,21 +858,22 @@ fun Queue(
                 return@LaunchedEffect
             }
 
-            // Display the full queue list including previously-played songs,
-            // REORDERED so that:
-            //   1. The currently playing song is at index 0 (top of the list).
-            //   2. Upcoming songs follow (indices 1..upcomingCount).
-            //   3. Previously-played songs are at the end, in reverse
-            //      chronological order (most recently played first), so the
-            //      user can swipe up to scroll through upcoming and then
-            //      review what just played.
-            // The drag logic continues to work because the final moveMediaItem
-            // call resolves UIDs against `queueWindows` (timeline order), not
-            // against this reordered display list.
-            val reordered = reorderedForDisplay(queueWindows, currentPlayingUid)
+            // Apple Music style: display the current song and upcoming songs
+            // first, then previously-played songs in reverse chronological
+            // order (SimpMusic / Spotify style "Continue Playing" header).
+            // All other player styles: show the full queue timeline in
+            // timeline order (matches upstream rukamori/ArchiveTune exactly).
+            // The full `queueWindows` (including played songs) is still used
+            // for queue stats, clear-queue, and drag-source resolution.
+            val displayList =
+                if (playerDesignStyle == PlayerDesignStyle.APPLE_MUSIC) {
+                    reorderedForDisplay(queueWindows, currentPlayingUid)
+                } else {
+                    queueWindows
+                }
             Snapshot.withMutableSnapshot {
                 mutableQueueWindows.clear()
-                mutableQueueWindows.addAll(reordered)
+                mutableQueueWindows.addAll(displayList)
             }
         }
 
@@ -1036,6 +1052,21 @@ fun Queue(
 
                                 val trackMetadata = window.mediaItem.metadata
                                 if (trackMetadata == null) return@content
+                                val onPlayNextFromQueue =
+                                    remember(
+                                        window.uid,
+                                        window.firstPeriodIndex,
+                                        currentPlayingUid,
+                                        nextPlayingUid,
+                                    ) {
+                                        if (window.uid != currentPlayingUid && window.uid != nextPlayingUid) {
+                                            {
+                                                playerConnection.moveQueueItemToNext(window.firstPeriodIndex)
+                                            }
+                                        } else {
+                                            null
+                                        }
+                                    }
                                 CompactQueueItem(
                                     mediaMetadata = trackMetadata,
                                     isActive = isActive,
@@ -1115,6 +1146,7 @@ fun Queue(
                                                 navController = navController,
                                                 playerBottomSheetState = playerBottomSheetState,
                                                 isQueueTrigger = true,
+                                                onPlayNextFromQueue = onPlayNextFromQueue,
                                                 onRemoveFromQueue = {
                                                     onRemoveWithUndo(window)
                                                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Queue.kt
@@ -740,10 +740,6 @@ fun Queue(
             remember(currentWindowIndex, queueWindows) {
                 queueWindows.getOrNull(currentWindowIndex + 1)?.uid
             }
-        val nextPlayingUid =
-            remember(currentWindowIndex, queueWindows) {
-                queueWindows.getOrNull(currentWindowIndex + 1)?.uid
-            }
 
         val reorderableState =
             rememberReorderableLazyListState(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/QueueComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/QueueComponents.kt
@@ -10,22 +10,10 @@
 package moe.rukamori.archivetune.ui.player
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,8 +21,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -42,7 +28,6 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
@@ -88,7 +73,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.media3.common.Player
 import coil3.compose.AsyncImage
-import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.EnableHapticFeedbackKey
 import moe.rukamori.archivetune.db.entities.FormatEntity
@@ -101,9 +85,7 @@ import moe.rukamori.archivetune.models.ActiveOutputDevice
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.ActionPromptDialog
 import moe.rukamori.archivetune.ui.component.BottomSheetState
-import moe.rukamori.archivetune.ui.component.ItemThumbnail
 import moe.rukamori.archivetune.ui.component.bottomSheetDraggable
-import moe.rukamori.archivetune.utils.joinByBullet
 import moe.rukamori.archivetune.utils.makeTimeString
 import moe.rukamori.archivetune.utils.rememberPreference
 import kotlin.math.roundToInt
@@ -139,54 +121,46 @@ fun CurrentSongHeader(
     val view = LocalView.current
     val (enableHapticFeedback) = rememberPreference(EnableHapticFeedbackKey, true)
 
-    // NOTE: The previous version applied `.bottomSheetDraggable(sheetState)` to this Column.
-    // That was redundant — the outer `BottomSheet` Box already has `bottomSheetDraggable`,
-    // so the user can still drag the sheet from anywhere in the header. Worse, the duplicate
-    // `detectVerticalDragGestures` pointerInput on the header was competing with the
-    // IconButtons' click handlers: when the user tapped the favourite or overflow-menu icon,
-    // any sub-touchSlop finger drift was enough for the drag detector to consume the gesture
-    // (cancelling the tap) and dispatch a small downward delta to the sheet. The sheet then
-    // flung-collapsed on pointer-up, taking the user back to the full player — the exact
-    // "clicking favourite / overflow on the queue page closes the queue" regression that was
-    // reported. Removing the redundant draggable here lets the IconButtons' clickables win
-    // the gesture uncontested, while the outer Box's draggable still handles real swipes.
     Column(
         modifier =
             modifier
                 .fillMaxWidth()
                 .background(backgroundColor)
-                // Use the cached status-bar top inset (LocalStableSystemBarsTopPadding) instead
-                // of the raw WindowInsets.systemBars — when the status bar is hidden (which
-                // happens for V7/APPLE_MUSIC player styles, the global HideStatusBar setting,
-                // and full-screen lyrics), WindowInsets.systemBars reports 0 for the top inset,
-                // causing the header — and the songs list below it — to slide under the
-                // notch / camera cutout. LocalStableSystemBarsTopPadding preserves the last
-                // non-zero value, so the layout stays below the notch regardless of bar
-                // visibility. Matches the pattern used by AlbumScreen / ArtistSongsScreen.
-                .windowInsetsPadding(
-                    WindowInsets(top = LocalStableSystemBarsTopPadding.current)
-                        .union(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)),
-                )
+                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal))
+                .bottomSheetDraggable(sheetState)
                 .padding(horizontal = 16.dp)
-                .padding(top = 12.dp, bottom = 8.dp),
+                .padding(top = 20.dp, bottom = 8.dp),
     ) {
-        // The drag-handle "dash" bar that previously sat at the top of the queue sheet
-        // has been removed per design feedback — the sheet remains draggable via the
-        // outer BottomSheet's `bottomSheetDraggable` modifier.
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .width(48.dp)
+                        .height(5.dp)
+                        .clip(RoundedCornerShape(2.5.dp))
+                        .background(onBackgroundColor.copy(alpha = 0.4f)),
+            )
+        }
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(14.dp),
         ) {
-            ItemThumbnail(
-                thumbnailUrl = mediaMetadata?.thumbnailUrl,
-                isActive = true,
-                isPlaying = isPlaying,
-                shape = RoundedCornerShape(12.dp),
+            AsyncImage(
+                model = mediaMetadata?.thumbnailUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
                 modifier =
                     Modifier
                         .size(64.dp)
+                        .clip(RoundedCornerShape(12.dp))
                         .background(onBackgroundColor.copy(alpha = 0.06f)),
             )
 
@@ -228,9 +202,9 @@ fun CurrentSongHeader(
                     painter =
                         painterResource(
                             if (liked) {
-                                R.drawable.player_favorite
+                                R.drawable.favorite
                             } else {
-                                R.drawable.player_favorite_border
+                                R.drawable.favorite_border
                             },
                         ),
                     contentDescription = stringResource(R.string.action_like),
@@ -264,7 +238,7 @@ fun CurrentSongHeader(
                         ),
                 ) {
                     Icon(
-                        painter = painterResource(if (locked) R.drawable.player_lock else R.drawable.player_lock_open),
+                        painter = painterResource(if (locked) R.drawable.lock else R.drawable.lock_open),
                         contentDescription = null,
                         modifier = Modifier.size(20.dp),
                     )
@@ -278,7 +252,7 @@ fun CurrentSongHeader(
                         ),
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.player_more_vert),
+                        painter = painterResource(R.drawable.more_vert),
                         contentDescription = null,
                         modifier = Modifier.size(20.dp),
                     )
@@ -292,7 +266,7 @@ fun CurrentSongHeader(
                         ),
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.player_delete),
+                        painter = painterResource(R.drawable.delete),
                         contentDescription = stringResource(R.string.clear),
                         modifier = Modifier.size(20.dp),
                     )
@@ -350,7 +324,7 @@ fun CurrentSongHeader(
                 colors = if (shuffleModeEnabled) checkedColors else uncheckedColors,
             ) {
                 Icon(
-                    painter = painterResource(R.drawable.player_shuffle),
+                    painter = painterResource(R.drawable.shuffle),
                     contentDescription = stringResource(R.string.action_shuffle_on),
                     modifier = Modifier.size(22.dp),
                 )
@@ -375,9 +349,9 @@ fun CurrentSongHeader(
                     painter =
                         painterResource(
                             when (repeatMode) {
-                                Player.REPEAT_MODE_ONE -> R.drawable.player_repeat_one_on
-                                Player.REPEAT_MODE_ALL -> R.drawable.player_repeat_on
-                                else -> R.drawable.player_repeat
+                                Player.REPEAT_MODE_ONE -> R.drawable.repeat_one_on
+                                Player.REPEAT_MODE_ALL -> R.drawable.repeat_on
+                                else -> R.drawable.repeat
                             },
                         ),
                     contentDescription = null,
@@ -404,7 +378,7 @@ fun CurrentSongHeader(
                         )
                     } else {
                         Icon(
-                            painter = painterResource(R.drawable.player_all_inclusive),
+                            painter = painterResource(R.drawable.all_inclusive),
                             contentDescription = stringResource(R.string.similar_content),
                             modifier = Modifier.size(22.dp),
                         )
@@ -648,7 +622,7 @@ fun QueueCollapsedContentV2(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    painter = painterResource(id = R.drawable.player_queue_music),
+                    painter = painterResource(id = R.drawable.queue_music),
                     contentDescription = null,
                     modifier = Modifier.size(iconSize),
                     tint = textBackgroundColor,
@@ -684,7 +658,7 @@ fun QueueCollapsedContentV2(
                         )
                     } else {
                         Icon(
-                            painter = painterResource(id = R.drawable.player_bedtime),
+                            painter = painterResource(id = R.drawable.bedtime),
                             contentDescription = null,
                             modifier = Modifier.size(iconSize),
                             tint = textBackgroundColor,
@@ -704,7 +678,7 @@ fun QueueCollapsedContentV2(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    painter = painterResource(id = R.drawable.player_lyrics),
+                    painter = painterResource(id = R.drawable.lyrics),
                     contentDescription = null,
                     modifier = Modifier.size(iconSize),
                     tint = textBackgroundColor,
@@ -748,9 +722,9 @@ fun QueueCollapsedContentV2(
                         painterResource(
                             id =
                                 when (repeatMode) {
-                                    Player.REPEAT_MODE_OFF, Player.REPEAT_MODE_ALL -> R.drawable.player_repeat
-                                    Player.REPEAT_MODE_ONE -> R.drawable.player_repeat_one
-                                    else -> R.drawable.player_repeat
+                                    Player.REPEAT_MODE_OFF, Player.REPEAT_MODE_ALL -> R.drawable.repeat
+                                    Player.REPEAT_MODE_ONE -> R.drawable.repeat_one
+                                    else -> R.drawable.repeat
                                 },
                         ),
                     contentDescription = null,
@@ -775,7 +749,7 @@ fun QueueCollapsedContentV2(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    painter = painterResource(id = R.drawable.player_more_vert),
+                    painter = painterResource(id = R.drawable.more_vert),
                     contentDescription = null,
                     modifier = Modifier.size(iconSize),
                     tint = iconButtonColor,
@@ -830,16 +804,13 @@ fun QueueCollapsedContentV3(
                         ),
                     ),
         ) {
-            // Queue button — enlarged touch target to 48dp (Material minimum) by increasing
-            // vertical padding from 8dp to 14dp. The previous ~34dp touch zone (18dp icon +
-            // 8dp+8dp padding) was below the 48dp minimum and contributed to missed taps,
-            // especially on V3 and (previously) V5 which used this composable.
+            // Queue button
             Box(
                 modifier =
                     Modifier
                         .clip(RoundedCornerShape(8.dp))
                         .clickable { onExpandQueue() }
-                        .padding(horizontal = 12.dp, vertical = 14.dp),
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Row(
@@ -847,9 +818,9 @@ fun QueueCollapsedContentV3(
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.player_queue_music),
+                        painter = painterResource(id = R.drawable.queue_music),
                         contentDescription = null,
-                        modifier = Modifier.size(20.dp),
+                        modifier = Modifier.size(18.dp),
                         tint = textBackgroundColor.copy(alpha = 0.7f),
                     )
                     Text(
@@ -883,7 +854,7 @@ fun QueueCollapsedContentV3(
                         )
                     } else {
                         Icon(
-                            painter = painterResource(id = R.drawable.player_bedtime),
+                            painter = painterResource(id = R.drawable.bedtime),
                             contentDescription = null,
                             modifier = Modifier.size(18.dp),
                             tint = textBackgroundColor.copy(alpha = 0.7f),
@@ -906,7 +877,7 @@ fun QueueCollapsedContentV3(
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.player_lyrics),
+                        painter = painterResource(id = R.drawable.lyrics),
                         contentDescription = null,
                         modifier = Modifier.size(18.dp),
                         tint = textBackgroundColor.copy(alpha = 0.7f),
@@ -930,7 +901,7 @@ fun QueueCollapsedContentV3(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    painter = painterResource(id = R.drawable.player_more_vert),
+                    painter = painterResource(id = R.drawable.more_vert),
                     contentDescription = null,
                     modifier = Modifier.size(18.dp),
                     tint = textBackgroundColor.copy(alpha = 0.7f),
@@ -992,7 +963,7 @@ fun QueueCollapsedContentV1(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.player_queue_music),
+                        painter = painterResource(id = R.drawable.queue_music),
                         contentDescription = null,
                         modifier = Modifier.size(20.dp),
                         tint = textBackgroundColor,
@@ -1020,7 +991,7 @@ fun QueueCollapsedContentV1(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.player_bedtime),
+                        painter = painterResource(id = R.drawable.bedtime),
                         contentDescription = null,
                         modifier = Modifier.size(20.dp),
                         tint = textBackgroundColor,
@@ -1064,7 +1035,7 @@ fun QueueCollapsedContentV1(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.player_lyrics),
+                        painter = painterResource(id = R.drawable.lyrics),
                         contentDescription = null,
                         modifier = Modifier.size(20.dp),
                         tint = textBackgroundColor,
@@ -1149,7 +1120,7 @@ fun QueueCollapsedContentV4(
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.player_queue_music),
+                        painter = painterResource(id = R.drawable.queue_music),
                         contentDescription = null,
                         modifier = Modifier.size(iconSize),
                         tint = textBackgroundColor,
@@ -1200,7 +1171,7 @@ fun QueueCollapsedContentV4(
                         )
                     } else {
                         Icon(
-                            painter = painterResource(id = R.drawable.player_bedtime),
+                            painter = painterResource(id = R.drawable.bedtime),
                             contentDescription = null,
                             modifier = Modifier.size(iconSize),
                             tint = textBackgroundColor,
@@ -1228,7 +1199,7 @@ fun QueueCollapsedContentV4(
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.player_lyrics),
+                        painter = painterResource(id = R.drawable.lyrics),
                         contentDescription = null,
                         modifier = Modifier.size(iconSize),
                         tint = textBackgroundColor,
@@ -1304,7 +1275,7 @@ fun QueueCollapsedContentV7(
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
-                            painter = painterResource(id = R.drawable.player_queue_music),
+                            painter = painterResource(id = R.drawable.queue_music),
                             contentDescription = null,
                             modifier = Modifier.size(iconSize),
                             tint = textBackgroundColor,
@@ -1323,7 +1294,7 @@ fun QueueCollapsedContentV7(
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
-                            painter = painterResource(id = R.drawable.player_lyrics),
+                            painter = painterResource(id = R.drawable.lyrics),
                             contentDescription = null,
                             modifier = Modifier.size(iconSize),
                             tint = textBackgroundColor,
@@ -1356,7 +1327,7 @@ fun QueueCollapsedContentV7(
                                 ),
                         ) {
                             Icon(
-                                painter = painterResource(id = R.drawable.player_bedtime),
+                                painter = painterResource(id = R.drawable.bedtime),
                                 contentDescription = stringResource(id = R.string.sleep_timer),
                                 modifier = Modifier.size(iconSize),
                                 tint = textBackgroundColor,
@@ -1479,7 +1450,7 @@ fun QueueCollapsedContentV9(
                     horizontalArrangement = Arrangement.Center,
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.player_bedtime),
+                        painter = painterResource(R.drawable.bedtime),
                         contentDescription = stringResource(R.string.sleep_timer),
                         tint = textBackgroundColor,
                         modifier = Modifier.size(18.dp),
@@ -1532,7 +1503,7 @@ fun QueueCollapsedContentV9(
                     colors = if (shuffleModeEnabled) checkedColors else uncheckedColors,
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.player_shuffle),
+                        painter = painterResource(R.drawable.shuffle),
                         contentDescription =
                             stringResource(
                                 if (shuffleModeEnabled) R.string.action_shuffle_on else R.string.action_shuffle_off,
@@ -1563,8 +1534,8 @@ fun QueueCollapsedContentV9(
                         painter =
                             painterResource(
                                 when (repeatMode) {
-                                    Player.REPEAT_MODE_ONE -> R.drawable.player_repeat_one
-                                    else -> R.drawable.player_repeat
+                                    Player.REPEAT_MODE_ONE -> R.drawable.repeat_one
+                                    else -> R.drawable.repeat
                                 },
                             ),
                         contentDescription =
@@ -1607,7 +1578,7 @@ fun QueueCollapsedContentV9(
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(
-                            painter = painterResource(R.drawable.player_more_horiz),
+                            painter = painterResource(R.drawable.more_horiz),
                             contentDescription = stringResource(R.string.more_options),
                             tint = textBackgroundColor,
                             modifier = Modifier.size(28.dp),
@@ -1615,433 +1586,6 @@ fun QueueCollapsedContentV9(
                     }
                 }
             }
-        }
-    }
-}
-
-// =====================================================================
-// Compact queue UI — Vivi Music / Apple Music "Up Next" inspired
-// =====================================================================
-//
-// Design contract (kept here so future editors don't drift):
-//   - Row height: ~60dp (was 72dp). More songs visible without scrolling.
-//   - Artwork: 48dp square, 12dp corner radius.
-//   - Active item: translucent highlight band + play/pause indicator
-//     over the artwork. No card-style background on inactive items.
-//   - Separators: 0.5dp hairline at 1dp from the bottom, alpha 0.08.
-//   - Trailing: vertical 3-dot menu, always present, right-aligned.
-//   - Drag handle: shown only when queue is unlocked (existing behaviour).
-//   - No huge rounded cards. The whole list reads as one continuous surface
-//     sitting on top of the player's blurred artwork.
-
-private val CompactQueueItemHeight = 60.dp
-private val CompactQueueThumbnailSize = 48.dp
-private val CompactQueueThumbnailRadius = 12.dp
-private val CompactQueueHorizontalPadding = 12.dp
-
-/**
- * Animated 3-bar equalizer indicator for the currently-playing queue row.
- * Bars oscillate with slightly different phases + durations so the motion
- * looks organic rather than mechanical. When [isPlaying] is false, bars
- * freeze at their current height (paused state) — matching the typical
- * "now playing" affordance in music apps.
- *
- * Visual spec: 3 rounded-rect bars, ~2.5dp wide, ~14dp max height, white,
- * sitting on a translucent black disc over the album artwork. The bars
- * animate from 30% → 100% height with a fast tween + reverse repeat.
- */
-@Composable
-private fun AnimatedEqualizerBars(
-    isPlaying: Boolean,
-    modifier: Modifier = Modifier,
-    barColor: Color = Color.White,
-) {
-    val transition = rememberInfiniteTransition(label = "eq")
-    // Three bars with different durations + initial phases so they don't sync.
-    val durations = intArrayOf(420, 540, 480)
-    val initialOffsets = floatArrayOf(0f, 0.33f, 0.66f)
-    val heights =
-        (0..2).map { i ->
-            transition.animateFloat(
-                initialValue = 0.30f + initialOffsets[i] * 0.40f,
-                targetValue = 1.0f,
-                animationSpec =
-                    infiniteRepeatable(
-                        animation =
-                            tween(
-                                durationMillis = durations[i],
-                                easing = LinearEasing,
-                            ),
-                        repeatMode = RepeatMode.Reverse,
-                    ),
-                label = "bar_$i",
-            )
-        }
-
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(2.dp),
-        verticalAlignment = Alignment.Bottom,
-    ) {
-        heights.forEachIndexed { i, h ->
-            // When paused, freeze the bar at 0.5f height by overriding the
-            // animated value. We can't actually pause an InfiniteTransition,
-            // so we gate the value with isPlaying instead.
-            val heightFraction = if (isPlaying) h.value else 0.5f
-            Box(
-                modifier =
-                    Modifier
-                        .width(2.5.dp)
-                        .height((14.dp * heightFraction).coerceAtLeast(2.dp))
-                        .clip(RoundedCornerShape(1.25.dp))
-                        .background(barColor),
-            )
-        }
-    }
-}
-
-/**
- * Minimal "Queue" heading with controls on the right.
- * Replaces the old [CurrentSongHeader] when the compact queue is enabled —
- * the active track's artwork and metadata are already visible in the
- * player above, so repeating them in the queue header was visual clutter.
- */
-@Composable
-fun CompactQueueHeader(
-    sheetState: BottomSheetState,
-    songCount: Int,
-    queueDuration: Int,
-    locked: Boolean,
-    infiniteQueueEnabled: Boolean,
-    infiniteQueueLoading: Boolean,
-    onBackgroundColor: Color,
-    onLockClick: () -> Unit,
-    onClearQueueClick: () -> Unit,
-    onInfiniteQueueClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    // Dynamic notch-aware top padding: combine the cached status-bar inset
-    // (LocalStableSystemBarsTopPadding — survives "hide status bar" mode by
-    // preserving the last non-zero value) with the physical display-cutout
-    // inset (which is reported independently of the status bar visibility
-    // state). Taking the max guarantees the queue header always sits below
-    // every phone's notch/punch-hole/camera cutout, even when the user has
-    // enabled "Hide status bar" in settings.
-    val stableStatusBarTop = LocalStableSystemBarsTopPadding.current
-    val displayCutoutTop = WindowInsets.displayCutout.only(WindowInsetsSides.Top).asPaddingValues().calculateTopPadding()
-    val notchSafeTopPadding = maxOf(stableStatusBarTop, displayCutoutTop)
-    // NOTE: no `.bottomSheetDraggable(sheetState)` here — the outer `BottomSheet`
-    // Box already has it, and an inner drag detector on this Column was competing
-    // with the header IconButtons' click handlers (finger drift during a tap
-    // cancelled the tap and flung the sheet). Same fix as CurrentSongHeader.
-    Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal))
-                .padding(top = notchSafeTopPadding)
-                .padding(horizontal = CompactQueueHorizontalPadding)
-                .padding(top = 12.dp, bottom = 4.dp),
-    ) {
-        // Drag handle — barely visible, just enough to signal "this sheet slides"
-        Box(
-            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Box(
-                modifier =
-                    Modifier
-                        .width(36.dp)
-                        .height(4.dp)
-                        .clip(RoundedCornerShape(2.dp))
-                        .background(onBackgroundColor.copy(alpha = 0.32f)),
-            )
-        }
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            // Heading + meta — single line, compact
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.weight(1f),
-            ) {
-                Text(
-                    text = stringResource(R.string.queue),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = onBackgroundColor,
-                    maxLines = 1,
-                )
-                Text(
-                    text =
-                        pluralStringResource(R.plurals.n_song, songCount, songCount) +
-                            "  •  " + makeTimeString(queueDuration * 1000L),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = onBackgroundColor.copy(alpha = 0.55f),
-                    maxLines = 1,
-                )
-            }
-
-            // Right-side controls: lock, infinite queue, clear — compact icon strip
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(0.dp),
-            ) {
-                IconButton(
-                    onClick = onInfiniteQueueClick,
-                    modifier = Modifier.size(40.dp),
-                    enabled = !infiniteQueueLoading,
-                    colors =
-                        IconButtonDefaults.iconButtonColors(
-                            contentColor =
-                                if (infiniteQueueEnabled) {
-                                    MaterialTheme.colorScheme.primary
-                                } else {
-                                    onBackgroundColor.copy(alpha = 0.7f)
-                                },
-                        ),
-                ) {
-                    if (infiniteQueueLoading) {
-                        CircularWavyProgressIndicator(
-                            modifier = Modifier.size(18.dp),
-                            color = LocalContentColor.current,
-                        )
-                    } else {
-                        Icon(
-                            painter = painterResource(R.drawable.player_all_inclusive),
-                            contentDescription = stringResource(R.string.similar_content),
-                            modifier = Modifier.size(18.dp),
-                        )
-                    }
-                }
-                IconButton(
-                    onClick = onLockClick,
-                    modifier = Modifier.size(40.dp),
-                    colors =
-                        IconButtonDefaults.iconButtonColors(
-                            contentColor = onBackgroundColor.copy(alpha = 0.7f),
-                        ),
-                ) {
-                    Icon(
-                        painter = painterResource(if (locked) R.drawable.player_lock else R.drawable.player_lock_open),
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
-                IconButton(
-                    onClick = onClearQueueClick,
-                    modifier = Modifier.size(40.dp),
-                    colors =
-                        IconButtonDefaults.iconButtonColors(
-                            contentColor = MaterialTheme.colorScheme.error,
-                        ),
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.player_delete),
-                        contentDescription = stringResource(R.string.clear),
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
-            }
-        }
-
-        HorizontalDivider(
-            color = onBackgroundColor.copy(alpha = 0.10f),
-            thickness = 0.5.dp,
-            modifier = Modifier.padding(top = 6.dp),
-        )
-    }
-}
-
-/**
- * Compact horizontal queue row.
- *
- * Visual contract (per user spec, 2026-08-09):
- *   - ~48dp square artwork on the left, 12dp corner radius
- *   - Song title to the right of artwork (single line, bold for active)
- *   - Artist + duration subtitle underneath (muted)
- *   - Vertical three-dot menu aligned to far right
- *   - Currently-playing item gets a translucent highlight band and a
- *     play/pause indicator layered over the artwork
- *   - Subtle 0.5dp hairline separator below each row, no big rounded cards
- *
- * Behavioural contract (UNCHANGED from previous implementation):
- *   - Click: play that queue item (or toggle play/pause for the active item)
- *   - Long-press: enter selection mode
- *   - Swipe-to-dismiss: removed by parent (this composable is just the row)
- *   - Drag handle (when unlocked): rendered as part of trailingContent
- */
-@Composable
-fun CompactQueueItem(
-    mediaMetadata: MediaMetadata,
-    isActive: Boolean,
-    isPlaying: Boolean,
-    isSelected: Boolean,
-    shouldLoadImage: Boolean,
-    onBackgroundColor: Color,
-    onClick: () -> Unit,
-    onLongClick: () -> Unit,
-    onMenuClick: () -> Unit,
-    dragHandle: @Composable () -> Unit = {},
-    modifier: Modifier = Modifier,
-) {
-    val titleColor =
-        if (isActive) {
-            onBackgroundColor
-        } else {
-            onBackgroundColor.copy(alpha = 0.92f)
-        }
-    val subtitleColor = onBackgroundColor.copy(alpha = if (isActive) 0.72f else 0.55f)
-
-    // Glassmorphism-style highlight for the active row: very low-opacity
-    // white tint that lets the blurred album-art background show through,
-    // plus a 1dp border at the same alpha for definition.
-    val activeOverlay = onBackgroundColor.copy(alpha = 0.12f)
-    val activeBorder = onBackgroundColor.copy(alpha = 0.18f)
-
-    Box(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .height(CompactQueueItemHeight)
-                .combinedClickable(
-                    onClick = onClick,
-                    onLongClick = onLongClick,
-                )
-                .then(
-                    if (isActive) {
-                        Modifier
-                            .clip(RoundedCornerShape(14.dp))
-                            .background(activeOverlay)
-                            .border(0.5.dp, activeBorder, RoundedCornerShape(14.dp))
-                    } else {
-                        Modifier
-                    },
-                ),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = CompactQueueHorizontalPadding),
-        ) {
-            // Artwork with optional play/pause indicator overlay for the active track
-            Box(contentAlignment = Alignment.Center) {
-                AsyncImage(
-                    model = mediaMetadata.thumbnailUrl,
-                    contentDescription = mediaMetadata.title,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .size(CompactQueueThumbnailSize)
-                            .clip(RoundedCornerShape(CompactQueueThumbnailRadius))
-                            .background(onBackgroundColor.copy(alpha = 0.08f))
-                            .then(
-                                if (isSelected) {
-                                    Modifier.border(
-                                        2.dp,
-                                        MaterialTheme.colorScheme.primary,
-                                        RoundedCornerShape(CompactQueueThumbnailRadius),
-                                    )
-                                } else {
-                                    Modifier
-                                },
-                            ),
-                )
-                if (isActive && shouldLoadImage) {
-                    // Translucent dim layer + animated equalizer bars — keeps
-                    // the artwork visible while making the playing state
-                    // unambiguous. Replaces the previous static pause/play
-                    // glyph with the classic 3-bar "now playing" indicator
-                    // that animates while music is playing and freezes when
-                    // paused.
-                    Box(
-                        modifier =
-                            Modifier
-                                .size(CompactQueueThumbnailSize)
-                                .clip(RoundedCornerShape(CompactQueueThumbnailRadius))
-                                .background(Color.Black.copy(alpha = 0.38f)),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        AnimatedEqualizerBars(
-                            isPlaying = isPlaying,
-                            modifier = Modifier.height(14.dp),
-                        )
-                    }
-                }
-            }
-
-            // Title + artist • duration
-            Column(
-                modifier =
-                    Modifier
-                        .weight(1f)
-                        .padding(start = 12.dp, end = 8.dp),
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    text = mediaMetadata.title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = if (isActive) FontWeight.Bold else FontWeight.Medium,
-                    fontSize = 14.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = titleColor,
-                )
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text =
-                        joinByBullet(
-                            mediaMetadata.artists.joinToString { it.name },
-                            makeTimeString(mediaMetadata.duration * 1000L),
-                        ),
-                    style = MaterialTheme.typography.bodySmall,
-                    fontSize = 12.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = subtitleColor,
-                )
-            }
-
-            // Drag handle (when unlocked) — kept in front of the menu so it
-            // remains grabbable. Visibility is controlled by the caller via
-            // the dragHandle composable; if empty, nothing renders.
-            dragHandle()
-
-            // Three-dot menu, always present, right-aligned
-            IconButton(
-                onClick = onMenuClick,
-                modifier = Modifier.size(36.dp),
-                colors =
-                    IconButtonDefaults.iconButtonColors(
-                        contentColor = onBackgroundColor.copy(alpha = 0.7f),
-                    ),
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.player_more_vert),
-                    contentDescription = stringResource(R.string.more_options),
-                    modifier = Modifier.size(18.dp),
-                )
-            }
-        }
-
-        // Hairline separator — sits at the bottom edge, full-width minus the
-        // horizontal padding so it visually aligns with the text columns.
-        // Skipped on the active row (the highlight band already separates it).
-        if (!isActive) {
-            HorizontalDivider(
-                color = onBackgroundColor.copy(alpha = 0.08f),
-                thickness = 0.5.dp,
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(horizontal = CompactQueueHorizontalPadding),
-            )
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
@@ -333,11 +333,13 @@ private fun HomeContent(
                     //  * When `uiState.minimalHomeMode == true`, the feed
                     //    collapses to:
                     //      hero -> Recently Played -> Keep Listening
-                    //      -> Live Performances
+                    //      -> Speed Dial -> Live Performances
                     //    All other shelves (category chips, remote/local quick
-                    //    picks, speed dial, account playlists, forgotten
-                    //    favorites, similar recommendations, and non-Live
-                    //    remote sections) are hidden.
+                    //    picks, account playlists, forgotten favorites, similar
+                    //    recommendations, and non-Live remote sections) are
+                    //    hidden. Speed Dial is preserved in minimal mode (placed
+                    //    directly below Keep Listening) so the user keeps one-tap
+                    //    access to their pinned items.
                     //
                     //  * When `uiState.minimalHomeMode == false` (default, also
                     //    matches upstream rukamori/ArchiveTune), the feed shows
@@ -469,6 +471,12 @@ private fun HomeContent(
                         }
                     }
 
+                    // In FULL mode, Speed Dial sits above Keep Listening (matches
+                    // upstream rukamori/ArchiveTune order). In MINIMAL mode, it is
+                    // relocated to sit directly below Keep Listening — the user
+                    // explicitly requested Speed Dial stay visible in minimal mode,
+                    // placed right under Keep Listening so they keep one-tap access
+                    // to their pinned items without re-enabling the full feed.
                     if (!minimalMode && uiState.speedDialItems.isNotEmpty()) {
                         sectionSpacer("speed_dial")
                         item(
@@ -519,6 +527,42 @@ private fun HomeContent(
                         ) {
                             KeepListeningSection(
                                 keepListening = uiState.keepListening,
+                                mediaMetadata = mediaMetadata,
+                                isPlaying = isPlaying,
+                                navController = navController,
+                                playerConnection = playerConnection,
+                                menuState = menuState,
+                                haptic = haptic,
+                                scope = scope,
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                    }
+
+                    // MINIMAL-mode-only Speed Dial placement: directly below
+                    // Keep Listening. Uses distinct item keys (`_minimal`
+                    // suffix) so LazyColumn doesn't try to reuse the full-mode
+                    // Speed Dial items when the toggle flips.
+                    if (minimalMode && uiState.speedDialItems.isNotEmpty()) {
+                        sectionSpacer("speed_dial_minimal")
+                        item(
+                            key = "home_speed_dial_header_minimal",
+                            contentType = "section_header",
+                        ) {
+                            HomeSectionHeader(
+                                title = stringResource(R.string.speed_dial),
+                                leadingIcon = {
+                                    HomeSectionLeadingIcon(iconRes = R.drawable.bolt)
+                                },
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                        item(
+                            key = "home_speed_dial_minimal",
+                            contentType = "speed_dial",
+                        ) {
+                            SpeedDialSection(
+                                speedDialItems = uiState.speedDialItems,
                                 mediaMetadata = mediaMetadata,
                                 isPlaying = isPlaying,
                                 navController = navController,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
@@ -324,23 +324,45 @@ private fun HomeContent(
                             .fillMaxWidth()
                             .align(Alignment.TopCenter),
                 ) {
-                    // Minimal home layout — the greeting and category-chips
-                    // rows are intentionally omitted so the "Jump back in"
-                    // hero artwork sits directly under the floating ArchiveTune
-                    // top bar with only the window-inset padding in between.
-                    // Sections below are curated to keep the feed focused:
-                    //   hero -> Recently Played -> Speed Dial -> Keep Listening
-                    //   -> Live Performances -> Forgotten Favourites.
-                    // Algorithmic shelves (account playlists, similar
-                    // recommendations, and the rest of the remote home sections
-                    // such as "Fresh finds" / "Old favourites") are dropped.
+                    // Home feed layout policy:
+                    //
+                    //  * "Jump back in" hero is ALWAYS rendered (when there are
+                    //    hero picks) regardless of Minimal Mode, so the top of
+                    //    the home screen always has the big artwork card.
+                    //
+                    //  * When `uiState.minimalHomeMode == true`, the feed
+                    //    collapses to:
+                    //      hero -> Recently Played -> Keep Listening
+                    //      -> Live Performances
+                    //    All other shelves (category chips, remote/local quick
+                    //    picks, speed dial, account playlists, forgotten
+                    //    favorites, similar recommendations, and non-Live
+                    //    remote sections) are hidden.
+                    //
+                    //  * When `uiState.minimalHomeMode == false` (default, also
+                    //    matches upstream rukamori/ArchiveTune), the feed shows
+                    //    the full set:
+                    //      hero -> category chips -> remote/local quick picks
+                    //      -> Recently Played -> Speed Dial -> Keep Listening
+                    //      -> Account Playlists -> Forgotten Favourites
+                    //      -> Similar Recommendations -> ALL remote homePage
+                    //      sections (including but not limited to "Live
+                    //      performance").
+                    //
+                    // The hero and Recently Played sections are 4nx3b fork
+                    // additions; everything else mirrors upstream so a fresh
+                    // install (with only remote content available) sees a
+                    // populated home screen.
+
+                    val minimalMode = uiState.minimalHomeMode
 
                     // "Jump back in" hero — large card + 2 stacked side cards.
                     // Uses `heroPicks` (3 random songs from listening-preference
                     // based quickPicks) instead of the last-played 3, so the hero
                     // rotates fresh picks each visit. Mirrors the Apple Music /
                     // Muzo home hero. Skipped entirely if the user has no
-                    // listening history yet (e.g. fresh install).
+                    // listening history yet (e.g. fresh install). PERSISTENT —
+                    // renders in both full and minimal modes.
                     if (uiState.heroPicks.isNotEmpty()) {
                         item(
                             key = "home_jump_back_in",
@@ -359,37 +381,63 @@ private fun HomeContent(
                         }
                     }
 
-                    if (remoteQuickPicks?.items?.isNotEmpty() == true) {
-                        sectionSpacer("remote_quick_picks")
+                    if (!minimalMode && uiState.showCategoryChips) {
                         item(
-                            key = "home_remote_quick_picks_header",
-                            contentType = "section_header",
+                            key = "home_category_chips",
+                            contentType = "category_chips",
                         ) {
-                            HomeSectionHeader(
-                                title = remoteQuickPicks.title,
-                                modifier = Modifier.animateItem(),
-                            )
-                        }
-                        item(
-                            key = "home_remote_quick_picks",
-                            contentType = "media_shelf",
-                        ) {
-                            HomePageSectionContent(
-                                section = remoteQuickPicks,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
+                            HomeCategoryChips(
+                                chips = uiState.homePage?.chips.orEmpty(),
+                                selectedChip = uiState.selectedChip,
+                                onChipSelected = { onAction(HomeAction.SelectChip(it)) },
                                 modifier = Modifier.animateItem(),
                             )
                         }
                     }
 
+                    if (!minimalMode) {
+                        if (remoteQuickPicks?.items?.isNotEmpty() == true) {
+                            sectionSpacer("remote_quick_picks")
+                            item(
+                                key = "home_remote_quick_picks_header",
+                                contentType = "section_header",
+                            ) {
+                                HomeSectionHeader(
+                                    title = remoteQuickPicks.title,
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
+                            item(
+                                key = "home_remote_quick_picks",
+                                contentType = "media_shelf",
+                            ) {
+                                HomePageSectionContent(
+                                    section = remoteQuickPicks,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
+                        }
+                        // Note: the local "Quick Picks" shelf (driven by
+                        // `uiState.quickPicks` and rendered by upstream's
+                        // `QuickPicksSection` composable) was intentionally
+                        // removed from this fork in commit 9bf3c6bd2 in favour
+                        // of the "Jump back in" hero (which is built from the
+                        // same listening-preference-based picks) plus the
+                        // remote YouTube Music "Quick picks" shelf above.
+                        // Restoring upstream's `QuickPicksSection` would
+                        // require porting back the composable and its
+                        // carousel dependencies — out of scope for this fix.
+                    }
+
                     // "Recently Played" — horizontal square-card row with a
-                    // clock-icon header (matches the screenshot).
+                    // clock-icon header. Renders in both full and minimal modes.
                     if (uiState.recentlyPlayed.size > 1) {
                         sectionSpacer("recently_played")
                         item(
@@ -421,7 +469,7 @@ private fun HomeContent(
                         }
                     }
 
-                    if (uiState.speedDialItems.isNotEmpty()) {
+                    if (!minimalMode && uiState.speedDialItems.isNotEmpty()) {
                         sectionSpacer("speed_dial")
                         item(
                             key = "home_speed_dial_header",
@@ -450,6 +498,7 @@ private fun HomeContent(
                         }
                     }
 
+                    // Keep Listening — renders in both full and minimal modes.
                     if (uiState.keepListening.isNotEmpty()) {
                         sectionSpacer("keep_listening")
                         item(
@@ -482,46 +531,33 @@ private fun HomeContent(
                         }
                     }
 
-                    // "Live performances" — surfaced from the YouTube Music
-                    // home feed. The remote `homePage.sections` list contains
-                    // several algorithmic shelves ("Fresh finds", "Old
-                    // favourites", …); only the one whose title mentions
-                    // "Live performance" is rendered so the home stays
-                    // minimal. Placed directly below Keep Listening.
-                    uiState.homePage?.sections.orEmpty().forEachIndexed { index, section ->
-                        if (!section.title.contains("Live performance", ignoreCase = true)) return@forEachIndexed
-
-                        val sectionKey = "${section.endpoint?.browseId ?: section.title}_$index"
-                        sectionSpacer("live_performances_$sectionKey")
+                    if (!minimalMode && uiState.accountPlaylists.isNotEmpty()) {
+                        sectionSpacer("account_playlists")
                         item(
-                            key = "home_live_performances_header_$sectionKey",
-                            contentType = "section_header",
-                        ) {
-                            HomePageSectionTitle(
-                                section = section,
-                                navController = navController,
-                                modifier = Modifier.animateItem(),
-                            )
-                        }
-                        item(
-                            key = "home_live_performances_$sectionKey",
+                            key = "home_account_playlists",
                             contentType = "media_shelf",
                         ) {
-                            HomePageSectionContent(
-                                section = section,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
-                                modifier = Modifier.animateItem(),
-                            )
+                            Column(modifier = Modifier.animateItem()) {
+                                AccountPlaylistsTitle(
+                                    accountName = uiState.accountName,
+                                    accountImageUrl = uiState.accountImageUrl,
+                                    onClick = { navController.navigate("account") },
+                                )
+                                AccountPlaylistsSection(
+                                    accountPlaylists = uiState.accountPlaylists,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                )
+                            }
                         }
                     }
 
-                    if (uiState.forgottenFavorites.isNotEmpty()) {
+                    if (!minimalMode && uiState.forgottenFavorites.isNotEmpty()) {
                         sectionSpacer("forgotten_favorites")
                         item(
                             key = "home_forgotten_favorites_header",
@@ -547,6 +583,82 @@ private fun HomeContent(
                                 playerConnection = playerConnection,
                                 menuState = menuState,
                                 haptic = haptic,
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                    }
+
+                    if (!minimalMode) {
+                        uiState.similarRecommendations.forEach { recommendation ->
+                            sectionSpacer("similar_${recommendation.title.id}")
+                            item(
+                                key = "home_similar_header_${recommendation.title.id}",
+                                contentType = "section_header",
+                            ) {
+                                SimilarRecommendationsTitle(
+                                    recommendation = recommendation,
+                                    navController = navController,
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
+                            item(
+                                key = "home_similar_${recommendation.title.id}",
+                                contentType = "media_shelf",
+                            ) {
+                                SimilarRecommendationsSection(
+                                    recommendation = recommendation,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
+                        }
+                    }
+
+                    // Remote homePage sections.
+                    //
+                    //  * Minimal mode: only render the "Live performance"-titled
+                    //    shelf, placed directly below Keep Listening.
+                    //
+                    //  * Full mode: render ALL remote shelves (including "Live
+                    //    performance", "Fresh finds", "Old favourites", and any
+                    //    other algorithmic shelves YouTube Music returns) —
+                    //    matches upstream rukamori/ArchiveTune.
+                    uiState.homePage?.sections.orEmpty().forEachIndexed { index, section ->
+                        if (minimalMode && !section.title.contains("Live performance", ignoreCase = true)) {
+                            return@forEachIndexed
+                        }
+
+                        val sectionKey = "${section.endpoint?.browseId ?: section.title}_$index"
+                        sectionSpacer(if (minimalMode) "live_performances_$sectionKey" else "remote_$sectionKey")
+                        item(
+                            key = if (minimalMode) "home_live_performances_header_$sectionKey" else "home_remote_header_$sectionKey",
+                            contentType = "section_header",
+                        ) {
+                            HomePageSectionTitle(
+                                section = section,
+                                navController = navController,
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                        item(
+                            key = if (minimalMode) "home_live_performances_$sectionKey" else "home_remote_$sectionKey",
+                            contentType = "media_shelf",
+                        ) {
+                            HomePageSectionContent(
+                                section = section,
+                                mediaMetadata = mediaMetadata,
+                                isPlaying = isPlaying,
+                                navController = navController,
+                                playerConnection = playerConnection,
+                                menuState = menuState,
+                                haptic = haptic,
+                                scope = scope,
                                 modifier = Modifier.animateItem(),
                             )
                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
@@ -351,12 +351,31 @@ private fun HomeContent(
                     //      sections (including but not limited to "Live
                     //      performance").
                     //
+                    //  * "Live performance" shelves are extracted from the
+                    //    remote homePage sections and rendered as a dedicated
+                    //    block IMMEDIATELY after Speed Dial in BOTH modes — so
+                    //    Live Performances always stays below Speed Dial whether
+                    //    Minimal Mode is on or off. Non-Live remote shelves
+                    //    continue to render at the bottom in full mode only.
+                    //
                     // The hero and Recently Played sections are 4nx3b fork
                     // additions; everything else mirrors upstream so a fresh
                     // install (with only remote content available) sees a
                     // populated home screen.
 
                     val minimalMode = uiState.minimalHomeMode
+
+                    // Partition remote sections into Live-performance and other.
+                    // Live-performance shelves are rendered in a dedicated block
+                    // right after Speed Dial (both modes); other remote shelves
+                    // are rendered at the bottom (full mode only).
+                    val allRemoteSections = uiState.homePage?.sections.orEmpty()
+                    val livePerformanceSections = allRemoteSections.filter { section ->
+                        section.title.contains("Live performance", ignoreCase = true)
+                    }
+                    val otherRemoteSections = allRemoteSections.filter { section ->
+                        !section.title.contains("Live performance", ignoreCase = true)
+                    }
 
                     // "Jump back in" hero — large card + 2 stacked side cards.
                     // Uses `heroPicks` (3 random songs from listening-preference
@@ -575,6 +594,42 @@ private fun HomeContent(
                         }
                     }
 
+                    // Live Performances — extracted from the remote homePage
+                    // sections and rendered as a dedicated block IMMEDIATELY
+                    // after Speed Dial in BOTH modes. This guarantees Live
+                    // Performances always stays below Speed Dial whether
+                    // Minimal Mode is on or off (user-requested invariant).
+                    livePerformanceSections.forEachIndexed { index, section ->
+                        val sectionKey = "${section.endpoint?.browseId ?: section.title}_$index"
+                        sectionSpacer("live_performances_$sectionKey")
+                        item(
+                            key = "home_live_performances_header_$sectionKey",
+                            contentType = "section_header",
+                        ) {
+                            HomePageSectionTitle(
+                                section = section,
+                                navController = navController,
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                        item(
+                            key = "home_live_performances_$sectionKey",
+                            contentType = "media_shelf",
+                        ) {
+                            HomePageSectionContent(
+                                section = section,
+                                mediaMetadata = mediaMetadata,
+                                isPlaying = isPlaying,
+                                navController = navController,
+                                playerConnection = playerConnection,
+                                menuState = menuState,
+                                haptic = haptic,
+                                scope = scope,
+                                modifier = Modifier.animateItem(),
+                            )
+                        }
+                    }
+
                     if (!minimalMode && uiState.accountPlaylists.isNotEmpty()) {
                         sectionSpacer("account_playlists")
                         item(
@@ -664,47 +719,46 @@ private fun HomeContent(
                         }
                     }
 
-                    // Remote homePage sections.
+                    // Other Remote homePage sections (non-Live-performance).
                     //
-                    //  * Minimal mode: only render the "Live performance"-titled
-                    //    shelf, placed directly below Keep Listening.
+                    //  * Minimal mode: HIDDEN — Live performances are already
+                    //    rendered above (right after Speed Dial). All other
+                    //    remote shelves are filtered out in minimal mode.
                     //
-                    //  * Full mode: render ALL remote shelves (including "Live
-                    //    performance", "Fresh finds", "Old favourites", and any
-                    //    other algorithmic shelves YouTube Music returns) —
-                    //    matches upstream rukamori/ArchiveTune.
-                    uiState.homePage?.sections.orEmpty().forEachIndexed { index, section ->
-                        if (minimalMode && !section.title.contains("Live performance", ignoreCase = true)) {
-                            return@forEachIndexed
-                        }
-
-                        val sectionKey = "${section.endpoint?.browseId ?: section.title}_$index"
-                        sectionSpacer(if (minimalMode) "live_performances_$sectionKey" else "remote_$sectionKey")
-                        item(
-                            key = if (minimalMode) "home_live_performances_header_$sectionKey" else "home_remote_header_$sectionKey",
-                            contentType = "section_header",
-                        ) {
-                            HomePageSectionTitle(
-                                section = section,
-                                navController = navController,
-                                modifier = Modifier.animateItem(),
-                            )
-                        }
-                        item(
-                            key = if (minimalMode) "home_live_performances_$sectionKey" else "home_remote_$sectionKey",
-                            contentType = "media_shelf",
-                        ) {
-                            HomePageSectionContent(
-                                section = section,
-                                mediaMetadata = mediaMetadata,
-                                isPlaying = isPlaying,
-                                navController = navController,
-                                playerConnection = playerConnection,
-                                menuState = menuState,
-                                haptic = haptic,
-                                scope = scope,
-                                modifier = Modifier.animateItem(),
-                            )
+                    //  * Full mode: render ALL non-Live remote shelves (e.g.
+                    //    "Fresh finds", "Old favourites", and any other
+                    //    algorithmic shelves YouTube Music returns) — matches
+                    //    upstream rukamori/ArchiveTune.
+                    if (!minimalMode) {
+                        otherRemoteSections.forEachIndexed { index, section ->
+                            val sectionKey = "${section.endpoint?.browseId ?: section.title}_$index"
+                            sectionSpacer("remote_$sectionKey")
+                            item(
+                                key = "home_remote_header_$sectionKey",
+                                contentType = "section_header",
+                            ) {
+                                HomePageSectionTitle(
+                                    section = section,
+                                    navController = navController,
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
+                            item(
+                                key = "home_remote_$sectionKey",
+                                contentType = "media_shelf",
+                            ) {
+                                HomePageSectionContent(
+                                    section = section,
+                                    mediaMetadata = mediaMetadata,
+                                    isPlaying = isPlaying,
+                                    navController = navController,
+                                    playerConnection = playerConnection,
+                                    menuState = menuState,
+                                    haptic = haptic,
+                                    scope = scope,
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
@@ -425,6 +425,9 @@ private fun HomeContent(
                             ) {
                                 HomeSectionHeader(
                                     title = remoteQuickPicks.title,
+                                    leadingIcon = {
+                                        HomeSectionLeadingIcon(iconRes = R.drawable.discover_tune)
+                                    },
                                     modifier = Modifier.animateItem(),
                                 )
                             }
@@ -504,6 +507,9 @@ private fun HomeContent(
                         ) {
                             HomeSectionHeader(
                                 title = stringResource(R.string.speed_dial),
+                                leadingIcon = {
+                                    HomeSectionLeadingIcon(iconRes = R.drawable.bolt)
+                                },
                                 modifier = Modifier.animateItem(),
                             )
                         }
@@ -664,6 +670,9 @@ private fun HomeContent(
                         ) {
                             HomeSectionHeader(
                                 title = stringResource(R.string.forgotten_favorites),
+                                leadingIcon = {
+                                    HomeSectionLeadingIcon(iconRes = R.drawable.cached)
+                                },
                                 modifier = Modifier.animateItem(),
                             )
                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreenComponents.kt
@@ -1229,12 +1229,25 @@ fun HomePageSectionTitle(
         title = section.title,
         label = section.label,
         leadingIcon = {
-            // Live performances section gets a microphone icon to match
+            // Every remote HomePage section now gets a leading icon — matches
             // the Recently Played (history) and Keep Listening (listening)
-            // headers — every home section now has a leading icon.
-            if (section.title.contains("Live performance", ignoreCase = true)) {
-                HomeSectionLeadingIcon(iconRes = R.drawable.mic)
-            }
+            // pattern so all home-section headers have a recognisable
+            // affordance before the title text. Live performances get a
+            // microphone; algorithmic shelves (Fresh finds, Old favourites,
+            // Quick picks, etc.) get an auto_awesome sparkle.
+            val iconRes =
+                when {
+                    section.title.contains("Live performance", ignoreCase = true) -> R.drawable.mic
+                    section.title.contains("Quick pick", ignoreCase = true) -> R.drawable.discover_tune
+                    section.title.contains("Fresh", ignoreCase = true) -> R.drawable.fire
+                    section.title.contains("Old", ignoreCase = true) ||
+                        section.title.contains("favourite", ignoreCase = true) ||
+                        section.title.contains("forgotten", ignoreCase = true) -> R.drawable.cached
+                    section.title.contains("New release", ignoreCase = true) -> R.drawable.new_release
+                    section.title.contains("Trending", ignoreCase = true) -> R.drawable.trending_up
+                    else -> R.drawable.auto_awesome
+                }
+            HomeSectionLeadingIcon(iconRes = iconRes)
         },
         thumbnail =
             section.thumbnail?.let { thumbnailUrl ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreenComponents.kt
@@ -1152,14 +1152,36 @@ fun SimilarRecommendationsTitle(
     navController: NavController,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+    val thumbSizePx =
+        with(LocalDensity.current) {
+            ListThumbnailSize.roundToPx().coerceAtLeast(1)
+        }
     HomeSectionHeader(
         label = stringResource(R.string.similar_to),
         title = recommendation.title.title,
         thumbnail =
             recommendation.title.thumbnailUrl?.let { thumbnailUrl ->
                 {
+                    // Sized ImageRequest so Coil asks the CDN for a thumbnail
+                    // bucket close to ListThumbnailSize (56dp ≈ 168px @ 3x)
+                    // instead of pulling the original maxresdefault (often
+                    // 1280x720+). Combined with the tuned OkHttp pool in
+                    // App.newImageLoader, this makes the similar-recommendations
+                    // header thumbnail load near-instantly.
+                    val imageRequest =
+                        remember(thumbnailUrl, thumbSizePx) {
+                            ImageRequest
+                                .Builder(context)
+                                .data(thumbnailUrl)
+                                .size(Size(thumbSizePx, thumbSizePx))
+                                .diskCachePolicy(CachePolicy.ENABLED)
+                                .memoryCachePolicy(CachePolicy.ENABLED)
+                                .crossfade(true)
+                                .build()
+                        }
                     AsyncImage(
-                        model = thumbnailUrl,
+                        model = imageRequest,
                         contentDescription = null,
                         modifier =
                             Modifier
@@ -1198,6 +1220,11 @@ fun HomePageSectionTitle(
     navController: NavController,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
+    val thumbSizePx =
+        with(LocalDensity.current) {
+            ListThumbnailSize.roundToPx().coerceAtLeast(1)
+        }
     HomeSectionHeader(
         title = section.title,
         label = section.label,
@@ -1212,8 +1239,24 @@ fun HomePageSectionTitle(
         thumbnail =
             section.thumbnail?.let { thumbnailUrl ->
                 {
+                    // Sized ImageRequest — same rationale as in
+                    // SimilarRecommendationsTitle: request a thumbnail bucket
+                    // close to 56dp instead of the original full-res artwork
+                    // the CDN would otherwise serve. This is the slow-loading
+                    // "playlist thumbnail" the user reported on the home feed.
+                    val imageRequest =
+                        remember(thumbnailUrl, thumbSizePx) {
+                            ImageRequest
+                                .Builder(context)
+                                .data(thumbnailUrl)
+                                .size(Size(thumbSizePx, thumbSizePx))
+                                .diskCachePolicy(CachePolicy.ENABLED)
+                                .memoryCachePolicy(CachePolicy.ENABLED)
+                                .crossfade(true)
+                                .build()
+                        }
                     AsyncImage(
-                        model = thumbnailUrl,
+                        model = imageRequest,
                         contentDescription = null,
                         modifier =
                             Modifier

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreenComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreenComponents.kt
@@ -1160,36 +1160,10 @@ fun SimilarRecommendationsTitle(
     HomeSectionHeader(
         label = stringResource(R.string.similar_to),
         title = recommendation.title.title,
-        thumbnail =
-            recommendation.title.thumbnailUrl?.let { thumbnailUrl ->
-                {
-                    // Sized ImageRequest so Coil asks the CDN for a thumbnail
-                    // bucket close to ListThumbnailSize (56dp ≈ 168px @ 3x)
-                    // instead of pulling the original maxresdefault (often
-                    // 1280x720+). Combined with the tuned OkHttp pool in
-                    // App.newImageLoader, this makes the similar-recommendations
-                    // header thumbnail load near-instantly.
-                    val imageRequest =
-                        remember(thumbnailUrl, thumbSizePx) {
-                            ImageRequest
-                                .Builder(context)
-                                .data(thumbnailUrl)
-                                .size(Size(thumbSizePx, thumbSizePx))
-                                .diskCachePolicy(CachePolicy.ENABLED)
-                                .memoryCachePolicy(CachePolicy.ENABLED)
-                                .crossfade(true)
-                                .build()
-                        }
-                    AsyncImage(
-                        model = imageRequest,
-                        contentDescription = null,
-                        modifier =
-                            Modifier
-                                .size(ListThumbnailSize)
-                                .clip(RoundedCornerShape(ThumbnailCornerRadius)),
-                    )
-                }
-            },
+        // Thumbnail (album art) removed per user request — the "Similar to"
+        // label + artist/album title is enough context without the leading
+        // image. Keeps these headers visually consistent with the other
+        // text-only section headers on the home page.
         onClick = {
             when (recommendation.title) {
                 is Song -> {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/LoginScreen.kt
@@ -14,6 +14,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -133,39 +134,13 @@ fun LoginScreen(
         },
     )
 
-    TopAppBar(
-        title = { Text(stringResource(R.string.login)) },
-        navigationIcon = {
-            IconButton(
-                onClick = {
-                    if (onNavigateBack != null) {
-                        onNavigateBack()
-                    } else {
-                        navController.navigateUp()
-                    }
-                },
-                onLongClick = {
-                    if (onNavigateBack != null) {
-                        onNavigateBack()
-                    } else {
-                        navController.backToMain()
-                    }
-                },
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-    )
-
-    BackHandler(enabled = onNavigateBack != null || webView?.canGoBack() == true) {
-        if (webView?.canGoBack() == true) {
-            webView?.goBack()
-        } else {
-            onNavigateBack?.invoke()
-        }
+    // The AuthWebViewScreen above already renders its own TopAppBar (with the
+    // login title and a back button wired to navController). When this screen
+    // is reached from onboarding (onNavigateBack != null), we add a BackHandler
+    // so the system back gesture routes through onNavigateBack instead of
+    // popping the nav stack.
+    BackHandler(enabled = onNavigateBack != null) {
+        onNavigateBack?.invoke()
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/LoginScreen.kt
@@ -56,6 +56,8 @@ private val YOUTUBE_COOKIE_URLS =
 fun LoginScreen(
     navController: NavController,
     startUrl: String? = null,
+    onLoginComplete: (() -> Unit)? = null,
+    onNavigateBack: (() -> Unit)? = null,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -66,7 +68,11 @@ fun LoginScreen(
     LaunchedEffect(screenState, loginSuccessMessage) {
         if (screenState is LoginScreenState.Success) {
             Toast.makeText(context, loginSuccessMessage, Toast.LENGTH_SHORT).show()
-            navController.navigateUp()
+            if (onLoginComplete != null) {
+                onLoginComplete()
+            } else {
+                navController.navigateUp()
+            }
         }
     }
 
@@ -126,6 +132,41 @@ fun LoginScreen(
             }
         },
     )
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.login)) },
+        navigationIcon = {
+            IconButton(
+                onClick = {
+                    if (onNavigateBack != null) {
+                        onNavigateBack()
+                    } else {
+                        navController.navigateUp()
+                    }
+                },
+                onLongClick = {
+                    if (onNavigateBack != null) {
+                        onNavigateBack()
+                    } else {
+                        navController.backToMain()
+                    }
+                },
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+    )
+
+    BackHandler(enabled = onNavigateBack != null || webView?.canGoBack() == true) {
+        if (webView?.canGoBack() == true) {
+            webView?.goBack()
+        } else {
+            onNavigateBack?.invoke()
+        }
+    }
 }
 
 private class YouTubeLoginWebViewClient(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,6 +35,7 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Album
@@ -44,15 +46,13 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -85,7 +85,6 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.GridThumbnailHeight
 import moe.rukamori.archivetune.innertube.models.AlbumItem
 import moe.rukamori.archivetune.ui.component.IconButton
-import moe.rukamori.archivetune.ui.component.LargeFrostedTopAppBar
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.YouTubeGridItem
 import moe.rukamori.archivetune.ui.component.shimmer.GridItemPlaceHolder
@@ -115,10 +114,30 @@ fun NewReleaseScreen(
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            LargeFrostedTopAppBar(
-                titleRes = R.string.new_releases,
-                onBack = navController::navigateUp,
-                onBackLongClick = navController::backToMain,
+            // Plain top bar — no frosted pills. Modern, minimal.
+            LargeFlexibleTopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.new_releases),
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.largeTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+                ),
                 scrollBehavior = scrollBehavior,
             )
         },
@@ -310,7 +329,7 @@ private fun NewReleaseGridContent(
             span = { GridItemSpan(maxLineSpan) },
             contentType = "new_release_summary",
         ) {
-            NewReleaseSummaryCard(
+            NewReleaseSummaryHeader(
                 content = content,
                 selectedTab = selectedTab,
                 onTabSelected = onTabSelected,
@@ -384,23 +403,37 @@ private fun NewReleaseSectionHeader(
     title: String,
     count: Int,
 ) {
-    Column(
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(start = 20.dp, top = 10.dp, end = 20.dp, bottom = 2.dp),
+                .padding(start = 20.dp, top = 18.dp, end = 20.dp, bottom = 6.dp),
     ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Text(
-            text = count.toString(),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.width(8.dp))
+            // Compact count chip — small rounded background with the count.
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .padding(horizontal = 8.dp, vertical = 2.dp),
+            ) {
+                Text(
+                    text = count.toString(),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 
@@ -447,25 +480,33 @@ private fun NewReleaseHorizontalSection(
     }
 }
 
+/**
+ * Modern summary header — replaces the old frosted-glass summary card.
+ *
+ * Layout:
+ *  - Top row: bold "Total releases" label + large count number on the right
+ *  - Bottom: tab strip as a horizontal row of clean tonal chips
+ *
+ * No frosted glass, no oversized rounded container — just typography +
+ * a clean tab strip.
+ */
 @Composable
-private fun NewReleaseSummaryCard(
+private fun NewReleaseSummaryHeader(
     content: NewReleaseContent,
     selectedTab: NewReleaseTab,
     onTabSelected: (NewReleaseTab) -> Unit,
 ) {
-    val summaryShape = remember { RoundedCornerShape(28.dp) }
-
-    Surface(
-        shape = summaryShape,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.86f),
-        tonalElevation = 3.dp,
+    Column(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(start = 20.dp, top = 12.dp, end = 20.dp, bottom = 8.dp),
     ) {
-        Column(
-            modifier = Modifier.padding(start = 20.dp, top = 18.dp, end = 20.dp, bottom = 10.dp),
+        // Total releases — inline row, no container background.
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
                 text = stringResource(R.string.total_releases),
@@ -475,16 +516,19 @@ private fun NewReleaseSummaryCard(
             )
             Text(
                 text = content.totalReleases.toString(),
-                style = MaterialTheme.typography.displaySmall,
+                style = MaterialTheme.typography.headlineLarge,
                 fontWeight = FontWeight.Black,
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            Spacer(Modifier.height(14.dp))
-            NewReleaseTabs(
-                selectedTab = selectedTab,
-                onTabSelected = onTabSelected,
-            )
         }
+
+        Spacer(Modifier.height(16.dp))
+
+        // Modern tab strip — clean chips with no frosted pill background.
+        NewReleaseTabs(
+            selectedTab = selectedTab,
+            onTabSelected = onTabSelected,
+        )
     }
 }
 
@@ -494,65 +538,45 @@ private fun NewReleaseTabs(
     onTabSelected: (NewReleaseTab) -> Unit,
 ) {
     val tabs = remember { NewReleaseTab.entries.toList() }
-    val selectedTabIndex = tabs.indexOf(selectedTab).coerceAtLeast(0)
-    val tabShape = remember { RoundedCornerShape(28.dp) }
-    val selectedContainer = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.56f)
-    val unselectedContainer = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.42f)
-    val selectedContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+    val selectedContainer = MaterialTheme.colorScheme.primary
+    val selectedContentColor = MaterialTheme.colorScheme.onPrimary
     val unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-    val indicatorColor = MaterialTheme.colorScheme.primary
 
-    TabRow(
-        selectedTabIndex = selectedTabIndex,
-        containerColor = Color.Transparent,
-        contentColor = selectedContentColor,
-        divider = {},
-        indicator = { tabPositions ->
-            Box(
-                contentAlignment = Alignment.BottomCenter,
-                modifier =
-                    Modifier
-                        .tabIndicatorOffset(tabPositions[selectedTabIndex])
-                        .fillMaxSize(),
-            ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .width(76.dp)
-                            .height(3.dp)
-                            .clip(RoundedCornerShape(3.dp))
-                            .background(indicatorColor),
-                )
-            }
-        },
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .height(66.dp),
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.fillMaxWidth(),
     ) {
         tabs.forEach { tab ->
             val selected = tab == selectedTab
             val title = stringResource(tab.titleRes)
 
-            Tab(
-                selected = selected,
-                onClick = { onTabSelected(tab) },
-                icon = {
-                    Icon(
-                        imageVector = tab.icon,
-                        contentDescription = title,
-                        modifier = Modifier.size(24.dp),
-                    )
-                },
-                selectedContentColor = selectedContentColor,
-                unselectedContentColor = unselectedContentColor,
-                modifier =
-                    Modifier
-                        .padding(horizontal = 3.dp, vertical = 6.dp)
-                        .height(56.dp)
-                        .clip(tabShape)
-                        .background(if (selected) selectedContainer else unselectedContainer),
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(44.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(if (selected) selectedContainer else Color.Transparent)
+                    .combinedClickable(onClick = { onTabSelected(tab) })
+                    .padding(horizontal = 8.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Icon(
+                    imageVector = tab.icon,
+                    contentDescription = title,
+                    modifier = Modifier.size(18.dp),
+                    tint = if (selected) selectedContentColor else unselectedContentColor,
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = if (selected) FontWeight.Bold else FontWeight.SemiBold,
+                    color = if (selected) selectedContentColor else unselectedContentColor,
+                    maxLines = 1,
+                )
+            }
         }
     }
 }
@@ -573,9 +597,9 @@ private fun NewReleaseCategoryEmptyState(onRefresh: () -> Unit) {
             textAlign = TextAlign.Center,
         )
         Spacer(Modifier.height(24.dp))
-        Button(
+        FilledTonalButton(
             onClick = onRefresh,
-            shapes = ButtonDefaults.shapes(),
+            shape = RoundedCornerShape(20.dp),
         ) {
             Text(stringResource(R.string.refresh))
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
@@ -148,6 +148,7 @@ fun NewReleaseScreen(
                             isSearchActive = !isSearchActive
                             if (!isSearchActive) searchQuery = ""
                         },
+                        onLongClick = {},
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.search),
@@ -780,7 +781,7 @@ private fun NewReleaseSearchField(
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .padding(horizontal = 4.dp, vertical = 4.dp),
     ) {
-        IconButton(onClick = onClose) {
+        IconButton(onClick = onClose, onLongClick = {}) {
             Icon(
                 painter = painterResource(R.drawable.arrow_back),
                 contentDescription = null,
@@ -816,7 +817,7 @@ private fun NewReleaseSearchField(
             },
         )
         if (query.isNotEmpty()) {
-            IconButton(onClick = { onQueryChange("") }) {
+            IconButton(onClick = { onQueryChange("") }, onLongClick = {}) {
                 Icon(
                     painter = painterResource(R.drawable.close),
                     contentDescription = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,11 +31,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -110,6 +113,11 @@ fun NewReleaseScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
     var selectedTab by rememberSaveable { mutableStateOf(NewReleaseTab.All) }
+    // Local search state — filters releases by album/artist name. The search
+    // icon in the top app bar toggles a search field; typing filters the
+    // visible grid in-place. Empty query = show all releases.
+    var searchQuery by rememberSaveable { mutableStateOf("") }
+    var isSearchActive by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -131,6 +139,19 @@ fun NewReleaseScreen(
                         Icon(
                             painter = painterResource(R.drawable.arrow_back),
                             contentDescription = null,
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            isSearchActive = !isSearchActive
+                            if (!isSearchActive) searchQuery = ""
+                        },
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.search),
+                            contentDescription = stringResource(R.string.search),
                         )
                     }
                 },
@@ -175,6 +196,13 @@ fun NewReleaseScreen(
                         activeAlbumId = mediaMetadata?.album?.id,
                         isPlaying = isPlaying,
                         coroutineScope = coroutineScope,
+                        searchQuery = searchQuery,
+                        isSearchActive = isSearchActive,
+                        onSearchQueryChange = { searchQuery = it },
+                        onClearSearch = {
+                            searchQuery = ""
+                            isSearchActive = false
+                        },
                         onReleaseClick = { album -> navController.navigate("album/${album.id}") },
                         onReleaseLongClick = { album ->
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -306,6 +334,10 @@ private fun NewReleaseGridContent(
     activeAlbumId: String?,
     isPlaying: Boolean,
     coroutineScope: CoroutineScope,
+    searchQuery: String,
+    isSearchActive: Boolean,
+    onSearchQueryChange: (String) -> Unit,
+    onClearSearch: () -> Unit,
     onReleaseClick: (AlbumItem) -> Unit,
     onReleaseLongClick: (AlbumItem) -> Unit,
     onRefresh: () -> Unit,
@@ -319,11 +351,44 @@ private fun NewReleaseGridContent(
             if (selectedTab == NewReleaseTab.All) emptyList() else content.releasesFor(selectedTab)
         }
 
+    // Apply search filter to releases — matches album title OR artist name,
+    // case-insensitive. Empty query = no filtering.
+    val query = searchQuery.trim()
+    fun matchesQuery(album: AlbumItem): Boolean {
+        if (query.isEmpty()) return true
+        val title = album.title.lowercase()
+        val artists = album.artists?.joinToString(" ") { it.name }?.lowercase().orEmpty()
+        val q = query.lowercase()
+        return title.contains(q) || artists.contains(q)
+    }
+
+    val filteredReleases = remember(releases, query) { releases.filter(::matchesQuery) }
+    val filteredAllSections = remember(allSections, query) {
+        if (query.isEmpty()) allSections
+        else allSections.map { it.copy(releases = it.releases.filter(::matchesQuery)) }.filter { it.releases.isNotEmpty() }
+    }
+
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
         contentPadding = paddingValues,
         modifier = Modifier.fillMaxSize(),
     ) {
+        // Search field — only shown when the user has tapped the search icon.
+        // Renders as a full-width row above the summary header.
+        if (isSearchActive) {
+            item(
+                key = "new_release_search_field",
+                span = { GridItemSpan(maxLineSpan) },
+                contentType = "new_release_search_field",
+            ) {
+                NewReleaseSearchField(
+                    query = searchQuery,
+                    onQueryChange = onSearchQueryChange,
+                    onClose = onClearSearch,
+                )
+            }
+        }
+
         item(
             key = "new_release_summary",
             span = { GridItemSpan(maxLineSpan) },
@@ -336,8 +401,16 @@ private fun NewReleaseGridContent(
             )
         }
 
-        if (selectedTab == NewReleaseTab.All) {
-            allSections.forEach { section ->
+        if (query.isNotEmpty() && filteredAllSections.isEmpty() && filteredReleases.isEmpty()) {
+            item(
+                key = "new_release_search_empty",
+                span = { GridItemSpan(maxLineSpan) },
+                contentType = "new_release_empty",
+            ) {
+                NewReleaseCategoryEmptyState(onRefresh = onRefresh)
+            }
+        } else if (selectedTab == NewReleaseTab.All) {
+            filteredAllSections.forEach { section ->
                 item(
                     key = "new_release_section_header_${section.tab.name}",
                     span = { GridItemSpan(maxLineSpan) },
@@ -346,6 +419,7 @@ private fun NewReleaseGridContent(
                     NewReleaseSectionHeader(
                         title = stringResource(section.tab.titleRes),
                         count = section.releases.size,
+                        leadingIcon = section.tab.icon,
                     )
                 }
 
@@ -365,7 +439,7 @@ private fun NewReleaseGridContent(
                     )
                 }
             }
-        } else if (releases.isEmpty()) {
+        } else if (filteredReleases.isEmpty()) {
             item(
                 key = "new_release_empty_${selectedTab.name}",
                 span = { GridItemSpan(maxLineSpan) },
@@ -375,7 +449,7 @@ private fun NewReleaseGridContent(
             }
         } else {
             items(
-                items = releases,
+                items = filteredReleases,
                 key = { it.id },
                 contentType = { selectedTab.contentType },
             ) { album ->
@@ -402,6 +476,7 @@ private fun NewReleaseGridContent(
 private fun NewReleaseSectionHeader(
     title: String,
     count: Int,
+    leadingIcon: ImageVector? = null,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -412,6 +487,27 @@ private fun NewReleaseSectionHeader(
                 .padding(start = 20.dp, top = 18.dp, end = 20.dp, bottom = 6.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
+            // Leading icon in a circular container — matches the Home page's
+            // HomeSectionLeadingIcon pattern (e.g. clock for Recently Played,
+            // bolt for Speed Dial) so every section header across the app has
+            // a recognisable affordance before its title.
+            if (leadingIcon != null) {
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = leadingIcon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+            }
             Text(
                 text = title,
                 style = MaterialTheme.typography.titleLarge,
@@ -484,8 +580,11 @@ private fun NewReleaseHorizontalSection(
  * Modern summary header — replaces the old frosted-glass summary card.
  *
  * Layout:
- *  - Top row: bold "Total releases" label + large count number on the right
- *  - Bottom: tab strip as a horizontal row of clean tonal chips
+ *  - Top row: "Total releases" label + count number grouped together on the
+ *    left (so the number sits beside the label, not floating at the right
+ *    edge — user-requested fix), with a search affordance icon on the right
+ *  - Bottom: tab strip as a horizontally-scrollable row of clean tonal chips
+ *    (scrollable so 4 tabs never truncate "Albums" → "Albu" on narrow screens)
  *
  * No frosted glass, no oversized rounded container — just typography +
  * a clean tab strip.
@@ -502,21 +601,42 @@ private fun NewReleaseSummaryHeader(
                 .fillMaxWidth()
                 .padding(start = 20.dp, top = 12.dp, end = 20.dp, bottom = 8.dp),
     ) {
-        // Total releases — inline row, no container background.
+        // Total releases — label and count grouped together on the LEFT so
+        // the count number reads as part of the label (e.g. "Total releases 200")
+        // rather than floating alone at the right edge of the screen. The
+        // search affordance icon is rendered by the top app bar instead.
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier.fillMaxWidth(),
         ) {
+            // Small leading icon — matches the section header pattern so the
+            // summary header has the same visual language as the per-section
+            // headers below it.
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.LibraryMusic,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
             Text(
                 text = stringResource(R.string.total_releases),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            // Count number — bold and prominent, immediately after the label.
             Text(
                 text = content.totalReleases.toString(),
-                style = MaterialTheme.typography.headlineLarge,
+                style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Black,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -525,6 +645,8 @@ private fun NewReleaseSummaryHeader(
         Spacer(Modifier.height(16.dp))
 
         // Modern tab strip — clean chips with no frosted pill background.
+        // Horizontally scrollable so all 4 tab labels ("All", "Albums",
+        // "Singles", "EP") are fully visible regardless of screen width.
         NewReleaseTabs(
             selectedTab = selectedTab,
             onTabSelected = onTabSelected,
@@ -541,11 +663,14 @@ private fun NewReleaseTabs(
     val selectedContainer = MaterialTheme.colorScheme.primary
     val selectedContentColor = MaterialTheme.colorScheme.onPrimary
     val unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val scrollState = rememberScrollState()
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(scrollState),
     ) {
         tabs.forEach { tab ->
             val selected = tab == selectedTab
@@ -554,12 +679,12 @@ private fun NewReleaseTabs(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
-                    .weight(1f)
+                    .wrapContentWidth()
                     .height(44.dp)
                     .clip(RoundedCornerShape(12.dp))
                     .background(if (selected) selectedContainer else Color.Transparent)
                     .combinedClickable(onClick = { onTabSelected(tab) })
-                    .padding(horizontal = 8.dp),
+                    .padding(horizontal = 14.dp),
                 horizontalArrangement = Arrangement.Center,
             ) {
                 Icon(
@@ -626,3 +751,78 @@ private fun NewReleaseContent.releaseSections(): List<NewReleaseSection> =
             add(NewReleaseSection(NewReleaseTab.Ep, eps))
         }
     }
+
+/**
+ * Inline search field for the New Releases screen — rendered as a full-width
+ * row above the summary header when the user taps the search icon in the top
+ * app bar. Filters releases by album title / artist name in real time.
+ *
+ * Layout mirrors the SearchScreen's input row (search icon + text field +
+ * clear button) but is rendered inside the grid content rather than as a
+ * top app bar, so it appears in-line with the rest of the page content.
+ */
+@Composable
+private fun NewReleaseSearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onClose: () -> Unit,
+) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
+    val primary = MaterialTheme.colorScheme.primary
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 4.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(horizontal = 4.dp, vertical = 4.dp),
+    ) {
+        IconButton(onClick = onClose) {
+            Icon(
+                painter = painterResource(R.drawable.arrow_back),
+                contentDescription = null,
+                tint = onSurfaceVariant,
+            )
+        }
+        androidx.compose.foundation.text.BasicTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            singleLine = true,
+            textStyle =
+                MaterialTheme.typography.bodyLarge.copy(color = onSurface),
+            cursorBrush = androidx.compose.ui.graphics.SolidColor(primary),
+            modifier = Modifier.weight(1f),
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    if (query.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.search),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = onSurfaceVariant,
+                            maxLines = 1,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+        if (query.isNotEmpty()) {
+            IconButton(onClick = { onQueryChange("") }) {
+                Icon(
+                    painter = painterResource(R.drawable.close),
+                    contentDescription = null,
+                    tint = onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
@@ -11,6 +11,8 @@ package moe.rukamori.archivetune.ui.screens
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -55,12 +57,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -70,8 +73,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -126,51 +127,115 @@ fun NewReleaseScreen(
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            // Plain top bar — no frosted pills. Modern, minimal.
-            LargeFlexibleTopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.new_releases),
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                    )
+            // Switch between the normal top app bar and a Material3 SearchBar
+            // when the user taps the search icon. Rendering the search bar in
+            // the topBar slot (instead of as a grid item below the top app bar)
+            // ensures it is always visible when search is active — even if the
+            // grid has been scrolled down. Matches the pattern used by
+            // NewsScreen and HistoryScreen.
+            AnimatedContent(
+                targetState = isSearchActive,
+                transitionSpec = {
+                    fadeIn(spring(stiffness = Spring.StiffnessMediumLow)) togetherWith
+                        fadeOut(spring(stiffness = Spring.StiffnessMediumLow))
                 },
-                navigationIcon = {
-                    AppIconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
-                        )
-                    }
-                },
-                actions = {
-                    // Using Material3's standard IconButton here (not the
-                    // custom AppIconButton) because the custom one uses
-                    // combinedClickable which can fail to register taps in
-                    // the LargeFlexibleTopAppBar actions slot on some
-                    // Material3 1.5.0-alpha builds. The standard IconButton
-                    // uses a plain clickable and is more reliable here.
-                    IconButton(
-                        onClick = {
-                            isSearchActive = !isSearchActive
-                            if (!isSearchActive) searchQuery = ""
+                label = "newReleaseTopBar",
+            ) { searching ->
+                if (searching) {
+                    SearchBar(
+                        inputField = {
+                            SearchBarDefaults.InputField(
+                                query = searchQuery,
+                                onQueryChange = { searchQuery = it },
+                                onSearch = { isSearchActive = false },
+                                expanded = false,
+                                onExpandedChange = {},
+                                placeholder = {
+                                    Text(text = stringResource(R.string.search))
+                                },
+                                leadingIcon = {
+                                    IconButton(
+                                        onClick = {
+                                            searchQuery = ""
+                                            isSearchActive = false
+                                        },
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.arrow_back),
+                                            contentDescription = null,
+                                        )
+                                    }
+                                },
+                                trailingIcon =
+                                    if (searchQuery.isNotEmpty()) {
+                                        {
+                                            IconButton(
+                                                onClick = { searchQuery = "" },
+                                            ) {
+                                                Icon(
+                                                    painter = painterResource(R.drawable.close),
+                                                    contentDescription = null,
+                                                )
+                                            }
+                                        }
+                                    } else {
+                                        null
+                                    },
+                            )
                         },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.search),
-                            contentDescription = stringResource(R.string.search),
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.largeTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-                ),
-                scrollBehavior = scrollBehavior,
-            )
+                        expanded = false,
+                        onExpandedChange = {},
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp)
+                                .padding(top = 8.dp, bottom = 4.dp),
+                    ) {}
+                } else {
+                    // Plain top bar — no frosted pills. Modern, minimal.
+                    LargeFlexibleTopAppBar(
+                        title = {
+                            Text(
+                                text = stringResource(R.string.new_releases),
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                            )
+                        },
+                        navigationIcon = {
+                            AppIconButton(
+                                onClick = navController::navigateUp,
+                                onLongClick = navController::backToMain,
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.arrow_back),
+                                    contentDescription = null,
+                                )
+                            }
+                        },
+                        actions = {
+                            // Using Material3's standard IconButton here (not the
+                            // custom AppIconButton) because the custom one uses
+                            // combinedClickable which can fail to register taps in
+                            // the LargeFlexibleTopAppBar actions slot on some
+                            // Material3 1.5.0-alpha builds. The standard IconButton
+                            // uses a plain clickable and is more reliable here.
+                            IconButton(
+                                onClick = { isSearchActive = true },
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.search),
+                                    contentDescription = stringResource(R.string.search),
+                                )
+                            }
+                        },
+                        colors = TopAppBarDefaults.largeTopAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+                        ),
+                        scrollBehavior = scrollBehavior,
+                    )
+                }
+            }
         },
         contentWindowInsets = LocalPlayerAwareWindowInsets.current,
     ) { paddingValues ->
@@ -207,12 +272,6 @@ fun NewReleaseScreen(
                         isPlaying = isPlaying,
                         coroutineScope = coroutineScope,
                         searchQuery = searchQuery,
-                        isSearchActive = isSearchActive,
-                        onSearchQueryChange = { searchQuery = it },
-                        onClearSearch = {
-                            searchQuery = ""
-                            isSearchActive = false
-                        },
                         onReleaseClick = { album -> navController.navigate("album/${album.id}") },
                         onReleaseLongClick = { album ->
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -345,9 +404,6 @@ private fun NewReleaseGridContent(
     isPlaying: Boolean,
     coroutineScope: CoroutineScope,
     searchQuery: String,
-    isSearchActive: Boolean,
-    onSearchQueryChange: (String) -> Unit,
-    onClearSearch: () -> Unit,
     onReleaseClick: (AlbumItem) -> Unit,
     onReleaseLongClick: (AlbumItem) -> Unit,
     onRefresh: () -> Unit,
@@ -383,22 +439,6 @@ private fun NewReleaseGridContent(
         contentPadding = paddingValues,
         modifier = Modifier.fillMaxSize(),
     ) {
-        // Search field — only shown when the user has tapped the search icon.
-        // Renders as a full-width row above the summary header.
-        if (isSearchActive) {
-            item(
-                key = "new_release_search_field",
-                span = { GridItemSpan(maxLineSpan) },
-                contentType = "new_release_search_field",
-            ) {
-                NewReleaseSearchField(
-                    query = searchQuery,
-                    onQueryChange = onSearchQueryChange,
-                    onClose = onClearSearch,
-                )
-            }
-        }
-
         item(
             key = "new_release_summary",
             span = { GridItemSpan(maxLineSpan) },
@@ -761,95 +801,3 @@ private fun NewReleaseContent.releaseSections(): List<NewReleaseSection> =
             add(NewReleaseSection(NewReleaseTab.Ep, eps))
         }
     }
-
-/**
- * Inline search field for the New Releases screen — rendered as a full-width
- * row above the summary header when the user taps the search icon in the top
- * app bar. Filters releases by album title / artist name in real time.
- *
- * Layout mirrors the SearchScreen's input row (search icon + text field +
- * clear button) but is rendered inside the grid content rather than as a
- * top app bar, so it appears in-line with the rest of the page content.
- *
- * Auto-focuses the text field on appearance so the keyboard opens
- * immediately — the user doesn't have to tap the field after tapping the
- * search icon in the top app bar.
- */
-@Composable
-private fun NewReleaseSearchField(
-    query: String,
-    onQueryChange: (String) -> Unit,
-    onClose: () -> Unit,
-) {
-    val onSurface = MaterialTheme.colorScheme.onSurface
-    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
-    val primary = MaterialTheme.colorScheme.primary
-    val focusRequester = remember { FocusRequester() }
-
-    // Auto-focus the text field when this composable first appears so the
-    // keyboard opens immediately. This makes the search feel responsive —
-    // tap search icon → field appears → keyboard is already up → start typing.
-    LaunchedEffect(Unit) {
-        runCatching { focusRequester.requestFocus() }
-    }
-
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 16.dp, top = 12.dp, end = 16.dp, bottom = 4.dp)
-            .clip(RoundedCornerShape(24.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            .padding(horizontal = 4.dp, vertical = 4.dp),
-    ) {
-        // Use Material3's standard IconButton (not the custom AppIconButton)
-        // for consistency with the top app bar search icon — and because
-        // these buttons don't need long-press support.
-        IconButton(onClick = onClose) {
-            Icon(
-                painter = painterResource(R.drawable.arrow_back),
-                contentDescription = null,
-                tint = onSurfaceVariant,
-            )
-        }
-        androidx.compose.foundation.text.BasicTextField(
-            value = query,
-            onValueChange = onQueryChange,
-            singleLine = true,
-            textStyle =
-                MaterialTheme.typography.bodyLarge.copy(color = onSurface),
-            cursorBrush = androidx.compose.ui.graphics.SolidColor(primary),
-            modifier = Modifier
-                .weight(1f)
-                .focusRequester(focusRequester),
-            decorationBox = { innerTextField ->
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 8.dp),
-                    contentAlignment = Alignment.CenterStart,
-                ) {
-                    if (query.isEmpty()) {
-                        Text(
-                            text = stringResource(R.string.search),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = onSurfaceVariant,
-                            maxLines = 1,
-                        )
-                    }
-                    innerTextField()
-                }
-            },
-        )
-        if (query.isNotEmpty()) {
-            IconButton(onClick = { onQueryChange("") }) {
-                Icon(
-                    painter = painterResource(R.drawable.close),
-                    contentDescription = null,
-                    tint = onSurfaceVariant,
-                )
-            }
-        }
-    }
-}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewReleaseScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -59,6 +60,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -68,6 +70,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -87,7 +91,7 @@ import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.GridThumbnailHeight
 import moe.rukamori.archivetune.innertube.models.AlbumItem
-import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.IconButton as AppIconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.YouTubeGridItem
 import moe.rukamori.archivetune.ui.component.shimmer.GridItemPlaceHolder
@@ -132,7 +136,7 @@ fun NewReleaseScreen(
                     )
                 },
                 navigationIcon = {
-                    IconButton(
+                    AppIconButton(
                         onClick = navController::navigateUp,
                         onLongClick = navController::backToMain,
                     ) {
@@ -143,12 +147,17 @@ fun NewReleaseScreen(
                     }
                 },
                 actions = {
+                    // Using Material3's standard IconButton here (not the
+                    // custom AppIconButton) because the custom one uses
+                    // combinedClickable which can fail to register taps in
+                    // the LargeFlexibleTopAppBar actions slot on some
+                    // Material3 1.5.0-alpha builds. The standard IconButton
+                    // uses a plain clickable and is more reliable here.
                     IconButton(
                         onClick = {
                             isSearchActive = !isSearchActive
                             if (!isSearchActive) searchQuery = ""
                         },
-                        onLongClick = {},
                     ) {
                         Icon(
                             painter = painterResource(R.drawable.search),
@@ -761,6 +770,10 @@ private fun NewReleaseContent.releaseSections(): List<NewReleaseSection> =
  * Layout mirrors the SearchScreen's input row (search icon + text field +
  * clear button) but is rendered inside the grid content rather than as a
  * top app bar, so it appears in-line with the rest of the page content.
+ *
+ * Auto-focuses the text field on appearance so the keyboard opens
+ * immediately — the user doesn't have to tap the field after tapping the
+ * search icon in the top app bar.
  */
 @Composable
 private fun NewReleaseSearchField(
@@ -771,6 +784,14 @@ private fun NewReleaseSearchField(
     val onSurface = MaterialTheme.colorScheme.onSurface
     val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
     val primary = MaterialTheme.colorScheme.primary
+    val focusRequester = remember { FocusRequester() }
+
+    // Auto-focus the text field when this composable first appears so the
+    // keyboard opens immediately. This makes the search feel responsive —
+    // tap search icon → field appears → keyboard is already up → start typing.
+    LaunchedEffect(Unit) {
+        runCatching { focusRequester.requestFocus() }
+    }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -781,7 +802,10 @@ private fun NewReleaseSearchField(
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .padding(horizontal = 4.dp, vertical = 4.dp),
     ) {
-        IconButton(onClick = onClose, onLongClick = {}) {
+        // Use Material3's standard IconButton (not the custom AppIconButton)
+        // for consistency with the top app bar search icon — and because
+        // these buttons don't need long-press support.
+        IconButton(onClick = onClose) {
             Icon(
                 painter = painterResource(R.drawable.arrow_back),
                 contentDescription = null,
@@ -795,7 +819,9 @@ private fun NewReleaseSearchField(
             textStyle =
                 MaterialTheme.typography.bodyLarge.copy(color = onSurface),
             cursorBrush = androidx.compose.ui.graphics.SolidColor(primary),
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester),
             decorationBox = { innerTextField ->
                 Box(
                     modifier =
@@ -817,7 +843,7 @@ private fun NewReleaseSearchField(
             },
         )
         if (query.isNotEmpty()) {
-            IconButton(onClick = { onQueryChange("") }, onLongClick = {}) {
+            IconButton(onClick = { onQueryChange("") }) {
                 Icon(
                     painter = painterResource(R.drawable.close),
                     contentDescription = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NewsScreen.kt
@@ -108,7 +108,6 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import moe.rukamori.archivetune.ui.component.IconButton as AppIconButton
-import moe.rukamori.archivetune.ui.component.LargeFrostedTopAppBar
 
 @Composable
 fun NewsScreen(
@@ -196,10 +195,30 @@ fun NewsScreen(
                                 .padding(top = 8.dp, bottom = 4.dp),
                     ) {}
                 } else {
-                    LargeFrostedTopAppBar(
-                        titleRes = R.string.news,
-                        onBack = navController::navigateUp,
-                        onBackLongClick = navController::backToMain,
+                    // Plain LargeFlexibleTopAppBar — no frosted pill backgrounds
+                    // around the title / back arrow / actions. The user
+                    // explicitly asked for the frosted enclosed pill headers
+                    // to be removed from the News page; this matches the
+                    // modern minimal styling already used on New Releases.
+                    LargeFlexibleTopAppBar(
+                        title = {
+                            Text(
+                                text = stringResource(R.string.news),
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                            )
+                        },
+                        navigationIcon = {
+                            AppIconButton(
+                                onClick = navController::navigateUp,
+                                onLongClick = navController::backToMain,
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.arrow_back),
+                                    contentDescription = null,
+                                )
+                            }
+                        },
                         actions = {
                             IconButton(onClick = { isSearchActive = true }) {
                                 Icon(
@@ -214,6 +233,10 @@ fun NewsScreen(
                                 )
                             }
                         },
+                        colors = TopAppBarDefaults.largeTopAppBarColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+                        ),
                         scrollBehavior = scrollBehavior,
                     )
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
@@ -63,12 +63,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
@@ -76,6 +79,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.size.Size
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.LocalDatabase
@@ -103,6 +110,42 @@ import moe.rukamori.archivetune.viewmodels.LibraryTopMixUiModel
 import moe.rukamori.archivetune.viewmodels.LibraryTopMixesUiState
 import moe.rukamori.archivetune.viewmodels.MostPlayedAlbumUiModel
 import moe.rukamori.archivetune.viewmodels.MostPlayedAlbumUiState
+
+/**
+ * Builds a sized, cache-enabled [ImageRequest] for a thumbnail that will be
+ * displayed at [widthDp] × [heightDp]. Without an explicit `.size()` Coil
+ * downloads the original full-resolution image (often 1280×720+ for YT
+ * thumbnails, 640×640 for Spotify playlist covers) and downsamples on the
+ * fly — slow on cold start, especially when the Library tab fires 10+
+ * parallel requests at once.
+ *
+ * Passing an explicit size lets the CDN serve the smallest bucket it has
+ * (YT `mqdefault` is 320×180, Spotify `image` URLs honour `=w300-h300`),
+ * which combined with the tuned OkHttp pool in [moe.rukamori.archivetune.App.newImageLoader]
+ * makes thumbnails load near-instantly after the first cache miss.
+ */
+@Composable
+private fun rememberSizedImageRequest(
+    url: String?,
+    widthDp: Dp,
+    heightDp: Dp,
+): ImageRequest? {
+    if (url.isNullOrBlank()) return null
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val widthPx = with(density) { widthDp.roundToPx().coerceAtLeast(1) }
+    val heightPx = with(density) { heightDp.roundToPx().coerceAtLeast(1) }
+    return remember(url, widthPx, heightPx) {
+        ImageRequest
+            .Builder(context)
+            .data(url)
+            .size(Size(widthPx, heightPx))
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .memoryCachePolicy(CachePolicy.ENABLED)
+            .crossfade(true)
+            .build()
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -375,7 +418,7 @@ fun LibraryMixScreen(
                                                     .clip(RoundedCornerShape(28.dp)),
                                         ) {
                                             AsyncImage(
-                                                model = song.song.thumbnailUrl,
+                                                model = rememberSizedImageRequest(song.song.thumbnailUrl, 110.dp, 110.dp),
                                                 contentDescription = null,
                                                 contentScale = ContentScale.Crop,
                                                 modifier = Modifier.fillMaxSize(),
@@ -536,7 +579,7 @@ fun LibraryMixScreen(
                                                     .clip(RoundedCornerShape(24.dp)),
                                         ) {
                                             AsyncImage(
-                                                model = playlist.thumbnails.getOrNull(0),
+                                                model = rememberSizedImageRequest(playlist.thumbnails.getOrNull(0), 106.dp, 106.dp),
                                                 contentDescription = null,
                                                 contentScale = ContentScale.Crop,
                                                 modifier = Modifier.fillMaxSize(),
@@ -696,7 +739,7 @@ fun LibraryMixScreen(
                                         horizontalAlignment = Alignment.CenterHorizontally,
                                     ) {
                                         AsyncImage(
-                                            model = artist.thumbnailUrl,
+                                            model = rememberSizedImageRequest(artist.thumbnailUrl, 72.dp, 72.dp),
                                             contentDescription = null,
                                             contentScale = ContentScale.Crop,
                                             modifier =
@@ -809,7 +852,7 @@ private fun SpotifyPlaylistCompactCard(
                     .clip(RoundedCornerShape(24.dp)),
         ) {
             AsyncImage(
-                model = thumbnailUrl,
+                model = rememberSizedImageRequest(thumbnailUrl, 106.dp, 106.dp),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
@@ -1141,7 +1184,7 @@ private fun LibraryTopMixCard(
                             )
                         } else {
                             AsyncImage(
-                                model = artworkUrl,
+                                model = rememberSizedImageRequest(artworkUrl, 28.dp, 28.dp),
                                 contentDescription = null,
                                 contentScale = ContentScale.Crop,
                                 modifier =
@@ -1234,7 +1277,7 @@ private fun MostPlayedAlbumSpotlightCard(
                     val thumbnailUrl = album.thumbnailUrl
                     if (thumbnailUrl != null) {
                         AsyncImage(
-                            model = thumbnailUrl,
+                            model = rememberSizedImageRequest(thumbnailUrl, 64.dp, 64.dp),
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/onboarding/OnboardingScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedListItem
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -74,6 +75,7 @@ import com.google.common.collect.ImmutableList
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.onboarding.OnboardingCommunityActionUiModel
 import moe.rukamori.archivetune.onboarding.OnboardingEvent
+import moe.rukamori.archivetune.onboarding.OnboardingLoginBenefitUiModel
 import moe.rukamori.archivetune.onboarding.OnboardingPageId
 import moe.rukamori.archivetune.onboarding.OnboardingPermissionAction
 import moe.rukamori.archivetune.onboarding.OnboardingPermissionStatus
@@ -85,6 +87,7 @@ import moe.rukamori.archivetune.onboarding.OnboardingViewModel
 @Composable
 fun OnboardingRoute(
     modifier: Modifier = Modifier,
+    onLoginRequested: () -> Unit = {},
     viewModel: OnboardingViewModel = hiltViewModel(),
 ) {
     val state by viewModel.screenState.collectAsStateWithLifecycle()
@@ -114,6 +117,8 @@ fun OnboardingRoute(
                     }
                 }
 
+                OnboardingEvent.OpenLogin -> onLoginRequested()
+
                 is OnboardingEvent.OpenUri -> {
                     runCatching {
                         context.startActivity(Intent(Intent.ACTION_VIEW, event.url.toUri()))
@@ -128,6 +133,7 @@ fun OnboardingRoute(
         onNext = viewModel::onNext,
         onBack = viewModel::onBack,
         onComplete = viewModel::complete,
+        onLogin = viewModel::onLogin,
         onPermissionAction = viewModel::onPermissionAction,
         onCommunityAction = viewModel::onCommunityAction,
         modifier = modifier,
@@ -140,6 +146,7 @@ fun OnboardingScreen(
     onNext: () -> Unit,
     onBack: () -> Unit,
     onComplete: () -> Unit,
+    onLogin: () -> Unit,
     onPermissionAction: (OnboardingPermissionAction) -> Unit,
     onCommunityAction: (OnboardingCommunityActionUiModel) -> Unit,
     modifier: Modifier = Modifier,
@@ -178,6 +185,7 @@ fun OnboardingScreen(
                     uiState = state.uiState,
                     onNext = onNext,
                     onBack = onBack,
+                    onLogin = onLogin,
                     onPermissionAction = onPermissionAction,
                     onCommunityAction = onCommunityAction,
                     contentPadding = padding,
@@ -244,6 +252,7 @@ private fun OnboardingSuccessContent(
     uiState: OnboardingUiState,
     onNext: () -> Unit,
     onBack: () -> Unit,
+    onLogin: () -> Unit,
     onPermissionAction: (OnboardingPermissionAction) -> Unit,
     onCommunityAction: (OnboardingCommunityActionUiModel) -> Unit,
     contentPadding: PaddingValues,
@@ -289,6 +298,16 @@ private fun OnboardingSuccessContent(
                 )
             }
 
+            OnboardingPageId.LOGIN -> {
+                LoginPage(
+                    uiState = uiState,
+                    pageIndex = pageIndex,
+                    onBack = onBack,
+                    onNext = onNext,
+                    onLogin = onLogin,
+                )
+            }
+
             OnboardingPageId.COMMUNITY -> {
                 CommunityPage(
                     uiState = uiState,
@@ -296,6 +315,221 @@ private fun OnboardingSuccessContent(
                     onBack = onBack,
                     onNext = onNext,
                     onCommunityAction = onCommunityAction,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LoginPage(
+    uiState: OnboardingUiState,
+    pageIndex: Int,
+    onBack: () -> Unit,
+    onNext: () -> Unit,
+    onLogin: () -> Unit,
+) {
+    val page = uiState.pages[pageIndex]
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = OnboardingPagePadding,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(ListItemDefaults.SegmentedGap),
+    ) {
+        item(key = page.id.name, contentType = "header") {
+            ExpressivePageHeader(
+                iconResId = page.iconResId,
+                titleResId = page.titleResId,
+                subtitleResId = page.subtitleResId,
+            )
+        }
+        item(key = "login-optional", contentType = "optional") {
+            Surface(
+                modifier =
+                    Modifier
+                        .widthIn(max = OnboardingContentMaxWidth)
+                        .fillMaxWidth(),
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                contentColor = MaterialTheme.colorScheme.onSurface,
+                tonalElevation = 1.dp,
+            ) {
+                Row(
+                    modifier = Modifier.padding(20.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Surface(
+                        modifier = Modifier.size(72.dp),
+                        shape = MaterialShapes.Sunny.toShape(0),
+                        color = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                painter = painterResource(R.drawable.account),
+                                contentDescription = null,
+                                modifier = Modifier.size(34.dp),
+                            )
+                        }
+                    }
+                    Text(
+                        text = stringResource(R.string.onboarding_login_optional),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+        item(key = "login-benefits-title", contentType = "benefits-title") {
+            Text(
+                text = stringResource(R.string.onboarding_login_benefits_title),
+                modifier =
+                    Modifier
+                        .widthIn(max = OnboardingContentMaxWidth)
+                        .fillMaxWidth(),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+        itemsIndexed(
+            items = uiState.loginBenefits,
+            key = { _, item -> item.id },
+            contentType = { _, item -> "login-benefit-${item.id}" },
+        ) { index, benefit ->
+            LoginBenefitRow(
+                benefit = benefit,
+                index = index,
+                count = uiState.loginBenefits.size,
+                onLogin = onLogin,
+            )
+        }
+        item(key = "login-actions", contentType = "actions") {
+            LoginActions(
+                onBack = onBack,
+                onLogin = onLogin,
+                onSkip = onNext,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun LoginBenefitRow(
+    benefit: OnboardingLoginBenefitUiModel,
+    index: Int,
+    count: Int,
+    onLogin: () -> Unit,
+) {
+    val onClick = remember(onLogin) { { onLogin() } }
+
+    SegmentedListItem(
+        onClick = onClick,
+        shapes = ListItemDefaults.segmentedShapes(index = index, count = count),
+        modifier =
+            Modifier
+                .widthIn(max = OnboardingContentMaxWidth)
+                .fillMaxWidth()
+                .heightIn(min = 88.dp),
+        colors = ListItemDefaults.segmentedColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        leadingContent = {
+            Surface(
+                modifier = Modifier.size(56.dp),
+                shape = MaterialTheme.shapes.large,
+                color = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.onSecondary,
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        painter = painterResource(benefit.iconResId),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+        },
+        supportingContent = {
+            Text(
+                text = stringResource(benefit.descriptionResId),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        trailingContent = {
+            Icon(
+                painter = painterResource(R.drawable.arrow_forward),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+    ) {
+        Text(
+            text = stringResource(benefit.titleResId),
+            style = MaterialTheme.typography.titleMedium,
+        )
+    }
+}
+
+@Composable
+private fun LoginActions(
+    onBack: () -> Unit,
+    onLogin: () -> Unit,
+    onSkip: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .widthIn(max = OnboardingContentMaxWidth)
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(top = 28.dp, bottom = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Button(
+            onClick = onLogin,
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = OnboardingActionButtonPadding,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.login),
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = stringResource(R.string.login),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedButton(
+                onClick = onBack,
+                modifier = Modifier.weight(1f),
+                contentPadding = OnboardingActionButtonPadding,
+            ) {
+                Text(
+                    text = stringResource(R.string.back_button_desc),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            TextButton(
+                onClick = onSkip,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = stringResource(R.string.onboarding_login_skip),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
                 )
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/SearchScreen.kt
@@ -268,30 +268,10 @@ fun SearchScreen(
                                 }
                             }
 
-                            // Section 2 — Based on what you like (2-col cards).
-                            if (currentState.data.moodAndGenres.isNotEmpty()) {
-                                item(
-                                    key = "search_explore_moods_title",
-                                    contentType = "section_title",
-                                ) {
-                                    SearchSectionHeader(
-                                        title = stringResource(R.string.search_based_on_what_you_like),
-                                        modifier = Modifier.animateItem(),
-                                    )
-                                }
-                                item(
-                                    key = "search_explore_moods",
-                                    contentType = "mood_genres_grid",
-                                ) {
-                                    BasedOnWhatYouLikeGrid(
-                                        data = currentState.data,
-                                        navController = navController,
-                                        modifier = Modifier.animateItem(),
-                                    )
-                                }
-                            }
-
-                            // Section 3 — Trending Searches (minimal chips).
+                            // Section 2 — Trending Searches (minimal chips).
+                            // "Based on what you like" section has been removed
+                            // from the Explore tab per user request — Explore
+                            // now shows only Recent Searches + Trending Searches.
                             if (currentState.data.suggestedArtists.isNotEmpty()) {
                                 item(
                                     key = "search_trending_searches_title",
@@ -715,6 +695,10 @@ private fun RecentSearchMonogram(query: String) {
     val initial = remember(query) {
         query.firstOrNull { it.isLetterOrDigit() }?.uppercaseChar()?.toString() ?: "·"
     }
+    // Search icon sits behind the initial letter, giving each recent-search
+    // row a recognizable "search" affordance (user-requested: "add icons
+    // behind recent searches"). The letter remains prominent in the
+    // foreground; the icon is dimmed so it doesn't compete.
     Box(
         contentAlignment = Alignment.Center,
         modifier =
@@ -723,6 +707,14 @@ private fun RecentSearchMonogram(query: String) {
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.surfaceContainerHigh),
     ) {
+        // Background search icon — dimmed, slightly offset down-right.
+        Icon(
+            painter = painterResource(R.drawable.search),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f),
+            modifier = Modifier.size(26.dp),
+        )
+        // Foreground initial letter.
         Text(
             text = initial,
             style = MaterialTheme.typography.titleMedium.copy(fontSize = 18.sp),
@@ -897,13 +889,23 @@ private fun TrendingChip(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier =
             Modifier
                 .clip(RoundedCornerShape(20.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerLow)
                 .clickable(onClick = onClick)
-                .padding(horizontal = 16.dp, vertical = 10.dp),
+                .padding(horizontal = 14.dp, vertical = 10.dp),
     ) {
+        // Leading trending icon — gives each chip a recognizable "trending"
+        // affordance, matching the user's request to add icons behind trending
+        // searches.
+        Icon(
+            painter = painterResource(R.drawable.trending_up),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp),
+        )
         Text(
             text = label,
             style = MaterialTheme.typography.labelLarge.copy(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/SearchScreen.kt
@@ -279,6 +279,7 @@ fun SearchScreen(
                                 ) {
                                     SearchSectionHeader(
                                         title = stringResource(R.string.search_trending_searches),
+                                        leadingIconRes = R.drawable.trending_up,
                                         modifier = Modifier.animateItem(),
                                     )
                                 }
@@ -535,14 +536,36 @@ private fun SearchSectionHeader(
     title: String,
     modifier: Modifier = Modifier,
     trailing: (@Composable () -> Unit)? = null,
+    leadingIconRes: Int? = null,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier =
             modifier
                 .fillMaxWidth()
                 .padding(horizontal = SearchHorizontalPadding, vertical = 8.dp),
     ) {
+        // Leading icon in a circular container — matches the Home page's
+        // HomeSectionLeadingIcon pattern (clock for Recently Played, bolt
+        // for Speed Dial) so every section header across the app has a
+        // recognisable affordance before its title text.
+        if (leadingIconRes != null) {
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(leadingIconRes),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
         Text(
             text = title,
             style = MaterialTheme.typography.titleLarge.copy(fontSize = 20.sp),
@@ -572,6 +595,7 @@ private fun RecentSearchesSection(
     Column(modifier = modifier.fillMaxWidth()) {
         SearchSectionHeader(
             title = stringResource(R.string.search_recent_searches),
+            leadingIconRes = R.drawable.history,
             trailing = {
                 Text(
                     text = stringResource(R.string.clear),
@@ -930,7 +954,7 @@ private fun <T> SearchSuggestionsRowSection(
     itemContent: @Composable (T) -> Unit,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
-        SearchSectionHeader(title = title)
+        SearchSectionHeader(title = title, leadingIconRes = R.drawable.search)
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             contentPadding = PaddingValues(horizontal = SearchHorizontalPadding),
@@ -970,7 +994,7 @@ private fun RecommendedSongsSection(
     val visibleSongs = remember(songs) { songs.take(6) }
 
     Column(modifier = modifier.fillMaxWidth()) {
-        SearchSectionHeader(title = stringResource(R.string.search_recommended_songs))
+        SearchSectionHeader(title = stringResource(R.string.search_recommended_songs), leadingIconRes = R.drawable.music_note)
         Column(
             modifier =
                 Modifier

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
@@ -704,7 +704,6 @@ private fun AiProvider.label(): String =
         AiProvider.OPENROUTER -> stringResource(R.string.ai_provider_openrouter)
         AiProvider.CUSTOM -> stringResource(R.string.custom)
         AiProvider.DEEPL -> "DeepL"
-        AiProvider.OPENROUTER -> "OpenRouter"
         AiProvider.MISTRAL -> "Mistral AI"
         AiProvider.NONE -> stringResource(R.string.ai_provider_none)
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
@@ -701,6 +701,7 @@ private fun AiProvider.label(): String =
     when (this) {
         AiProvider.CHATGPT -> "OpenAI"
         AiProvider.GEMINI -> "Gemini"
+        AiProvider.OPENROUTER -> stringResource(R.string.ai_provider_openrouter)
         AiProvider.CUSTOM -> stringResource(R.string.custom)
         AiProvider.DEEPL -> "DeepL"
         AiProvider.OPENROUTER -> "OpenRouter"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -90,6 +90,7 @@ import moe.rukamori.archivetune.constants.HidePlayerThumbnailKey
 import moe.rukamori.archivetune.constants.HideScrollbarKey
 import moe.rukamori.archivetune.constants.LibraryFilter
 import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
+import moe.rukamori.archivetune.constants.MinimalHomeModeKey
 import moe.rukamori.archivetune.constants.LyricsBackgroundStyle
 import moe.rukamori.archivetune.constants.LyricsBackgroundStyleKey
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyle
@@ -250,6 +251,8 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
         )
     val (hideScrollbar, onHideScrollbarChange) =
         rememberPreference(HideScrollbarKey, defaultValue = false)
+    val (minimalHomeMode, onMinimalHomeModeChange) =
+        rememberPreference(MinimalHomeModeKey, defaultValue = false)
 
     val customFontPickerLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
@@ -982,6 +985,16 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                         icon = { Icon(painterResource(R.drawable.desktop_windows), null) },
                         checked = tabletModeEnabled,
                         onCheckedChange = onTabletModeEnabledChange,
+                    )
+                }
+
+                item {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.minimal_home_mode)) },
+                        description = stringResource(R.string.minimal_home_mode_desc),
+                        icon = { Icon(painterResource(R.drawable.home_outlined), null) },
+                        checked = minimalHomeMode,
+                        onCheckedChange = onMinimalHomeModeChange,
                     )
                 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -97,6 +97,8 @@ import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.SongItem
 import moe.rukamori.archivetune.ui.component.IconButton as AppIconButton
 import moe.rukamori.archivetune.constants.DarkModeKey
+import moe.rukamori.archivetune.ui.utils.YTThumbQuality
+import moe.rukamori.archivetune.ui.utils.buildYTThumbnailUrl
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import javax.inject.Inject
@@ -651,9 +653,14 @@ private suspend fun resolveCatalogueCover(lookup: ArtworkLookup): String? {
     if (lookup.title.isBlank()) return null
     val title = lookup.title
     val artist = lookup.artist
-    return TelegramCoverProvider.coverUrl(title, artist)
+    // YouTube Music is the primary source — user-requested. The YT thumbnail
+    // is reliably available via i.ytimg.com and matches what the user sees in
+    // the rest of the app (album art comes from YT Music). Other catalogue
+    // providers (iTunes/Deezer/Last.fm/Cover Art Archive/Spotify) are kept as
+    // fallbacks for tracks that YT search can't resolve.
+    return resolveYtThumbnail(title, artist)
+        ?: TelegramCoverProvider.coverUrl(title, artist)
         ?: CatalogueCoverProvider.resolveCoverUrl(title, artist)
-        ?: resolveYtThumbnail(title, artist)
 }
 
 private suspend fun resolveYtThumbnail(title: String, artist: String?): String? {
@@ -664,7 +671,16 @@ private suspend fun resolveYtThumbnail(title: String, artist: String?): String? 
         YouTube.search(term, YouTube.SearchFilter.FILTER_SONG).getOrNull()
             ?: return null
     val first = searchResult.items.firstOrNull { it is SongItem } as? SongItem ?: return null
-    return first.thumbnail.takeIf(String::isNotBlank)
+    // Prefer the canonical i.ytimg.com URL (built from the videoId) over the
+    // search-result thumbnail URL — the canonical URL is more cache-friendly
+    // and supports on-the-fly quality switching (hqdefault is always present
+    // even when maxresdefault isn't).
+    val videoId = first.id
+    return if (videoId.length == 11) {
+        buildYTThumbnailUrl(videoId, YTThumbQuality.HQ)
+    } else {
+        first.thumbnail.takeIf(String::isNotBlank)
+    }
 }
 
 private fun List<RecentTrack>.dedupeNowPlayingEchoes(): List<RecentTrack> {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
@@ -143,15 +143,17 @@ private data class HomeContent(
      * will actually render on screen.
      *
      * IMPORTANT: this must stay in sync with the `if (...) item { ... }`
-     * guards in [HomeScreen.HomeContent]. The previous implementation counted
-     * `local.quickPicks`, `remote.similarRecommendations`,
-     * `remote.accountPlaylists`, and *every* `homePage.sections` entry as
-     * "content" — but [HomeContent] only renders `heroPicks`, `remoteQuickPicks`,
-     * `recentlyPlayed` (size > 1), `speedDialItems`, `keepListening`,
-     * "Live performance"-titled sections, and `forgottenFavorites`. When only
-     * the un-rendered sources had data, the state machine returned `Success`
-     * but the `LazyColumn` emitted zero items — producing the completely
-     * blank home screen the user reported (see IMG_20260810_225138_667.jpg).
+     * guards in [HomeScreen.HomeContent]. The home composable renders:
+     *   - heroPicks (always, when non-empty)
+     *   - category chips (full mode only)
+     *   - remote/local quick picks (full mode only)
+     *   - recentlyPlayed (size > 1)
+     *   - speedDialItems (full mode only)
+     *   - keepListening
+     *   - accountPlaylists (full mode only)
+     *   - forgottenFavorites (full mode only)
+     *   - similarRecommendations (full mode only)
+     *   - ALL homePage.sections (full mode) or only "Live performance" (minimal mode)
      *
      * If you add a new section to the composable, mirror its visibility guard
      * here. If you remove one, drop it from here too.
@@ -159,14 +161,15 @@ private data class HomeContent(
     val hasContent: Boolean
         get() =
             local.heroPicks.isNotEmpty() ||
+                local.quickPicks.isNotEmpty() ||
                 local.speedDialItems.isNotEmpty() ||
                 local.forgottenFavorites.isNotEmpty() ||
                 local.keepListening.isNotEmpty() ||
                 (local.recentlyPlayed?.size ?: 0) > 1 ||
                 remote.remoteQuickPicks?.items?.isNotEmpty() == true ||
-                remote.homePage?.sections?.any {
-                    it.title.contains("Live performance", ignoreCase = true)
-                } == true
+                remote.similarRecommendations.isNotEmpty() ||
+                remote.accountPlaylists.isNotEmpty() ||
+                remote.homePage?.sections?.isNotEmpty() == true
 }
 
 private data class HomeStateInputs(
@@ -209,6 +212,7 @@ private data class HomeStateInputs(
                 quickPicksMode = preferences.quickPicksMode,
                 showCategoryChips = preferences.showCategoryChips,
                 showTonalBackdrop = preferences.showTonalBackdrop,
+                minimalHomeMode = preferences.minimalHomeMode,
                 isRefreshing = isRefreshing,
                 isLoadingMore = isLoadingMore,
             ),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -113,6 +113,23 @@ class LyricsMenuViewModel
         private val _translationUndo = MutableStateFlow<LyricsTranslationUndoSnapshot?>(null)
         val translationUndo: StateFlow<LyricsTranslationUndoSnapshot?> = _translationUndo.asStateFlow()
 
+        /**
+         * Set of media IDs for which the user has clicked "Undo Translation".
+         * While a media ID is in this set, auto-translation is suppressed —
+         * the user explicitly reverted the translation and does NOT want it
+         * re-translated automatically. The dismissal is cleared when the user
+         * manually triggers translation again via [translateLyricsWithAi].
+         *
+         * This is session-scoped (in-memory) rather than persisted, because
+         * the user's intent is "don't auto-translate this song again for now"
+         * — not "never translate this song again forever". If the app is
+         * restarted, auto-translate may fire once more; the user can undo
+         * again if desired.
+         */
+        private val _translationDismissedMediaIds = MutableStateFlow<Set<String>>(emptySet())
+        val translationDismissedMediaIds: StateFlow<Set<String>> =
+            _translationDismissedMediaIds.asStateFlow()
+
         private val _aiTranslationEvents = MutableSharedFlow<String>()
         val aiTranslationEvents: SharedFlow<String> = _aiTranslationEvents.asSharedFlow()
 
@@ -231,6 +248,12 @@ class LyricsMenuViewModel
             viewModelScope.launch(Dispatchers.IO) {
                 if (source == LyricsEntity.Source.AI_TRANSLATION) {
                     captureLyricsBeforeTranslation(mediaMetadata.id)
+                    // Clear the translation dismissal for this media ID —
+                    // the user is manually applying a translation (via the
+                    // standard translator), so any previous "Undo Translation"
+                    // dismissal is no longer relevant.
+                    _translationDismissedMediaIds.value =
+                        _translationDismissedMediaIds.value - mediaMetadata.id
                 }
                 val lyricsToSave =
                     when (source) {
@@ -262,6 +285,14 @@ class LyricsMenuViewModel
             targetLanguage: String,
         ) {
             if (isAiTranslating.value || lyrics.isBlank()) return
+            // Clear the translation dismissal for this media ID — the user
+            // is explicitly requesting a translation (either manually or via
+            // auto-translate), so any previous "Undo Translation" dismissal
+            // is no longer relevant. This ensures that after a manual
+            // translation, future auto-translate can fire again if the lyrics
+            // change back to a non-translated source.
+            _translationDismissedMediaIds.value =
+                _translationDismissedMediaIds.value - mediaMetadata.id
             aiTranslationJob =
                 viewModelScope.launch(Dispatchers.IO) {
                     isAiTranslating.value = true
@@ -354,6 +385,14 @@ class LyricsMenuViewModel
                     )
                 }
                 _translationUndo.value = null
+                // Mark this media ID as "translation dismissed" so that
+                // auto-translate does NOT re-translate it. The user clicked
+                // "Undo Translation" — they explicitly do not want the
+                // translation back. Auto-translate will be re-enabled for
+                // this song only when the user manually triggers translation
+                // again (which clears the dismissal via translateLyricsWithAi).
+                _translationDismissedMediaIds.value =
+                    _translationDismissedMediaIds.value + mediaId
             }
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -240,8 +240,10 @@ class LyricsMenuViewModel
                         -> LyricsUtils.lyricsOrNotFound(lyrics)
 
                         LyricsEntity.Source.USER_EDIT,
-                        LyricsEntity.Source.AI_TRANSLATION,
                         -> lyrics
+
+                        LyricsEntity.Source.AI_TRANSLATION ->
+                            usableTranslatedLyrics(lyrics) ?: return@launch
                     }
                 database.query {
                     replaceLyrics(
@@ -289,9 +291,14 @@ class LyricsMenuViewModel
                                 lyrics = lyrics,
                                 targetLanguage = targetLanguage.ifBlank { "ENGLISH" },
                             )
+                        val usableLyrics = usableTranslatedLyrics(translatedLyrics)
+                        if (usableLyrics == null) {
+                            _aiTranslationEvents.emit(context.getString(R.string.translation_failed))
+                            return@launch
+                        }
                         saveTranslatedLyrics(
                             mediaId = mediaMetadata.id,
-                            lyrics = translatedLyrics,
+                            lyrics = usableLyrics,
                         )
                         Log.d(TAG, "AI translate success: song=${mediaMetadata.title} automatic=$isAutomatic")
                         if (!isAutomatic) {
@@ -323,6 +330,11 @@ class LyricsMenuViewModel
                     }
                 }
         }
+
+        private fun usableTranslatedLyrics(lyrics: String): String? =
+            LyricsUtils
+                .normalizeLyricsText(lyrics)
+                .takeIf(LyricsUtils::hasMeaningfulLyricsContent)
 
         fun cancelAiTranslation() {
             aiTranslationJob?.cancel()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/voicesearch/VoiceSearchController.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/voicesearch/VoiceSearchController.kt
@@ -1,0 +1,41 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.voicesearch
+
+import android.content.Context
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Cross-flavor voice search abstraction.
+ *
+ * - `gms` flavor uses `com.google.android.gms:play-services-speech` (on-device
+ *   SpeechRecognizer backed by Google Play Services — does NOT require the
+ *   standalone Google app to be installed).
+ * - `foss` flavor uses a no-op implementation (FOSS builds have no GMS dependency).
+ *
+ * The UI calls [startListening] and observes [state]; when recognition completes
+ * successfully the recognized text is emitted via [StateFlow] and the search bar
+ * can route it through the existing play-from-voice-search pipeline.
+ */
+interface VoiceSearchController {
+    val state: StateFlow<VoiceSearchState>
+
+    fun startListening(context: Context)
+
+    fun cancel()
+}
+
+sealed interface VoiceSearchState {
+    data object Idle : VoiceSearchState
+
+    data object Listening : VoiceSearchState
+
+    data class Error(val message: String) : VoiceSearchState
+
+    data class Result(val text: String) : VoiceSearchState
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/voicesearch/VoiceSearchControllerLocator.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/voicesearch/VoiceSearchControllerLocator.kt
@@ -1,0 +1,28 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.voicesearch
+
+import android.content.Context
+
+/**
+ * Process-wide locator for the [VoiceSearchController]. The concrete impl is
+ * selected per-flavor via [DefaultVoiceSearchController] (defined in the
+ * `gms`/`foss` source sets) — this mirrors the existing
+ * `CastPlaybackRepositoryLocator` pattern so we don't need a Hilt module.
+ */
+object VoiceSearchControllerLocator {
+    @Volatile private var instance: VoiceSearchController? = null
+
+    fun get(context: Context): VoiceSearchController =
+        instance ?: synchronized(this) {
+            // `DefaultVoiceSearchController` is defined per-flavor (gms/foss).
+            // At compile time only one flavor is active so the FQN resolves
+            // unambiguously to the correct implementation.
+            instance ?: DefaultVoiceSearchController().also { instance = it }
+        }
+}

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -520,7 +520,7 @@
     <string name="no_releases">Aucune version disponible</string>
     <string name="you_might_like">Vous pourriez aimer</string>
     <string name="refresh_suggestions">Actualiser les suggestions</string>
-    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="music_together">Listen Together</string>
     <string name="together_display_name">Nom d\'affichage</string>
     <string name="together_display_name_placeholder">Votre nom</string>
     <string name="together_port">Port de session</string>
@@ -564,7 +564,7 @@
     <string name="together_error_state">Erreur</string>
     <string name="got_it">Compris</string>
     <string name="together_dont_show_again">Ne plus afficher ce message</string>
-    <string name="together_welcome_title">Bienvenue sur ArchiveTune Music Together</string>
+    <string name="together_welcome_title">Bienvenue sur Listen Together</string>
     <string name="together_welcome_body">Music Together permet à plusieurs appareils de partager une session en direct avec une file d\'attente et une lecture synchronisées.</string>
     <string name="together_welcome_host_title">Organiser une session</string>
     <string name="together_welcome_host_body">Appuyez sur « Démarrer la session », puis partagez le lien de la session. Laissez ArchiveTune ouvert en arrière-plan pendant l\'hébergement.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -877,7 +877,7 @@
     <string name="playlist_suggestion_source_title">プレイリストタイトル</string>
     <string name="playlist_suggestion_source_content">プレイリスト内容</string>
     <string name="playlist_suggestion_source_both">プレイリストタイトルと内容</string>
-    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="music_together">Listen Together</string>
     <string name="together_display_name">表示名</string>
     <string name="together_display_name_placeholder">あなたの名前</string>
     <string name="together_port">セッションポート</string>
@@ -948,7 +948,7 @@
     <string name="together_activity_error">エラー: %1$s</string>
     <string name="got_it">了解</string>
     <string name="together_dont_show_again">今後表示しない</string>
-    <string name="together_welcome_title">ArchiveTune Music Togetherへようこそ</string>
+    <string name="together_welcome_title">Listen Togetherへようこそ</string>
     <string name="together_welcome_body">Music Togetherでは、複数の端末で同期キューと再生を共有するライブセッションが使える。</string>
     <string name="together_welcome_host_title">セッションをホスト</string>
     <string name="together_welcome_host_body">「セッションを開始」をタップしてセッションリンクを共有。ホスト中はArchiveTuneをバックグラウンドで開いたままにしてね。</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -866,7 +866,7 @@
     <string name="playlist_suggestion_source_title">Título da playlist</string>
     <string name="playlist_suggestion_source_content">Conteúdo da playlist</string>
     <string name="playlist_suggestion_source_both">Título e conteúdo da playlist</string>
-    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="music_together">Listen Together</string>
     <string name="together_display_name">Nome de exibição</string>
     <string name="together_display_name_placeholder">Seu nome</string>
     <string name="together_port">Porta da sessão</string>
@@ -937,7 +937,7 @@
     <string name="together_activity_error">Erro: %1$s</string>
     <string name="got_it">Entendi</string>
     <string name="together_dont_show_again">Não mostrar novamente</string>
-    <string name="together_welcome_title">Bem-vindo ao ArchiveTune Music Together</string>
+    <string name="together_welcome_title">Bem-vindo ao Listen Together</string>
     <string name="together_welcome_body">O Music Together permite que vários dispositivos compartilhem uma sessão ao vivo com fila e reprodução sincronizadas.</string>
     <string name="together_welcome_host_title">Hospedar uma sessão</string>
     <string name="together_welcome_host_body">Toque em Iniciar sessão e compartilhe o link da sessão. Mantenha o ArchiveTune aberto em segundo plano enquanto hospeda.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -529,7 +529,7 @@
     <string name="allow">Разрешить</string>
     <string name="you_might_like">Вам может понравиться</string>
     <string name="refresh_suggestions">Обновить предложения</string>
-    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="music_together">Listen Together</string>
     <string name="together_display_name">Отображаемое имя</string>
     <string name="together_display_name_placeholder">Ваше имя</string>
     <string name="together_port">Порт сессии</string>
@@ -574,7 +574,7 @@
     <string name="together_error_state">Ошибка</string>
     <string name="got_it">Ясно</string>
     <string name="together_dont_show_again">Не показывать снова</string>
-    <string name="together_welcome_title">Добро пожаловать в ArchiveTune Music Together</string>
+    <string name="together_welcome_title">Добро пожаловать в Listen Together</string>
     <string name="together_welcome_body">Music Together позволяет нескольким устройствам делить сессию в реальном времени с синхронизированными очередью и воспроизведением.</string>
     <string name="together_welcome_host_title">Захостить сессию</string>
     <string name="together_welcome_host_body">Нажмите Начать сессию, потом поделитесь ссылкой сессии. Держите ArchiveTune открытым в фоне во время хостинга.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -586,7 +586,7 @@
     <string name="share_logs">Chia sẻ nhật ký</string>
     <string name="you_might_like">Có thể bạn sẽ thích</string>
     <string name="refresh_suggestions">Làm mới gợi ý</string>
-    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="music_together">Listen Together</string>
     <string name="together_display_name">Tên hiển thị</string>
     <string name="together_display_name_placeholder">Tên của bạn</string>
     <string name="together_port">Cổng phiên</string>
@@ -629,7 +629,7 @@
     <string name="together_error_state">Lỗi</string>
     <string name="got_it">Hiểu rồi</string>
     <string name="together_dont_show_again">Không hiển thị lại nữa</string>
-    <string name="together_welcome_title">Chào mừng đến với ArchiveTune Music Together</string>
+    <string name="together_welcome_title">Chào mừng đến với Listen Together</string>
     <string name="together_welcome_body">Music Together cho phép nhiều thiết bị chia sẻ một phiên trực tiếp với Queue đồng bộ và phát nhạc.</string>
     <string name="together_welcome_host_title">Tổ chức một phiên</string>
     <string name="together_welcome_host_body">Nhấn Bắt đầu phiên, sau đó chia sẻ liên kết phiên. Giữ ArchiveTune mở trong nền trong khi tổ chức.</string>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -676,6 +676,7 @@
     <string name="ai_provider">AI provider</string>
     <string name="ai_provider_desc">Choose the AI service.</string>
     <string name="ai_provider_none">None (Disabled)</string>
+    <string name="ai_provider_openrouter">OpenRouter</string>
     <string name="ai_custom_endpoint">Custom endpoint</string>
     <string name="ai_api_key">API key</string>
     <string name="ai_api_key_missing">Required before AI features can run.</string>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -89,7 +89,7 @@
     <string name="remote_history">Remote</string>
     <string name="charts">Charts</string>
     <string name="back_button_desc">Back</string>
-    <string name="news">News From Developers</string>
+    <string name="news">News</string>
     <string name="news_loading">Loading news…</string>
     <string name="news_empty_title">Nothing here yet</string>
     <string name="news_empty_desc">No announcements at the moment. Check back soon.</string>

--- a/app/src/main/res/values/fork_strings.xml
+++ b/app/src/main/res/values/fork_strings.xml
@@ -62,4 +62,11 @@
     <string name="clear_downloaded_updates_auto_info">Downloaded update APKs are cleared automatically after a successful install. You can also delete them manually from storage settings.</string>
     <string name="manual_delete_hint_title">Manual delete</string>
     <string name="manual_delete_hint_desc">If an update download was interrupted, the partial file lives in cache/app_update and is safe to delete.</string>
+
+    <!-- Minimal Home Mode (AppearanceSettings.kt + HomeScreen.kt).
+         When enabled, the Home feed collapses to a focused subset:
+         hero (Jump back in) + Recently Played + Keep Listening + Live Performances.
+         The hero is always shown regardless of this toggle. -->
+    <string name="minimal_home_mode">Minimal mode</string>
+    <string name="minimal_home_mode_desc">Hide all home sections except Keep listening, Recently played and Live performances. The hero card at the top stays visible.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="keep_listening">Keep listening</string>
     <string name="your_youtube_playlists">Your YouTube playlists</string>
     <string name="similar_to">Similar to</string>
-    <string name="new_release_albums">New release albums</string>
+    <string name="new_release_albums">New Releases</string>
     <string name="integration">Integration</string>
     <string name="integration_accounts">Accounts</string>
     <string name="youtube_music_account">YouTube Music</string>
@@ -1273,7 +1273,7 @@
     <string name="playlist_suggestion_source_title">Playlist title</string>
     <string name="playlist_suggestion_source_content">Playlist content</string>
     <string name="playlist_suggestion_source_both">Playlist title and content</string>
-    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="music_together">Listen Together</string>
     <string name="together_display_name">Display name</string>
     <string name="together_display_name_placeholder">Your name</string>
     <string name="together_port">Session port</string>
@@ -1344,7 +1344,7 @@
     <string name="together_activity_error">Error: %1$s</string>
     <string name="got_it">Got it</string>
     <string name="together_dont_show_again">Don\'t show this again</string>
-    <string name="together_welcome_title">Welcome to ArchiveTune Music Together</string>
+    <string name="together_welcome_title">Welcome to Listen Together</string>
     <string name="together_welcome_body">Music Together lets multiple devices share a live session with a synced queue and playback.</string>
     <string name="together_welcome_host_title">Host a session</string>
     <string name="together_welcome_host_body">Tap Start session, then share the session link. Keep ArchiveTune open in the background while hosting.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1224,6 +1224,17 @@
     <string name="onboarding_welcome_subtitle">Set up playback, local music, and update permissions before you start listening.</string>
     <string name="onboarding_permissions_title">Review permissions</string>
     <string name="onboarding_permissions_subtitle">Grant only what you want now. You can continue and allow permissions later.</string>
+    <string name="onboarding_login_title">Sync your listening</string>
+    <string name="onboarding_login_subtitle">Log in to sync your library and history across devices and get more reliable playback.</string>
+    <string name="onboarding_login_optional">Optional. You can log in later from Settings.</string>
+    <string name="onboarding_login_benefits_title">Your account helps ArchiveTune</string>
+    <string name="onboarding_login_library_title">Sync your library</string>
+    <string name="onboarding_login_library_desc">Keep your saved music and playlists available wherever you listen.</string>
+    <string name="onboarding_login_history_title">Keep your history</string>
+    <string name="onboarding_login_history_desc">Continue your listening journey across devices with synced history.</string>
+    <string name="onboarding_login_playback_title">Better playback</string>
+    <string name="onboarding_login_playback_desc">Use your account context for a more dependable playback experience.</string>
+    <string name="onboarding_login_skip">Skip for now</string>
     <string name="onboarding_community_title">Stay connected</string>
     <string name="onboarding_community_subtitle">Follow development, report issues, or support ArchiveTune.</string>
     <string name="onboarding_finish">Start listening</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,9 @@ media3-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.r
 media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
 mediarouter = { module = "androidx.mediarouter:mediarouter", version = "1.8.1" }
+# On-device speech recognition (Google Play Services speech). Used by the in-app
+# voice search mic button so users do NOT need to install the standalone Google app.
+play-services-speech = { module = "com.google.android.gms:play-services-speech", version = "20.5.0" }
 
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,9 +117,6 @@ media3-okhttp = { module = "androidx.media3:media3-datasource-okhttp", version.r
 media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 media3-cast = { module = "androidx.media3:media3-cast", version.ref = "media3" }
 mediarouter = { module = "androidx.mediarouter:mediarouter", version = "1.8.1" }
-# On-device speech recognition (Google Play Services speech). Used by the in-app
-# voice search mic button so users do NOT need to install the standalone Google app.
-play-services-speech = { module = "com.google.android.gms:play-services-speech", version = "20.5.0" }
 
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary

Fixes 8 user-reported issues + cherry-picks 10 safe commits from upstream `rukamori/ArchiveTune` dev branch (last 5 days).

## Issues fixed

### 1. Lyrics text in Apple Music style light mode now always white
Previously inherited `MaterialTheme.colorScheme.onSurface` for the `FOLLOW_THEME` lyrics background, making lyrics dark grey on the dark blurred backdrop in light mode. Also fixed the same pattern in `LyricsV2.kt`, `LyricsEnhanced.kt`, and `Lyrics.kt` so all lyrics renderers stay readable.

### 2. In-app voice search mic button (no Google app required)
Added a mic button to the search bar that uses `com.google.android.gms:play-services-speech:20.5.0`. Users no longer need to install the standalone Google app — only Google Play Services (which the `gms` flavor already depends on for Cast). Added `VoiceSearchController` abstraction with `gms` (SpeechRecognizer-backed) and `foss` (no-op) implementations.

### 3. Restored lyrics sheet back handler + cross button
`Player.kt` previously hard-coded `backHandlerEnabled = false` for `MikoLyricsTransition`, which applied to ALL player styles — making the system back button unable to dismiss the lyrics sheet. Now only Apple Music style suppresses the back handler. Also added a close (cross) button to the left of the heart button in `AppleMusicTrackHeader`.

### 4. V9 "Material Extended" dynamic-color system
Ported the dynamic-color system from upstream dev: `dominantColor` is extracted from the artwork palette and used to derive animated background/accent/text/icon-button colors (800ms tween). The `BottomSheet` background for V9 now uses `dynamicBgColor` instead of blur, so the controls blend smoothly with the artwork via a pure color gradient (no blur behind the controls).

### 5. Queue text in Apple Music style now always white
`queueOnBackgroundColor` in `Player.kt` previously fell back to `MaterialTheme.colorScheme.onSurface` when not in pure-black mode. Now always `Color.White`. The queue selection toolbar colors are also pinned to white.

### 6. Qobuz no longer disappears from source picker
`availableSourcesForSong` now also includes the user per-song override source, so the user can always see/change/clear their pinned choice even when the last resolution attempt failed transiently.

## Upstream cherry-picks (last 5 days)

Safe, non-conflicting commits from `rukamori/ArchiveTune` dev branch:

- `9d30e6feb` fix(LyricsMenuViewModel): prevent invalid AI lyrics persistence
- `a3c7a8d3c` fix(Queue): route collapsed taps through queue opener
- `d3b5509ef` fix(MusicService): recover extractor bounds failures
- `d7f9a730a` fix(SongEntity): preserve manually edited titles #1152
- `c6e445492` fix(YouTubeSongMenu): resolve stored song entity fallback #1152
- `8ce047a19` fix(DefaultCastPlaybackRepository): preserve Cast stream mime type #1156
- `dac7e7fde` feat(MusicService): add queue play-next action #1061
- `16a0f2254` feat(AiIntegrationSettings): restore OpenRouter support
- `869b877d0` fix(Player): prevent seekbar reset during seeking
- `36fd84ee5` feat: integrate optional login to onboarding models

## Notes

- Build is **not** compiled locally — please monitor CI.
- Target: `4nx3b:main` (fork only, not upstream).