### PR TITLE
fix(lastfm): decode user.getInfo envelope, preserve long playcount, and open profile from hero arrow

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -835,7 +835,13 @@ fun LastFmDashboardScreen(
                     albumCount = (statsTopAlbums ?: topAlbums)
                         ?.getOrNull()?.topalbums?.attr?.total?.toIntOrNull() ?: 0,
                     onRetry = ::refresh,
-                    onOpenGenres = { navController.navigate(Screens.MoodAndGenres.route) },
+                    onOpenProfile = {
+                        userInfo?.getOrNull()?.url
+                            ?.takeIf { it.isNotBlank() }
+                            ?.let { profileUrl ->
+                                context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(profileUrl)))
+                            }
+                    },
                     theme = theme,
                 )
 
@@ -1290,7 +1296,7 @@ private fun HeaderPillRow(
  *   - accent/primaryContainer-equivalent inner hero area (theme.statsHeroInner)
  *     with the formatted scrobbles count
  *   - a 46dp hero-arrow Surface with a forward-arrow IconButton on the right
- *     of the hero (opens mood_and_genres — LastWave-native's "Genres" target)
+ *     of the hero that opens the user's Last.fm profile in their browser
  *   - three StatPills below for Tracks / Artists / Albums
  */
 @Composable
@@ -1301,7 +1307,7 @@ private fun HeroStatsCard(
     artistCount: Int,
     albumCount: Int,
     onRetry: () -> Unit,
-    onOpenGenres: () -> Unit,
+    onOpenProfile: () -> Unit,
     theme: DashboardTheme,
 ) {
     when {
@@ -1356,10 +1362,10 @@ private fun HeroStatsCard(
                                         .align(Alignment.CenterEnd),
                                 ) {
                                     Box(contentAlignment = Alignment.Center) {
-                                        IconButton(onClick = onOpenGenres) {
+                                        IconButton(onClick = onOpenProfile) {
                                             Icon(
                                                 painter = painterResource(R.drawable.solar_forward_linear),
-                                                contentDescription = stringResource(R.string.mood_and_genres),
+                                                contentDescription = stringResource(R.string.lastfm_open_in_lastfm),
                                                 tint = theme.heroArrowIconTint,
                                             )
                                         }

--- a/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/LastFM.kt
+++ b/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/LastFM.kt
@@ -27,7 +27,7 @@ import moe.rukamori.archivetune.lastfm.models.TopArtistsResponse
 import moe.rukamori.archivetune.lastfm.models.TopAlbumsResponse
 import moe.rukamori.archivetune.lastfm.models.TopTracksResponse
 import moe.rukamori.archivetune.lastfm.models.TokenResponse
-import moe.rukamori.archivetune.lastfm.models.UserInfo
+import moe.rukamori.archivetune.lastfm.models.UserInfoResponse
 import java.net.URI
 import java.security.MessageDigest
 
@@ -208,10 +208,10 @@ object LastFM {
      */
     suspend fun getUserInfo(username: String) =
         runCatching {
-            postAndDecode<UserInfo>(
+            postAndDecode<UserInfoResponse>(
                 method = "user.getInfo",
                 extra = mapOf("user" to username),
-            )
+            ).user
         }
 
     /**

--- a/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfo.kt
+++ b/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfo.kt
@@ -12,7 +12,20 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Subset of Last.fm's `user.getInfo` response — only the fields
+ * Top-level response returned by Last.fm's `user.getInfo` method.
+ *
+ * The actual profile is nested under `user`. Keeping that envelope is
+ * important: decoding the response directly into [UserInfo] silently drops
+ * the `user` property (because the client ignores unknown keys), leaving all
+ * of the optional profile values null and displaying a zero scrobble count.
+ */
+@Serializable
+data class UserInfoResponse(
+    val user: UserInfo,
+)
+
+/**
+ * Subset of the profile nested in a `user.getInfo` response — only the fields
  * surfaced on the in-app dashboard.
  *
  * See https://www.last.fm/api/show/user.getInfo
@@ -35,7 +48,7 @@ data class UserInfo(
     val playlists: Int? = null,
     val registered: UserRegistered? = null,
 ) {
-    val playcount: Int? get() = _playcount?.toIntOrNull()
+    val playcount: Long? get() = _playcount?.toLongOrNull()
 }
 
 @Serializable

--- a/lastfm/src/test/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfoTest.kt
+++ b/lastfm/src/test/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfoTest.kt
@@ -1,0 +1,31 @@
+package moe.rukamori.archivetune.lastfm.models
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserInfoTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `decodes profile and long playcount from user getInfo envelope`() {
+        val response =
+            json.decodeFromString<UserInfoResponse>(
+                """
+                {
+                  "user": {
+                    "name": "archive-tune",
+                    "url": "https://www.last.fm/user/archive-tune",
+                    "playcount": "2147483648"
+                  }
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals("archive-tune", response.user.name)
+        assertEquals("https://www.last.fm/user/archive-tune", response.user.url)
+        assertEquals(2_147_483_648L, response.user.playcount)
+    }
+}


### PR DESCRIPTION
### Motivation
- The Last.fm dashboard showed a total scrobble count of 0 because the `user.getInfo` response was decoded directly into the profile type and the top-level `user` envelope was ignored. 
- Play counts can exceed 32-bit `Int`, so the code must preserve larger values to avoid truncation or incorrect zero displays. 
- The hero-card arrow should open the user’s Last.fm profile in the browser for a better UX.

### Description
- Added a top-level `UserInfoResponse` wrapper and updated `LastFM.getUserInfo` to decode the response envelope and return the nested `user` object. 
- Changed `UserInfo.playcount` to a `Long?` and parse the JSON `playcount` string into `Long` to support values > Int.MAX_VALUE. 
- Updated the Hero stats UI API: replaced `onOpenGenres` with `onOpenProfile` and wired the hero-arrow IconButton to open the authenticated user’s Last.fm `url` in the device browser using an `Intent`, also using the `lastfm_open_in_lastfm` accessibility string. 
- Added a unit test `lastfm/src/test/.../UserInfoTest.kt` that verifies decoding the `user` envelope and parsing a large `playcount` value.

### Testing
- Ran the new unit test class via Gradle (`:lastfm:test`), but the Gradle configuration phase failed due to missing submodule project directories in the environment, so the test execution did not complete. 
- Ran local pre-commit checks (`diff --cached --check`) and code staging checks which passed prior to commit creation. 
- Full CI/build could not be run in this environment because repository submodules could not be populated (network/proxy restrictions prevented fetching submodules), so a complete build/test run must be executed in CI or a developer environment with submodules available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b02bdb20483288d7e492ee17e5c33)