### PR TITLE
Revert all port-related commits (innertubex + YTPlayerUtils + Chaquopy + PR-clean-build chore)

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./gradlew --console=plain --no-build-cache clean assembleGmsMobileUniversalDebug :app:lintGmsMobileUniversalDebug --warning-mode summary 2>&1 | python3 -c "import re,sys;p=re.compile(r'^(WARNING: )?\[CXX5202\] This app only has 32-bit \[(armeabi-v7a|x86)\] native libraries\. Beginning August 1, 2019 Google Play store requires that all apps that include native libraries must provide 64-bit versions\. For more information, visit https://g\.co/64-bit-requirement\$');[sys.stdout.write(l) for l in sys.stdin if not p.match(l.rstrip())]"
+          ./gradlew --console=plain assembleGmsMobileUniversalDebug :app:lintGmsMobileUniversalDebug --warning-mode summary 2>&1 | python3 -c "import re,sys;p=re.compile(r'^(WARNING: )?\[CXX5202\] This app only has 32-bit \[(armeabi-v7a|x86)\] native libraries\. Beginning August 1, 2019 Google Play store requires that all apps that include native libraries must provide 64-bit versions\. For more information, visit https://g\.co/64-bit-requirement\$');[sys.stdout.write(l) for l in sys.stdin if not p.match(l.rstrip())]"
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           PULL_REQUEST: "true"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "core"]
         path = core
-        url = https://github.com/4nx3b/core.git
+        url = https://github.com/vossgraves/core.git
 [submodule "lyrics"]
         path = lyrics
         url = https://github.com/4nx3b/lyrics.git

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixLyricsProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixLyricsProvider.kt
@@ -1,54 +1,39 @@
-package moe.rukamori.archivetune.paxsenix
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
 
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.client.request.parameter
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.json.Json
-import moe.rukamori.archivetune.paxsenix.models.PaxsenixLyricsResponse
+package moe.rukamori.archivetune.lyrics
 
-object PaxsenixLyrics {
-    private const val API_KEY = "Sk-paxsenix-Cd3wtTnii7rZYR_vFUbsNuY408zwRUh079PDLhVgQI2LdDPr"
-    private const val DIRECT_ENDPOINT = "https://api.paxsenix.biz.id/lyrics"
+import android.content.Context
+import moe.rukamori.archivetune.constants.EnablePaxsenixLyricsKey
+import moe.rukamori.archivetune.paxsenix.PaxsenixLyrics
+import moe.rukamori.archivetune.utils.dataStore
+import moe.rukamori.archivetune.utils.get
 
-    private val client = HttpClient(OkHttp) {
-        install(ContentNegotiation) {
-            json(
-                Json {
-                    ignoreUnknownKeys = true
-                    isLenient = true
-                }
-            )
-        }
-    }
+object PaxsenixLyricsProvider : LyricsProvider {
+    override val name = "Paxsenix (Auto)"
 
-    suspend fun getLyrics(
+    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixLyricsKey] ?: true
+
+    override suspend fun getLyrics(
+        id: String,
         title: String,
         artist: String,
+        album: String?,
         duration: Int,
-    ): Result<String> = runCatching {
-        val response = client.get(DIRECT_ENDPOINT) {
-            header("Authorization", "Bearer $API_KEY")
-            parameter("title", title)
-            parameter("artist", artist)
-            parameter("duration", duration)
-        }.body<PaxsenixLyricsResponse>()
+    ): Result<String> = PaxsenixLyrics.getLyrics(title, artist, duration)
 
-        response.lyrics ?: throw Exception("No lyrics found")
-    }
-
-    suspend fun getAllLyrics(
+    override suspend fun getAllLyrics(
+        id: String,
         title: String,
         artist: String,
+        album: String?,
         duration: Int,
         callback: (String) -> Unit,
     ) {
-        getLyrics(title, artist, duration).onSuccess {
-            callback(it)
-        }
+        PaxsenixLyrics.getAllLyrics(title, artist, duration, callback)
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
@@ -304,56 +304,10 @@ object YTPlayerUtils {
     ): PlaybackAuthState {
         val sessionId = authState.sessionId ?: return authState
         val tokenResult = BotGuardTokenGenerator.mintToken(videoId, sessionId) ?: return authState
-        return authState.withGeneratedPoTokens(videoId, tokenResult)
+        return authState.withGeneratedPoTokens(tokenResult)
     }
 
-    suspend fun ensureWebPoTokensForSubtitles(videoId: String): PlaybackAuthState {
-        var authState = YouTube.currentPlaybackAuthState()
-        if (!authState.resolveSubsPoToken(WEB_REMIX, videoId).isNullOrBlank()) return authState
-
-        if (authState.sessionId.isNullOrBlank()) {
-            authState =
-                ensureVisitorDataReady(
-                    videoId = videoId,
-                    authState = authState,
-                    reason = "subtitle playback authentication",
-                )
-        }
-        return mintWebPlaybackPoTokens(videoId, authState)
-    }
-
-    suspend fun ensureWebPoTokensForPlayback(
-        videoId: String,
-        authState: PlaybackAuthState = YouTube.currentPlaybackAuthState(),
-    ): PlaybackAuthState {
-        var resolvedAuthState = authState
-        val hasPlayerToken =
-            !resolvedAuthState
-                .resolvePlayerPoToken(
-                    client = WEB_REMIX,
-                    videoId = videoId,
-                ).isNullOrBlank()
-        if (hasPlayerToken && !resolvedAuthState.resolveGvsPoToken(WEB_REMIX, videoId).isNullOrBlank()) {
-            return resolvedAuthState
-        }
-
-        if (resolvedAuthState.sessionId.isNullOrBlank()) {
-            resolvedAuthState =
-                ensureVisitorDataReady(
-                    videoId = videoId,
-                    authState = resolvedAuthState,
-                    reason = "playback authentication",
-                )
-        }
-        if (resolvedAuthState.sessionId.isNullOrBlank()) return resolvedAuthState
-
-        return mintWebPlaybackPoTokens(videoId, resolvedAuthState)
-    }
-
-    private fun PlaybackAuthState.withGeneratedPoTokens(
-        videoId: String,
-        tokenResult: PoTokenResult,
-    ): PlaybackAuthState {
+    private fun PlaybackAuthState.withGeneratedPoTokens(tokenResult: PoTokenResult): PlaybackAuthState {
         val updatedAuthState =
             copy(
                 poTokenGvs = tokenResult.sessionToken,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ kuromojiIpadic = "0.9.0"
 # short commit hash. To move to a newer commit, the CI JDK and :core's
 # `jvmToolchain(...)` both need to be bumped to ≥ 25.
 extractor = "08a64867704c"
-innertubex = "v0.1.2"
 translator = "1.1.1"
 rhino = "1.9.1"
 markwon = "4.6.2"
@@ -164,7 +163,6 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 # existing NewPipe imports keep working. Published on JitPack only.
 # Coordinates match the upstream Metrolist Android app (MetrolistGroup/Metrolist).
 metrolist-extractor = { module = "com.github.MetrolistGroup:MetrolistExtractor", version.ref = "extractor" }
-innertubex = { module = "com.github.MetrolistGroup:innertubex", version.ref = "innertubex" }
 translator = { module = "com.github.therealbush:translator", version.ref = "translator" }
 
 kuromoji-ipadic = { module = "com.atilika.kuromoji:kuromoji-ipadic", version.ref = "kuromojiIpadic" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -92,9 +92,6 @@ dependencyResolutionManagement {
                 // every sub-module artifact fails to download.
                 includeGroup("com.github.MetrolistGroup")
                 includeGroup("com.github.MetrolistGroup.MetrolistExtractor")
-                // InnerTubeX KMP sub-modules are published under
-                // com.github.MetrolistGroup.innertubex group.
-                includeGroup("com.github.MetrolistGroup.innertubex")
             }
         }
     }


### PR DESCRIPTION
## Summary

Reverts all port-related commits that landed on `main` via PRs #153, #154, #155. After this revert, `dev` returns to the pre-port state plus three good fixes that came along with the port PRs:

- `da20f62d7` fix: update lyrics submodule URL to 4nx3b/lyrics fork
- `cbe28562b` fix(lastfm): decode profile scrobble count
- `b3bcdb8a1` fix(lyrics): resume enhanced animation after repeat

## What was reverted

### innertubex port
- `014d9fd96` feat: add innertubex dependency + update core submodule to 4nx3b/core fork
- `e9fbf2071` fix: correct innertubex JitPack coordinate
- `ec9ff8065` fix: add com.github.MetrolistGroup.innertubex to JitPack filter
- `82d0dfaf4` fix: update core submodule (remove innertubex from JVM module)
- `2f1a6326c` fix: revert core submodule to previous working commit
- `7ab29a576` fix: remove duplicate MoriCipherRuntime from core submodule

### YTPlayerUtils port (cherry-pick-aug22)
- `4deee98ce` feat: port ensureWebPoTokensForPlayback + ensureWebPoTokensForSubtitles
- `14e58d60d` Merge feature/cherry-pick-aug22: port upstream YTPlayerUtils web playback tokens
- `1826c4029` fix: remove videoId param from resolvePlayerPoToken call
- `d5a0279d5` fix: restore per-video-id PO token scoping for YouTube playback
- `fd055155c` fix: update core submodule (NewPipe.kt extractor API fix)
- `953c7fbe0` fix: revert core NewPipe.kt to fork version
- `e4479cb05` fix: update core submodule (NewPipe Downloader API fix)
- `0fe3c7cc5` fix: AsyncCallback.onSuccess not onResult

### Port-PR CI chasers
- `2f6d24597` chore: trigger PR rebuild (lyrics submodule sync) [empty commit]
- `5e7e62ae4` chore: bump lyrics submodule to force PR cache invalidation [lyrics pointer kept at 6f3f3fc2 — functionally equivalent]
- `4b8b118a5` fix: force clean build in PR workflow to avoid stale lyrics cache

## Files restored to pre-port (d164ce27c) state

- `.github/workflows/build_pull_request.yml` — removed `--no-build-cache clean` flag added by 4b8b118a5
- `.gitmodules` — core URL back to `vossgraves/core`; lyrics URL stays at `4nx3b/lyrics` per da20f62d7
- `app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt` — `ensureWebPoTokensForPlayback` / `ensureWebPoTokensForSubtitles` functions removed; `withGeneratedPoTokens` signature restored to take only `tokenResult` (no `videoId`)
- `gradle/libs.versions.toml` — innertubex version + library declaration removed
- `settings.gradle.kts` — innertubex JitPack filter line removed
- `core` submodule pointer — `6357030769` → `b49f56d` (pre-port vossgraves/core state)

## Files preserved from main (NOT touched)

- `da20f62d7` — lyrics URL fix (4nx3b/lyrics)
- `cbe28562b` — LastFm decode fix (LastFM.kt, UserInfo.kt, UserInfoTest.kt, LastFmDashboardScreen.kt)
- `b3bcdb8a1` — lyrics repeat animation fix (LyricsEnhanced.kt)

## Why

The innertubex port and the upstream `YTPlayerUtils` cherry-pick both required bumping the `core` submodule to the `4nx3b/core` fork. This in turn produced a cascade of `MoriCipherRuntime` / `NewPipe.kt` / `AsyncCallback` fixes (12 commits across two days) that never fully settled — each fix prompted another fix, and the resulting `core` pointer (`6357030769`) had not been validated independently.

Reverting to the pre-port `core` pointer (`b49f56d` at `vossgraves/core`) returns the build to a known-green CI state. The pre-port `dev` HEAD (`da20f62d7`) was 100% green across all 11 CI checks:

- `check` (lint): success
- `Build Nightly APKs` (7 matrix jobs): success
- `Build Release APKs` (2 matrix jobs): success

## Test plan

CI on the new `dev` head (`a274fcd21`) should reproduce the green state from `da20f62d7`'s last run. If any errors surface from interaction between the preserved non-port fixes (lyrics URL, LastFm decode, lyrics animation) and the reverted port code, they will be addressed as follow-up fix commits on top of `dev`.