### PR TITLE
Fix lyrics auto-scroll on repeat; decode Last.fm user.getInfo envelope and open profile from hero card

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -439,7 +439,12 @@ fun LyricsEnhanced(
     var positionResetCounter by remember { mutableIntStateOf(0) }
     var isManualScrolling by remember { mutableStateOf(false) }
     var lastManualScrollTime by remember { mutableLongStateOf(0L) }
-    val listState = key(lyricsSessionKey, positionResetCounter) { rememberLazyListState() }
+    // Keep the scroll state for the whole lyrics session. Recreating it on a
+    // repeat makes the visible list jump to the top, but also disconnects the
+    // running auto-scroll collector from the list that the karaoke view is now
+    // rendering. Only the karaoke subtree needs to be recreated to clear the
+    // library's stale word-progress state.
+    val listState = key(lyricsSessionKey) { rememberLazyListState() }
 
     LaunchedEffect(lyricsSessionKey) {
         playbackPositionMs.longValue = player.currentPosition.coerceAtLeast(0L)
@@ -660,17 +665,14 @@ fun LyricsEnhanced(
     // and updates `currentLineIndexState`, which flows through the snapshotFlow
     // and triggers a normal (non-forced) scroll.
     val latestSyncedLyricsForScroll = rememberUpdatedState(syncedLyrics)
-    // Use rememberUpdatedState so the auto-scroll effect always reads the
-    // CURRENT listState without needing to re-launch. When positionResetCounter
-    // changes (song repeat), listState is recreated by the key() wrapper above —
-    // latestListState.value automatically points to the new one. This avoids
-    // the restart-and-lose-state problem that adding positionResetCounter to
-    // the effect keys caused (animation wouldn't start).
-    val latestListState = rememberUpdatedState(listState)
-    LaunchedEffect(lyricsSessionKey, isSynced) {
+    // Restart this collector after a repeat. The karaoke view is re-keyed at
+    // the same time, and the fresh collector resets its focus state before it
+    // observes the first new active line. Keeping listState stable means the
+    // collector always targets the list currently on screen.
+    LaunchedEffect(lyricsSessionKey, isSynced, positionResetCounter) {
         if (!isSynced || latestSyncedLyricsForScroll.value.lines.isEmpty()) return@LaunchedEffect
         snapshotFlow {
-            latestListState.value.layoutInfo.viewportEndOffset > latestListState.value.layoutInfo.viewportStartOffset
+            listState.layoutInfo.viewportEndOffset > listState.layoutInfo.viewportStartOffset
         }.first { it }
 
         var forceNextScroll = true
@@ -688,7 +690,7 @@ fun LyricsEnhanced(
                     return@collectLatest
                 }
 
-                latestListState.value.scrollLyricIntoFocus(
+                listState.scrollLyricIntoFocus(
                     index = index,
                     animateToNearbyItem = !forceNextScroll,
                     force = forceNextScroll,
@@ -697,21 +699,13 @@ fun LyricsEnhanced(
             }
     }
 
-    // When the song repeats (positionResetCounter changes), directly scroll
-    // the new listState to the top AND reset the current line index. This
-    // forces the auto-scroll effect to re-fire with forceNextScroll=true on
-    // the next emission (since currentLineIndex goes -1 -> valid, the
-    // distinctUntilChanged snapshotFlow will emit).
-    //
-    // We use the latestListState (rememberUpdatedState) so we always scroll
-    // the CURRENT listState instance — not a stale one from before the
-    // positionResetCounter change.
+    // Reset both the visible position and the tracked active line after a
+    // backward discontinuity. The re-keyed auto-scroll collector above then
+    // resumes from the first active line instead of remaining at the line from
+    // the prior play-through.
     LaunchedEffect(positionResetCounter) {
         if (positionResetCounter > 0) {
-            // Wait one frame so the key() wrapper has created the new listState
-            // and rememberUpdatedState has captured it.
-            withFrameNanos { }
-            latestListState.value.scrollToItem(0)
+            listState.scrollToItem(0)
             currentLineIndexState.intValue = -1
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -835,7 +835,13 @@ fun LastFmDashboardScreen(
                     albumCount = (statsTopAlbums ?: topAlbums)
                         ?.getOrNull()?.topalbums?.attr?.total?.toIntOrNull() ?: 0,
                     onRetry = ::refresh,
-                    onOpenGenres = { navController.navigate(Screens.MoodAndGenres.route) },
+                    onOpenProfile = {
+                        userInfo?.getOrNull()?.url
+                            ?.takeIf { it.isNotBlank() }
+                            ?.let { profileUrl ->
+                                context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(profileUrl)))
+                            }
+                    },
                     theme = theme,
                 )
 
@@ -1290,7 +1296,7 @@ private fun HeaderPillRow(
  *   - accent/primaryContainer-equivalent inner hero area (theme.statsHeroInner)
  *     with the formatted scrobbles count
  *   - a 46dp hero-arrow Surface with a forward-arrow IconButton on the right
- *     of the hero (opens mood_and_genres — LastWave-native's "Genres" target)
+ *     of the hero that opens the user's Last.fm profile in their browser
  *   - three StatPills below for Tracks / Artists / Albums
  */
 @Composable
@@ -1301,7 +1307,7 @@ private fun HeroStatsCard(
     artistCount: Int,
     albumCount: Int,
     onRetry: () -> Unit,
-    onOpenGenres: () -> Unit,
+    onOpenProfile: () -> Unit,
     theme: DashboardTheme,
 ) {
     when {
@@ -1356,10 +1362,10 @@ private fun HeroStatsCard(
                                         .align(Alignment.CenterEnd),
                                 ) {
                                     Box(contentAlignment = Alignment.Center) {
-                                        IconButton(onClick = onOpenGenres) {
+                                        IconButton(onClick = onOpenProfile) {
                                             Icon(
                                                 painter = painterResource(R.drawable.solar_forward_linear),
-                                                contentDescription = stringResource(R.string.mood_and_genres),
+                                                contentDescription = stringResource(R.string.lastfm_open_in_lastfm),
                                                 tint = theme.heroArrowIconTint,
                                             )
                                         }

--- a/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/LastFM.kt
+++ b/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/LastFM.kt
@@ -27,7 +27,7 @@ import moe.rukamori.archivetune.lastfm.models.TopArtistsResponse
 import moe.rukamori.archivetune.lastfm.models.TopAlbumsResponse
 import moe.rukamori.archivetune.lastfm.models.TopTracksResponse
 import moe.rukamori.archivetune.lastfm.models.TokenResponse
-import moe.rukamori.archivetune.lastfm.models.UserInfo
+import moe.rukamori.archivetune.lastfm.models.UserInfoResponse
 import java.net.URI
 import java.security.MessageDigest
 
@@ -208,10 +208,10 @@ object LastFM {
      */
     suspend fun getUserInfo(username: String) =
         runCatching {
-            postAndDecode<UserInfo>(
+            postAndDecode<UserInfoResponse>(
                 method = "user.getInfo",
                 extra = mapOf("user" to username),
-            )
+            ).user
         }
 
     /**

--- a/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfo.kt
+++ b/lastfm/src/main/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfo.kt
@@ -12,7 +12,20 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Subset of Last.fm's `user.getInfo` response — only the fields
+ * Top-level response returned by Last.fm's `user.getInfo` method.
+ *
+ * The actual profile is nested under `user`. Keeping that envelope is
+ * important: decoding the response directly into [UserInfo] silently drops
+ * the `user` property (because the client ignores unknown keys), leaving all
+ * of the optional profile values null and displaying a zero scrobble count.
+ */
+@Serializable
+data class UserInfoResponse(
+    val user: UserInfo,
+)
+
+/**
+ * Subset of the profile nested in a `user.getInfo` response — only the fields
  * surfaced on the in-app dashboard.
  *
  * See https://www.last.fm/api/show/user.getInfo
@@ -35,7 +48,7 @@ data class UserInfo(
     val playlists: Int? = null,
     val registered: UserRegistered? = null,
 ) {
-    val playcount: Int? get() = _playcount?.toIntOrNull()
+    val playcount: Long? get() = _playcount?.toLongOrNull()
 }
 
 @Serializable

--- a/lastfm/src/test/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfoTest.kt
+++ b/lastfm/src/test/kotlin/moe/rukamori/archivetune/lastfm/models/UserInfoTest.kt
@@ -1,0 +1,31 @@
+package moe.rukamori.archivetune.lastfm.models
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserInfoTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun `decodes profile and long playcount from user getInfo envelope`() {
+        val response =
+            json.decodeFromString<UserInfoResponse>(
+                """
+                {
+                  "user": {
+                    "name": "archive-tune",
+                    "url": "https://www.last.fm/user/archive-tune",
+                    "playcount": "2147483648"
+                  }
+                }
+                """.trimIndent(),
+            )
+
+        assertEquals("archive-tune", response.user.name)
+        assertEquals("https://www.last.fm/user/archive-tune", response.user.url)
+        assertEquals(2_147_483_648L, response.user.playcount)
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent lyrics karaoke auto-scroll from getting stuck or jumping when a track repeats or when lyric content updates, and avoid recreating the whole list state unnecessarily.
- Correctly decode Last.fm's `user.getInfo` response envelope and support playcounts larger than 32-bit integers to avoid showing zero scrobbles for some users.
- Replace the hero-arrow action to open the user's Last.fm profile in a browser instead of navigating to genres per updated UX intent.

### Description

- Stabilize lyrics auto-scroll by keeping the `LazyListState` stable across a lyrics session (`listState = key(lyricsSessionKey) { rememberLazyListState() }`) and hoisting `syncedLyrics` into a `rememberUpdatedState`, while re-keying the karaoke subtree on repeat using `positionResetCounter` so the karaoke view resets without disconnecting the running auto-scroll collector in `LyricsEnhanced.kt`.
- Simplify snapshotFlow usage to read `listState` directly and ensure the auto-scroll collector restarts only when appropriate, and reset visible position and tracked active line on backward discontinuities via a `LaunchedEffect(positionResetCounter)` that calls `listState.scrollToItem(0)`.
- Change Last.fm client to decode the `user.getInfo` envelope by introducing `UserInfoResponse` and return `.user` from `getUserInfo`, and widen `UserInfo.playcount` from `Int?` to `Long?` to support large counts in `lastfm` module.
- Update the dashboard hero to expose `onOpenProfile` (instead of `onOpenGenres`) and wire the hero arrow button in `LastFmDashboardScreen` to open the user's Last.fm profile URL with an `Intent` and update the icon content description.
- Add a unit test `lastfm.models.UserInfoTest` that verifies decoding of the `user` envelope and a long `playcount` value.

### Testing

- Added `UserInfoTest` in `lastfm` that decodes a `UserInfoResponse` with a 64-bit playcount and asserts fields; the test passed.
- Ran the `lastfm` module unit tests (including the new test) and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b02bdb20483288d7e492ee17e5c33)