### PR TITLE
fix(lastfm): close LaunchedEffect lambda in TrackOverflowSheet (missing brace broke compile)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -2085,6 +2085,7 @@ private fun TrackOverflowSheet(
                         ?.joinToString(", ")
                 }
             }
+    }
 
     // (Task 5a) Pre-resolve the YT search once on sheet open so the
     // banner can show the YouTube thumbnail when Last.fm has no artwork,


### PR DESCRIPTION
## Summary

Fixes the broken `Build APKs` run on `main` (commit `c042ee872`, run [32658979675](https://github.com/4nx3b/ArchiveTune/actions/runs/32658979675)) — the `Build Release APKs (gms-tv-universal)` job failed at `:app:compileGmsTvUniversalReleaseKotlin` with 30+ "Unresolved reference" errors pointing at private helpers defined in the same file.

## Root cause

PR #158 (commit `51ecafdde`) added a genre-fetching `LaunchedEffect` inside `TrackOverflowSheet`:

```kotlin
LaunchedEffect(track.title, track.artist) {
    genre = track.artist
        ?.takeIf { it.isNotBlank() }
        ?.let { artist ->
            withContext(Dispatchers.IO) {
                LastFM.getTrackInfo(...)
                    .getOrNull()
                    ?.toptags
                    ?.tag
                    ?.mapNotNull { it.name?.trim()?.takeIf(String::isNotBlank) }
                    ?.take(3)
                    ?.joinToString(", ")
            }
        }
    // ← MISSING closing brace for LaunchedEffect lambda
```

Only 2 of the 3 required closing braces were present (`withContext` + `let`, but no `LaunchedEffect` close).

The unclosed lambda caused the Kotlin parser to lose scope from line 2088 onward, manifesting as spurious errors for every private helper defined later in the same file:

- `bestArtwork`, `NotSignedIn`, `CachedArtworkStore`, `trackArtworkKey`, `EmptyHint`, `LastFmDashboardViewModel`, `associateArtworkByTrack`, `resolveArtistImage`, `resolveCatalogueCover`, `ArtworkLookup`, `repository`
- `@Composable invocations can only happen from the context of a @Composable function` at line 2097 (the `bannerArtworkUrl` mutableStateOf)
- `Argument type mismatch: actual type is 'MatchGroup', but 'String' was expected` (downstream type inference failures)

## Fix

One-line change — add the missing closing brace for the `LaunchedEffect` lambda.

Verified: brace balance is now 314 open / 314 close (was 313 close before).

## Test plan

CI on the new `dev` head (`4f51f85f5`) should compile cleanly. The PR's own `check` + `build` + `Build Nightly APKs` matrix jobs should all pass.