### PR TITLE
fix(LyricsEnhanced): reset karaoke view on song repeat / backward seek

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -183,6 +183,12 @@ private const val SMOOTH_PLAYBACK_DRIFT_CORRECTION = 0.55f
 // while still looking smooth rather than instant.
 private const val LYRIC_FOCUS_SCROLL_DURATION_MS = 280
 private const val MIN_KARAOKE_SYLLABLE_DURATION_MS = 1
+// Minimum backward position jump (in ms) that we treat as a "reset" trigger —
+// large enough to ride through ExoPlayer's normal position jitter (which is
+// well under 200ms even on a stuttering device) and minor playback corrections,
+// small enough to catch any real seek-backward or REPEAT_MODE_ONE wrap (which
+// is typically a jump from near the end of the song back to 0, i.e. minutes).
+private const val POSITION_RESET_BACKWARD_THRESHOLD_MS = 1000L
 
 @Composable
 fun LyricsEnhanced(
@@ -390,9 +396,21 @@ fun LyricsEnhanced(
     // rebuilt when romanization finishes) without re-launching the loop and stuttering the
     // 60 Hz position interpolation.
     val latestSyncedLyrics = rememberUpdatedState(syncedLyrics)
+    // Incremented every time we detect a backward position discontinuity larger
+    // than 1 second — this happens when REPEAT_MODE_ONE wraps the song back to
+    // the start (or when the user seeks backward by more than a second). The
+    // KaraokeLyricsView from com.mocharealm.accompanist:lyrics-ui doesn't reset
+    // its internal karaoke-progress / current-line state when the player
+    // position jumps backward, so the highlight gets stuck at whatever line
+    // was last active before the wrap. Forcing a re-key here disposes the old
+    // view instance and creates a fresh one, which restarts the karaoke
+    // animation from the current line. The user-visible symptom of the bug is
+    // "lyrics stuck at start, no highlight, only fixed by closing and
+    // reopening the lyrics sheet".
+    var positionResetCounter by remember { mutableIntStateOf(0) }
     var isManualScrolling by remember { mutableStateOf(false) }
     var lastManualScrollTime by remember { mutableLongStateOf(0L) }
-    val listState = key(lyricsSessionKey) { rememberLazyListState() }
+    val listState = key(lyricsSessionKey, positionResetCounter) { rememberLazyListState() }
 
     LaunchedEffect(lyricsSessionKey) {
         playbackPositionMs.longValue = player.currentPosition.coerceAtLeast(0L)
@@ -409,6 +427,7 @@ fun LyricsEnhanced(
         var wasSliderActive = false
         var anchorPlayerPositionMs = player.currentPosition.coerceAtLeast(0L)
         var anchorFrameNanos = 0L
+        var lastRawPositionMs = player.currentPosition.coerceAtLeast(0L)
         // Cache the current line index + boundary timestamps to avoid calling
         // findLastStartedLineIndex (binary search) every frame. In the common
         // case the position stays within the current line for several seconds,
@@ -435,6 +454,19 @@ fun LyricsEnhanced(
             wasSliderActive = isSliderActive
 
             val rawPosition = (sliderPosition ?: player.currentPosition).coerceAtLeast(0L)
+            // Detect a backward position discontinuity. We only count it as a
+            // reset when the player isn't being scrubbed via the slider (slider
+            // position is null) and the new position is more than 1 second
+            // behind the last seen position — that threshold excludes normal
+            // playback jitter and minor ExoPlayer position corrections but
+            // catches both REPEAT_MODE_ONE wraps (which jump from
+            // duration -> 0) and explicit backward seeks.
+            if (sliderPosition == null &&
+                lastRawPositionMs - rawPosition > POSITION_RESET_BACKWARD_THRESHOLD_MS
+            ) {
+                positionResetCounter += 1
+            }
+            lastRawPositionMs = rawPosition
             // effectivePositionMs is the synced position (offset + lead +
             // tuning) that we'd otherwise compute via playbackSyncPosition().
                        // Computing it here inline avoids a redundant State read of
@@ -837,9 +869,15 @@ fun LyricsEnhanced(
                 ) {
                     val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.08f }
 
-                    // Keyed on the session only: romanization updates flow in as new state instead
-                    // of disposing and rebuilding the whole karaoke view mid-playback.
-                    key(lyricsSessionKey) {
+                    // Keyed on the session + a position-reset counter so that when
+                    // the song repeats (REPEAT_MODE_ONE wraps position to 0) or the
+                    // user seeks backward by more than 1 second, the
+                    // KaraokeLyricsView instance is disposed and recreated — the
+                    // library's internal highlight state doesn't reset on
+                    // backward position jumps, so without this re-key the
+                    // karaoke animation freezes at the line that was active
+                    // just before the repeat.
+                    key(lyricsSessionKey, positionResetCounter) {
                         KaraokeLyricsView(
                             listState = listState,
                             lyrics = syncedLyrics,


### PR DESCRIPTION
When a song repeats (REPEAT_MODE_ONE wraps position back to 0) the karaoke highlight in the Apple Music style lyrics sheet freezes at whatever line was last active before the wrap — no line is highlighted and the per-word fill animation stops advancing. The only way to recover was to close the lyrics sheet and reopen it, which recreated the LyricsEnhanced composable and got a fresh KaraokeLyricsView.

Root cause: KaraokeLyricsView (from com.mocharealm.accompanist:lyrics-ui) doesn't reset its internal karaoke-progress / current-line state when the player position jumps backward. The wrap-around at key(lyricsSessionKey) { KaraokeLyricsView(...) } did NOT re-create the view on song repeat because mediaMetadata.id and lyrics text both stay the same when the same song plays again.

Fix: track the player's raw position in the smooth-playback loop and detect backward jumps larger than POSITION_RESET_BACKWARD_THRESHOLD_MS (1s) — large enough to ride through ExoPlayer's normal jitter and minor playback corrections, small enough to catch any real seek-backward or REPEAT_MODE_ONE wrap (which is typically minutes). On every such backward jump, increment a positionResetCounter state and use it as an additional key on both the listState and the KaraokeLyricsView, forcing them to be disposed and recreated with fresh internal state.

The user-visible effect: on song repeat, the karaoke view now re-anchors to the first lyric line and the highlight + per-word fill animation advance normally — same behavior as closing and reopening the lyrics sheet, but fully automatic.

# Pull Request

## Summary

<!-- Describe the change in 2-5 concise sentences. Include the user-facing behavior, architectural change, or maintenance outcome. -->

## Linked Work

<!-- Link related issues, discussions, releases, or design notes. Use "Closes #123" only when the PR fully resolves the issue. -->

- Closes:
- Related:

## Change Type

<!-- Check every category that applies. -->

- [ ] Feature
- [ ] Bug fix
- [ ] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

<!-- Be explicit so reviewers can focus on the correct runtime paths. -->

- [ ] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

<!-- Required for UI, widget, notification, player, lyrics, settings, and visual changes. Include before/after when possible. -->

| Before | After |
| --- | --- |
|  |  |

## Behavior Notes

<!-- Describe the exact behavior reviewers should verify. Include edge cases, fallback behavior, and migration behavior. -->

## Architecture Checklist

- [ ] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [ ] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [ ] Business work is not triggered directly from composition.
- [ ] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [ ] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [ ] UI state is hoisted out of composable layout code.
- [ ] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [ ] New UI models are annotated with `@Immutable` or `@Stable`.
- [ ] Lazy layouts use stable `key` values and explicit `contentType`.
- [ ] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered.
- [ ] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [ ] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided.
- [ ] Interactive elements keep a minimum 48dp touch target.
- [ ] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [ ] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [ ] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [ ] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [ ] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [ ] The change avoids blocking the main thread.
- [ ] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [ ] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [ ] DataStore or preference-key changes are backward compatible.
- [ ] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

- [ ] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [ ] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [ ] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [ ] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

## Privacy / Security Checklist

- [ ] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [ ] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [ ] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [ ] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

<!-- Do not leave this blank. If a check is not applicable, state why. -->

- [ ] Android Studio sync:
- [ ] Manual device/emulator verification:
- [ ] UI screenshot/recording attached:
- [ ] Accessibility or touch-target review:
- [ ] Regression areas checked:
- [ ] CI expectation:

## Reviewer Focus

<!-- Call out the exact files, architecture decisions, performance-sensitive paths, or risky behavior that need close review. -->

## Release Notes

<!-- Write one concise user-facing sentence, or "None" for internal-only changes. -->

