### PR TITLE
Qobuz backup source, Telegram streaming fixes, album canvas, settings deep links

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -45,12 +45,14 @@ import moe.rukamori.archivetune.kugou.KuGou
 import moe.rukamori.archivetune.lastfm.LastFM
 import moe.rukamori.archivetune.lyrics.JapaneseLanguagePackManager
 import moe.rukamori.archivetune.canvas.AppleMusicProvider
+import moe.rukamori.archivetune.canvas.SpotifyCanvasProvider
 import moe.rukamori.archivetune.morideobfuscator.ytdlp.YtDlpJavaScriptRuntime
 import moe.rukamori.archivetune.morideobfuscator.ytdlp.YtDlpRuntimeStore
 import moe.rukamori.archivetune.morideobfuscator.ytdlp.YtDlpUpdateScheduler
 import moe.rukamori.archivetune.paxsenix.PaxsenixLyrics
 import moe.rukamori.archivetune.playback.stream.YtDlpRuntime
 import moe.rukamori.archivetune.scrobbling.LastFmServiceConfig
+import moe.rukamori.archivetune.spotify.Spotify
 import moe.rukamori.archivetune.storage.StorageFolderKind
 import moe.rukamori.archivetune.storage.StorageLocationRepository
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
@@ -169,6 +171,23 @@ class App :
         // as `I/System.out:` with no tag/level, bypassing the in-app log viewer.
         AppleMusicProvider.logger = { level, tag, message ->
             moe.rukamori.archivetune.utils.GlobalLog.append(level, tag, message)
+        }
+
+        // Spotify Canvas. The canvas module deliberately has no dependency on the
+        // app's Spotify code, so it takes the access token and the song → Spotify
+        // track mapping as injected callbacks. Both yield null when the user has
+        // no Spotify session, in which case the provider falls back to the
+        // kouzu.in resolver on its own.
+        SpotifyCanvasProvider.logger = { message ->
+            moe.rukamori.archivetune.utils.GlobalLog.append(
+                android.util.Log.INFO,
+                "SpotifyCanvas",
+                message,
+            )
+        }
+        SpotifyCanvasProvider.tokenProvider = { Spotify.accessToken }
+        SpotifyCanvasProvider.trackUriResolver = { _, title, artist ->
+            resolveSpotifyTrackUri(title, artist)
         }
 
         // Pre-warm the Apple Music web player JWT on startup so the first
@@ -571,6 +590,62 @@ internal data class ImageDiskCacheConfig(
     val policy: CachePolicy,
     val maxSizeBytes: Long,
 )
+
+/**
+ * Maps a now-playing song to its `spotify:track:<id>` URI so [SpotifyCanvasProvider]
+ * can ask Spotify for the track's Canvas.
+ *
+ * Returns null when the user has no Spotify session, when there is nothing to
+ * search on, or when no result looks like the same song. The artist check matters:
+ * an unrelated track's canvas is worse than no canvas, and the search is a plain
+ * text match that will happily return a cover or a remix.
+ *
+ * Callers are rate-limited by [SpotifyCanvasProvider]'s own one-hour result cache,
+ * so this runs at most once per song per hour.
+ */
+private suspend fun resolveSpotifyTrackUri(
+    title: String?,
+    artist: String?,
+): String? {
+    if (!Spotify.isAuthenticated()) return null
+    val cleanTitle = title?.trim().orEmpty()
+    val cleanArtist = artist?.trim().orEmpty()
+    if (cleanTitle.isBlank()) return null
+
+    val query = listOf(cleanTitle, cleanArtist).filter { it.isNotBlank() }.joinToString(" ")
+    val tracks =
+        Spotify
+            .search(query = query, types = listOf("track"), limit = 5)
+            .getOrNull()
+            ?.tracks
+            ?.items
+            .orEmpty()
+    if (tracks.isEmpty()) return null
+
+    fun matchesTitle(name: String): Boolean =
+        name.equals(cleanTitle, ignoreCase = true) ||
+            name.contains(cleanTitle, ignoreCase = true) ||
+            cleanTitle.contains(name, ignoreCase = true)
+
+    fun matchesArtist(names: List<String>): Boolean =
+        cleanArtist.isBlank() ||
+            names.any { candidate ->
+                candidate.isNotBlank() &&
+                    (
+                        candidate.equals(cleanArtist, ignoreCase = true) ||
+                            candidate.contains(cleanArtist, ignoreCase = true) ||
+                            cleanArtist.contains(candidate, ignoreCase = true)
+                    )
+            }
+
+    val match =
+        tracks.firstOrNull { track ->
+            matchesTitle(track.name) && matchesArtist(track.artists.map { it.name })
+        } ?: return null
+
+    return match.uri?.takeIf { it.startsWith("spotify:track:") }
+        ?: match.id.takeIf { it.isNotBlank() }?.let { "spotify:track:$it" }
+}
 
 internal fun resolveImageDiskCacheConfig(maxImageCacheSizeMb: Int?): ImageDiskCacheConfig {
     val sizeMb = maxImageCacheSizeMb ?: 512

--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -53,6 +53,7 @@ import moe.rukamori.archivetune.paxsenix.PaxsenixLyrics
 import moe.rukamori.archivetune.playback.stream.YtDlpRuntime
 import moe.rukamori.archivetune.scrobbling.LastFmServiceConfig
 import moe.rukamori.archivetune.spotify.Spotify
+import moe.rukamori.archivetune.spotify.SpotifyLibraryRepository
 import moe.rukamori.archivetune.storage.StorageFolderKind
 import moe.rukamori.archivetune.storage.StorageLocationRepository
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
@@ -62,6 +63,7 @@ import moe.rukamori.archivetune.ui.player.CanvasArtworkPlaybackCache
 import moe.rukamori.archivetune.ui.screens.settings.ThemePalettes
 import moe.rukamori.archivetune.ui.theme.ThemeSeedPalette
 import moe.rukamori.archivetune.ui.theme.ThemeSeedPaletteCodec
+import moe.rukamori.archivetune.utils.CanvasResolverEndpoints
 import moe.rukamori.archivetune.utils.PoolAccountManager
 import moe.rukamori.archivetune.utils.PreferenceStore
 import moe.rukamori.archivetune.utils.ProxyUtils
@@ -93,6 +95,13 @@ class App :
     SingletonImageLoader.Factory {
     @Inject
     lateinit var ytDlpRuntime: YtDlpRuntime
+
+    /**
+     * Injected only so the canvas provider can mint a Spotify token on demand — see
+     * [SpotifyLibraryRepository.ensureAccessToken].
+     */
+    @Inject
+    lateinit var spotifyLibraryRepository: SpotifyLibraryRepository
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -185,9 +194,18 @@ class App :
                 message,
             )
         }
-        SpotifyCanvasProvider.tokenProvider = { Spotify.accessToken }
+        // Mint/refresh on demand rather than reading the `Spotify.accessToken` global:
+        // that global is only set as a side effect of an earlier Spotify library call, so
+        // on a fresh launch a connected user still had no token here and the official
+        // Canvas endpoint was skipped entirely.
+        SpotifyCanvasProvider.tokenProvider = { spotifyLibraryRepository.ensureAccessToken() }
         SpotifyCanvasProvider.trackUriResolver = { _, title, artist ->
+            // Same reason: identifying the track on Spotify needs the session too.
+            spotifyLibraryRepository.ensureAccessToken()
             resolveSpotifyTrackUri(title, artist)
+        }
+        SpotifyCanvasProvider.extraResolverEndpointsProvider = {
+            CanvasResolverEndpoints.parse(dataStore.get(CanvasResolverEndpointsKey, ""))
         }
 
         // Pre-warm the Apple Music web player JWT on startup so the first
@@ -391,7 +409,7 @@ class App :
                 .distinctUntilChanged()
                 .collect { (key, endpoint) ->
                     PaxsenixLyrics.setApiKey(key)
-                    PaxsenixLyrics.setEndpoint(endpoint)
+                    PaxsenixLyrics.setEndpoint(normalizePaxsenixEndpoint(endpoint))
                 }
         }
 
@@ -590,6 +608,66 @@ internal data class ImageDiskCacheConfig(
     val policy: CachePolicy,
     val maxSizeBytes: Long,
 )
+
+/**
+ * Per-provider sub-paths served by the Paxsenix ("Lyrically") API, longest first
+ * so `apple-music/cache/cleanup` is stripped before `apple-music/cache`.
+ *
+ * [PaxsenixLyrics] appends the sub-path for whichever provider is being queried,
+ * so the configured endpoint has to be the *service root*.
+ */
+private val PAXSENIX_PROVIDER_PATHS =
+    listOf(
+        "apple-music/cache/cleanup",
+        "apple-music/lyrics",
+        "apple-music/cache",
+        "musixmatch/lyrics",
+        "spotify/lyrics",
+        "spotify/search",
+        "spotify/home",
+        "netease/lyrics",
+        "netease/search",
+        "youtube/lyrics",
+        "youtube/search",
+        "deezer/lyrics",
+        "genius/lyrics",
+        "kugou/lyrics",
+        "kugou/search",
+        "qq/lyrics",
+        "qq/search",
+        "api/stats",
+        "playground",
+        "docs",
+    )
+
+/**
+ * Normalises a user-supplied Paxsenix endpoint down to the service root.
+ *
+ * The API documents a *separate* URL per lyrics provider
+ * (`…/apple-music/lyrics`, `…/spotify/lyrics`, and so on), so users reasonably
+ * paste one of those into the endpoint field. [PaxsenixLyrics] then appends its
+ * own provider sub-path, producing `…/apple-music/lyrics/spotify/lyrics` and a
+ * 404 for every request. Stripping any known provider path (plus query string
+ * and fragment) means pasting any documented URL resolves to the same working
+ * root, and a blank value still falls through to the built-in default.
+ */
+private fun normalizePaxsenixEndpoint(raw: String): String {
+    val trimmed = raw.trim()
+    if (trimmed.isBlank()) return ""
+
+    var url = trimmed.substringBefore('?').substringBefore('#').trimEnd('/')
+    for (path in PAXSENIX_PROVIDER_PATHS) {
+        if (url.endsWith("/$path", ignoreCase = true)) {
+            url = url.removeRange(url.length - path.length - 1, url.length)
+            break
+        }
+        if (url.endsWith(path, ignoreCase = true)) {
+            url = url.removeRange(url.length - path.length, url.length)
+            break
+        }
+    }
+    return url.trimEnd('/').ifBlank { "" }
+}
 
 /**
  * Maps a now-playing song to its `spotify:track:<id>` URI so [SpotifyCanvasProvider]

--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
@@ -464,3 +464,34 @@ object SongSourceQobuzTrackId {
         return serialize(map)
     }
 }
+
+/**
+ * Codec for per-song Qobuz-backup video-id overrides.
+ *
+ * The backup mirror addresses tracks by YouTube video id, so this maps
+ * `songId → mirrorVideoId`. Set when the user picks a specific row in the
+ * "Play from" search popup; read by `MusicService.buildSourceQuery` and passed to
+ * `resolveQobuzBackupStream` so it fetches that exact mirror entry rather than the
+ * playing song's own id.
+ *
+ * The wire format is identical to [SongSourceQobuzTrackId] (`id=value` pairs
+ * joined by `;`), so the parsing/serialisation is shared rather than duplicated —
+ * only the DataStore key differs.
+ */
+object SongSourceQobuzBackupVideoId {
+    fun parse(raw: String?): Map<String, String> = SongSourceQobuzTrackId.parse(raw)
+
+    fun serialize(map: Map<String, String>): String = SongSourceQobuzTrackId.serialize(map)
+
+    fun get(
+        raw: String?,
+        songId: String,
+    ): String? = SongSourceQobuzTrackId.get(raw, songId)
+
+    /** Returns the updated raw string with [songId] set to [videoId], or cleared when [videoId] is null. */
+    fun withOverride(
+        raw: String?,
+        songId: String,
+        videoId: String?,
+    ): String = SongSourceQobuzTrackId.withOverride(raw, songId, videoId)
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/FlacStreamInfo.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/FlacStreamInfo.kt
@@ -1,0 +1,139 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.audiosource
+
+/**
+ * Reads a FLAC `STREAMINFO` block out of the first bytes of a stream.
+ *
+ * ## Why this exists
+ *
+ * Sources that hand us a bare file URL (the Qobuz backup mirror, self-hosted
+ * proxies, any direct FLAC link) report no technical metadata at all, so
+ * `MusicService.persistDirectStreamFormat` had nothing to work with and fell back
+ * to a tier heuristic keyed off the stream's label: anything labelled "lossless"
+ * became 44 100 Hz / 1 411 kbps. Every lossless track therefore showed *identical*
+ * numbers in the player's Details card regardless of what was actually playing —
+ * a 24-bit/44.1 kHz FLAC and a 16-bit/48 kHz FLAC were indistinguishable.
+ *
+ * FLAC puts everything needed in a fixed 34-byte `STREAMINFO` block that is
+ * mandated to be the *first* metadata block, immediately after the 4-byte `fLaC`
+ * marker. Parsing 42 bytes therefore yields the real sample rate, bit depth,
+ * channel count and total sample count without decoding anything.
+ *
+ * The layout ([STREAMINFO](https://xiph.org/flac/format.html#metadata_block_streaminfo),
+ * all big-endian, bit-packed after the first four fields):
+ *
+ * ```
+ * offset 0  4B   "fLaC"
+ *        4  1B   metadata block header: bit7 = last-block flag, bits6-0 = block type (0 = STREAMINFO)
+ *        5  3B   block length (34 for STREAMINFO)
+ *        8  2B   min block size
+ *       10  2B   max block size
+ *       12  3B   min frame size
+ *       15  3B   max frame size
+ *       18  8B   packed: 20 bits sample rate | 3 bits (channels-1) | 5 bits (bitDepth-1) | 36 bits total samples
+ * ```
+ *
+ * so the packed field sits at absolute offset 18 (block data starts at 8, and the
+ * field is 10 bytes into the block).
+ */
+object FlacStreamInfo {
+    /** Bytes needed to cover `fLaC` + block header + the whole STREAMINFO block. */
+    const val REQUIRED_BYTES: Int = 42
+
+    private const val MAGIC_LENGTH = 4
+    private const val BLOCK_HEADER_LENGTH = 4
+    private const val STREAMINFO_LENGTH = 34
+    private const val BLOCK_TYPE_STREAMINFO = 0
+
+    /**
+     * Offset of the packed 64-bit field *within* the STREAMINFO block: it follows
+     * min/max block size (2 B each) and min/max frame size (3 B each) = 10 bytes.
+     */
+    private const val PACKED_FIELD_OFFSET = 10
+
+    data class Info(
+        val sampleRate: Int,
+        val channels: Int,
+        val bitDepth: Int,
+        /** Total interchannel samples, or null when the encoder left it unset (0 = unknown). */
+        val totalSamples: Long?,
+    ) {
+        /** Track length in milliseconds, or null when the encoder left the sample count unset. */
+        val durationMs: Long?
+            get() {
+                val samples = totalSamples ?: return null
+                if (samples <= 0L || sampleRate <= 0) return null
+                return samples * 1000L / sampleRate
+            }
+
+        /**
+         * Uncompressed PCM rate in bits/sec — the figure streaming services quote
+         * for a tier. The true average rate of the encoded file is lower; derive
+         * that from the byte length and [durationMs] when both are known.
+         */
+        val pcmBitrate: Int
+            get() = sampleRate * bitDepth * channels
+    }
+
+    /**
+     * Parses [bytes] (the beginning of a FLAC file) into an [Info], or returns null
+     * when the data is too short, is not FLAC, or the first metadata block is not
+     * a well-formed `STREAMINFO`.
+     *
+     * Never throws: callers use this on network data they do not control, and a
+     * missing Details row is preferable to a crashed playback path.
+     */
+    fun parse(bytes: ByteArray): Info? {
+        if (bytes.size < MAGIC_LENGTH + BLOCK_HEADER_LENGTH + STREAMINFO_LENGTH) return null
+        if (bytes[0] != 'f'.code.toByte() ||
+            bytes[1] != 'L'.code.toByte() ||
+            bytes[2] != 'a'.code.toByte() ||
+            bytes[3] != 'C'.code.toByte()
+        ) {
+            return null
+        }
+
+        val blockType = bytes[MAGIC_LENGTH].toInt() and 0x7F
+        if (blockType != BLOCK_TYPE_STREAMINFO) return null
+        val blockLength = readUnsigned(bytes, MAGIC_LENGTH + 1, 3).toInt()
+        if (blockLength != STREAMINFO_LENGTH) return null
+
+        val packedOffset = MAGIC_LENGTH + BLOCK_HEADER_LENGTH + PACKED_FIELD_OFFSET
+        val packed = readUnsigned(bytes, packedOffset, 8)
+
+        val sampleRate = ((packed ushr 44) and 0xFFFFF).toInt()
+        val channels = (((packed ushr 41) and 0x7).toInt()) + 1
+        val bitDepth = (((packed ushr 36) and 0x1F).toInt()) + 1
+        val totalSamples = packed and 0xF_FFFF_FFFFL
+
+        // A zero sample rate is illegal in FLAC and means we mis-parsed; refuse
+        // rather than reporting "0 Hz" in the UI.
+        if (sampleRate <= 0) return null
+
+        return Info(
+            sampleRate = sampleRate,
+            channels = channels,
+            bitDepth = bitDepth,
+            totalSamples = totalSamples.takeIf { it > 0L },
+        )
+    }
+
+    /** Big-endian unsigned read of [length] (1..8) bytes starting at [offset]. */
+    private fun readUnsigned(
+        bytes: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Long {
+        var value = 0L
+        for (index in 0 until length) {
+            value = (value shl 8) or (bytes[offset + index].toLong() and 0xFF)
+        }
+        return value
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -48,6 +48,25 @@ val ShowPlayerVolumeBarKey = booleanPreferencesKey("showPlayerVolumeBar")
 val HidePlayerThumbnailKey = booleanPreferencesKey("hidePlayerThumbnail")
 val ArchiveTuneCanvasKey = booleanPreferencesKey("archiveTuneCanvas")
 val SpotifyCanvasKey = booleanPreferencesKey("spotifyCanvas")
+
+/**
+ * Whether an album page plays the album's looping motion artwork behind its header.
+ *
+ * Deliberately separate from [ArchiveTuneCanvasKey], which governs the *player's*
+ * now-playing canvas: the two are different surfaces with different costs (the album
+ * header loop starts as soon as a page opens, whether or not anything is playing), and
+ * a user who wants one does not necessarily want the other. Default on, so albums that
+ * have motion artwork animate the way they do in Apple Music.
+ */
+val AlbumCanvasEnabledKey = booleanPreferencesKey("albumCanvasEnabled")
+
+/**
+ * Newline-separated list of extra Spotify Canvas resolver endpoints, tried in order after
+ * Spotify's own Canvas endpoint. Empty (the default) means only the built-in resolver is
+ * used. See [moe.rukamori.archivetune.utils.CanvasResolverEndpoints] for why this is user
+ * supplied rather than a shipped list.
+ */
+val CanvasResolverEndpointsKey = stringPreferencesKey("canvasResolverEndpoints")
 val ThumbnailCornerRadiusKey = floatPreferencesKey("thumbnailCornerRadius")
 val CropThumbnailToSquareKey = booleanPreferencesKey("cropThumbnailToSquare")
 
@@ -1332,6 +1351,20 @@ val SongSourceOverrideKey = stringPreferencesKey("songSourceOverride")
  * registered as a new entry in the playback history / "recently listened".
  */
 val SongSourceQobuzTrackIdKey = stringPreferencesKey("songSourceQobuzTrackId")
+
+/**
+ * Per-song Qobuz-**backup** video-id override (CSV of `songId=youtubeVideoId;…`).
+ *
+ * The backup mirror is keyed by YouTube video id, and until now the resolver
+ * simply reused the playing song's own media id. That works for the automatic
+ * path but not for an explicit pick in the "Play from" popup: the row the user
+ * chose is a *different* catalogue entry, whose id is the only way to address the
+ * FLAC they asked for. Storing it here lets `resolveQobuzBackupStream` fetch that
+ * exact mirror entry while the song keeps its own media id — so the queue, the
+ * artwork, the title and the listening history are all untouched, and only the
+ * audio changes.
+ */
+val SongSourceQobuzBackupVideoIdKey = stringPreferencesKey("songSourceQobuzBackupVideoId")
 
 // The primary audio source the user prefers to search/resolve first (AudioSourceType name).
 // Named distinctly from the unrelated SearchSourceKey (LOCAL/ONLINE search scope) above.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixMusixmatchLyricsProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixMusixmatchLyricsProvider.kt
@@ -16,7 +16,18 @@ import moe.rukamori.archivetune.utils.get
 object PaxsenixMusixmatchLyricsProvider : LyricsProvider {
     override val name = "Paxsenix: Musixmatch"
 
-    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixMusixmatchLyricsKey] ?: true
+    // Paxsenix retired every provider endpoint except /apple-music/lyrics: the
+    // others answer 403 with "This endpoint is no longer available due to the
+    // massive amount of traffic and the lack of support needed to keep it
+    // running." Verified against the live API — the 403 is unconditional and
+    // is returned with a valid key, an invalid key and no key at all, so it is
+    // not a quota or auth problem.
+    //
+    // The default is therefore false: left on, this provider burned one
+    // guaranteed-failing round trip per song before the lyrics chain could
+    // fall through to a working provider. Users who front the API with their
+    // own mirror can still switch it back on.
+    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixMusixmatchLyricsKey] ?: false
 
     override suspend fun getLyrics(
         id: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixNeteaseLyricsProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixNeteaseLyricsProvider.kt
@@ -16,7 +16,18 @@ import moe.rukamori.archivetune.utils.get
 object PaxsenixNeteaseLyricsProvider : LyricsProvider {
     override val name = "Paxsenix: NetEase"
 
-    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixNeteaseLyricsKey] ?: true
+    // Paxsenix retired every provider endpoint except /apple-music/lyrics: the
+    // others answer 403 with "This endpoint is no longer available due to the
+    // massive amount of traffic and the lack of support needed to keep it
+    // running." Verified against the live API — the 403 is unconditional and
+    // is returned with a valid key, an invalid key and no key at all, so it is
+    // not a quota or auth problem.
+    //
+    // The default is therefore false: left on, this provider burned one
+    // guaranteed-failing round trip per song before the lyrics chain could
+    // fall through to a working provider. Users who front the API with their
+    // own mirror can still switch it back on.
+    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixNeteaseLyricsKey] ?: false
 
     override suspend fun getLyrics(
         id: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixSpotifyLyricsProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixSpotifyLyricsProvider.kt
@@ -16,7 +16,18 @@ import moe.rukamori.archivetune.utils.get
 object PaxsenixSpotifyLyricsProvider : LyricsProvider {
     override val name = "Paxsenix: Spotify"
 
-    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixSpotifyLyricsKey] ?: true
+    // Paxsenix retired every provider endpoint except /apple-music/lyrics: the
+    // others answer 403 with "This endpoint is no longer available due to the
+    // massive amount of traffic and the lack of support needed to keep it
+    // running." Verified against the live API — the 403 is unconditional and
+    // is returned with a valid key, an invalid key and no key at all, so it is
+    // not a quota or auth problem.
+    //
+    // The default is therefore false: left on, this provider burned one
+    // guaranteed-failing round trip per song before the lyrics chain could
+    // fall through to a working provider. Users who front the API with their
+    // own mirror can still switch it back on.
+    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixSpotifyLyricsKey] ?: false
 
     override suspend fun getLyrics(
         id: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixYouTubeLyricsProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixYouTubeLyricsProvider.kt
@@ -16,7 +16,18 @@ import moe.rukamori.archivetune.utils.get
 object PaxsenixYouTubeLyricsProvider : LyricsProvider {
     override val name = "Paxsenix: YouTube"
 
-    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixYouTubeLyricsKey] ?: true
+    // Paxsenix retired every provider endpoint except /apple-music/lyrics: the
+    // others answer 403 with "This endpoint is no longer available due to the
+    // massive amount of traffic and the lack of support needed to keep it
+    // running." Verified against the live API — the 403 is unconditional and
+    // is returned with a valid key, an invalid key and no key at all, so it is
+    // not a quota or auth problem.
+    //
+    // The default is therefore false: left on, this provider burned one
+    // guaranteed-failing round trip per song before the lyrics chain could
+    // fall through to a working provider. Users who front the API with their
+    // own mirror can still switch it back on.
+    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixYouTubeLyricsKey] ?: false
 
     override suspend fun getLyrics(
         id: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -223,10 +223,14 @@ import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
 import moe.rukamori.archivetune.audiosource.DirectStream
+import moe.rukamori.archivetune.audiosource.FlacStreamInfo
 import moe.rukamori.archivetune.audiosource.SongSourceOverride
+import moe.rukamori.archivetune.audiosource.SongSourceQobuzBackupVideoId
 import moe.rukamori.archivetune.audiosource.SongSourceQobuzTrackId
 import moe.rukamori.archivetune.audiosource.TitleMatch
+import moe.rukamori.archivetune.audiosource.pcmBitrateOrNull
 import moe.rukamori.archivetune.constants.SongSourceOverrideKey
+import moe.rukamori.archivetune.constants.SongSourceQobuzBackupVideoIdKey
 import moe.rukamori.archivetune.constants.SongSourceQobuzTrackIdKey
 import moe.rukamori.archivetune.tidal.TidalAccountManager
 import moe.rukamori.archivetune.tidal.TidalArtworkProvider
@@ -8556,6 +8560,14 @@ class MusicService :
          * extracts it into this field.
          */
         val directQobuzTrackId: String? = null,
+        /**
+         * When non-null, the Qobuz-backup resolver asks the mirror for THIS video id
+         * instead of [mediaId]. Set when the user picks a specific row in the
+         * "Play from" search popup — the mirror is keyed by YouTube video id, and the
+         * row they chose is a different catalogue entry from the song that is playing.
+         * Keeping [mediaId] untouched is what makes the switch audio-only.
+         */
+        val directQobuzBackupVideoId: String? = null,
     )
 
     /**
@@ -8643,7 +8655,21 @@ class MusicService :
             runBlocking { dataStore.data.first()[SongSourceQobuzTrackIdKey] }
         }.getOrNull()
         val directQobuzTrackId = SongSourceQobuzTrackId.get(qobuzTrackIdRaw, mediaId)
-        return SourceQuery(mediaId, title, artists, album, durationMs, directQobuzTrackId)
+        // Same treatment for the Qobuz-backup mirror's video id (see the field docs
+        // on SourceQuery.directQobuzBackupVideoId), read fresh for the same reason.
+        val qobuzBackupVideoIdRaw = runCatching {
+            runBlocking { dataStore.data.first()[SongSourceQobuzBackupVideoIdKey] }
+        }.getOrNull()
+        val directQobuzBackupVideoId = SongSourceQobuzBackupVideoId.get(qobuzBackupVideoIdRaw, mediaId)
+        return SourceQuery(
+            mediaId = mediaId,
+            title = title,
+            artists = artists,
+            album = album,
+            durationMs = durationMs,
+            directQobuzTrackId = directQobuzTrackId,
+            directQobuzBackupVideoId = directQobuzBackupVideoId,
+        )
     }
 
     // mediaId -> set of sources known to have this track (passed the metadata match gate during a recent
@@ -8824,7 +8850,7 @@ class MusicService :
         mediaId: String,
         source: AudioSourceType?,
     ) {
-        setSongSourceOverrideInternal(mediaId, source, qobuzTrackId = null)
+        setSongSourceOverrideInternal(mediaId, source, qobuzTrackId = null, qobuzBackupVideoId = null)
     }
 
     /**
@@ -8847,13 +8873,32 @@ class MusicService :
         source: AudioSourceType?,
         qobuzTrackId: String?,
     ) {
-        setSongSourceOverrideInternal(mediaId, source, qobuzTrackId)
+        setSongSourceOverrideInternal(mediaId, source, qobuzTrackId, qobuzBackupVideoId = null)
+    }
+
+    /**
+     * Sets a per-song source override AND persists the chosen Qobuz-**backup** mirror
+     * video id — the counterpart of [setSongSourceOverrideWithQobuzTrackId] for the
+     * kouzu.in mirror, which is keyed by YouTube video id rather than a catalogue
+     * track id.
+     *
+     * As with the Qobuz variant, the song's own mediaId is left alone: the queue, its
+     * position, the artwork and the listening history are all preserved, and only the
+     * bytes being decoded change.
+     */
+    fun setSongSourceOverrideWithQobuzBackupVideoId(
+        mediaId: String,
+        source: AudioSourceType?,
+        qobuzBackupVideoId: String?,
+    ) {
+        setSongSourceOverrideInternal(mediaId, source, qobuzTrackId = null, qobuzBackupVideoId = qobuzBackupVideoId)
     }
 
     private fun setSongSourceOverrideInternal(
         mediaId: String,
         source: AudioSourceType?,
         qobuzTrackId: String?,
+        qobuzBackupVideoId: String?,
     ) {
         // A direct Qobuz selection is an explicit user choice. A failed
         // background probe may have left the provider's negative cache or an
@@ -8863,7 +8908,12 @@ class MusicService :
         if (source == AudioSourceType.QOBUZ && !qobuzTrackId.isNullOrBlank()) {
             QobuzAudioProvider.clearTransientCaches()
         }
-        // Persist the Qobuz trackId (if any) BEFORE triggering re-resolution.
+        // Persist the exact-track ids (if any) BEFORE triggering re-resolution.
+        //
+        // Both are always written, with null for whichever is not part of this
+        // selection: a song can only play from one source at a time, so leaving a
+        // previous pick's id behind would keep pinning the resolver to the old source
+        // even after the user chose a different one.
         runCatching {
             runBlocking {
                 dataStore.edit { prefs ->
@@ -8871,6 +8921,11 @@ class MusicService :
                         prefs[SongSourceQobuzTrackIdKey],
                         mediaId,
                         qobuzTrackId,
+                    )
+                    prefs[SongSourceQobuzBackupVideoIdKey] = SongSourceQobuzBackupVideoId.withOverride(
+                        prefs[SongSourceQobuzBackupVideoIdKey],
+                        mediaId,
+                        qobuzBackupVideoId,
                     )
                 }
             }
@@ -9037,6 +9092,19 @@ class MusicService :
         }.getOrNull()
         val directQobuzTrackId = SongSourceQobuzTrackId.get(qobuzTrackIdRaw, mediaId)
         val isDirectQobuzTrack = directQobuzTrackId != null
+        // Same for an explicit Qobuz-backup pick: the mirror is addressed by video id,
+        // so a chosen row is only reachable through the stored id. Treat it exactly like
+        // a direct Qobuz track — force the chain to that one source, skip the
+        // DirectStream cache (which may hold the previous source's URL for this media
+        // id) and let it through low-data mode, because it is an explicit user choice.
+        val qobuzBackupVideoIdRaw = runCatching {
+            runBlocking { dataStore.data.first()[SongSourceQobuzBackupVideoIdKey] }
+        }.getOrNull()
+        val directQobuzBackupVideoId = SongSourceQobuzBackupVideoId.get(qobuzBackupVideoIdRaw, mediaId)
+        val isDirectQobuzBackupTrack = directQobuzBackupVideoId != null
+        // A song can only be pinned to one source at a time, so at most one of these is
+        // set; `isDirectPick` is the shared "the user chose this exact track" signal.
+        val isDirectPick = isDirectQobuzTrack || isDirectQobuzBackupTrack
         // Read the source override FRESH from DataStore — not from the stale
         // PreferenceStore cache. The PreferenceStore collector is async and
         // may not have received the write from setSongSourceOverride yet.
@@ -9053,7 +9121,7 @@ class MusicService :
         // re-resolve through Qobuz even if a cached YouTube stream exists.
         val now = System.currentTimeMillis()
         val cached = directStreamCache[mediaId]
-        if (!isDirectQobuzTrack && cached != null && cached.expiresAtMs > now) {
+        if (!isDirectPick && cached != null && cached.expiresAtMs > now) {
             val override = SongSourceOverride.get(sourceOverrideRaw, mediaId)
             val cacheHitsOverride = override == null || override == cached.stream.source
             if (cacheHitsOverride && !lowDataModeActive) {
@@ -9093,14 +9161,20 @@ class MusicService :
         // lossless sources are still enabled. Instead we fall through to the full enabled
         // chain so a different lossless source can still win. The stale pin remains in
         // storage and will become effective again if the user re-enables the source.
-        val override = if (isDirectQobuzTrack) AudioSourceType.QOBUZ else SongSourceOverride.get(sourceOverrideRaw, mediaId)
+        val override =
+            when {
+                isDirectQobuzTrack -> AudioSourceType.QOBUZ
+                isDirectQobuzBackupTrack -> AudioSourceType.QOBUZ_BACKUP
+                else -> SongSourceOverride.get(sourceOverrideRaw, mediaId)
+            }
         val overrideStillEnabled =
             override == null ||
                 override == AudioSourceType.YOUTUBE ||
                 isSourceEnabled(override)
         val chain =
-            if (isDirectQobuzTrack) {
-                listOf(AudioSourceType.QOBUZ)
+            if (isDirectPick) {
+                // `override` was pinned to the picked source above.
+                listOfNotNull(override)
             } else when (override) {
                 null -> sourceResolutionChain()
                 AudioSourceType.YOUTUBE -> {
@@ -9129,7 +9203,7 @@ class MusicService :
         // Qobuz track the user explicitly selected in the Play from popup. That choice carries
         // a concrete Qobuz track id and must not silently turn into a YouTube Opus stream on a
         // metered network.
-        if (lowDataModeActive && !isDirectQobuzTrack) {
+        if (lowDataModeActive && !isDirectPick) {
             tidalActiveMediaIds.remove(mediaId)
             Timber.tag("MusicService").i("Low-data mode active; skipping Tidal/Qobuz for %s", mediaId)
             return null
@@ -9153,7 +9227,7 @@ class MusicService :
         // title formatting often differs from the YouTube-derived wanted title enough to fail the
         // metadata gate, the resolver silently fell back to YouTube, and the user saw no change.
         // The override is the user's manual override of the gate — we should respect it.
-        val overrideIsSourceOverride = (override != null && override != AudioSourceType.YOUTUBE) || isDirectQobuzTrack
+        val overrideIsSourceOverride = (override != null && override != AudioSourceType.YOUTUBE) || isDirectPick
         var best: DirectStream? = null
         var bestSource: AudioSourceType? = null
         var bestScore = 0.0
@@ -9661,7 +9735,10 @@ class MusicService :
      * the song the user is playing, so we skip the title/artist metadata gate.
      */
     private fun resolveQobuzBackupStream(query: SourceQuery): DirectStream? {
-        val ytId = query.mediaId.trim()
+        // An explicit pick from the "Play from" popup addresses a specific mirror entry,
+        // which is usually NOT the playing song's own id — honour it when present and
+        // fall back to the media id for the automatic path.
+        val ytId = (query.directQobuzBackupVideoId ?: query.mediaId).trim()
         // YouTube video ids are 11 characters. Anything else isn't a valid id for
         // the kouzu.in endpoint — bail early so we don't waste a network call.
         if (ytId.length != 11 || ytId.any { !it.isLetterOrDigit() && it != '_' && it != '-' }) {
@@ -9758,11 +9835,14 @@ class MusicService :
                     return@runBlocking null
                 }
                 Timber.tag("MusicService").i(
-                    "Qobuz backup resolved \"%s\" via mlc-ytify.kouzu.in → %s [%s%s]",
+                    "Qobuz backup resolved \"%s\" via mlc-ytify.kouzu.in → %s [%s%s%s]",
                     query.title,
                     probe.url.take(80),
                     probe.contentType,
                     if (probe.isLossless) ", lossless" else "",
+                    probe.sampleRate?.let { rate ->
+                        ", ${probe.bitDepth?.toString() ?: "?"}bit/${rate / 1000f}kHz"
+                    }.orEmpty(),
                 )
                 DirectStream(
                     uri = probe.url,
@@ -9771,6 +9851,8 @@ class MusicService :
                     contentLength = probe.contentLength,
                     label = if (probe.isLossless) "Qobuz backup (lossless)" else "Qobuz backup (kouzu.in)",
                     source = AudioSourceType.QOBUZ_BACKUP,
+                    sampleRate = probe.sampleRate,
+                    bitDepth = probe.bitDepth,
                     // The YouTube mediaId is the authoritative identity of the
                     // song the user is playing — we trust it without requiring
                     // the backup server to echo back matching metadata.
@@ -9778,7 +9860,10 @@ class MusicService :
                     matchedTitle = query.title,
                     matchedArtist = query.artists.joinToString(", ").ifBlank { null },
                     matchedAlbum = query.album,
-                    matchedDurationMs = query.durationMs,
+                    // The FLAC header's own sample count is the exact length of the file
+                    // being served; prefer it over the catalogue duration so the Details
+                    // card and the measured bitrate are both computed from the real file.
+                    matchedDurationMs = probe.durationMs ?: query.durationMs,
                 )
             }
         }.onFailure { error ->
@@ -9800,6 +9885,15 @@ class MusicService :
         val contentLength: Long?,
         val contentType: String,
         val isLossless: Boolean,
+        /**
+         * Real stream properties read out of the FLAC STREAMINFO block that the probe
+         * already downloads. Null for the lossy mirror (and for any FLAC whose header
+         * did not parse), in which case the Details card falls back to its tier
+         * heuristic rather than inventing precision.
+         */
+        val sampleRate: Int? = null,
+        val bitDepth: Int? = null,
+        val durationMs: Long? = null,
     )
 
     /**
@@ -9809,8 +9903,11 @@ class MusicService :
      *
      * HEAD is deliberately not used: the CDN replies `405 Method Not Allowed`
      * with `allow: GET` for HEAD on every object, so a HEAD probe can only ever
-     * fail. `Range: bytes=0-1` keeps the probe to two bytes while still
-     * returning the headers we need.
+     * fail. The range is sized to exactly cover a FLAC `STREAMINFO` block
+     * ([FlacStreamInfo.REQUIRED_BYTES]) so the same round trip that establishes
+     * reachability also yields the track's real sample rate, bit depth and length —
+     * that is what stops every lossless track from showing the same numbers in the
+     * player's Details card.
      */
     private fun probeQobuzBackupMirror(url: String): QobuzBackupProbe? =
         runCatching {
@@ -9820,10 +9917,11 @@ class MusicService :
                     .url(url)
                     .get()
                     .header("User-Agent", "ArchiveTune-Android")
-                    .header("Range", "bytes=0-1")
+                    .header("Range", "bytes=0-${FlacStreamInfo.REQUIRED_BYTES - 1}")
                     .build()
             mediaOkHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) return@use null
+                val headerBytes = runCatching { response.body?.bytes() }.getOrNull()
                 val contentType = response.header("Content-Type")?.lowercase().orEmpty()
                 // A JSON body here is the CDN's {"detail":"Not Found"} envelope for a
                 // mirror that hasn't been populated for this track yet.
@@ -9844,7 +9942,10 @@ class MusicService :
                         ?.trim()
                         ?.toLongOrNull()
                         ?: response.header("Content-Length")?.toLongOrNull()?.takeIf { response.code != 206 }
-                val isFlac = contentType.contains("flac") || url.contains("/lossless/")
+                // Trust the bytes over the labels: a mirror that serves FLAC is FLAC even
+                // if the CDN mislabels the Content-Type, and the header is already here.
+                val streamInfo = headerBytes?.let(FlacStreamInfo::parse)
+                val isFlac = streamInfo != null || contentType.contains("flac") || url.contains("/lossless/")
                 QobuzBackupProbe(
                     url = url,
                     mimeType = if (isFlac) "audio/flac" else "audio/mp4",
@@ -9852,6 +9953,9 @@ class MusicService :
                     contentLength = totalLength?.takeIf { it > 0 },
                     contentType = contentType.ifBlank { "unknown" },
                     isLossless = isFlac,
+                    sampleRate = streamInfo?.sampleRate,
+                    bitDepth = streamInfo?.bitDepth,
+                    durationMs = streamInfo?.durationMs,
                 )
             }
         }.onFailure { error ->
@@ -10091,16 +10195,16 @@ class MusicService :
                 label.contains("LOSSLESS") || codecs.contains("flac", true) || codecs.contains("alac", true) -> 44_100
                 else -> null
             }
-        val bitDepth = stream.bitDepth?.takeIf { it > 0 }
-        val bitrate = when {
-            stream.sampleRate != null && stream.sampleRate > 0 && bitDepth != null && bitDepth > 0 ->
-                stream.sampleRate * bitDepth * 2 // stereo: channels=2
-            label.contains("HI_RES") || label.contains("MASTER") || label.contains("MQA") -> 2_304_000
-            label.contains("LOSSLESS") || codecs.contains("flac", true) || codecs.contains("alac", true) -> 1_411_000
-            label.contains("HIGH") -> 320_000
-            else -> 0
-        }
         val knownContentLength = stream.contentLength?.takeIf { it > 0L }
+        val bitrate =
+            measuredBitrate(knownContentLength, stream.matchedDurationMs)
+                ?: stream.pcmBitrateOrNull()
+                ?: when {
+                    label.contains("HI_RES") || label.contains("MASTER") || label.contains("MQA") -> 2_304_000
+                    label.contains("LOSSLESS") || codecs.contains("flac", true) || codecs.contains("alac", true) -> 1_411_000
+                    label.contains("HIGH") -> 320_000
+                    else -> 0
+                }
         val formatEntity =
             FormatEntity(
                 id = mediaId,
@@ -10153,11 +10257,19 @@ class MusicService :
                         if (len > 0L) {
                             // Re-read the row so we don't clobber any concurrent
                             // updates to other fields (e.g. loudness) — only
-                            // patch the contentLength column.
+                            // patch the contentLength column, plus the bitrate that
+                            // can now be measured from it (the row was written with
+                            // the tier estimate because the length was unknown).
+                            val backfilledBitrate = measuredBitrate(len, stream.matchedDurationMs)
                             val refreshed =
                                 runBlocking(Dispatchers.IO) {
                                     database.getFormatsByIds(listOf(mediaId)).firstOrNull()
-                                }?.copy(contentLength = len)
+                                }?.let { row ->
+                                    row.copy(
+                                        contentLength = len,
+                                        bitrate = backfilledBitrate ?: row.bitrate,
+                                    )
+                                }
                             if (refreshed != null) {
                                 database.query { upsert(refreshed) }
                             }
@@ -10172,6 +10284,31 @@ class MusicService :
                 }
             }
         }
+    }
+
+    /**
+     * The stream's true average bitrate in bits/sec, derived from its byte length and
+     * playing time, or null when either is unknown.
+     *
+     * This is what makes the Details card show something specific to the track that is
+     * actually playing. The alternative — sample rate x bit depth x channels — is the
+     * *uncompressed* PCM ceiling, and it is identical for every file that shares a tier:
+     * the Qobuz backup mirror serves almost its whole catalogue as 24-bit/44.1 kHz FLAC,
+     * so every lossless track reported exactly the same "2116 kbps" no matter how
+     * compressible it was. A measured rate distinguishes them (a sparse ballad
+     * compresses to well under half of a dense mix) and is the honest figure for a
+     * variable-bitrate codec.
+     */
+    private fun measuredBitrate(
+        contentLength: Long?,
+        durationMs: Long?,
+    ): Int? {
+        val bytes = contentLength?.takeIf { it > 0L } ?: return null
+        val millis = durationMs?.takeIf { it > 0L } ?: return null
+        val bitsPerSecond = bytes * 8_000L / millis
+        // Guard against a bogus duration producing an absurd rate; 50 Mbps is far above
+        // anything a music file reaches, so treat it as "unknown" instead of showing it.
+        return bitsPerSecond.takeIf { it in 1L..50_000_000L }?.toInt()
     }
 
     private fun sourceCacheKey(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -9685,7 +9685,7 @@ class MusicService :
                         .header("User-Agent", "ArchiveTune-Android")
                         .header("Accept", "application/json")
                         .build()
-                val resolvedUrl = mediaOkHttpClient.newCall(resolverRequest).execute().use { response ->
+                val resolvedCandidates = mediaOkHttpClient.newCall(resolverRequest).execute().use { response ->
                     if (!response.isSuccessful) {
                         Timber.tag("MusicService").d(
                             "Qobuz backup resolver miss for %s: HTTP %d",
@@ -9708,14 +9708,22 @@ class MusicService :
                         )
                         return@runBlocking null
                     }
-                    // The resolver returns the actual stream URL in the `url` field.
-                    // Tolerant: also accept `canvas_url` / `video_url` (same field
-                    // names as the Spotify canvas resolver).
-                    val streamUrl =
-                        root.optString("url").takeIf { it.isNotBlank() }
-                            ?: root.optString("canvas_url").takeIf { it.isNotBlank() }
-                            ?: root.optString("video_url").takeIf { it.isNotBlank() }
-                    if (streamUrl.isNullOrBlank()) {
+                    // The resolver envelope carries TWO mirrors for the same track:
+                    //   "url"      → https://…/song/<id>     lossy AAC-in-MP4 transcode
+                    //   "lossless" → https://…/lossless/<id> the real FLAC
+                    // Reading only `url` is why "Qobuz backup" never actually played
+                    // lossless: the lossy mirror was picked every time and the FLAC
+                    // mirror was ignored. Try lossless first and keep the lossy
+                    // mirror as a fallback for entries that have no FLAC yet.
+                    val candidates =
+                        buildList {
+                            root.optString("lossless").takeIf { it.isNotBlank() }?.let(::add)
+                            root.optString("flac").takeIf { it.isNotBlank() }?.let(::add)
+                            root.optString("url").takeIf { it.isNotBlank() }?.let(::add)
+                            root.optString("canvas_url").takeIf { it.isNotBlank() }?.let(::add)
+                            root.optString("video_url").takeIf { it.isNotBlank() }?.let(::add)
+                        }.distinct()
+                    if (candidates.isEmpty()) {
                         Timber.tag("MusicService").d(
                             "Qobuz backup resolver miss for %s: no url field in response (first 200 chars: %s)",
                             ytId,
@@ -9723,52 +9731,45 @@ class MusicService :
                         )
                         return@runBlocking null
                     }
-                    streamUrl
+                    candidates
                 } ?: return@runBlocking null
 
-                // Step 2: HEAD-probe the resolved CDN URL to verify it's reachable
-                // and returns an audio content type. This is informational — ExoPlayer
-                // will issue the actual GET with byte-range requests through the same
-                // OkHttp client. The CDN host (velamhere-img.hf.space) doesn't need
-                // the x-request-source: muzo header.
-                val cdnHeadRequest =
-                    okhttp3.Request
-                        .Builder()
-                        .url(resolvedUrl)
-                        .head()
-                        .header("User-Agent", "ArchiveTune-Android")
-                        .build()
-                val (finalStreamUrl, contentLength, contentType) = mediaOkHttpClient.newCall(cdnHeadRequest).execute().use { cdnResponse ->
-                    if (!cdnResponse.isSuccessful) {
-                        Timber.tag("MusicService").d(
-                            "Qobuz backup CDN miss for %s: HTTP %d (resolved url: %s)",
-                            ytId,
-                            cdnResponse.code,
-                            resolvedUrl.take(80),
-                        )
-                        // Fallback: use the resolver-resolved URL directly even
-                        // though the HEAD probe failed — ExoPlayer's GET might
-                        // still succeed (some CDNs reject HEAD but accept GET).
-                        Triple(resolvedUrl, null, "audio/mp4")
-                    } else {
-                        val ct = cdnResponse.header("Content-Type")?.lowercase().orEmpty()
-                        Timber.tag("MusicService").i(
-                            "Qobuz backup resolved \"%s\" via mlc-ytify.kouzu.in → %s [%s]",
-                            query.title,
-                            resolvedUrl.take(80),
-                            ct,
-                        )
-                        Triple(resolvedUrl, cdnResponse.header("Content-Length")?.toLongOrNull(), ct)
+                // Step 2: probe each candidate mirror with a two-byte ranged GET and
+                // take the first that answers with real audio.
+                //
+                // This used to be a HEAD probe, which could never succeed: the CDN
+                // answers HEAD with `405 Method Not Allowed` and `allow: GET`. The
+                // old code papered over that by falling through to the URL anyway
+                // and hardcoding `audio/mp4`, so a FLAC mirror would have been
+                // mislabelled as AAC even if it had been selected. A ranged GET is
+                // honoured (206 + Content-Type + Content-Range) so we learn the real
+                // container and the real length, and we can tell a genuine 404 for
+                // this track apart from a method-not-allowed.
+                val probe =
+                    resolvedCandidates.firstNotNullOfOrNull { candidate ->
+                        probeQobuzBackupMirror(candidate)
                     }
+                if (probe == null) {
+                    Timber.tag("MusicService").d(
+                        "Qobuz backup CDN miss for %s: no candidate mirror served audio (tried %d)",
+                        ytId,
+                        resolvedCandidates.size,
+                    )
+                    return@runBlocking null
                 }
-                // The CDN serves audio/mp4 (an MP4 container with lossless ALAC
-                // inside, verified by direct probe — Content-Type: audio/mp4).
+                Timber.tag("MusicService").i(
+                    "Qobuz backup resolved \"%s\" via mlc-ytify.kouzu.in → %s [%s%s]",
+                    query.title,
+                    probe.url.take(80),
+                    probe.contentType,
+                    if (probe.isLossless) ", lossless" else "",
+                )
                 DirectStream(
-                    uri = finalStreamUrl,
-                    mimeType = if (contentType.contains("flac")) "audio/flac" else "audio/mp4",
-                    codecs = if (contentType.contains("flac")) "flac" else "mp4a.40.2",
-                    contentLength = contentLength,
-                    label = "Qobuz backup (kouzu.in)",
+                    uri = probe.url,
+                    mimeType = probe.mimeType,
+                    codecs = probe.codecs,
+                    contentLength = probe.contentLength,
+                    label = if (probe.isLossless) "Qobuz backup (lossless)" else "Qobuz backup (kouzu.in)",
                     source = AudioSourceType.QOBUZ_BACKUP,
                     // The YouTube mediaId is the authoritative identity of the
                     // song the user is playing — we trust it without requiring
@@ -9784,6 +9785,78 @@ class MusicService :
             Timber.tag("MusicService").w(error, "Qobuz backup resolution failed for %s", ytId)
         }.getOrNull()
     }
+
+    /**
+     * A Qobuz-backup CDN mirror that answered a probe with real audio bytes.
+     *
+     * [contentLength] is the *full* resource size taken from the `Content-Range`
+     * total (`bytes 0-1/40802970`), not the two bytes the probe actually asked
+     * for — ExoPlayer wants the whole-resource length.
+     */
+    private data class QobuzBackupProbe(
+        val url: String,
+        val mimeType: String,
+        val codecs: String,
+        val contentLength: Long?,
+        val contentType: String,
+        val isLossless: Boolean,
+    )
+
+    /**
+     * Issues a 2-byte ranged GET against a Qobuz-backup CDN mirror and maps the
+     * response to a [QobuzBackupProbe], or null when the mirror doesn't exist
+     * (404) or doesn't serve audio.
+     *
+     * HEAD is deliberately not used: the CDN replies `405 Method Not Allowed`
+     * with `allow: GET` for HEAD on every object, so a HEAD probe can only ever
+     * fail. `Range: bytes=0-1` keeps the probe to two bytes while still
+     * returning the headers we need.
+     */
+    private fun probeQobuzBackupMirror(url: String): QobuzBackupProbe? =
+        runCatching {
+            val request =
+                okhttp3.Request
+                    .Builder()
+                    .url(url)
+                    .get()
+                    .header("User-Agent", "ArchiveTune-Android")
+                    .header("Range", "bytes=0-1")
+                    .build()
+            mediaOkHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                val contentType = response.header("Content-Type")?.lowercase().orEmpty()
+                // A JSON body here is the CDN's {"detail":"Not Found"} envelope for a
+                // mirror that hasn't been populated for this track yet.
+                if (contentType.contains("json") || contentType.contains("html")) return@use null
+                if (contentType.isNotBlank() &&
+                    !contentType.startsWith("audio/") &&
+                    !contentType.startsWith("video/") &&
+                    !contentType.contains("octet-stream")
+                ) {
+                    return@use null
+                }
+                // Prefer the Content-Range total ("bytes 0-1/40802970") — Content-Length
+                // on a 206 is just the two probed bytes.
+                val totalLength =
+                    response
+                        .header("Content-Range")
+                        ?.substringAfter('/', "")
+                        ?.trim()
+                        ?.toLongOrNull()
+                        ?: response.header("Content-Length")?.toLongOrNull()?.takeIf { response.code != 206 }
+                val isFlac = contentType.contains("flac") || url.contains("/lossless/")
+                QobuzBackupProbe(
+                    url = url,
+                    mimeType = if (isFlac) "audio/flac" else "audio/mp4",
+                    codecs = if (isFlac) "flac" else "mp4a.40.2",
+                    contentLength = totalLength?.takeIf { it > 0 },
+                    contentType = contentType.ifBlank { "unknown" },
+                    isLossless = isFlac,
+                )
+            }
+        }.onFailure { error ->
+            Timber.tag("MusicService").d(error, "Qobuz backup mirror probe failed for %s", url.take(80))
+        }.getOrNull()
 
     private fun parseQobuzInstances(): List<String> =
         dataStore

--- a/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzBackupProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzBackupProvider.kt
@@ -1,0 +1,190 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.qobuz
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+/**
+ * Catalogue lookups for the **Qobuz backup** source (the community-hosted
+ * `mlc-ytify.kouzu.in` mirror, which serves a FLAC per YouTube video id).
+ *
+ * Streaming itself lives in `MusicService.resolveQobuzBackupStream` — this object
+ * only covers the parts the *UI* needs, which the resolver has no use for:
+ *
+ *  - [searchCandidates] backs the player's "Play from" search popup. The popup
+ *    used to hard-exclude this source with a "search backend not yet available"
+ *    empty state, on the assumption that the mirror could only be addressed by
+ *    video id. It does in fact expose `GET /api/search?q=&limit=`, which returns
+ *    the mirror's own indexed catalogue (~64k tracks), so results can be listed
+ *    and picked like any other source.
+ *
+ * The `x-request-source: muzo` header is required on every kouzu.in request —
+ * without it the server rate-limits aggressively. `MusicService.mediaOkHttpClient`
+ * injects it for playback traffic via an interceptor; this object uses its own
+ * client, so it sets the header explicitly.
+ */
+object QobuzBackupProvider {
+    private const val BASE_URL = "https://mlc-ytify.kouzu.in"
+    private const val USER_AGENT = "ArchiveTune-Android"
+    private const val SEARCH_CACHE_MS = 10 * 60 * 1000L
+
+    /** YouTube video ids are exactly 11 chars of `[A-Za-z0-9_-]`. */
+    private val VIDEO_ID_REGEX = Regex("^[A-Za-z0-9_-]{11}$")
+
+    private val client =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(12, TimeUnit.SECONDS)
+            .callTimeout(20, TimeUnit.SECONDS)
+            .build()
+
+    /**
+     * One track from the backup mirror's index.
+     *
+     * [videoId] is a YouTube video id and doubles as the mirror's primary key:
+     * the stream URLs are `…/lossless/<videoId>` and `…/song/<videoId>`, and it
+     * is what `resolveQobuzBackupStream` needs. It is deliberately NOT assumed to
+     * equal the currently playing song's media id — picking a row in the popup
+     * pins this id for the current song (see `SongSourceQobuzBackupVideoId`).
+     */
+    data class Candidate(
+        val videoId: String,
+        val title: String,
+        val artist: String?,
+        /** True when the mirror advertises a FLAC mirror for this track. */
+        val isLossless: Boolean,
+    ) {
+        /**
+         * Cover art. The mirror's search response carries no artwork, but its key
+         * *is* a YouTube video id, so the standard i.ytimg thumbnail always
+         * exists. `hqdefault` (480x360) is the largest size guaranteed to be
+         * present for every video — `maxresdefault` 404s for a large share of
+         * the catalogue, which would leave the row with a placeholder icon.
+         */
+        val thumbnailUrl: String
+            get() = "https://i.ytimg.com/vi/$videoId/hqdefault.jpg"
+    }
+
+    private data class CachedSearch(
+        val candidates: List<Candidate>,
+        val expiresAt: Long,
+    )
+
+    private val searchCache = ConcurrentHashMap<String, CachedSearch>()
+
+    /**
+     * Searches the backup mirror's catalogue. Blocking — call from `Dispatchers.IO`,
+     * matching [QobuzAudioProvider.searchCandidates].
+     *
+     * Returns an empty list when the query is too short, the mirror is
+     * unreachable, or it has nothing indexed for the query. Callers treat that as
+     * "no results", never as a hard error.
+     */
+    fun searchCandidates(
+        query: String,
+        limit: Int = 8,
+    ): List<Candidate> {
+        val trimmed = query.trim()
+        if (trimmed.length < 2 || limit <= 0) return emptyList()
+
+        val cacheKey = "${trimmed.lowercase()}|$limit"
+        val now = System.currentTimeMillis()
+        searchCache[cacheKey]?.takeIf { it.expiresAt > now }?.let { return it.candidates }
+
+        val url =
+            "$BASE_URL/api/search"
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("q", trimmed)
+                .addQueryParameter("limit", limit.toString())
+                .build()
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("User-Agent", USER_AGENT)
+                .header("Accept", "application/json")
+                .header("x-request-source", "muzo")
+                .build()
+
+        val candidates =
+            runCatching {
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        Timber.tag("QobuzBackup").d(
+                            "search \"%s\" failed: HTTP %d",
+                            trimmed,
+                            response.code,
+                        )
+                        return@use emptyList()
+                    }
+                    parseSearchResponse(response.body?.string().orEmpty(), limit)
+                }
+            }.onFailure { error ->
+                Timber.tag("QobuzBackup").d(error, "search \"%s\" failed", trimmed)
+            }.getOrDefault(emptyList())
+
+        // Cache successes only: a transient network failure should not pin an
+        // empty result for the next ten minutes.
+        if (candidates.isNotEmpty()) {
+            searchCache[cacheKey] = CachedSearch(candidates, now + SEARCH_CACHE_MS)
+        }
+        return candidates
+    }
+
+    /**
+     * Parses the mirror's search payload:
+     * `[{"id":"J7p4bzqLvCw","name":"Blinding Lights","artists":"The Weeknd",
+     *    "lossless":"4:flac","stream_sources":"m4a"}, …]`
+     *
+     * Rows without a usable video id or title are skipped rather than surfaced as
+     * unplayable entries.
+     */
+    private fun parseSearchResponse(
+        body: String,
+        limit: Int,
+    ): List<Candidate> {
+        if (body.isBlank()) return emptyList()
+        val array = runCatching { JSONArray(body) }.getOrNull() ?: return emptyList()
+        val out = mutableListOf<Candidate>()
+        for (index in 0 until array.length()) {
+            if (out.size >= limit) break
+            val item = array.optJSONObject(index) ?: continue
+            val videoId = item.optString("id").trim()
+            if (!VIDEO_ID_REGEX.matches(videoId)) continue
+            val title = item.optString("name").trim()
+            if (title.isEmpty()) continue
+            val artist = item.optString("artists").trim().takeIf { it.isNotEmpty() }
+            // "lossless" is a tier descriptor ("4:flac") when a FLAC mirror exists
+            // and absent/blank when only the lossy m4a transcode is available.
+            val isLossless = item.optString("lossless").contains("flac", ignoreCase = true)
+            out.add(
+                Candidate(
+                    videoId = videoId,
+                    title = title,
+                    artist = artist,
+                    isLossless = isLossless,
+                ),
+            )
+        }
+        return out
+    }
+
+    /** Drops cached search results. Called when the user clears app caches. */
+    fun clearCaches() {
+        searchCache.clear()
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
@@ -381,6 +381,25 @@ class SpotifyLibraryRepository
             }
 
 
+        /**
+         * Returns a usable Spotify access token, minting one from the stored `sp_dc`
+         * cookie when the cached token is missing or expired, or null when the user has
+         * not connected a Spotify account.
+         *
+         * Exists because features outside the Spotify library screens need the session
+         * too. `SpotifyCanvasProvider` read the `Spotify.accessToken` global directly,
+         * which is only populated as a side effect of some *earlier* Spotify library
+         * call — so on a fresh launch the official Canvas endpoint was skipped for want
+         * of a token even though the user was connected, and canvas silently fell through
+         * to the (empty) community resolver. Going through the repository reuses the same
+         * mutex, DataStore cache and refresh logic as every other Spotify call.
+         */
+        suspend fun ensureAccessToken(): String? =
+            runCatching {
+                ensureAuthenticated()
+                Spotify.accessToken?.takeIf { it.isNotBlank() }
+            }.getOrNull()
+
         private suspend fun ensureAuthenticated() {
             val prefs = context.dataStore.data.first()
             val token = prefs[SpotifyAccessTokenKey].orEmpty()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramChannelSync.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramChannelSync.kt
@@ -143,13 +143,21 @@ object TelegramChannelSync {
         // the chat here ensures the message index is warm before we page.
         runCatching { TelegramClient.openChat(chatId) }
             .onFailure { Timber.tag(TAG).w(it, "openChat(%d) failed (non-fatal)", chatId) }
-        // Settle delay: give TDLib time to actually load the chat history into
-        // its local index after OpenChat returns. Without this wait, the first
-        // SearchChatMessages call for a private channel frequently returns an
-        // empty page (no exception) because the history isn't indexed yet —
-        // this was the root cause of "private channel shows empty until I tap
-        // Refresh". The manual Refresh worked because by then enough time had
-        // elapsed for TDLib to finish indexing.
+        // OpenChat on its own only marks the chat as viewed; it does not
+        // guarantee that TDLib has pulled any history from the server. Because
+        // SearchChatMessages is answered out of TDLib's *local* message
+        // database, a freshly added private channel has nothing to search and
+        // returns an empty page with no error — which is why the playlist
+        // materialised empty until "Refresh from Telegram" was tapped.
+        //
+        // primeChatHistory forces the fetch with GetChatHistory and waits until
+        // messages actually land, so the search below has an index to hit. A
+        // false result is not fatal (the channel may genuinely be empty), so we
+        // still fall through to the paging loop.
+        runCatching { TelegramClient.primeChatHistory(chatId) }
+            .onFailure { Timber.tag(TAG).w(it, "primeChatHistory(%d) failed (non-fatal)", chatId) }
+        // Small settle delay so the messages primeChatHistory pulled are fully
+        // committed to the local index before the first search.
         delay(OPEN_CHAT_SETTLE_MS)
 
         val playlistId = playlistId(chatId)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramClient.kt
@@ -18,6 +18,7 @@ package moe.rukamori.archivetune.telegram
 
 import android.content.Context
 import android.os.Build
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,6 +87,15 @@ object TelegramClient {
     /** TDLib download priority for actively-playing streams (1..32, higher = sooner). */
     const val STREAM_DOWNLOAD_PRIORITY = 32
 
+    /**
+     * Messages requested per [primeChatHistory] round. TDLib caps a single
+     * GetChatHistory at 100 and may return fewer while it fetches.
+     */
+    private const val HISTORY_PRIME_LIMIT = 100
+
+    /** Chats returned by the local [TdApi.SearchChats] pass in [searchChannels]. */
+    private const val LOCAL_CHAT_SEARCH_LIMIT = 30
+
     private val lock = Any()
 
     @Volatile
@@ -132,6 +142,10 @@ object TelegramClient {
      * database).
      */
     suspend fun logOut() {
+        // Streaming leaves downloads running past the player's close() so the transfer can
+        // get ahead of playback (see TelegramDataSource.close); they must not outlive the
+        // session being wiped.
+        runCatching { TelegramDataSource.cancelRetainedDownloads() }
         runCatching { send(TdApi.LogOut()) }
             .onFailure { Timber.tag(TAG).w(it, "logOut failed") }
     }
@@ -207,6 +221,12 @@ object TelegramClient {
         }
         runCatching { send(TdApi.SearchPublicChats(trimmed)) }
             .onSuccess { chatIds += it.chatIds.toList() }
+        // SearchPublicChats only ever returns chats with a public username, so a private
+        // channel the user is already a member of could not be found by name at all — the
+        // only way in was to re-paste its invite link. SearchChats searches the user's own
+        // chat list locally, which is exactly where a joined private channel lives.
+        runCatching { send(TdApi.SearchChats(trimmed, LOCAL_CHAT_SEARCH_LIMIT)) }
+            .onSuccess { chatIds += it.chatIds.toList() }
 
         return chatIds.mapNotNull { chatId ->
             runCatching { toChannel(getChat(chatId)) }.getOrNull()
@@ -224,6 +244,62 @@ object TelegramClient {
      */
     suspend fun openChat(chatId: Long) {
         send(TdApi.OpenChat(chatId))
+    }
+
+    /**
+     * Forces TDLib to pull a chat's message history from the server so that a
+     * subsequent [fetchAudioPage] (SearchChatMessages) has something to search.
+     *
+     * `OpenChat` alone is not enough for a private channel that the user has
+     * never scrolled: TDLib's local message database is empty, and
+     * `SearchChatMessages` is answered from that local index, so the first call
+     * returns an empty page with no error. That is why a freshly added private
+     * channel materialised an empty playlist until "Refresh from Telegram" was
+     * tapped — by then TDLib had populated the history in the background.
+     *
+     * `GetChatHistory` is the documented way to force the fetch, and TDLib
+     * deliberately returns fewer messages than requested (often zero on the
+     * first call) while it goes to the network — the documentation says to
+     * repeat the request. This loops until a call returns messages, or until
+     * [maxRounds] is exhausted.
+     *
+     * Returns true when history was observed, false when the chat genuinely has
+     * nothing (or the calls kept failing) — callers can still try to search,
+     * since a false negative here is not fatal.
+     */
+    suspend fun primeChatHistory(
+        chatId: Long,
+        maxRounds: Int = 8,
+        perRoundDelayMs: Long = 400L,
+    ): Boolean {
+        // Getting the chat first makes sure TDLib knows about it at all; for a
+        // channel joined via invite link this is what populates the chat object.
+        runCatching { getChat(chatId) }
+
+        var fromMessageId = 0L
+        repeat(maxRounds) { round ->
+            val messages =
+                runCatching {
+                    // onlyLocal = false → allowed to hit the network.
+                    send(TdApi.GetChatHistory(chatId, fromMessageId, 0, HISTORY_PRIME_LIMIT, false))
+                }.getOrNull()
+
+            val count = messages?.messages?.size ?: 0
+            if (count > 0) {
+                Timber.tag(TAG).d(
+                    "primeChatHistory(%d): round %d loaded %d messages",
+                    chatId,
+                    round + 1,
+                    count,
+                )
+                return true
+            }
+            // Nothing yet — TDLib is still fetching. Wait and ask again.
+            delay(perRoundDelayMs)
+            fromMessageId = 0L
+        }
+        Timber.tag(TAG).w("primeChatHistory(%d): no history after %d rounds", chatId, maxRounds)
+        return false
     }
 
     suspend fun channelInfo(chatId: Long): TelegramChannel? =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramDataSource.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/telegram/TelegramDataSource.kt
@@ -63,6 +63,9 @@ class TelegramDataSource : BaseDataSource(true) {
         runBlocking {
             ensureDownloading(position)
         }
+        // Let this file keep downloading after the player closes the source (see
+        // [close]), evicting whichever files fell out of the retained window.
+        retainDownload(fileId)
 
         bytesRemaining =
             when {
@@ -119,16 +122,31 @@ class TelegramDataSource : BaseDataSource(true) {
 
     override fun getUri(): Uri? = currentUri
 
+    /**
+     * Releases the player's handle on the stream but deliberately leaves TDLib
+     * **downloading**.
+     *
+     * This used to cancel the download, which quietly capped how far ahead of playback
+     * the file could ever get. ExoPlayer stops loading once its buffer is full (60 s of
+     * media here) and closes the data source; cancelling on close meant TDLib stopped
+     * fetching at that same point and only resumed when the buffer drained enough for
+     * the player to reopen. The downloaded prefix therefore tracked playback at a fixed
+     * distance instead of racing ahead, so a lossless track was streamed at roughly its
+     * own bitrate for its entire duration — and any sustained dip in throughput (which,
+     * for a large file on Telegram, is most likely *late* in the transfer) drained the
+     * buffer and stalled playback. That is the "plays fine for the first few minutes,
+     * buffers near the end" report.
+     *
+     * Leaving the download running lets TDLib finish the file well before playback
+     * reaches the end, after which reads are served from local disk and cannot stall.
+     * The number of concurrently retained files is bounded by [retainDownload], and the
+     * bytes land in TDLib's own cache — the same place a completed listen would have
+     * put them — so pause/resume and replays still cost nothing.
+     */
     override fun close() {
         if (opened) {
             opened = false
             transferEnded()
-            val id = fileId
-            runBlocking {
-                // Stop pulling data once the player lets go of the stream; the partial file stays
-                // in TDLib's cache, so resuming later picks up where this left off.
-                TelegramClient.cancelDownload(id)
-            }
         }
         currentUri = null
         mediaId = null
@@ -171,8 +189,16 @@ class TelegramDataSource : BaseDataSource(true) {
     }
 
     /**
-     * Waits until [count] bytes at [offset] are present in TDLib's partial download, then reads
-     * them. Returns fewer bytes near EOF; the overall wait is bounded by the caller's timeout.
+     * Waits until at least one byte at [offset] is present in TDLib's partial download, then
+     * returns as much of the contiguous downloaded run as fits in [count].
+     *
+     * Returning a short read is both legal for a [DataSource] and important here: the previous
+     * implementation waited for the *entire* requested range before handing back any bytes. Near
+     * the end of a track `count` is clamped to `fileSize - offset`, so the condition became
+     * "the whole remainder of the file must be downloaded" — one large ExoPlayer request would
+     * block until the download fully completed, which is what made long lossless files stall
+     * within the last stretch of the song even though bytes were arriving steadily. Serving the
+     * available prefix keeps the renderer fed while the tail downloads.
      */
     private suspend fun awaitAndRead(
         offset: Long,
@@ -190,17 +216,22 @@ class TelegramDataSource : BaseDataSource(true) {
                 if (untilEof <= 0) return ByteArray(0)
                 wanted = minOf(wanted, untilEof)
             }
-            val end = offset + wanted
-            val available =
-                local.isDownloadingCompleted ||
-                    (
-                        local.downloadOffset <= offset &&
-                            local.downloadOffset + local.downloadedPrefixSize >= end
-                    )
-            if (available) {
+            if (local.isDownloadingCompleted) {
                 return TelegramClient.readFilePart(fileId, offset, wanted)
             }
-            if (!local.isDownloadingActive) {
+            // Bytes downloaded so far form the contiguous run
+            // [downloadOffset, downloadOffset + downloadedPrefixSize).
+            val runStart = local.downloadOffset
+            val runEnd = local.downloadOffset + local.downloadedPrefixSize
+            if (runStart <= offset && runEnd > offset) {
+                val available = runEnd - offset
+                return TelegramClient.readFilePart(fileId, offset, minOf(wanted, available))
+            }
+            // The requested position is outside the downloaded run — re-target the
+            // download. Only do this when the download isn't already working toward
+            // us, because DownloadFile with a new offset makes TDLib restart the run
+            // and discard the prefix it had built up.
+            if (!local.isDownloadingActive || runStart > offset) {
                 TelegramClient.startDownload(fileId, offset)
             }
             delay(POLL_INTERVAL_MS)
@@ -215,5 +246,64 @@ class TelegramDataSource : BaseDataSource(true) {
         private const val TAG = "TelegramDataSource"
         private const val READ_TIMEOUT_MS = 40_000L
         private const val POLL_INTERVAL_MS = 150L
+
+        /**
+         * How many Telegram files may keep downloading at once.
+         *
+         * Three covers everything playback legitimately needs in flight: the track being
+         * played, the next one being prefetched, and the previous one (so an immediate
+         * "back" is instant). Anything older is cancelled, which is what keeps a long
+         * skip-heavy session from leaving a pile of downloads running.
+         */
+        private const val MAX_RETAINED_DOWNLOADS = 3
+
+        /** Most-recently-opened first. Guarded by its own monitor. */
+        private val retainedFileIds = LinkedHashSet<Int>()
+
+        /**
+         * Marks [fileId] as the most recently used stream and cancels the downloads of
+         * any files that fall outside [MAX_RETAINED_DOWNLOADS].
+         *
+         * Cancelling only stops the transfer — TDLib keeps whatever it already wrote, so
+         * a cancelled file resumes from its existing prefix if it is opened again.
+         */
+        private fun retainDownload(fileId: Int) {
+            if (fileId <= 0) return
+            val evicted =
+                synchronized(retainedFileIds) {
+                    // Re-inserting moves the id to the most-recent end of the set.
+                    retainedFileIds.remove(fileId)
+                    retainedFileIds.add(fileId)
+                    val overflow = retainedFileIds.size - MAX_RETAINED_DOWNLOADS
+                    if (overflow <= 0) {
+                        emptyList()
+                    } else {
+                        val oldest = retainedFileIds.take(overflow)
+                        retainedFileIds.removeAll(oldest.toSet())
+                        oldest
+                    }
+                }
+            if (evicted.isEmpty()) return
+            runBlocking {
+                evicted.forEach { id ->
+                    Timber.tag(TAG).d("Cancelling retained Telegram download for file %d", id)
+                    TelegramClient.cancelDownload(id)
+                }
+            }
+        }
+
+        /**
+         * Cancels every retained download. Called when the Telegram session itself goes
+         * away (logout) so no transfer outlives the account that authorised it.
+         */
+        suspend fun cancelRetainedDownloads() {
+            val ids =
+                synchronized(retainedFileIds) {
+                    val snapshot = retainedFileIds.toList()
+                    retainedFileIds.clear()
+                    snapshot
+                }
+            ids.forEach { TelegramClient.cancelDownload(it) }
+        }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -439,12 +439,19 @@ fun LyricsEnhanced(
     var positionResetCounter by remember { mutableIntStateOf(0) }
     var isManualScrolling by remember { mutableStateOf(false) }
     var lastManualScrollTime by remember { mutableLongStateOf(0L) }
-    // Keep the scroll state for the whole lyrics session. Recreating it on a
-    // repeat makes the visible list jump to the top, but also disconnects the
-    // running auto-scroll collector from the list that the karaoke view is now
-    // rendering. Only the karaoke subtree needs to be recreated to clear the
-    // library's stale word-progress state.
-    val listState = key(lyricsSessionKey) { rememberLazyListState() }
+    // The scroll state is recreated together with the subtree that owns it.
+    //
+    // The karaoke view is re-keyed on [positionResetCounter] (see the KaraokeLyricsView
+    // call site) because the mocharealm library keeps no per-play state of its own. That
+    // re-key disposes one LazyColumn and composes another; keeping a single hoisted
+    // LazyListState across the swap left the state briefly bound to two lazy layouts and
+    // then owned by the disposed one, so scrolls silently went nowhere and layoutInfo
+    // reported a stale viewport — the list snapped to the first line and then sat there,
+    // which is the "resets on repeat but never animates again, fixed only by reopening
+    // the lyrics" symptom. Recreating the state with its layout keeps the two in step,
+    // and every effect that drives scrolling is keyed on the same counter so they all
+    // observe the live state.
+    val listState = key(lyricsSessionKey, positionResetCounter) { rememberLazyListState() }
 
     LaunchedEffect(lyricsSessionKey) {
         playbackPositionMs.longValue = player.currentPosition.coerceAtLeast(0L)
@@ -488,19 +495,22 @@ fun LyricsEnhanced(
             wasSliderActive = isSliderActive
 
             val rawPosition = (sliderPosition ?: player.currentPosition).coerceAtLeast(0L)
-            // Detect a backward position discontinuity. We only count it as a
-            // reset when the player isn't being scrubbed via the slider (slider
-            // position is null) and the new position is more than 1 second
-            // behind the last seen position — that threshold excludes normal
-            // playback jitter and minor ExoPlayer position corrections but
-            // catches both REPEAT_MODE_ONE wraps (which jump from
-            // duration -> 0) and explicit backward seeks.
-            if (sliderPosition == null &&
-                lastRawPositionMs - rawPosition > POSITION_RESET_BACKWARD_THRESHOLD_MS
-            ) {
+            // Detect a backward position discontinuity, measured against the
+            // PLAYER's clock rather than the slider-provided value. This catches
+            // both REPEAT_MODE_ONE wraps (duration -> 0) and explicit backward
+            // seeks, while the 1s threshold excludes playback jitter and minor
+            // ExoPlayer position corrections.
+            //
+            // This used to additionally require `sliderPosition == null`, which
+            // disabled restart detection entirely in the Apple Music player —
+            // that player always installs a slider provider, so on repeat the
+            // lyrics snapped back to the first line but never re-animated until
+            // the overlay was reopened.
+            val rawPlayerPosition = player.currentPosition.coerceAtLeast(0L)
+            if (lastRawPositionMs - rawPlayerPosition > POSITION_RESET_BACKWARD_THRESHOLD_MS) {
                 positionResetCounter += 1
             }
-            lastRawPositionMs = rawPosition
+            lastRawPositionMs = rawPlayerPosition
             // effectivePositionMs is the synced position (offset + lead +
             // tuning) that we'd otherwise compute via playbackSyncPosition().
                        // Computing it here inline avoids a redundant State read of
@@ -699,13 +709,16 @@ fun LyricsEnhanced(
             }
     }
 
-    // Reset both the visible position and the tracked active line after a
-    // backward discontinuity. The re-keyed auto-scroll collector above then
-    // resumes from the first active line instead of remaining at the line from
-    // the prior play-through.
+    // Clear the tracked active line after a backward discontinuity so the re-keyed
+    // auto-scroll collector above force-scrolls to the first line of the new
+    // play-through instead of treating the previous line index as still current.
+    //
+    // No explicit scroll here: [listState] is recreated alongside the karaoke subtree on
+    // the same counter, so the fresh list already starts at the top. Scrolling the old
+    // state was both redundant and a way to touch a state whose layout was being
+    // disposed.
     LaunchedEffect(positionResetCounter) {
         if (positionResetCounter > 0) {
-            listState.scrollToItem(0)
             currentLineIndexState.intValue = -1
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateListOf
@@ -170,6 +171,13 @@ private const val LYRIC_VISUAL_TUNING_OFFSET_MS = 150L
  * short enough not to lag noticeably behind the audio for typical words.
  */
 private const val MIN_SWEEP_MS = 180L
+
+/**
+ * Backward jump in the player's clock that counts as a restart (REPEAT_MODE_ONE
+ * wrapping from duration back to 0, or an explicit backward seek) rather than
+ * playback jitter or an ExoPlayer position correction.
+ */
+private const val V2_POSITION_RESET_BACKWARD_THRESHOLD_MS = 1_000L
 
 /** Seconds to wait before auto-scroll resumes after manual scroll. */
 private const val MANUAL_SCROLL_TIMEOUT_MS = 3000L
@@ -446,10 +454,21 @@ fun LyricsV2(
             // restart detection never fires. Re-key the word subtree on the
             // actual backward clock discontinuity to give every Animatable a
             // fresh zero value for the next play-through.
-            if (sliderPos == null && lastRawPositionMs - pos > 1_000L) {
+            //
+            // The discontinuity is measured against the PLAYER's clock, not the
+            // value returned by `sliderPositionProvider`. The previous version
+            // additionally required `sliderPos == null`, which silently disabled
+            // repeat detection in the Apple Music player: that player always
+            // installs a slider provider, so the branch never ran. The scroll
+            // still snapped back to the first line (currentLineIndex recomputes
+            // from the position) but every word kept its completed sweep, so the
+            // lyrics sat frozen until the overlay was closed and reopened —
+            // exactly the "resets but never animates" symptom.
+            val rawPlayerPositionMs = player.currentPosition.coerceAtLeast(0L)
+            if (lastRawPositionMs - rawPlayerPositionMs > V2_POSITION_RESET_BACKWARD_THRESHOLD_MS) {
                 playbackResetTick++
             }
-            lastRawPositionMs = pos
+            lastRawPositionMs = rawPlayerPositionMs
 
             playbackPositionMs = (pos + lyricsSyncOffset.toLong()).coerceAtLeast(0L)
             currentPositionMs = (playbackPositionMs + leadMs + LYRIC_VISUAL_TUNING_OFFSET_MS).coerceAtLeast(0L)
@@ -464,7 +483,15 @@ fun LyricsV2(
     }
 
     // ── Scroll State ──
-    val listState = rememberLazyListState()
+    // Recreated on a repeat/backward-seek for the same reason the item keys below include
+    // [playbackResetTick]: that tick changes EVERY item key at once, so the LazyColumn's
+    // bookkeeping (its remembered first-visible key, its item animations, the pending
+    // animateScrollToItem target) all refer to items that no longer exist. Carrying the
+    // old state across that swap left the list anchored to a vanished key while the
+    // position loop kept feeding it a new play-through — visible as lyrics that snap back
+    // to the start and then never move. A fresh state starts cleanly at the top, and the
+    // auto-scroll effect takes over from the first active line.
+    val listState = key(playbackResetTick) { rememberLazyListState() }
     var isManualScrolling by remember { mutableStateOf(false) }
     var lastManualScrollTime by remember { mutableLongStateOf(0L) }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -115,6 +115,7 @@ import moe.rukamori.archivetune.innertube.models.SongItem
 import moe.rukamori.archivetune.jiosaavn.SaavnService
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
+import moe.rukamori.archivetune.qobuz.QobuzBackupProvider
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 import moe.rukamori.archivetune.ui.component.ChipsRow
 import moe.rukamori.archivetune.ui.component.DefaultDialog
@@ -415,20 +416,32 @@ fun PlayerMenu(
                     onSongSourceChange(
                         SongSourceOverride.withOverride(songSourceRaw, mediaMetadata.id, source),
                     )
-                    // For Qobuz: persist the exact trackId so the resolver
-                    // downloads the exact track. For other sources (Tidal/
-                    // JioSaavn/Deezer) the resolver searches by title+artist.
-                    if (source == AudioSourceType.QOBUZ) {
-                        playerConnection.service.setSongSourceOverrideWithQobuzTrackId(
-                            mediaId = mediaMetadata.id,
-                            source = source,
-                            qobuzTrackId = trackId,
-                        )
-                    } else {
-                        playerConnection.service.setSongSourceOverride(
-                            mediaId = mediaMetadata.id,
-                            source = source,
-                        )
+                    // Sources with an addressable per-track id get that id persisted so the
+                    // resolver fetches exactly the row the user tapped:
+                    //   - Qobuz     → catalogue trackId
+                    //   - Qobuz Backup → the mirror's YouTube video id (its primary key)
+                    // For the rest (Tidal / JioSaavn / Deezer) the resolver still searches
+                    // by title + artist, which is all their APIs expose here.
+                    when (source) {
+                        AudioSourceType.QOBUZ ->
+                            playerConnection.service.setSongSourceOverrideWithQobuzTrackId(
+                                mediaId = mediaMetadata.id,
+                                source = source,
+                                qobuzTrackId = trackId,
+                            )
+
+                        AudioSourceType.QOBUZ_BACKUP ->
+                            playerConnection.service.setSongSourceOverrideWithQobuzBackupVideoId(
+                                mediaId = mediaMetadata.id,
+                                source = source,
+                                qobuzBackupVideoId = trackId,
+                            )
+
+                        else ->
+                            playerConnection.service.setSongSourceOverride(
+                                mediaId = mediaMetadata.id,
+                                source = source,
+                            )
                     }
                     showSourceDialog = false
                 }
@@ -1928,17 +1941,25 @@ private fun SongSourceDialog(
     val noResultsText = stringResource(R.string.source_search_no_results)
     val noBackendText = stringResource(R.string.source_search_no_backend)
 
-    // Provider filter → "search backend not yet available" empty state. YTM, Tidal, Qobuz and
-    // JioSaavn are the providers with a usable list-search API right now (Tidal via
-    // searchCandidates, Qobuz via QobuzAudioProvider.searchCandidates, JioSaavn via
-    // SaavnService.searchSongs). Qobuz Backup (kouzu.in) doesn't have a search API — it only
-    // streams by YouTube video id. Deezer has no public list search.
-    val backendMissing =
-        sourceFilter != null &&
-            sourceFilter != AudioSourceType.YOUTUBE &&
-            sourceFilter != AudioSourceType.TIDAL &&
-            sourceFilter != AudioSourceType.QOBUZ &&
-            sourceFilter != AudioSourceType.JIOSAAVN
+    // Provider filter → "search backend not yet available" empty state. These are the
+    // providers with a usable list-search API: YTM, Tidal (searchCandidates), Qobuz
+    // (QobuzAudioProvider.searchCandidates), Qobuz Backup (QobuzBackupProvider.searchCandidates)
+    // and JioSaavn (SaavnService.searchSongs). Deezer still has no public list search.
+    //
+    // Qobuz Backup used to be excluded here on the assumption that the kouzu.in mirror could
+    // only be addressed by YouTube video id. It does expose `GET /api/search`, which returns
+    // its own indexed catalogue, so its rows are searchable and pickable like any other
+    // source's — which is what the "search and select tracks from the Qobuz backup source"
+    // request was about.
+    val searchableSources =
+        setOf(
+            AudioSourceType.YOUTUBE,
+            AudioSourceType.TIDAL,
+            AudioSourceType.QOBUZ,
+            AudioSourceType.QOBUZ_BACKUP,
+            AudioSourceType.JIOSAAVN,
+        )
+    val backendMissing = sourceFilter != null && sourceFilter !in searchableSources
 
     // Debounced search — only fires when searchMode is on and query length >= 2.
     val results by produceState<List<SourceSearchResult>>(
@@ -1956,6 +1977,7 @@ private fun SongSourceDialog(
         val searchYtm = sourceFilter == null || sourceFilter == AudioSourceType.YOUTUBE
         val searchTidal = sourceFilter == null || sourceFilter == AudioSourceType.TIDAL
         val searchQobuz = sourceFilter == null || sourceFilter == AudioSourceType.QOBUZ
+        val searchQobuzBackup = sourceFilter == null || sourceFilter == AudioSourceType.QOBUZ_BACKUP
         val searchSaavn = sourceFilter == null || sourceFilter == AudioSourceType.JIOSAAVN
 
         if (searchYtm) {
@@ -2057,6 +2079,31 @@ private fun SongSourceDialog(
                     }
             }
         }
+        if (searchQobuzBackup) {
+            // The kouzu.in mirror answers with its own catalogue index; every row it
+            // returns is keyed by a YouTube video id, which is both the mirror's primary
+            // key and the source of the row's cover art (no artwork field in the payload).
+            withContext(Dispatchers.IO) {
+                runCatching { QobuzBackupProvider.searchCandidates(searchQuery, limit = 8) }
+                    .getOrDefault(emptyList())
+                    .forEach { candidate ->
+                        out.add(
+                            SourceSearchResult(
+                                source = AudioSourceType.QOBUZ_BACKUP,
+                                trackId = candidate.videoId,
+                                title = candidate.title,
+                                artist = candidate.artist.orEmpty(),
+                                thumbnailUrl = candidate.thumbnailUrl,
+                                // The search payload carries no duration; the row simply
+                                // omits it rather than showing a made-up length.
+                                durationMs = null,
+                                qualityLabel = if (candidate.isLossless) losslessLabel else aacLabel,
+                                songItem = null,
+                            ),
+                        )
+                    }
+            }
+        }
         if (searchSaavn) {
             withContext(Dispatchers.IO) {
                 runCatching { SaavnService.searchSongs(searchQuery).getOrDefault(emptyList()) }
@@ -2131,6 +2178,7 @@ private fun SongSourceDialog(
                             null to stringResource(R.string.source_search_filter_all),
                             AudioSourceType.TIDAL to stringResource(R.string.source_tidal),
                             AudioSourceType.QOBUZ to stringResource(R.string.source_qobuz),
+                            AudioSourceType.QOBUZ_BACKUP to stringResource(R.string.source_qobuz_backup),
                             AudioSourceType.DEEZER to stringResource(R.string.source_deezer),
                             AudioSourceType.JIOSAAVN to stringResource(R.string.source_jiosaavn),
                             AudioSourceType.YOUTUBE to stringResource(R.string.source_youtube),
@@ -2142,6 +2190,7 @@ private fun SongSourceDialog(
                             null to R.drawable.search,
                             AudioSourceType.TIDAL to R.drawable.provider_tidal,
                             AudioSourceType.QOBUZ to R.drawable.provider_qobuz,
+                            AudioSourceType.QOBUZ_BACKUP to R.drawable.provider_qobuz,
                             AudioSourceType.DEEZER to R.drawable.provider_deezer,
                             AudioSourceType.JIOSAAVN to R.drawable.provider_jiosaavn,
                             AudioSourceType.YOUTUBE to R.drawable.play,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -365,7 +365,13 @@ fun SongMenu(
                     }
                 }
                 if (spotifyCanvasEnabled && !song.song.isLocal) {
-                    runCatching { SpotifyCanvasProvider.getByVideoId(song.id) }
+                    runCatching {
+                        SpotifyCanvasProvider.getByVideoId(
+                            videoId = song.id,
+                            songTitle = title,
+                            artistName = artist,
+                        )
+                    }
                         .getOrNull()
                         ?.let { artwork ->
                             artwork.preferredAnimationUrl?.takeIf { it.isNotBlank() }?.let { url ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/CanvasArtworkResolver.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/CanvasArtworkResolver.kt
@@ -69,7 +69,11 @@ internal suspend fun resolveCanvasArtworkForPlayback(
         if (trySpotifyCanvas && strictIdentity) {
             val spotifyCanvas =
                 runCatching {
-                    SpotifyCanvasProvider.getByVideoId(mediaId)
+                    SpotifyCanvasProvider.getByVideoId(
+                        videoId = mediaId,
+                        songTitle = songTitleRaw,
+                        artistName = artistNameRaw,
+                    )
                 }.onFailure { throwable ->
                     Timber.tag(CanvasArtworkLogTag).w(throwable, "Spotify Canvas lookup failed for %s", mediaId)
                 }.getOrNull()
@@ -222,8 +226,13 @@ internal suspend fun fetchAllCanvasSourcesForSong(
     // Spotify Canvas lookup (by video ID) — only for YouTube media (not local/Telegram).
     val spotifyDeferred = async {
         if (strictIdentity && mediaId.isNotBlank()) {
-            runCatching { SpotifyCanvasProvider.getByVideoId(mediaId) }
-                .getOrNull()
+            runCatching {
+                SpotifyCanvasProvider.getByVideoId(
+                    videoId = mediaId,
+                    songTitle = songTitleRaw,
+                    artistName = artistNameRaw,
+                )
+            }.getOrNull()
                 ?.takeIf { it.hasRequiredCanvasVariant(requireVertical = false) }
         } else {
             null

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
@@ -89,6 +89,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AlbumCanvasEnabledKey
 import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.HideExplicitKey
 import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
@@ -151,6 +152,9 @@ fun AlbumScreen(
     val otherVersions by viewModel.otherVersions.collectAsStateWithLifecycle()
     val canvasArtwork by viewModel.canvasArtwork.collectAsStateWithLifecycle()
     val hideExplicit by rememberPreference(key = HideExplicitKey, defaultValue = false)
+    // Appearance → "Enable canvas in albums page". Independent of the player's canvas
+    // toggle; see AlbumCanvasEnabledKey for why.
+    val albumCanvasEnabled by rememberPreference(key = AlbumCanvasEnabledKey, defaultValue = true)
     // Liquid Glass master toggle. When off, the Liquid Glass header pills are not
     // shown and the standard TopAppBar is used instead. The kyant RuntimeShader
     // stack requires Android 12+, so we also gate on SDK_INT.
@@ -374,8 +378,15 @@ fun AlbumScreen(
                         // canvas ExoPlayer is a separate audio-disabled
                         // instance (see CanvasArtworkPlayer), so playing it
                         // has no effect on the main playback queue.
-                        canvasPrimaryUrl = canvasArtwork?.animated ?: canvasArtwork?.videoUrl,
-                        canvasFallbackUrl = canvasArtwork?.videoUrl,
+                        //
+                        // `albumCanvasEnabled` is re-checked here, not just in the view
+                        // model: the fetch is skipped when the preference is off, but a
+                        // canvas already resolved before the user turned it off would
+                        // otherwise keep looping until the page was reopened.
+                        canvasPrimaryUrl =
+                            (canvasArtwork?.animated ?: canvasArtwork?.videoUrl)
+                                ?.takeIf { albumCanvasEnabled },
+                        canvasFallbackUrl = canvasArtwork?.videoUrl?.takeIf { albumCanvasEnabled },
                         canvasIsPlaying = true,
                         // Hide the canvas TextureView (and skip its per-frame
                         // blur RenderEffect) while the lyrics overlay is open.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -421,23 +421,35 @@ fun NavGraphBuilder.navigationBuilder(
     ) {
         AppearanceSettings(navController, it.savedStateHandle["scrollTo"])
     }
-    composable("settings/appearance/extras") {
-        AppearanceExtrasSettings(navController)
+    composable(
+        route = "settings/appearance/extras?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        AppearanceExtrasSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
-    composable("settings/appearance/navigation_bar") {
-        NavigationBarSettings(navController)
+    composable(
+        route = "settings/appearance/navigation_bar?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        NavigationBarSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable("settings/appearance/icon") {
         IconScreen(navController)
     }
-    composable("settings/appearance/aod_customized") {
-        AodCustomizedScreen(navController)
+    composable(
+        route = "settings/appearance/aod_customized?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        AodCustomizedScreen(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable("settings/appearance/palette_picker") {
         PalettePickerScreen(navController)
     }
-    composable("settings/appearance/lyrics_animations") {
-        LyricsAnimationSettings(navController)
+    composable(
+        route = "settings/appearance/lyrics_animations?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        LyricsAnimationSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable("settings/appearance/theme_creator") {
         ThemeCreatorScreen(navController)
@@ -454,11 +466,17 @@ fun NavGraphBuilder.navigationBuilder(
     ) {
         LyricsSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
-    composable("settings/lyrics/providers") {
-        LyricsProvidersSettings(navController)
+    composable(
+        route = "settings/lyrics/providers?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        LyricsProvidersSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
-    composable("settings/lyrics/romanisation") {
-        LyricsRomanisationSettings(navController)
+    composable(
+        route = "settings/lyrics/romanisation?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        LyricsRomanisationSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable("settings/language_packs") {
         LanguagePackSettings(navController)
@@ -490,8 +508,11 @@ fun NavGraphBuilder.navigationBuilder(
     composable("settings/storage/export_songs") {
         ExportDownloadedSongsScreen(navController)
     }
-    composable("settings/player/ytdlp") {
-        YtDlpSettings(navController)
+    composable(
+        route = "settings/player/ytdlp?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        YtDlpSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable(
         route = "settings/downloads?scrollTo={scrollTo}",
@@ -535,11 +556,17 @@ fun NavGraphBuilder.navigationBuilder(
     ) {
         QobuzSettings(navController, it.savedStateHandle["scrollTo"])
     }
-    composable("settings/deezer") {
-        DeezerSettings(navController)
+    composable(
+        route = "settings/deezer?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        DeezerSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
-    composable("settings/jiosaavn") {
-        JioSettings(navController)
+    composable(
+        route = "settings/jiosaavn?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        JioSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable(TIDAL_LOGIN_ROUTE) {
         TidalLoginScreen(navController)
@@ -556,8 +583,11 @@ fun NavGraphBuilder.navigationBuilder(
     composable(LASTFM_LIBREFM_LOGIN_ROUTE) {
         LibreFmLoginScreen(navController)
     }
-    composable("settings/telegram") {
-        TelegramSettings(navController)
+    composable(
+        route = "settings/telegram?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        TelegramSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable(TELEGRAM_LOGIN_ROUTE) {
         TelegramLoginScreen(navController)
@@ -577,8 +607,11 @@ fun NavGraphBuilder.navigationBuilder(
             navController = navController,
         )
     }
-    composable("settings/ai_integration") {
-        AiIntegrationSettings(navController)
+    composable(
+        route = "settings/ai_integration?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
+        AiIntegrationSettings(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable("settings/music_together") {
         MusicTogetherScreen(navController)
@@ -592,9 +625,12 @@ fun NavGraphBuilder.navigationBuilder(
     composable("lastfm_dashboard") {
         LastFmDashboardScreen(navController)
     }
-    composable("settings/discord/experimental") {
+    composable(
+        route = "settings/discord/experimental?scrollTo={scrollTo}",
+        arguments = listOf(navArgument("scrollTo") { type = NavType.StringType; nullable = true; defaultValue = null }),
+    ) {
         moe.rukamori.archivetune.ui.screens.settings
-            .DiscordExperimental(navController)
+            .DiscordExperimental(navController, scrollTo = it.savedStateHandle["scrollTo"])
     }
     composable("settings/misc") {
         DebugSettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
@@ -136,6 +136,7 @@ private enum class TestApiVisualState { Idle, Testing, Success, Failed }
 fun AiIntegrationSettings(
     navController: NavController,
     viewModel: AiIntegrationSettingsViewModel = hiltViewModel(),
+    scrollTo: String? = null,
 ) {
     val context = LocalContext.current
     val actionState by viewModel.actionState.collectAsStateWithLifecycle()
@@ -325,11 +326,16 @@ fun AiIntegrationSettings(
             .only(WindowInsetsSides.Bottom)
             .asPaddingValues()
             .calculateBottomPadding()
+    val scrollState = rememberScrollState()
+    val positions = rememberPreferencePositions()
+    androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
-            .verticalScroll(rememberScrollState())
+            // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+            .then(positions.containerModifier())
+            .verticalScroll(scrollState)
             .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
     ) {
         Spacer(
@@ -341,6 +347,7 @@ fun AiIntegrationSettings(
         PreferenceGroup(title = stringResource(R.string.ai_provider_settings)) {
             item {
                 ListPreference(
+                    modifier = positions.modifierFor("ai_provider"),
                     title = { Text(stringResource(R.string.ai_provider)) },
                     description = stringResource(R.string.ai_provider_desc),
                     icon = { Icon(painterResource(R.drawable.auto_awesome), null) },
@@ -369,6 +376,7 @@ fun AiIntegrationSettings(
 
             item(visible = provider == AiProvider.CUSTOM) {
                 EditTextPreference(
+                    modifier = positions.modifierFor("ai_custom_endpoint"),
                     title = { Text(stringResource(R.string.ai_custom_endpoint)) },
                     icon = { Icon(painterResource(R.drawable.website), null) },
                     value = customEndpoint,
@@ -408,6 +416,7 @@ fun AiIntegrationSettings(
 
             item {
                 PreferenceEntry(
+                    modifier = positions.modifierFor("ai_api_key"),
                     title = { Text(stringResource(R.string.ai_api_key)) },
                     description =
                         if (apiKey.isBlank()) {
@@ -439,6 +448,7 @@ fun AiIntegrationSettings(
 
             item(visible = provider == AiProvider.CUSTOM) {
                 EditTextPreference(
+                    modifier = positions.modifierFor("ai_model"),
                     title = { Text(stringResource(R.string.ai_model)) },
                     icon = { Icon(painterResource(R.drawable.auto_awesome), null) },
                     value = customModel,
@@ -459,6 +469,7 @@ fun AiIntegrationSettings(
                         else -> TestApiVisualState.Idle
                     }
                 PreferenceEntry(
+                    modifier = positions.modifierFor("ai_test_api"),
                     title = { Text(stringResource(R.string.ai_test_api)) },
                     icon = {
                         AnimatedContent(
@@ -538,6 +549,7 @@ fun AiIntegrationSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("hide_ai_mix"),
                     title = { Text(stringResource(R.string.hide_ai_mix)) },
                     description = stringResource(R.string.hide_ai_mix_desc),
                     icon = { Icon(painterResource(R.drawable.auto_awesome), null) },
@@ -548,6 +560,7 @@ fun AiIntegrationSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("auto_translate_lyrics"),
                     title = { Text(stringResource(R.string.auto_translate_lyrics)) },
                     description = stringResource(R.string.auto_translate_lyrics_desc),
                     icon = { Icon(painterResource(R.drawable.translate), null) },
@@ -572,6 +585,7 @@ fun AiIntegrationSettings(
                             .ifEmpty { null }
                     }
                 PreferenceEntry(
+                    modifier = positions.modifierFor("auto_translate_excluded_languages"),
                     title = { Text(stringResource(R.string.auto_translate_excluded_languages)) },
                     description =
                         selectedNames
@@ -590,6 +604,7 @@ fun AiIntegrationSettings(
                 if (provider == AiProvider.DEEPL) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("deepl_api_key"),
                             title = { Text(stringResource(R.string.deepl_api_key)) },
                             description = if (deeplApiKey.isBlank()) stringResource(R.string.deepl_api_key_not_set) else stringResource(R.string.deepl_api_key_set),
                             icon = { Icon(painterResource(R.drawable.token), null) },
@@ -598,6 +613,7 @@ fun AiIntegrationSettings(
                     }
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("deepl_formality"),
                             title = { Text(stringResource(R.string.deepl_formality)) },
                             description = deeplFormality,
                             icon = { Icon(painterResource(R.drawable.text_fields), null) },
@@ -608,6 +624,7 @@ fun AiIntegrationSettings(
                 if (provider == AiProvider.OPENROUTER) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("openrouter_api_key"),
                             title = { Text(stringResource(R.string.openrouter_api_key)) },
                             description = if (openRouterApiKey.isBlank()) stringResource(R.string.openrouter_api_key_not_set) else stringResource(R.string.openrouter_api_key_set),
                             icon = { Icon(painterResource(R.drawable.token), null) },
@@ -636,6 +653,7 @@ fun AiIntegrationSettings(
                 if (provider == AiProvider.MISTRAL) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("mistral_api_key"),
                             title = { Text(stringResource(R.string.mistral_api_key)) },
                             description = if (apiKey.isBlank()) stringResource(R.string.mistral_api_key_not_set) else stringResource(R.string.mistral_api_key_set),
                             icon = { Icon(painterResource(R.drawable.token), null) },
@@ -655,6 +673,7 @@ fun AiIntegrationSettings(
                 // Translation target language + mode shared by DeepL/OpenRouter/Mistral.
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("translate_language"),
                         title = { Text(stringResource(R.string.translate_language)) },
                         description = translateLanguage,
                         icon = { Icon(painterResource(R.drawable.translate), null) },
@@ -663,6 +682,7 @@ fun AiIntegrationSettings(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("translate_mode"),
                         title = { Text(stringResource(R.string.translate_mode)) },
                         description = if (translateMode == "romanize") stringResource(R.string.translate_mode_romanize) else stringResource(R.string.translate_mode_translate),
                         icon = { Icon(painterResource(R.drawable.text_fields), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
@@ -149,7 +149,10 @@ private data class AodPreviewSettings(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AodCustomizedScreen(navController: NavController) {
+fun AodCustomizedScreen(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val scrollBehavior = appBarScrollBehavior()
     val (thumbnailShape, onThumbnailShapeChange) =
         rememberEnumPreference(
@@ -308,7 +311,11 @@ fun AodCustomizedScreen(navController: NavController) {
                 .only(WindowInsetsSides.Bottom)
                 .asPaddingValues()
                 .calculateBottomPadding()
+        val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, listState) }
         LazyColumn(
+            state = listState,
             modifier =
                 Modifier
                     .fillMaxSize()
@@ -317,7 +324,9 @@ fun AodCustomizedScreen(navController: NavController) {
                         LocalPlayerAwareWindowInsets.current.only(
                             WindowInsetsSides.Horizontal,
                         ),
-                    ),
+                    )
+                    // A LazyColumn *is* its own viewport, so the position it reports is the one scrollToKey measures against.
+                    .then(positions.containerModifier()),
             contentPadding = PaddingValues(bottom = playerAwareBottomPadding + 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
@@ -338,6 +347,7 @@ fun AodCustomizedScreen(navController: NavController) {
                 PreferenceGroup(title = stringResource(R.string.aod_customize_visibility)) {
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_thumbnail"),
                             title = { Text(stringResource(R.string.aod_customize_show_thumbnail)) },
                             icon = { Icon(painterResource(R.drawable.image), null) },
                             checked = showThumbnail,
@@ -346,6 +356,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_artist"),
                             title = { Text(stringResource(R.string.aod_customize_show_artist)) },
                             icon = { Icon(painterResource(R.drawable.artist), null) },
                             checked = showArtist,
@@ -354,6 +365,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_album"),
                             title = { Text(stringResource(R.string.aod_customize_show_album)) },
                             icon = { Icon(painterResource(R.drawable.album), null) },
                             checked = showAlbum,
@@ -362,6 +374,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_progress"),
                             title = { Text(stringResource(R.string.aod_customize_show_progress)) },
                             icon = { Icon(painterResource(R.drawable.sliders), null) },
                             checked = showProgress,
@@ -370,6 +383,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item(visible = showProgress) {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_time_labels"),
                             title = { Text(stringResource(R.string.aod_customize_show_time_labels)) },
                             icon = { Icon(painterResource(R.drawable.timer), null) },
                             checked = showTimeLabels,
@@ -378,6 +392,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_controls"),
                             title = { Text(stringResource(R.string.aod_customize_show_controls)) },
                             icon = { Icon(painterResource(R.drawable.buttons), null) },
                             checked = showControls,
@@ -386,6 +401,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_exit_button"),
                             title = { Text(stringResource(R.string.aod_customize_show_exit_button)) },
                             icon = { Icon(painterResource(R.drawable.close), null) },
                             checked = showExitButton,
@@ -394,6 +410,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_show_lyrics"),
                             title = { Text(stringResource(R.string.aod_customize_show_lyrics)) },
                             description = stringResource(R.string.aod_customize_show_lyrics_desc),
                             icon = { Icon(painterResource(R.drawable.lyrics), null) },
@@ -424,6 +441,7 @@ fun AodCustomizedScreen(navController: NavController) {
                 PreferenceGroup(title = stringResource(R.string.aod_customize_layout)) {
                     item {
                         EnumListPreference(
+                            modifier = positions.modifierFor("aod_customize_background_style"),
                             title = { Text(stringResource(R.string.aod_customize_background_style)) },
                             icon = { Icon(painterResource(R.drawable.gradient), null) },
                             selectedValue = backgroundStyle,
@@ -433,6 +451,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         EnumListPreference(
+                            modifier = positions.modifierFor("aod_customize_accent_style"),
                             title = { Text(stringResource(R.string.aod_customize_accent_style)) },
                             icon = { Icon(painterResource(R.drawable.palette), null) },
                             selectedValue = accentStyle,
@@ -442,6 +461,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         EnumListPreference(
+                            modifier = positions.modifierFor("aod_customize_content_position"),
                             title = { Text(stringResource(R.string.aod_customize_content_position)) },
                             icon = { Icon(painterResource(R.drawable.format_align_center), null) },
                             selectedValue = contentPosition,
@@ -451,6 +471,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         EnumListPreference(
+                            modifier = positions.modifierFor("aod_customize_text_alignment"),
                             title = { Text(stringResource(R.string.aod_customize_text_alignment)) },
                             icon = { Icon(painterResource(R.drawable.text_fields), null) },
                             selectedValue = textAlignment,
@@ -477,6 +498,7 @@ fun AodCustomizedScreen(navController: NavController) {
                 PreferenceGroup(title = stringResource(R.string.aod_customize_progress)) {
                     item {
                         EnumListPreference(
+                            modifier = positions.modifierFor("aod_customize_slider_style"),
                             title = { Text(stringResource(R.string.aod_customize_slider_style)) },
                             icon = { Icon(painterResource(R.drawable.style), null) },
                             selectedValue = sliderStyle,
@@ -550,6 +572,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_artwork_glow"),
                             title = { Text(stringResource(R.string.aod_customize_artwork_glow)) },
                             icon = { Icon(painterResource(R.drawable.auto_awesome), null) },
                             checked = artworkGlow,
@@ -566,6 +589,7 @@ fun AodCustomizedScreen(navController: NavController) {
                 PreferenceGroup(title = stringResource(R.string.aod_customize_controls)) {
                     item {
                         EnumListPreference(
+                            modifier = positions.modifierFor("aod_customize_control_style"),
                             title = { Text(stringResource(R.string.aod_customize_control_style)) },
                             icon = { Icon(painterResource(R.drawable.buttons), null) },
                             selectedValue = controlStyle,
@@ -613,6 +637,7 @@ fun AodCustomizedScreen(navController: NavController) {
                     }
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("aod_customize_auto_on_screen_dim"),
                             title = { Text(stringResource(R.string.aod_customize_auto_on_screen_dim)) },
                             description = stringResource(R.string.aod_customize_auto_on_screen_dim_desc),
                             icon = { Icon(painterResource(R.drawable.bedtime), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
@@ -44,7 +44,10 @@ import moe.rukamori.archivetune.utils.rememberPreference
 import androidx.compose.foundation.layout.asPaddingValues
 
 @Composable
-fun AppearanceExtrasSettings(navController: NavController) {
+fun AppearanceExtrasSettings(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val (showHomeCategoryChips, onShowHomeCategoryChipsChange) =
         rememberPreference(ShowHomeCategoryChipsKey, defaultValue = false)
     val (showTagsInLibrary, onShowTagsInLibraryChange) =
@@ -86,6 +89,8 @@ fun AppearanceExtrasSettings(navController: NavController) {
                 .calculateBottomPadding()
         val topPadding = innerPadding.calculateTopPadding()
         val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
@@ -94,12 +99,16 @@ fun AppearanceExtrasSettings(navController: NavController) {
                     LocalPlayerAwareWindowInsets.current.only(
                         WindowInsetsSides.Horizontal,
                     ),
-                ).verticalScroll(scrollState)
+                )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
+                .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
             PreferenceGroup(title = stringResource(R.string.extras)) {
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("show_home_category_chips"),
                         title = { Text(stringResource(R.string.show_home_category_chips)) },
                         description = stringResource(R.string.show_home_category_chips_desc),
                         icon = { Icon(painterResource(R.drawable.home_outlined), null) },
@@ -110,6 +119,7 @@ fun AppearanceExtrasSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("show_tags_in_library"),
                         title = { Text(stringResource(R.string.show_tags_in_library)) },
                         description = stringResource(R.string.show_tags_in_library_desc),
                         icon = { Icon(painterResource(R.drawable.filter_alt), null) },
@@ -120,6 +130,7 @@ fun AppearanceExtrasSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("hide_liked_songs_card"),
                         title = { Text(stringResource(R.string.hide_liked_songs_card)) },
                         description = stringResource(R.string.hide_liked_songs_card_desc),
                         icon = { Icon(painterResource(R.drawable.favorite), null) },
@@ -130,6 +141,7 @@ fun AppearanceExtrasSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("hide_offline_card"),
                         title = { Text(stringResource(R.string.hide_offline_card)) },
                         description = stringResource(R.string.hide_offline_card_desc),
                         icon = { Icon(painterResource(R.drawable.offline), null) },
@@ -140,6 +152,7 @@ fun AppearanceExtrasSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("hide_cached_card"),
                         title = { Text(stringResource(R.string.hide_cached_card)) },
                         description = stringResource(R.string.hide_cached_card_desc),
                         icon = { Icon(painterResource(R.drawable.cached), null) },
@@ -150,6 +163,7 @@ fun AppearanceExtrasSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("hide_local_files_card"),
                         title = { Text(stringResource(R.string.hide_local_files_card)) },
                         description = stringResource(R.string.hide_local_files_card_desc),
                         icon = { Icon(painterResource(R.drawable.snippet_folder), null) },
@@ -160,6 +174,7 @@ fun AppearanceExtrasSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("hide_top50_card"),
                         title = { Text(stringResource(R.string.hide_top50_card)) },
                         description = stringResource(R.string.hide_top50_card_desc),
                         icon = { Icon(painterResource(R.drawable.trending_up), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -70,6 +70,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.AppFontPreference
 import moe.rukamori.archivetune.constants.BackdropBlurAmountKey
+import moe.rukamori.archivetune.constants.AlbumCanvasEnabledKey
 import moe.rukamori.archivetune.constants.BackdropEnabledKey
 import moe.rukamori.archivetune.constants.BlurRadiusKey
 import moe.rukamori.archivetune.constants.ChipSortTypeKey
@@ -221,6 +222,8 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
         )
     val (blurRadius, onBlurRadiusChange) = rememberPreference(BlurRadiusKey, defaultValue = 48f)
     val (backdropEnabled, onBackdropEnabledChange) = rememberPreference(BackdropEnabledKey, defaultValue = true)
+    val (albumCanvasEnabled, onAlbumCanvasEnabledChange) =
+        rememberPreference(AlbumCanvasEnabledKey, defaultValue = true)
     val (backdropBlurAmount, onBackdropBlurAmountChange) = rememberPreference(BackdropBlurAmountKey, defaultValue = 60)
     val (fontPreference, onFontPreferenceChange) =
         rememberEnumPreference(
@@ -450,6 +453,8 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -493,6 +498,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = !dynamicTheme || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                     SwitchPreference(
+                        modifier = positions.modifierFor("random_theme_on_startup"),
                         title = { Text(stringResource(R.string.random_theme_on_startup)) },
                         description = stringResource(R.string.random_theme_on_startup_desc),
                         icon = { Icon(painterResource(R.drawable.shuffle), null) },
@@ -504,6 +510,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 item(visible = !dynamicTheme || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
                     Column(modifier = positions.modifierFor("color_palette")) {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("palette_picker"),
                             title = { Text(stringResource(R.string.color_palette)) },
                             description = stringResource(R.string.customize_theme_colors),
                             icon = { Icon(painterResource(R.drawable.format_paint), null) },
@@ -564,6 +571,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("disable_animations"),
                         title = { Text(stringResource(R.string.disable_animations)) },
                         description = stringResource(R.string.disable_animations_desc),
                         icon = { Icon(painterResource(R.drawable.animation), null) },
@@ -649,6 +657,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("backdrop_blur_amount"),
                         title = { Text(stringResource(R.string.backdrop_blur_amount)) },
                         description = stringResource(R.string.backdrop_blur_amount_value, backdropBlurAmount),
                         icon = { Icon(painterResource(R.drawable.blur_on), null) },
@@ -670,6 +679,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 item {
                     Column(modifier = positions.modifierFor("font_preference")) {
                         EnumListPreference(
+                            modifier = positions.modifierFor("use_system_font"),
                             title = { Text(stringResource(R.string.font_preference)) },
                             description = stringResource(R.string.font_preference_desc),
                             icon = { Icon(painterResource(R.drawable.text_fields), null) },
@@ -696,6 +706,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                             customFontUri
                         }
                     PreferenceEntry(
+                        modifier = positions.modifierFor("custom_font"),
                         title = { Text(stringResource(R.string.custom_font)) },
                         description = customFontDescription,
                         icon = { Icon(painterResource(R.drawable.text_fields), null) },
@@ -736,6 +747,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("show_player_volume_bar"),
                         title = { Text(stringResource(R.string.show_player_volume_bar)) },
                         description =
                             if (isVolumeBarSupported) {
@@ -794,6 +806,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 item {
                     Column(modifier = positions.modifierFor("lyrics_background_style")) {
                         ListPreference(
+                            modifier = positions.modifierFor("lyrics_background_style"),
                             title = { Text(stringResource(R.string.lyrics_background_style)) },
                             icon = { Icon(painterResource(R.drawable.lyrics), null) },
                             selectedValue = lyricsBackground,
@@ -828,6 +841,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = playerBackground == PlayerBackgroundStyle.CUSTOM) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("customized_background"),
                         title = { Text(stringResource(R.string.customized_background)) },
                         icon = { Icon(painterResource(R.drawable.image), null) },
                         onClick = { navController.navigate("customize_background") },
@@ -902,6 +916,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("hide_player_thumbnail"),
                         title = { Text(stringResource(R.string.hide_player_thumbnail)) },
                         description = stringResource(R.string.hide_player_thumbnail_desc),
                         icon = { Icon(painterResource(R.drawable.hide_image), null) },
@@ -918,6 +933,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("crop_thumbnail_to_square"),
                         title = { Text(stringResource(R.string.crop_thumbnail_to_square)) },
                         description = stringResource(R.string.crop_thumbnail_to_square_desc),
                         icon = { Icon(painterResource(R.drawable.image), null) },
@@ -975,11 +991,28 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
             }
 
             PreferenceGroup(
+                modifier = positions.modifierFor("album_page"),
+                title = stringResource(R.string.album_page),
+            ) {
+                item {
+                    SwitchPreference(
+                        modifier = positions.modifierFor("album_canvas_enabled"),
+                        title = { Text(stringResource(R.string.album_canvas_enabled)) },
+                        description = stringResource(R.string.album_canvas_enabled_desc),
+                        icon = { Icon(painterResource(R.drawable.album), null) },
+                        checked = albumCanvasEnabled,
+                        onCheckedChange = onAlbumCanvasEnabledChange,
+                    )
+                }
+            }
+
+            PreferenceGroup(
                 modifier = positions.modifierFor("app_language"),
                 title = stringResource(R.string.misc),
             ) {
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("tablet_mode"),
                         title = { Text(stringResource(R.string.tablet_mode)) },
                         description = stringResource(R.string.tablet_mode_desc),
                         icon = { Icon(painterResource(R.drawable.desktop_windows), null) },
@@ -990,6 +1023,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("minimal_home_mode"),
                         title = { Text(stringResource(R.string.minimal_home_mode)) },
                         description = stringResource(R.string.minimal_home_mode_desc),
                         icon = { Icon(painterResource(R.drawable.home_outlined), null) },
@@ -1010,6 +1044,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("hide_scrollbar"),
                         title = { Text(stringResource(R.string.hide_scrollbar)) },
                         description = stringResource(R.string.hide_scrollbar_desc),
                         icon = { Icon(painterResource(R.drawable.filter_alt), null) },
@@ -1020,6 +1055,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("navigation_bar_settings"),
                         title = { Text(stringResource(R.string.navigation_bar_settings_title)) },
                         description = stringResource(R.string.navigation_bar_settings_subtitle),
                         icon = { Icon(painterResource(R.drawable.tune), null) },
@@ -1047,6 +1083,7 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("default_lib_chips"),
                         title = { Text(stringResource(R.string.default_lib_chips)) },
                         icon = { Icon(painterResource(R.drawable.tab), null) },
                         selectedValue = defaultChip,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -298,6 +298,8 @@ fun BackupAndRestore(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -399,6 +401,7 @@ fun BackupAndRestore(
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("restore"),
                         title = { Text(stringResource(R.string.action_restore)) },
                         description = stringResource(R.string.restore_select_backup),
                         icon = { Icon(painterResource(R.drawable.restore), null) },
@@ -408,6 +411,7 @@ fun BackupAndRestore(
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("import_online"),
                         title = { Text(stringResource(R.string.import_online)) },
                         description = stringResource(R.string.import_m3u_format),
                         icon = { Icon(painterResource(R.drawable.playlist_import), null) },
@@ -417,6 +421,7 @@ fun BackupAndRestore(
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("import_csv"),
                         title = { Text(stringResource(R.string.import_csv)) },
                         description = stringResource(R.string.import_csv_format),
                         icon = { Icon(painterResource(R.drawable.playlist_add), null) },
@@ -626,6 +631,7 @@ private fun ScheduledBackupSection(
     ) {
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("scheduled_backup_enabled"),
                 title = { Text(stringResource(R.string.scheduled_backup_enabled)) },
                 description =
                     stringResource(
@@ -644,6 +650,7 @@ private fun ScheduledBackupSection(
 
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("scheduled_backup_frequency"),
                 title = { Text(stringResource(R.string.scheduled_backup_frequency)) },
                 description =
                     if (data.frequency == ScheduledBackupFrequency.CUSTOM && data.customDateLabel != null) {
@@ -661,6 +668,7 @@ private fun ScheduledBackupSection(
 
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("scheduled_backup_directory"),
                 title = { Text(stringResource(R.string.scheduled_backup_directory)) },
                 description =
                     data.directoryName
@@ -673,6 +681,7 @@ private fun ScheduledBackupSection(
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("scheduled_backup_overwrite"),
                 title = { Text(stringResource(R.string.scheduled_backup_overwrite)) },
                 description = stringResource(R.string.scheduled_backup_overwrite_description),
                 icon = { Icon(painterResource(R.drawable.backup), contentDescription = null) },
@@ -847,6 +856,7 @@ private fun GoogleDriveSyncSection(
         }
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("google_drive_sync_remote_folder"),
                 title = { Text(stringResource(R.string.google_drive_sync_remote_folder)) },
                 description =
                     when {
@@ -864,6 +874,7 @@ private fun GoogleDriveSyncSection(
         if (folderConfigured) {
             item {
                 PreferenceEntry(
+                    modifier = positions.modifierFor("google_drive_sync_clear_folder"),
                     title = { Text(stringResource(R.string.google_drive_sync_clear_folder)) },
                     description = stringResource(R.string.google_drive_sync_clear_folder_description),
                     icon = { Icon(painterResource(R.drawable.close), contentDescription = null) },
@@ -875,6 +886,7 @@ private fun GoogleDriveSyncSection(
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("google_drive_sync_enabled"),
                 title = { Text(stringResource(R.string.google_drive_sync_enabled)) },
                 description =
                     stringResource(
@@ -893,6 +905,7 @@ private fun GoogleDriveSyncSection(
 
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("google_drive_sync_frequency"),
                 title = { Text(stringResource(R.string.scheduled_backup_frequency)) },
                 description =
                     if (data.frequency == ScheduledBackupFrequency.CUSTOM && data.customDateLabel != null) {
@@ -910,6 +923,7 @@ private fun GoogleDriveSyncSection(
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("google_drive_sync_overwrite"),
                 title = { Text(stringResource(R.string.google_drive_sync_overwrite)) },
                 description = stringResource(R.string.google_drive_sync_overwrite_description),
                 icon = { Icon(painterResource(R.drawable.backup), contentDescription = null) },
@@ -921,6 +935,7 @@ private fun GoogleDriveSyncSection(
 
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("google_drive_sync_run_now"),
                 title = { Text(stringResource(R.string.google_drive_sync_run_now)) },
                 description =
                     when {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
@@ -120,6 +120,8 @@ fun ContentSettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal))
+            // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+            .then(positions.containerModifier())
             .verticalScroll(scrollState)
             .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
     ) {
@@ -156,6 +158,7 @@ fun ContentSettings(
 
             item {
                 ListPreference(
+                    modifier = positions.modifierFor("content_country"),
                     title = { Text(stringResource(R.string.content_country)) },
                     icon = { Icon(painterResource(R.drawable.location_on), null) },
                     selectedValue = contentCountry,
@@ -181,6 +184,7 @@ fun ContentSettings(
 
             item {
                 ListPreference(
+                    modifier = positions.modifierFor("you_might_like_source"),
                     title = { Text(stringResource(R.string.you_might_like_source)) },
                     icon = { Icon(painterResource(R.drawable.playlist_play), null) },
                     selectedValue = playlistSuggestionSource,
@@ -203,6 +207,7 @@ fun ContentSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("hide_explicit"),
                     title = { Text(stringResource(R.string.hide_explicit)) },
                     icon = { Icon(painterResource(R.drawable.explicit), null) },
                     checked = hideExplicit,
@@ -212,6 +217,7 @@ fun ContentSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("hide_video"),
                     title = { Text(stringResource(R.string.hide_video)) },
                     icon = { Icon(painterResource(R.drawable.slow_motion_video), null) },
                     checked = hideVideo,
@@ -221,6 +227,7 @@ fun ContentSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("allow_age_restricted"),
                     title = { Text(stringResource(R.string.allow_age_restricted)) },
                     description = stringResource(R.string.allow_age_restricted_summary),
                     icon = { Icon(painterResource(R.drawable.login), null) },
@@ -236,6 +243,7 @@ fun ContentSettings(
             onIncludeModerateChange = viewModel::setAiContentFilterIncludeModerate,
             onRefresh = viewModel::refreshAiContentFilter,
             onOpenSource = viewModel::openAiContentFilterSource,
+            positions = positions,
         )
 
         PreferenceGroup(
@@ -286,6 +294,7 @@ fun ContentSettings(
         ) {
             item {
                 EditTextPreference(
+                    modifier = positions.modifierFor("ai_content_filter"),
                     title = { Text(stringResource(R.string.top_length)) },
                     icon = { Icon(painterResource(R.drawable.trending_up), null) },
                     value = lengthTop,
@@ -331,6 +340,7 @@ private fun AiContentFilterPreferences(
     onIncludeModerateChange: (Boolean) -> Unit,
     onRefresh: () -> Unit,
     onOpenSource: () -> Unit,
+    positions: PreferencePositions,
 ) {
     PreferenceGroup(title = stringResource(R.string.ai_content_filter)) {
         when (state) {
@@ -364,6 +374,7 @@ private fun AiContentFilterPreferences(
                 val model = state.model
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("ai_content_filter_hide"),
                         title = { Text(stringResource(R.string.ai_content_filter_hide)) },
                         description = stringResource(R.string.ai_content_filter_hide_summary),
                         icon = { Icon(painterResource(R.drawable.auto_awesome), null) },
@@ -373,6 +384,7 @@ private fun AiContentFilterPreferences(
                 }
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("ai_content_filter_moderate"),
                         title = { Text(stringResource(R.string.ai_content_filter_moderate)) },
                         description = stringResource(R.string.ai_content_filter_moderate_summary),
                         icon = { Icon(painterResource(R.drawable.filter_alt), null) },
@@ -383,6 +395,7 @@ private fun AiContentFilterPreferences(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ai_content_filter_update"),
                         title = { Text(stringResource(R.string.ai_content_filter_update)) },
                         description =
                             if (model.refreshing) {
@@ -401,6 +414,7 @@ private fun AiContentFilterPreferences(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ai_content_filter_source"),
                         title = { Text(stringResource(R.string.ai_content_filter_source)) },
                         description = stringResource(R.string.ai_content_filter_source_summary),
                         icon = { Icon(painterResource(R.drawable.info), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
@@ -46,7 +46,10 @@ import androidx.compose.foundation.layout.asPaddingValues
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DeezerSettings(navController: NavController) {
+fun DeezerSettings(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val context = LocalContext.current
 
     val (accountName, onAccountNameChange) = rememberPreference(DeezerAccountNameKey, "")
@@ -79,11 +82,15 @@ fun DeezerSettings(navController: NavController) {
                 .calculateBottomPadding()
         val topPadding = innerPadding.calculateTopPadding()
         val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + 16.dp),
         ) {
@@ -93,6 +100,7 @@ fun DeezerSettings(navController: NavController) {
                 if (accountName.isEmpty()) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("deezer_login"),
                             title = { Text(stringResource(R.string.deezer_login)) },
                             description = stringResource(R.string.deezer_login_description),
                             icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
@@ -102,6 +110,7 @@ fun DeezerSettings(navController: NavController) {
                 } else {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("deezer_sign_out"),
                             title = { Text(stringResource(R.string.deezer_sign_out)) },
                             description = stringResource(R.string.deezer_signed_in_as, accountName),
                             icon = { Icon(painterResource(R.drawable.logout), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordExperimental.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordExperimental.kt
@@ -34,7 +34,10 @@ private val DiscordExperimentalButtonUrlOptions =
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DiscordExperimental(navController: NavController) {
+fun DiscordExperimental(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val context = LocalContext.current
     val languages = remember(context) { TranslatorLanguages.load(context) }
     val languageCodes = remember(languages) { languages.map { it.code } }
@@ -92,6 +95,10 @@ fun DiscordExperimental(navController: NavController) {
             defaultValue = "https://github.com/rukamori/ArchiveTune",
         )
 
+    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val positions = rememberPreferencePositions()
+    androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, listState) }
+
     Scaffold { inner ->
         Column(Modifier.fillMaxSize()) {
             TopAppBar(
@@ -104,7 +111,9 @@ fun DiscordExperimental(navController: NavController) {
             )
 
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
+                state = listState,
+                // A LazyColumn *is* its own viewport, so the position it reports is the one scrollToKey measures against.
+                modifier = Modifier.fillMaxSize().then(positions.containerModifier()),
                 contentPadding =
                     PaddingValues(
                         bottom = inner.calculateBottomPadding() + 80.dp,
@@ -115,6 +124,7 @@ fun DiscordExperimental(navController: NavController) {
                     PreferenceGroup(title = stringResource(R.string.translator_options)) {
                         item {
                             SwitchPreference(
+                                modifier = positions.modifierFor("enable_translator", "translate_lyrics"),
                                 title = { Text(stringResource(R.string.enable_translator)) },
                                 description = stringResource(R.string.enable_translator_desc),
                                 icon = { Icon(painterResource(R.drawable.translate), null) },
@@ -135,6 +145,7 @@ fun DiscordExperimental(navController: NavController) {
 
                         item(visible = translatorEnabled) {
                             ListPreference(
+                                modifier = positions.modifierFor("target_language"),
                                 title = { Text(stringResource(R.string.target_language)) },
                                 icon = { Icon(painterResource(R.drawable.translate), null) },
                                 selectedValue = translatorTargetLang,
@@ -150,6 +161,7 @@ fun DiscordExperimental(navController: NavController) {
                     PreferenceGroup(title = stringResource(R.string.discord_button_options)) {
                         item {
                             SwitchPreference(
+                                modifier = positions.modifierFor("discord_show_button_1"),
                                 title = { Text(stringResource(R.string.show_button)) },
                                 description = stringResource(R.string.show_button1_description),
                                 icon = { Icon(painterResource(R.drawable.buttons), null) },
@@ -160,6 +172,7 @@ fun DiscordExperimental(navController: NavController) {
 
                         item(visible = button1Enabled) {
                             ListPreference(
+                                modifier = positions.modifierFor("discord_activity_button_1_url"),
                                 title = { Text(stringResource(R.string.discord_activity_button_1_url)) },
                                 icon = { Icon(painterResource(R.drawable.link), null) },
                                 selectedValue = button1UrlSource,
@@ -191,6 +204,7 @@ fun DiscordExperimental(navController: NavController) {
 
                         item {
                             SwitchPreference(
+                                modifier = positions.modifierFor("discord_show_button_2"),
                                 title = { Text(stringResource(R.string.show_button)) },
                                 description = stringResource(R.string.show_button2_description),
                                 icon = { Icon(painterResource(R.drawable.buttons), null) },
@@ -201,6 +215,7 @@ fun DiscordExperimental(navController: NavController) {
 
                         item(visible = button2Enabled) {
                             ListPreference(
+                                modifier = positions.modifierFor("discord_activity_button_2_url"),
                                 title = { Text(stringResource(R.string.discord_activity_button_2_url)) },
                                 icon = { Icon(painterResource(R.drawable.link), null) },
                                 selectedValue = button2UrlSource,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
@@ -462,6 +462,8 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
                             WindowInsetsSides.Horizontal,
                         ),
                     )
+                    // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                    .then(positions.containerModifier())
                     .verticalScroll(scrollState)
                     .padding(
                         top = innerPadding.calculateTopPadding() + 16.dp,
@@ -547,6 +549,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("activity_status"),
                         title = { Text(stringResource(R.string.activity_status)) },
                         icon = { Icon(painterResource(R.drawable.status), null) },
                         selectedValue = activityStatusSelection,
@@ -558,6 +561,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("platform_status"),
                         title = { Text(stringResource(R.string.platform_status)) },
                         icon = { Icon(painterResource(R.drawable.desktop_windows), null) },
                         selectedValue = platformSelection,
@@ -574,6 +578,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     EnumListPreference(
+                        modifier = positions.modifierFor("discord_activity_name"),
                         title = { Text(stringResource(R.string.discord_activity_name)) },
                         selectedValue = nameSource,
                         onValueSelected = onNameSourceChange,
@@ -583,6 +588,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
                 }
                 item {
                     EnumListPreference(
+                        modifier = positions.modifierFor("discord_activity_details"),
                         title = { Text(stringResource(R.string.discord_activity_details)) },
                         selectedValue = detailsSource,
                         onValueSelected = onDetailsSourceChange,
@@ -592,6 +598,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
                 }
                 item {
                     EnumListPreference(
+                        modifier = positions.modifierFor("discord_activity_state"),
                         title = { Text(stringResource(R.string.discord_activity_state)) },
                         selectedValue = stateSource,
                         onValueSelected = onStateSourceChange,
@@ -602,6 +609,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("discord_show_when_paused"),
                         title = { Text(stringResource(R.string.discord_show_when_paused)) },
                         description = stringResource(R.string.discord_show_when_paused_desc),
                         icon = { Icon(painterResource(R.drawable.ic_pause_white), null) },
@@ -612,6 +620,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("discord_activity_type"),
                         title = { Text(stringResource(R.string.discord_activity_type)) },
                         icon = { Icon(painterResource(R.drawable.discord), null) },
                         selectedValue = activityType,
@@ -628,6 +637,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("large_image"),
                         title = { Text(stringResource(R.string.large_image)) },
                         icon = { Icon(painterResource(R.drawable.image), null) },
                         selectedValue = largeImageType,
@@ -649,6 +659,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("large_text"),
                         title = { Text(stringResource(R.string.large_text)) },
                         icon = { Icon(painterResource(R.drawable.text_fields), null) },
                         selectedValue = largeTextSource,
@@ -670,6 +681,7 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("small_image"),
                         title = { Text(stringResource(R.string.small_image)) },
                         icon = { Icon(painterResource(R.drawable.image), null) },
                         selectedValue = smallImageType,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
@@ -177,6 +177,8 @@ fun DownloadsSettings(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -186,6 +188,7 @@ fun DownloadsSettings(
             ) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("clear_all_downloads"),
                         title = { Text(stringResource(R.string.clear_all_downloads)) },
                         description = stringResource(R.string.clear_downloads_dialog),
                         icon = {
@@ -199,6 +202,7 @@ fun DownloadsSettings(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("export_downloaded_songs"),
                         title = { Text(stringResource(R.string.export_downloaded_songs)) },
                         description = stringResource(R.string.export_downloaded_songs_description),
                         icon = {
@@ -262,6 +266,7 @@ fun DownloadsSettings(
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("external_downloader_package"),
                         title = { Text(stringResource(R.string.external_downloader_package)) },
                         description = externalDownloaderPackage.ifEmpty { stringResource(R.string.external_downloader_package_desc) },
                         icon = { Icon(painterResource(R.drawable.integration), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -112,6 +112,8 @@ fun IntegrationScreen(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -138,6 +140,7 @@ fun IntegrationScreen(
             ) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("discord_account"),
                         title = { Text(stringResource(R.string.discord_integration)) },
                         icon = { Icon(painterResource(R.drawable.discord), null) },
                         onClick = {
@@ -161,6 +164,7 @@ fun IntegrationScreen(
                 if (manualSourceLogin) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("tidal"),
                             title = { Text(stringResource(R.string.tidal_integration)) },
                             description = stringResource(R.string.tidal_integration_description),
                             icon = { Icon(painterResource(R.drawable.provider_tidal), null) },
@@ -172,6 +176,7 @@ fun IntegrationScreen(
 
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("qobuz"),
                             title = { Text(stringResource(R.string.qobuz_integration)) },
                             description = stringResource(R.string.qobuz_integration_description),
                             icon = { Icon(painterResource(R.drawable.provider_qobuz), null) },
@@ -183,6 +188,7 @@ fun IntegrationScreen(
 
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("deezer"),
                             title = { Text(stringResource(R.string.deezer_integration)) },
                             description = stringResource(R.string.deezer_integration_description),
                             icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
@@ -195,6 +201,7 @@ fun IntegrationScreen(
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("telegram"),
                         title = { Text(stringResource(R.string.telegram_integration)) },
                         description = stringResource(R.string.telegram_integration_description),
                         icon = { Icon(painterResource(R.drawable.provider_telegram), null) },
@@ -210,7 +217,12 @@ fun IntegrationScreen(
             // "Music Sources" makes the distinction clear: Music Sources feed the player,
             // External Sources feed the Library (playlist sync, scrobbling, etc.).
             PreferenceGroup(
-                modifier = positions.modifierFor("external_sources"),
+                // Also carries "spotify": Spotify is the only account in this group, so a search
+                // hit on it scrolls here. Chaining is safe — modifierFor only records a position.
+                modifier =
+                    positions
+                        .modifierFor("external_sources")
+                        .then(positions.modifierFor("spotify")),
                 title = stringResource(R.string.external_sources),
             ) {
                 spotifyAccountPreferences(
@@ -236,6 +248,7 @@ fun IntegrationScreen(
             ) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("lastfm_account"),
                         title = { Text(stringResource(R.string.lastfm_integration)) },
                         icon = { Icon(painterResource(R.drawable.token), null) },
                         onClick = {
@@ -256,6 +269,7 @@ fun IntegrationScreen(
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("listenbrainz_token"),
                         title = {
                             Text(
                                 if (listenBrainzToken.isBlank()) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -220,6 +220,8 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -335,6 +337,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("dns_over_https"),
                         title = { Text(stringResource(R.string.dns_over_https)) },
                         description = stringResource(R.string.dns_over_https_desc),
                         icon = { Icon(painterResource(R.drawable.security), null) },
@@ -345,6 +348,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = dnsOverHttpsEnabled) {
                     ListPreference(
+                        modifier = positions.modifierFor("dns_provider"),
                         title = { Text(stringResource(R.string.dns_provider)) },
                         icon = { Icon(painterResource(R.drawable.website), null) },
                         selectedValue = dnsProvider,
@@ -356,6 +360,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = dnsOverHttpsEnabled && dnsProvider == "Custom") {
                     EditTextPreference(
+                        modifier = positions.modifierFor("dns_custom_url"),
                         title = { Text(stringResource(R.string.dns_custom_url)) },
                         value = customDnsUrl,
                         onValueChange = onCustomDnsUrlChange,
@@ -381,6 +386,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = proxyEnabled) {
                     ListPreference(
+                        modifier = positions.modifierFor("proxy_type"),
                         title = { Text(stringResource(R.string.proxy_type)) },
                         selectedValue = proxyType,
                         values = proxyTypes,
@@ -394,6 +400,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = proxyEnabled) {
                     EditTextPreference(
+                        modifier = positions.modifierFor("proxy_host"),
                         title = { Text(stringResource(R.string.proxy_host)) },
                         value = proxyHost,
                         onValueChange = {
@@ -405,6 +412,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = proxyEnabled) {
                     NumberEditTextPreference(
+                        modifier = positions.modifierFor("proxy_port"),
                         title = { Text(stringResource(R.string.proxy_port)) },
                         value = proxyPort,
                         onValueChange = {
@@ -420,6 +428,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
                 PreferenceGroup(title = stringResource(R.string.proxy_auth)) {
                     item {
                         EditTextPreference(
+                            modifier = positions.modifierFor("proxy_username"),
                             title = { Text(stringResource(R.string.proxy_username)) },
                             value = proxyUsername,
                             onValueChange = {
@@ -431,6 +440,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                     item {
                         EditTextPreference(
+                            modifier = positions.modifierFor("proxy_password"),
                             title = { Text(stringResource(R.string.proxy_password)) },
                             value = proxyPassword,
                             onValueChange = {
@@ -442,6 +452,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                     item {
                         SwitchPreference(
+                            modifier = positions.modifierFor("stream_bypass_proxy"),
                             title = { Text(stringResource(R.string.stream_bypass_proxy)) },
                             description = stringResource(R.string.stream_bypass_proxy_desc),
                             icon = { Icon(painterResource(R.drawable.wifi_proxy), null) },
@@ -455,6 +466,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("test_proxy"),
                             title = { Text(stringResource(R.string.test_proxy_connection)) },
                             icon = { Icon(painterResource(R.drawable.check), null) },
                             onClick = {
@@ -524,6 +536,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     IpRotationPreference(
+                        modifier = positions.modifierFor("ip_rotation"),
                         title = { Text(stringResource(R.string.ip_rotation)) },
                         description = ipRotationDescription,
                         icon = { Icon(painterResource(R.drawable.wifi_proxy), null) },
@@ -593,6 +606,7 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun IpRotationPreference(
+    modifier: Modifier = Modifier,
     title: @Composable () -> Unit,
     description: String,
     icon: @Composable () -> Unit,
@@ -602,6 +616,7 @@ private fun IpRotationPreference(
     onRefresh: () -> Unit,
 ) {
     PreferenceEntry(
+        modifier = modifier,
         title = title,
         description = description,
         icon = icon,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/JioSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/JioSettings.kt
@@ -52,7 +52,10 @@ import moe.rukamori.archivetune.utils.rememberPreference
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun JioSettings(navController: NavController) {
+fun JioSettings(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val (saavnEnabled, onSaavnEnabledChange) = rememberPreference(JioSaavnEnabledKey, false)
     val (saavnQuality, onSaavnQualityChange) =
         rememberEnumPreference(SaavnAudioQualityKey, SaavnAudioQuality.QUALITY_320)
@@ -80,11 +83,15 @@ fun JioSettings(navController: NavController) {
                 .calculateBottomPadding()
         val topPadding = innerPadding.calculateTopPadding()
         val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + 16.dp),
         ) {
@@ -101,6 +108,7 @@ fun JioSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("jiosaavn_enable"),
                         title = { Text(stringResource(R.string.jiosaavn_enable)) },
                         description = stringResource(R.string.jiosaavn_enable_description),
                         icon = { Icon(painterResource(R.drawable.play), null) },
@@ -111,6 +119,7 @@ fun JioSettings(navController: NavController) {
 
                 item {
                     EnumListPreference(
+                        modifier = positions.modifierFor("jiosaavn_audio_quality"),
                         title = { Text(stringResource(R.string.jiosaavn_audio_quality)) },
                         icon = { Icon(painterResource(R.drawable.play), null) },
                         selectedValue = saavnQuality,
@@ -125,6 +134,7 @@ fun JioSettings(navController: NavController) {
             PreferenceGroup(title = stringResource(R.string.jiosaavn_credit_title)) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("jiosaavn_credit"),
                         title = { Text(stringResource(R.string.jiosaavn_credit)) },
                         description = stringResource(R.string.jiosaavn_credit_description),
                         icon = { Icon(painterResource(R.drawable.info), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
@@ -181,6 +181,8 @@ private fun LastFmSettingsContent(
         Modifier
             .padding(top = topPadding)
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+            // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+            .then(positions.containerModifier())
             .verticalScroll(scrollState)
             .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
     ) {
@@ -322,6 +324,7 @@ private fun LastFmSettingsSuccess(
         // password fields — the baked-in LastFmAppCredentials identifies the app.
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("lastfm_connect_button"),
                 title = { Text(stringResource(R.string.lastfm_connect_button)) },
                 description = stringResource(R.string.lastfm_connect_button_description),
                 icon = { Icon(painterResource(R.drawable.login), null) },
@@ -338,6 +341,7 @@ private fun LastFmSettingsSuccess(
         // Libre.fm instead of Last.fm.
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("lastfm_connect_librefm_button"),
                 title = { Text(stringResource(R.string.lastfm_connect_librefm_button)) },
                 description = stringResource(R.string.lastfm_connect_librefm_button_description),
                 icon = { Icon(painterResource(R.drawable.login), null) },
@@ -353,6 +357,7 @@ private fun LastFmSettingsSuccess(
         // entered values.
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("lastfm_connect_custom_button"),
                 title = { Text(stringResource(R.string.lastfm_connect_custom_button)) },
                 description = stringResource(R.string.lastfm_connect_custom_button_description),
                 icon = { Icon(painterResource(R.drawable.token), null) },
@@ -390,6 +395,7 @@ private fun LastFmSettingsSuccess(
     ) {
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("enable_scrobbling"),
                 title = { Text(stringResource(R.string.enable_scrobbling)) },
                 checked = model.scrobblingEnabled,
                 onCheckedChange = onScrobblingChange,
@@ -399,6 +405,7 @@ private fun LastFmSettingsSuccess(
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("lastfm_now_playing"),
                 title = { Text(stringResource(R.string.lastfm_now_playing)) },
                 checked = model.nowPlayingEnabled,
                 onCheckedChange = onNowPlayingChange,
@@ -408,6 +415,7 @@ private fun LastFmSettingsSuccess(
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("lastfm_prefer_yt_thumbnails"),
                 title = { Text(stringResource(R.string.lastfm_prefer_yt_thumbnails)) },
                 description = stringResource(R.string.lastfm_prefer_yt_thumbnails_desc),
                 checked = preferYtThumbnails,
@@ -422,6 +430,7 @@ private fun LastFmSettingsSuccess(
     ) {
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("scrobble_min_track_duration"),
                 title = { Text(stringResource(R.string.scrobble_min_track_duration)) },
                 description = stringResource(R.string.duration_seconds_short, model.minTrackDurationSeconds),
                 onClick = { onOpenTimingEditor(LastFmTimingSetting.MIN_TRACK_DURATION) },
@@ -430,6 +439,7 @@ private fun LastFmSettingsSuccess(
 
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("scrobble_delay_percent"),
                 title = { Text(stringResource(R.string.scrobble_delay_percent)) },
                 description =
                     stringResource(
@@ -442,6 +452,7 @@ private fun LastFmSettingsSuccess(
 
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("scrobble_delay_minutes"),
                 title = { Text(stringResource(R.string.scrobble_delay_minutes)) },
                 description = stringResource(R.string.duration_seconds_short, model.scrobbleDelaySeconds),
                 onClick = { onOpenTimingEditor(LastFmTimingSetting.DELAY_SECONDS) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
@@ -43,7 +43,10 @@ import androidx.compose.foundation.layout.asPaddingValues
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LyricsAnimationSettings(navController: NavController) {
+fun LyricsAnimationSettings(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val (bounceFactor, onBounceFactorChange) = rememberPreference(LyricsV2BounceFactorKey, defaultValue = 1f)
     val (glowFactor, onGlowFactorChange) = rememberPreference(LyricsV2GlowFactorKey, defaultValue = 1f)
     val (fillTransitionWidth, onFillTransitionWidthChange) = rememberPreference(LyricsV2FillTransitionWidthKey, defaultValue = 8f)
@@ -74,12 +77,17 @@ fun LyricsAnimationSettings(navController: NavController) {
                 .asPaddingValues()
                 .calculateBottomPadding()
         val topPadding = innerPadding.calculateTopPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
 
         Column(
             modifier =
                 Modifier
                     .padding(top = topPadding)
-                    .verticalScroll(rememberScrollState())
+                    // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                    .then(positions.containerModifier())
+                    .verticalScroll(scrollState)
                     .windowInsetsPadding(
                         LocalPlayerAwareWindowInsets.current.only(
                             WindowInsetsSides.Horizontal,
@@ -89,6 +97,7 @@ fun LyricsAnimationSettings(navController: NavController) {
             PreferenceGroup(title = "Animation Tuning") {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("lyrics_animation_style"),
                         title = { Text("Line Bounce Effect") },
                         description = "Enable bounce animation for line-synced (LRC) lyrics",
                         icon = { Icon(painterResource(R.drawable.animation), null) },
@@ -103,6 +112,7 @@ fun LyricsAnimationSettings(navController: NavController) {
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("lyrics_scale_animation"),
                         title = { Text("Bounce Amplitude") },
                         description = "Adjust the bounce effect when a word is sung (${(bounceFactor * 100).toInt()}%)",
                         icon = { Icon(painterResource(R.drawable.animation), null) },
@@ -118,6 +128,7 @@ fun LyricsAnimationSettings(navController: NavController) {
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("lyrics_glow_animation"),
                         title = { Text("Glow Intensity") },
                         description = "Adjust the glow brightness of the sung word (${(glowFactor * 100).toInt()}%)",
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
@@ -133,6 +144,7 @@ fun LyricsAnimationSettings(navController: NavController) {
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("lyrics_fade_animation"),
                         title = { Text("Fill Transition Smoothness") },
                         description = "Adjust the gradient edge width of the liquid fill effect (${fillTransitionWidth.toInt()} dp)",
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsProvidersSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsProvidersSettings.kt
@@ -9,28 +9,36 @@
 
 package moe.rukamori.archivetune.ui.screens.settings
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -63,6 +71,8 @@ import moe.rukamori.archivetune.constants.LyricsProviderOrderKey
 import moe.rukamori.archivetune.constants.PreferredLyricsProvider
 import moe.rukamori.archivetune.constants.PrioritizeWordSyncedLyricsKey
 import moe.rukamori.archivetune.constants.deserializeLyricsProviderOrder
+import moe.rukamori.archivetune.paxsenix.PaxsenixLyrics
+import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -71,6 +81,7 @@ import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.viewmodels.ContentSettingsViewModel
+import moe.rukamori.archivetune.viewmodels.PaxsenixEndpointCheckState
 import moe.rukamori.archivetune.viewmodels.PaxsenixStatsState
 import androidx.compose.foundation.layout.asPaddingValues
 
@@ -89,6 +100,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 fun LyricsProvidersSettings(
     navController: NavController,
     viewModel: ContentSettingsViewModel = hiltViewModel(),
+    scrollTo: String? = null,
 ) {
     val (enableLrclib, onEnableLrclibChange) = rememberPreference(key = EnableLrcLibKey, defaultValue = true)
     val (enableKugou, onEnableKugouChange) = rememberPreference(key = EnableKugouKey, defaultValue = true)
@@ -107,13 +119,13 @@ fun LyricsProvidersSettings(
     val (enablePaxsenixAppleMusicLyrics, onEnablePaxsenixAppleMusicLyricsChange) =
         rememberPreference(key = EnablePaxsenixAppleMusicLyricsKey, defaultValue = true)
     val (enablePaxsenixNeteaseLyrics, onEnablePaxsenixNeteaseLyricsChange) =
-        rememberPreference(key = EnablePaxsenixNeteaseLyricsKey, defaultValue = true)
+        rememberPreference(key = EnablePaxsenixNeteaseLyricsKey, defaultValue = false)
     val (enablePaxsenixSpotifyLyrics, onEnablePaxsenixSpotifyLyricsChange) =
-        rememberPreference(key = EnablePaxsenixSpotifyLyricsKey, defaultValue = true)
+        rememberPreference(key = EnablePaxsenixSpotifyLyricsKey, defaultValue = false)
     val (enablePaxsenixMusixmatchLyrics, onEnablePaxsenixMusixmatchLyricsChange) =
-        rememberPreference(key = EnablePaxsenixMusixmatchLyricsKey, defaultValue = true)
+        rememberPreference(key = EnablePaxsenixMusixmatchLyricsKey, defaultValue = false)
     val (enablePaxsenixYouTubeLyrics, onEnablePaxsenixYouTubeLyricsChange) =
-        rememberPreference(key = EnablePaxsenixYouTubeLyricsKey, defaultValue = true)
+        rememberPreference(key = EnablePaxsenixYouTubeLyricsKey, defaultValue = false)
     val (paxsenixApiKey, onPaxsenixApiKeyChange) =
         rememberPreference(key = PaxsenixApiKeyKey, defaultValue = "")
     val (paxsenixEndpoint, onPaxsenixEndpointChange) =
@@ -137,6 +149,7 @@ fun LyricsProvidersSettings(
 
     var showPaxsenixStatsDialog by remember { mutableStateOf(false) }
     var showProviderOrderDialog by remember { mutableStateOf(false) }
+    var showPaxsenixEndpointCheckDialog by remember { mutableStateOf(false) }
 
     if (showPaxsenixStatsDialog) {
         val statsState by viewModel.paxsenixStatsState.collectAsStateWithLifecycle()
@@ -147,6 +160,18 @@ fun LyricsProvidersSettings(
             state = statsState,
             onDismiss = { showPaxsenixStatsDialog = false },
             onRetry = { viewModel.fetchPaxsenixStats() },
+        )
+    }
+
+    if (showPaxsenixEndpointCheckDialog) {
+        val checkState by viewModel.paxsenixEndpointCheckState.collectAsStateWithLifecycle()
+        androidx.compose.runtime.LaunchedEffect(Unit) {
+            viewModel.checkPaxsenixEndpoints()
+        }
+        PaxsenixEndpointCheckDialog(
+            state = checkState,
+            onDismiss = { showPaxsenixEndpointCheckDialog = false },
+            onRetry = { viewModel.checkPaxsenixEndpoints() },
         )
     }
 
@@ -186,6 +211,8 @@ fun LyricsProvidersSettings(
                 .asPaddingValues()
                 .calculateBottomPadding()
         val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
         Column(
             Modifier
                 .padding(top = innerPadding.calculateTopPadding())
@@ -194,6 +221,8 @@ fun LyricsProvidersSettings(
                         WindowInsetsSides.Horizontal,
                     ),
                 )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -205,6 +234,7 @@ fun LyricsProvidersSettings(
                 // first makes the override relationship visually obvious.
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("prioritize_word_synced_lyrics"),
                         title = { Text(stringResource(R.string.prioritize_word_synced_lyrics)) },
                         description = stringResource(R.string.prioritize_word_synced_lyrics_desc),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
@@ -224,6 +254,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_betterlyrics", "betterlyrics"),
                         title = { Text(stringResource(R.string.enable_betterlyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableBetterLyrics,
@@ -234,6 +265,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_betterlyrics_portato", "betterlyrics_portato"),
                         title = { Text(stringResource(R.string.enable_betterlyrics_portato)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableBetterLyricsPortato,
@@ -244,6 +276,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_youlyplus_lyrics", "youlyplus_lyrics"),
                         title = { Text(stringResource(R.string.enable_youlyplus_lyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableYouLyPlusLyrics,
@@ -254,6 +287,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_lrclib", "lrclib"),
                         title = { Text(stringResource(R.string.enable_lrclib)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableLrclib,
@@ -264,6 +298,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_kugou", "kugou"),
                         title = { Text(stringResource(R.string.enable_kugou)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableKugou,
@@ -274,6 +309,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_unison_lyrics", "unison_lyrics"),
                         title = { Text(stringResource(R.string.enable_unison_lyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableUnisonLyrics,
@@ -284,6 +320,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_simpmusic_lyrics", "simpmusic_lyrics"),
                         title = { Text(stringResource(R.string.enable_simpmusic_lyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableSimpMusicLyrics,
@@ -294,6 +331,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_megalobiz_lyrics", "megalobiz_lyrics"),
                         title = { Text(stringResource(R.string.enable_megalobiz_lyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableMegalobizLyrics,
@@ -304,6 +342,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_paxsenix_lyrics", "paxsenix_lyrics"),
                         title = { Text(stringResource(R.string.enable_paxsenix_lyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enablePaxsenixLyrics,
@@ -314,6 +353,7 @@ fun LyricsProvidersSettings(
 
                 item(visible = enablePaxsenixLyrics) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("paxsenix_stats"),
                         title = { Text(stringResource(R.string.paxsenix_stats)) },
                         icon = { Icon(painterResource(R.drawable.stats), null) },
                         onClick = { showPaxsenixStatsDialog = true },
@@ -327,6 +367,7 @@ fun LyricsProvidersSettings(
                 item(visible = enablePaxsenixLyrics) {
                     var showApiKeyDialog by remember { mutableStateOf(false) }
                     PreferenceEntry(
+                        modifier = positions.modifierFor("paxsenix_api_key"),
                         title = { Text(stringResource(R.string.paxsenix_api_key)) },
                         description = if (paxsenixApiKey.isNotBlank()) {
                             stringResource(R.string.paxsenix_api_key_set)
@@ -354,6 +395,7 @@ fun LyricsProvidersSettings(
                 item(visible = enablePaxsenixLyrics) {
                     var showEndpointDialog by remember { mutableStateOf(false) }
                     PreferenceEntry(
+                        modifier = positions.modifierFor("paxsenix_endpoint"),
                         title = { Text(stringResource(R.string.paxsenix_endpoint)) },
                         description = paxsenixEndpoint.ifBlank {
                             stringResource(R.string.paxsenix_endpoint_default)
@@ -366,6 +408,7 @@ fun LyricsProvidersSettings(
                         TextFieldDialog(
                             onDismiss = { showEndpointDialog = false },
                             title = { Text(stringResource(R.string.paxsenix_endpoint)) },
+                            placeholder = { Text(stringResource(R.string.paxsenix_endpoint_hint)) },
                             textFieldValue = paxsenixEndpoint,
                             onTextFieldValueChange = onPaxsenixEndpointChange,
                             singleLine = true,
@@ -376,6 +419,23 @@ fun LyricsProvidersSettings(
                             },
                         )
                     }
+                }
+
+                // Which per-provider Paxsenix paths the configured endpoint actually serves.
+                // Upstream has retired most of them (unconditional 403), which from inside the
+                // app is indistinguishable from a wrong endpoint or a bad key — every affected
+                // provider simply returns nothing. This makes the difference visible, and it
+                // probes whatever endpoint is configured, so a self-hosted instance reports its
+                // own coverage rather than the public service's.
+                item(visible = enablePaxsenixLyrics) {
+                    PreferenceEntry(
+                        modifier = positions.modifierFor("paxsenix_check_endpoints"),
+                        title = { Text(stringResource(R.string.paxsenix_check_endpoints)) },
+                        description = stringResource(R.string.paxsenix_check_endpoints_description),
+                        icon = { Icon(painterResource(R.drawable.wifi_proxy), null) },
+                        onClick = { showPaxsenixEndpointCheckDialog = true },
+                        isEnabled = providerTogglesEnabled,
+                    )
                 }
 
                 item(visible = enablePaxsenixLyrics) {
@@ -391,6 +451,7 @@ fun LyricsProvidersSettings(
                 item(visible = enablePaxsenixLyrics) {
                     SwitchPreference(
                         title = { Text("Paxsenix: NetEase") },
+                        description = stringResource(R.string.paxsenix_endpoint_retired),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enablePaxsenixNeteaseLyrics,
                         onCheckedChange = onEnablePaxsenixNeteaseLyricsChange,
@@ -401,6 +462,7 @@ fun LyricsProvidersSettings(
                 item(visible = enablePaxsenixLyrics) {
                     SwitchPreference(
                         title = { Text("Paxsenix: Spotify") },
+                        description = stringResource(R.string.paxsenix_endpoint_retired),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enablePaxsenixSpotifyLyrics,
                         onCheckedChange = onEnablePaxsenixSpotifyLyricsChange,
@@ -411,6 +473,7 @@ fun LyricsProvidersSettings(
                 item(visible = enablePaxsenixLyrics) {
                     SwitchPreference(
                         title = { Text("Paxsenix: Musixmatch") },
+                        description = stringResource(R.string.paxsenix_endpoint_retired),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enablePaxsenixMusixmatchLyrics,
                         onCheckedChange = onEnablePaxsenixMusixmatchLyricsChange,
@@ -421,6 +484,7 @@ fun LyricsProvidersSettings(
                 item(visible = enablePaxsenixLyrics) {
                     SwitchPreference(
                         title = { Text("Paxsenix: YouTube") },
+                        description = stringResource(R.string.paxsenix_endpoint_retired),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enablePaxsenixYouTubeLyrics,
                         onCheckedChange = onEnablePaxsenixYouTubeLyricsChange,
@@ -430,6 +494,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_tidal_lyrics"),
                         title = { Text(stringResource(R.string.enable_tidal_lyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableTidalLyrics,
@@ -440,6 +505,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_deezer_lyrics"),
                         title = { Text(stringResource(R.string.enable_deezer_lyrics)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = enableDeezerLyrics,
@@ -450,6 +516,7 @@ fun LyricsProvidersSettings(
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("set_first_lyrics_provider", "first_lyrics_provider"),
                         title = { Text(stringResource(R.string.set_first_lyrics_provider)) },
                         description = providerOrder.firstOrNull()?.displayName(),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
@@ -462,6 +529,7 @@ fun LyricsProvidersSettings(
             PreferenceGroup(title = stringResource(R.string.musixmatch_experimental_section)) {
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_musixmatch_experimental"),
                         title = { Text(stringResource(R.string.enable_musixmatch_experimental)) },
                         description = stringResource(R.string.enable_musixmatch_experimental_desc),
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
@@ -482,6 +550,122 @@ fun LyricsProvidersSettings(
                             color = MaterialTheme.colorScheme.onErrorContainer,
                             modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
                         )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Shows, per Paxsenix provider, whether the configured endpoint still serves its route.
+ *
+ * The three outcomes are deliberately distinct: a provider can be *available*, *retired
+ * upstream* (the service answers 403 for that route no matter what key is sent — turning its
+ * toggle on cannot help), or *unreachable* (network/DNS/5xx, which may be temporary). Only the
+ * middle case means "stop expecting this provider to ever work on this endpoint".
+ */
+@Composable
+private fun PaxsenixEndpointCheckDialog(
+    state: PaxsenixEndpointCheckState,
+    onDismiss: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    DefaultDialog(
+        onDismiss = onDismiss,
+        title = { Text(stringResource(R.string.paxsenix_check_endpoints)) },
+        icon = { Icon(painterResource(R.drawable.wifi_proxy), contentDescription = null) },
+        buttons = {
+            if (state is PaxsenixEndpointCheckState.Success) {
+                TextButton(onClick = onRetry) {
+                    Text(stringResource(R.string.retry))
+                }
+            }
+            Spacer(Modifier.weight(1f))
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+    ) {
+        when (state) {
+            PaxsenixEndpointCheckState.Idle,
+            PaxsenixEndpointCheckState.Running,
+            -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        LoadingIndicator()
+                    }
+                    Text(
+                        text = stringResource(R.string.paxsenix_check_running),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            is PaxsenixEndpointCheckState.Success -> {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    state.results.forEach { result ->
+                        val label =
+                            when (result.status) {
+                                PaxsenixLyrics.PathStatus.AVAILABLE ->
+                                    stringResource(R.string.paxsenix_check_result_ok, result.provider)
+
+                                PaxsenixLyrics.PathStatus.RETIRED ->
+                                    stringResource(R.string.paxsenix_check_result_retired, result.provider)
+
+                                PaxsenixLyrics.PathStatus.UNREACHABLE ->
+                                    stringResource(R.string.paxsenix_check_result_failed, result.provider)
+                            }
+                        val tint =
+                            when (result.status) {
+                                PaxsenixLyrics.PathStatus.AVAILABLE -> MaterialTheme.colorScheme.primary
+                                PaxsenixLyrics.PathStatus.RETIRED -> MaterialTheme.colorScheme.error
+                                PaxsenixLyrics.PathStatus.UNREACHABLE -> MaterialTheme.colorScheme.onSurfaceVariant
+                            }
+                        val iconRes =
+                            when (result.status) {
+                                PaxsenixLyrics.PathStatus.AVAILABLE -> R.drawable.check
+                                PaxsenixLyrics.PathStatus.RETIRED -> R.drawable.error
+                                PaxsenixLyrics.PathStatus.UNREACHABLE -> R.drawable.info
+                            }
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            Icon(
+                                painterResource(iconRes),
+                                contentDescription = null,
+                                tint = tint,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = label,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = tint,
+                                )
+                                Text(
+                                    text = result.path,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsRomanisationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsRomanisationSettings.kt
@@ -52,7 +52,10 @@ import androidx.compose.foundation.layout.asPaddingValues
  * matching the original inline implementation.
  */
 @Composable
-fun LyricsRomanisationSettings(navController: NavController) {
+fun LyricsRomanisationSettings(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val (lyricsRomanizeJapanese, onLyricsRomanizeJapaneseChange) =
         rememberPreference(LyricsRomanizeJapaneseKey, defaultValue = false)
     val (lyricsRomanizeKorean, onLyricsRomanizeKoreanChange) =
@@ -90,6 +93,8 @@ fun LyricsRomanisationSettings(navController: NavController) {
                 .asPaddingValues()
                 .calculateBottomPadding()
         val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
         Column(
             Modifier
                 .padding(top = innerPadding.calculateTopPadding())
@@ -98,12 +103,15 @@ fun LyricsRomanisationSettings(navController: NavController) {
                         WindowInsetsSides.Horizontal,
                     ),
                 )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
             PreferenceGroup(title = stringResource(R.string.romanization)) {
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("lyrics_romanize_japanese"),
                         title = { Text(stringResource(R.string.lyrics_romanize_japanese)) },
                         description =
                             if (japaneseLanguagePackState is JapaneseLanguagePackState.Installed) {
@@ -120,6 +128,7 @@ fun LyricsRomanisationSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("lyrics_romanize_korean"),
                         title = { Text(stringResource(R.string.lyrics_romanize_korean)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeKorean,
@@ -129,6 +138,7 @@ fun LyricsRomanisationSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("lyrics_romanize_chinese"),
                         title = { Text(stringResource(R.string.lyrics_romanize_chinese)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeChinese,
@@ -138,6 +148,7 @@ fun LyricsRomanisationSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("lyrics_romanize_hindi"),
                         title = { Text(stringResource(R.string.lyrics_romanize_hindi)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeHindi,
@@ -147,6 +158,7 @@ fun LyricsRomanisationSettings(navController: NavController) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("lyrics_romanize_other_languages", "lyrics_romanize_other"),
                         title = { Text(stringResource(R.string.lyrics_romanize_other_languages)) },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeOtherLanguages,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -232,6 +232,8 @@ fun LyricsSettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+            // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+            .then(positions.containerModifier())
             .verticalScroll(scrollState)
             .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
@@ -395,6 +397,7 @@ fun LyricsSettings(
         ) {
             item {
                 PreferenceEntry(
+                    modifier = positions.modifierFor("providers"),
                     title = { Text(stringResource(R.string.providers)) },
                     description = stringResource(R.string.settings_lyrics_providers_subtitle),
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
@@ -411,6 +414,7 @@ fun LyricsSettings(
         ) {
             item {
                 PreferenceEntry(
+                    modifier = positions.modifierFor("romanization"),
                     title = { Text(stringResource(R.string.romanization)) },
                     description = stringResource(R.string.settings_lyrics_romanisation_subtitle),
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
@@ -425,6 +429,7 @@ fun LyricsSettings(
         ) {
             item {
                 EnumListPreference(
+                    modifier = positions.modifierFor("lyrics_mode", "use_lyrics_v2"),
                     title = { Text(stringResource(R.string.lyrics_mode)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     selectedValue = lyricsMode,
@@ -442,6 +447,7 @@ fun LyricsSettings(
                 val animationSettingsEnabled = lyricsMode == LyricsMode.V2
 
                 PreferenceEntry(
+                    modifier = positions.modifierFor("lyrics_animation_style"),
                     title = { Text(stringResource(R.string.lyrics_animation_style)) },
                     description = if (animationSettingsEnabled) null else stringResource(R.string.lyrics_animation_style_v2_only),
                     icon = { Icon(painterResource(R.drawable.animation), null) },
@@ -452,6 +458,7 @@ fun LyricsSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("lyrics_click"),
                     title = { Text(stringResource(R.string.lyrics_click_change)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = lyricsClick,
@@ -461,6 +468,7 @@ fun LyricsSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("lyrics_scroll"),
                     title = { Text(stringResource(R.string.lyrics_auto_scroll)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = lyricsScroll,
@@ -469,6 +477,7 @@ fun LyricsSettings(
             }
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("show_lyrics_player_controls"),
                     title = { Text(stringResource(R.string.show_lyrics_player_controls)) },
                     icon = { Icon(painterResource(R.drawable.play), null) },
                     checked = showPlayerControls,
@@ -478,6 +487,7 @@ fun LyricsSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("auto_hide_lyrics_player_controls"),
                     title = { Text(stringResource(R.string.auto_hide_lyrics_player_controls)) },
                     description = stringResource(R.string.auto_hide_lyrics_player_controls_description),
                     icon = { Icon(painterResource(R.drawable.timer), null) },
@@ -490,6 +500,7 @@ fun LyricsSettings(
 
             item {
                 SwitchPreference(
+                    modifier = positions.modifierFor("lyrics_line_blur"),
                     title = { Text(stringResource(R.string.lyrics_line_blur)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     checked = lyricsLineBlur,
@@ -499,6 +510,7 @@ fun LyricsSettings(
 
             item {
                 PreferenceEntry(
+                    modifier = positions.modifierFor("lyrics_text_size"),
                     title = { Text(stringResource(R.string.lyrics_text_size)) },
                     description = "${lyricsTextSize.roundToInt()} sp",
                     icon = { Icon(painterResource(R.drawable.text_fields), null) },
@@ -508,6 +520,7 @@ fun LyricsSettings(
 
             item {
                 PreferenceEntry(
+                    modifier = positions.modifierFor("lyrics_line_spacing"),
                     title = { Text(stringResource(R.string.lyrics_line_spacing)) },
                     description = "${String.format("%.1f", lyricsLineSpacing)}x",
                     icon = { Icon(painterResource(R.drawable.text_fields), null) },
@@ -532,6 +545,7 @@ fun LyricsSettings(
             // shows "Off" when 0.
             item {
                 NumberPickerPreference(
+                    modifier = positions.modifierFor("preload_queue_lyrics"),
                     title = { Text(stringResource(R.string.preload_queue_lyrics)) },
                     icon = { Icon(painterResource(R.drawable.lyrics), null) },
                     value = queueLyricsPreloadCount,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
@@ -187,7 +187,10 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                     LocalPlayerAwareWindowInsets.current.only(
                         WindowInsetsSides.Horizontal,
                     ),
-                ).verticalScroll(scrollState)
+                )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
+                .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
             PreferenceGroup(title = stringResource(R.string.general)) {
@@ -213,6 +216,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                 item {
                     Column {
                         SwitchPreference(
+                            modifier = positions.modifierFor("navigation_bar_frosted_blur"),
                             title = { Text(stringResource(R.string.navigation_bar_frosted_blur)) },
                             description = stringResource(R.string.navigation_bar_frosted_blur_desc),
                             icon = { Icon(painterResource(R.drawable.blur_on), null) },
@@ -233,6 +237,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                 item {
                     Column {
                         SwitchPreference(
+                            modifier = positions.modifierFor("navigation_bar_tint_frosted_blur"),
                             title = { Text(stringResource(R.string.navigation_bar_tint_frosted_blur)) },
                             description = stringResource(R.string.navigation_bar_tint_frosted_blur_desc),
                             icon = { Icon(painterResource(R.drawable.blur_on), null) },
@@ -253,6 +258,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                 item {
                     Column {
                         SwitchPreference(
+                            modifier = positions.modifierFor("liquid_glass_nav_bar"),
                             title = { Text(stringResource(R.string.liquid_glass_nav_bar)) },
                             description = stringResource(R.string.liquid_glass_nav_bar_desc),
                             icon = { Icon(painterResource(R.drawable.blur_on), null) },
@@ -302,7 +308,10 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
             // dialog with a live preview that reflects the in-progress value (and the
             // committed values of the other dimensions) so the user can see exactly how
             // the bar will look before committing.
-            PreferenceGroup(title = stringResource(R.string.navigation_bar_dimensions)) {
+            PreferenceGroup(
+                modifier = positions.modifierFor("navigation_bar_dimensions"),
+                title = stringResource(R.string.navigation_bar_dimensions),
+            ) {
                 item {
                     SliderPreferenceRow(
                         title = stringResource(R.string.navigation_bar_width),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -121,9 +121,16 @@ private fun AudioSourceType.iconRes(): Int =
  * Renders all streaming-source preference groups inline in the caller's scrolling Column. Meant to
  * be called from [PlayerSettings]. Emits, in order: the common "Sources" group (preferred-source
  * picker + YouTube history sync), then YouTube, Tidal and Qobuz specific groups.
+ *
+ * [positions] belongs to the *host* screen: these rows are searchable, and settings search deep
+ * links to them with `?scrollTo=<key>`, which only resolves if the anchors register against the
+ * scroll state the host owns.
  */
 @Composable
-fun PlaybackSourceSections(navController: NavController) {
+fun PlaybackSourceSections(
+    navController: NavController,
+    positions: PreferencePositions,
+) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -223,6 +230,7 @@ fun PlaybackSourceSections(navController: NavController) {
     PreferenceGroup(title = stringResource(R.string.playback_sources)) {
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("preferred_sources"),
                 title = { Text(stringResource(R.string.preferred_sources)) },
                 description = preferred.displayName(context),
                 icon = { Icon(painterResource(preferred.iconRes()), null) },
@@ -233,6 +241,7 @@ fun PlaybackSourceSections(navController: NavController) {
     PreferenceGroup(title = stringResource(R.string.catalog_sources)) {
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("default_metadata_source"),
                 title = { Text(stringResource(R.string.default_metadata_source)) },
                 description = stringResource(R.string.default_metadata_source_desc),
                 icon = { Icon(painterResource(R.drawable.album), null) },
@@ -249,6 +258,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("default_search_source"),
                 title = { Text(stringResource(R.string.default_search_source)) },
                 description = stringResource(R.string.default_search_source_desc),
                 icon = { Icon(painterResource(R.drawable.language), null) },
@@ -265,6 +275,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("spotify_catalog_source"),
                 title = { Text(stringResource(R.string.spotify_catalog_source)) },
                 description = stringResource(R.string.spotify_catalog_source_desc),
                 icon = { Icon(painterResource(R.drawable.spotify_icon), null) },
@@ -294,6 +305,7 @@ fun PlaybackSourceSections(navController: NavController) {
         }
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("auto_choose_playback_client"),
                 title = { Text(stringResource(R.string.auto_choose_playback_client)) },
                 description =
                     stringResource(
@@ -312,6 +324,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             ListPreference(
+                modifier = positions.modifierFor("player_stream_client"),
                 title = { Text(stringResource(R.string.player_stream_client)) },
                 description = stringResource(R.string.player_stream_client_desc),
                 icon = { Icon(painterResource(R.drawable.integration), null) },
@@ -361,6 +374,7 @@ fun PlaybackSourceSections(navController: NavController) {
     PreferenceGroup(title = stringResource(R.string.tidal_specific)) {
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("tidal_enable"),
                 title = { Text(stringResource(R.string.tidal_enable)) },
                 description = stringResource(R.string.tidal_enable_description),
                 icon = { Icon(painterResource(R.drawable.provider_tidal), null) },
@@ -371,6 +385,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("tidal_account_first"),
                 title = { Text(stringResource(R.string.tidal_account_first)) },
                 description = stringResource(R.string.tidal_account_first_description),
                 icon = { Icon(painterResource(R.drawable.token), null) },
@@ -382,6 +397,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("tidal_audio_quality"),
                 title = { Text(stringResource(R.string.tidal_audio_quality)) },
                 icon = { Icon(painterResource(R.drawable.play), null) },
                 selectedValue = audioQuality,
@@ -399,6 +415,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("tidal_animated_covers"),
                 title = { Text(stringResource(R.string.tidal_animated_covers)) },
                 description = stringResource(R.string.tidal_animated_covers_description),
                 checked = animatedCovers,
@@ -409,6 +426,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("tidal_manage_instances"),
                 title = { Text(stringResource(R.string.tidal_manage_instances)) },
                 description = stringResource(R.string.manage_in_integration),
                 icon = { Icon(painterResource(R.drawable.integration), null) },
@@ -424,6 +442,7 @@ fun PlaybackSourceSections(navController: NavController) {
     PreferenceGroup(title = stringResource(R.string.qobuz_specific)) {
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("qobuz_enable"),
                 title = { Text(stringResource(R.string.qobuz_enable)) },
                 description = stringResource(R.string.qobuz_enable_description),
                 icon = { Icon(painterResource(R.drawable.provider_qobuz), null) },
@@ -434,6 +453,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("qobuz_audio_quality"),
                 title = { Text(stringResource(R.string.qobuz_audio_quality)) },
                 icon = { Icon(painterResource(R.drawable.play), null) },
                 selectedValue = qobuzQuality,
@@ -451,6 +471,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             PreferenceEntry(
+                modifier = positions.modifierFor("qobuz_manage_instances"),
                 title = { Text(stringResource(R.string.qobuz_manage_instances)) },
                 description = stringResource(R.string.manage_in_integration),
                 icon = { Icon(painterResource(R.drawable.integration), null) },
@@ -466,6 +487,7 @@ fun PlaybackSourceSections(navController: NavController) {
     PreferenceGroup(title = stringResource(R.string.qobuz_backup_specific)) {
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("qobuz_backup_enable"),
                 title = { Text(stringResource(R.string.qobuz_backup_enable)) },
                 description = stringResource(R.string.qobuz_backup_enable_description),
                 icon = { Icon(painterResource(R.drawable.provider_qobuz), null) },
@@ -482,6 +504,7 @@ fun PlaybackSourceSections(navController: NavController) {
     PreferenceGroup(title = stringResource(R.string.deezer_specific)) {
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("deezer_enable"),
                 title = { Text(stringResource(R.string.deezer_enable)) },
                 description = stringResource(R.string.deezer_enable_description),
                 icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
@@ -492,6 +515,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("deezer_audio_quality"),
                 title = { Text(stringResource(R.string.deezer_audio_quality)) },
                 icon = { Icon(painterResource(R.drawable.play), null) },
                 selectedValue = deezerQuality,
@@ -515,6 +539,7 @@ fun PlaybackSourceSections(navController: NavController) {
     PreferenceGroup(title = stringResource(R.string.jiosaavn_specific)) {
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("jiosaavn_enable"),
                 title = { Text(stringResource(R.string.jiosaavn_enable)) },
                 description = stringResource(R.string.jiosaavn_enable_description),
                 icon = { Icon(painterResource(R.drawable.play), null) },
@@ -525,6 +550,7 @@ fun PlaybackSourceSections(navController: NavController) {
 
         item {
             EnumListPreference(
+                modifier = positions.modifierFor("jiosaavn_audio_quality"),
                 title = { Text(stringResource(R.string.jiosaavn_audio_quality)) },
                 icon = { Icon(painterResource(R.drawable.play), null) },
                 selectedValue = saavnQuality,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -63,6 +63,7 @@ import moe.rukamori.archivetune.constants.AudioQualityKey
 import moe.rukamori.archivetune.constants.AudioOffload
 import moe.rukamori.archivetune.constants.AutoSkipNextOnErrorKey
 import moe.rukamori.archivetune.constants.AutoStartOnBluetoothKey
+import moe.rukamori.archivetune.constants.CanvasResolverEndpointsKey
 import moe.rukamori.archivetune.constants.CrossfadeDurationKey
 import moe.rukamori.archivetune.constants.CrossfadeEnabledKey
 import moe.rukamori.archivetune.constants.CrossfadeGaplessKey
@@ -98,7 +99,9 @@ import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SliderPreference
 import moe.rukamori.archivetune.ui.component.SwitchPreference
 import moe.rukamori.archivetune.ui.component.TagsManagementDialog
+import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.utils.backToMain
+import moe.rukamori.archivetune.utils.CanvasResolverEndpoints
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import sh.calvin.reorderable.ReorderableItem
@@ -220,6 +223,15 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
             SpotifyCanvasKey,
             defaultValue = false,
         )
+    // Extra Spotify Canvas resolver endpoints, one per line. Every community canvas API on
+    // GitHub is a self-hosted wrapper around Spotify's own canvaz-cache endpoint and needs the
+    // operator's own sp_dc cookie, so there is no stable public instance worth hardcoding —
+    // the user supplies whichever instances they have access to and they are tried in order.
+    val (canvasResolverEndpointsRaw, onCanvasResolverEndpointsChange) =
+        rememberPreference(
+            CanvasResolverEndpointsKey,
+            defaultValue = "",
+        )
     val (tidalEnabled, _) =
         rememberPreference(
             TidalEnabledKey,
@@ -326,6 +338,8 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -427,6 +441,7 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 item {
                     Column(modifier = positions.modifierFor("crossfade_gapless")) {
                         SwitchPreference(
+                            modifier = positions.modifierFor("crossfade_gapless_title"),
                             title = { Text(stringResource(R.string.crossfade_gapless_title)) },
                             description = stringResource(R.string.crossfade_gapless_description),
                             icon = { Icon(painterResource(R.drawable.fast_forward), null) },
@@ -498,6 +513,7 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 item {
                     Column(modifier = positions.modifierFor("seek_seconds")) {
                         SwitchPreference(
+                            modifier = positions.modifierFor("seek_seconds_addup"),
                             title = { Text(stringResource(R.string.seek_seconds_addup)) },
                             description = stringResource(R.string.seek_seconds_addup_description),
                             icon = { Icon(painterResource(R.drawable.arrow_forward), null) },
@@ -581,6 +597,52 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                             icon = { Icon(painterResource(R.drawable.slow_motion_video), null) },
                             checked = spotifyCanvasEnabled,
                             onCheckedChange = onSpotifyCanvasEnabledChange,
+                        )
+                    }
+                }
+
+                item(visible = spotifyCanvasEnabled) {
+                    var showCanvasResolversDialog by remember { mutableStateOf(false) }
+                    val configuredResolvers =
+                        remember(canvasResolverEndpointsRaw) {
+                            CanvasResolverEndpoints.parse(canvasResolverEndpointsRaw)
+                        }
+                    Column(modifier = positions.modifierFor("canvas_resolvers")) {
+                        PreferenceEntry(
+                            title = { Text(stringResource(R.string.canvas_resolvers)) },
+                            description =
+                                if (configuredResolvers.isEmpty()) {
+                                    stringResource(R.string.canvas_resolvers_none)
+                                } else {
+                                    stringResource(
+                                        R.string.canvas_resolvers_count,
+                                        configuredResolvers.size,
+                                    )
+                                },
+                            icon = { Icon(painterResource(R.drawable.solar_server_linear), null) },
+                            onClick = { showCanvasResolversDialog = true },
+                        )
+                    }
+                    if (showCanvasResolversDialog) {
+                        TextFieldDialog(
+                            onDismiss = { showCanvasResolversDialog = false },
+                            title = { Text(stringResource(R.string.canvas_resolvers)) },
+                            placeholder = {
+                                Text(stringResource(R.string.canvas_resolvers_description))
+                            },
+                            textFieldValue = canvasResolverEndpointsRaw,
+                            onTextFieldValueChange = onCanvasResolverEndpointsChange,
+                            singleLine = false,
+                            maxLines = 8,
+                            // Blank is valid: it means "built-in resolver only".
+                            isInputValid = { true },
+                            onDone = { raw ->
+                                onCanvasResolverEndpointsChange(
+                                    CanvasResolverEndpoints.serialize(
+                                        CanvasResolverEndpoints.parse(raw),
+                                    ),
+                                )
+                            },
                         )
                     }
                 }
@@ -670,6 +732,7 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
                 // was previously shown inline on the Appearance page.
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("enable_swipe_thumbnail"),
                         title = { Text(stringResource(R.string.enable_swipe_thumbnail)) },
                         icon = { Icon(painterResource(R.drawable.swipe), null) },
                         checked = swipeThumbnail,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
@@ -206,6 +206,8 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -224,6 +226,7 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("clear_listen_history"),
                         title = { Text(stringResource(R.string.clear_listen_history)) },
                         icon = { Icon(painterResource(R.drawable.delete_history), null) },
                         onClick = { showClearListenHistoryDialog = true },
@@ -246,6 +249,7 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("clear_search_history"),
                         title = { Text(stringResource(R.string.clear_search_history)) },
                         icon = { Icon(painterResource(R.drawable.clear_all), null) },
                         onClick = { showClearSearchHistoryDialog = true },
@@ -259,6 +263,7 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("low_data_mode"),
                         title = { Text(stringResource(R.string.low_data_mode_title)) },
                         description = stringResource(R.string.low_data_mode_description),
                         icon = { Icon(painterResource(R.drawable.android_cell), null) },
@@ -269,6 +274,7 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("force_high_refresh_rate"),
                         title = { Text(stringResource(R.string.force_high_refresh_rate)) },
                         icon = { Icon(painterResource(R.drawable.speed), null) },
                         checked = forceHighRefreshRate,
@@ -288,6 +294,7 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("disable_screenshot"),
                         title = { Text(stringResource(R.string.disable_screenshot)) },
                         description = stringResource(R.string.disable_screenshot_desc),
                         icon = { Icon(painterResource(R.drawable.screenshot), null) },
@@ -301,6 +308,7 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
                 if (isAndroid12OrLater) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("open_supported_links"),
                             title = { Text(stringResource(R.string.open_supported_links)) },
                             description = stringResource(R.string.default_links),
                             icon = { Icon(painterResource(R.drawable.link), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
@@ -574,6 +574,8 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                         WindowInsetsSides.Horizontal,
                     ),
                 )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -583,6 +585,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("qobuz_enable"),
                         title = { Text(stringResource(R.string.qobuz_enable)) },
                         description = stringResource(R.string.qobuz_enable_description),
                         icon = { Icon(painterResource(R.drawable.provider_qobuz), null) },
@@ -593,6 +596,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
 
                 item {
                     EnumListPreference(
+                        modifier = positions.modifierFor("qobuz_audio_quality"),
                         title = { Text(stringResource(R.string.qobuz_audio_quality)) },
                         icon = { Icon(painterResource(R.drawable.graphic_eq), null) },
                         selectedValue = audioQuality,
@@ -615,6 +619,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
             ) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("qobuz_login_web"),
                         title = { Text(stringResource(R.string.qobuz_login_web)) },
                         icon = { Icon(painterResource(R.drawable.provider_qobuz), null) },
                         onClick = { navController.navigate(QOBUZ_LOGIN_ROUTE) },
@@ -623,6 +628,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showTokenManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("qobuz_add_tokens"),
                         title = { Text(stringResource(R.string.qobuz_add_tokens)) },
                         icon = { Icon(painterResource(R.drawable.token), null) },
                         onClick = { showAddTokensDialog = true },
@@ -659,6 +665,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                         tokenHealth[it.id] == TidalAudioProvider.InstanceHealth.UNREACHABLE
                     }
                     PreferenceEntry(
+                        modifier = positions.modifierFor("qobuz_manage_accounts"),
                         title = { Text(stringResource(R.string.qobuz_manage_accounts)) },
                         description = stringResource(
                             R.string.source_health_summary,
@@ -746,6 +753,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                 if (tokens.isNotEmpty()) {
                     item(visible = showTokenManagement) {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("qobuz_reset_tokens"),
                             title = { Text(stringResource(R.string.qobuz_reset_tokens)) },
                             icon = { Icon(painterResource(R.drawable.close), null) },
                             onClick = {
@@ -790,6 +798,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                         healthStatus[it] == TidalAudioProvider.InstanceHealth.UNREACHABLE
                     }
                     PreferenceEntry(
+                        modifier = positions.modifierFor("source_manage_instances"),
                         title = { Text(stringResource(R.string.source_manage_instances)) },
                         description = stringResource(
                             R.string.source_health_summary,
@@ -861,6 +870,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("qobuz_add_instance"),
                         title = { Text(stringResource(R.string.qobuz_add_instance)) },
                         icon = { Icon(painterResource(R.drawable.add), null) },
                         onClick = { showAddDialog = true },
@@ -869,6 +879,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("source_bulk_add"),
                         title = { Text(stringResource(R.string.source_bulk_add)) },
                         description = stringResource(R.string.source_bulk_hint),
                         icon = { Icon(painterResource(R.drawable.playlist_add), null) },
@@ -879,6 +890,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
                 if (effectiveInstances.isNotEmpty()) {
                     item(visible = showInstanceManagement) {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("source_copy_online"),
                             title = { Text(stringResource(R.string.source_copy_online)) },
                             icon = { Icon(painterResource(R.drawable.copy), null) },
                             onClick = { copyOnlineInstances() },
@@ -887,6 +899,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
 
                     item(visible = showInstanceManagement) {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("source_remove_dead"),
                             title = { Text(stringResource(R.string.source_remove_dead)) },
                             icon = { Icon(painterResource(R.drawable.delete), null) },
                             onClick = {
@@ -897,6 +910,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
 
                     item(visible = showInstanceManagement) {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("source_remove_deprecated"),
                             title = { Text(stringResource(R.string.source_remove_deprecated)) },
                             icon = { Icon(painterResource(R.drawable.delete), null) },
                             onClick = {
@@ -908,6 +922,7 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("qobuz_reset_instances"),
                         title = { Text(stringResource(R.string.qobuz_reset_instances)) },
                         icon = { Icon(painterResource(R.drawable.close), null) },
                         onClick = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
@@ -7,56 +7,223 @@
 
 package moe.rukamori.archivetune.ui.screens.settings
 
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlin.math.abs
 
 /**
- * Provides a [Modifier] that registers the global y-position of a composable
- * under the given [key]. Multiple keys can be tracked by calling [modifierFor]
- * for each target item.
+ * Reveals one preference on a settings sub-page: scrolls it into view and flashes a tint over
+ * it. Drives the `?scrollTo=<key>` deep links that settings search hands out.
  *
- * Usage in a sub-settings page:
+ * ## Usage
+ *
  * ```kotlin
  * fun SomeSettings(navController: NavController, scrollTo: String? = null) {
- *   val positions = rememberPreferencePositions()
- *   Column(Modifier.verticalScroll(scrollState)) {
- *     PreferenceGroup(
- *       modifier = positions.modifierFor("dynamic_theme"),
- *       title = "Theme"
- *     ) { ... }
- *   }
- *   LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
+ *     val positions = rememberPreferencePositions()
+ *     val scrollState = rememberScrollState()
+ *     Column(
+ *         Modifier
+ *             .then(positions.containerModifier())   // must be OUTSIDE verticalScroll
+ *             .verticalScroll(scrollState),
+ *     ) {
+ *         PreferenceGroup(modifier = positions.modifierFor("dynamic_theme"), title = "Theme") { … }
+ *     }
+ *     LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
  * }
  * ```
+ *
+ * ## Why the container modifier is required
+ *
+ * [modifierFor] can only measure a row in *root* coordinates — preference rows sit two or three
+ * layout levels deep (scrolling Column > PreferenceGroup's Column > inner Column), so a
+ * parent-relative offset would be measured against the wrong box. A root y-position, however,
+ * includes everything above the list: status bar, top app bar, and content padding. The old
+ * implementation scrolled straight to that number, so every jump overshot the target by the
+ * height of the app bar — the requested row ended up above the viewport and the row *below* it
+ * was what the user saw.
+ *
+ * Registering the viewport's own root y-position closes that gap: the distance to travel is
+ * `rowTop - viewportTop`, which is a pure delta and needs no knowledge of the current scroll
+ * offset. [containerModifier] must therefore be chained *before* `verticalScroll`, where it
+ * measures the viewport instead of the content that slides inside it.
+ *
+ * When a screen forgets the container modifier the viewport top is treated as 0, which
+ * reproduces the old overshooting behaviour rather than failing outright.
  */
 @Composable
 internal fun rememberPreferencePositions(): PreferencePositions {
-    val positions = remember { mutableMapOf<String, Int>() }
-    return remember { PreferencePositions(positions) }
+    val highlightColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
+    val positions = remember { PreferencePositions() }
+    // Re-read every composition instead of capturing once: Appearance settings is itself one of
+    // the deep-linkable screens, so the theme can change while a highlight is on screen.
+    positions.highlightColor = highlightColor
+    return positions
 }
 
-internal class PreferencePositions(private val positions: MutableMap<String, Int>) {
-    /** Returns a [Modifier] that records the composable's y-position under [key]. */
-    fun modifierFor(key: String): Modifier =
+@Stable
+internal class PreferencePositions {
+    private val positions = mutableMapOf<String, Float>()
+    private var viewportTop: Float? = null
+    private var viewportHeight: Float = 0f
+
+    internal var highlightColor: Color = Color.Transparent
+
+    /** Read at draw time, so a change repaints without recomposing the whole screen. */
+    private var highlightedKey by mutableStateOf<String?>(null)
+    private var highlightAlpha by mutableFloatStateOf(0f)
+
+    /**
+     * Records the scrolling viewport. Chain this *before* `verticalScroll` so it measures the
+     * window the content scrolls inside, not the content itself.
+     */
+    fun containerModifier(): Modifier =
         Modifier.onGloballyPositioned { coordinates ->
-            positions[key] = coordinates.positionInRoot().y.toInt()
+            viewportTop = coordinates.positionInRoot().y
+            viewportHeight = coordinates.size.height.toFloat()
         }
 
-    /** Scrolls the [scrollState] to the position registered for [key]. */
-    suspend fun scrollToKey(key: String?, scrollState: androidx.compose.foundation.ScrollState) {
-        if (key.isNullOrBlank()) return
-        repeat(20) {
-            val targetY = positions[key]
-            if (targetY != null) {
-                scrollState.animateScrollTo(value = targetY.coerceAtLeast(0))
-                return
+    /**
+     * Marks a preference as the row identified by [keys]: records where it is and draws the
+     * reveal tint when one of them is the one being revealed.
+     *
+     * More than one key is accepted because the search index and the screens disagree in places:
+     * the same row is listed under a legacy key on a parent page and under its own key on the
+     * sub-page that actually owns it (`lrclib` vs `enable_lrclib`). Registering both aliases on
+     * the one row is cheaper and less error-prone than renaming index entries users may already
+     * be searching for.
+     *
+     * The tint is drawn *over* the row rather than behind it, because preference rows are Cards
+     * with an opaque container colour — anything painted behind them is covered up.
+     */
+    fun modifierFor(vararg keys: String): Modifier =
+        Modifier
+            .onGloballyPositioned { coordinates ->
+                val y = coordinates.positionInRoot().y
+                keys.forEach { key -> positions[key] = y }
+            }.drawWithContent {
+                drawContent()
+                // Local copy: highlightedKey is a delegated property, so it cannot be smart-cast.
+                val active = highlightedKey
+                val progress = if (active != null && active in keys) highlightAlpha else 0f
+                if (progress <= 0f) return@drawWithContent
+                val inset = HighlightInset.toPx()
+                drawRoundRect(
+                    color = highlightColor.copy(alpha = highlightColor.alpha * progress),
+                    topLeft = Offset(inset, inset),
+                    size = Size(size.width - inset * 2, size.height - inset * 2),
+                    cornerRadius = CornerRadius(HighlightCornerRadius.toPx()),
+                )
             }
-            kotlinx.coroutines.delay(100L)
+
+    /**
+     * Scrolls [scrollState] until the row registered for [key] sits at the top of the viewport,
+     * then flashes the highlight.
+     *
+     * Waits for the row to be measured first: a deep link composes the screen and starts this
+     * effect in the same frame, before any [modifierFor] callback has run. Rows that are never
+     * registered (a search result whose target has no anchor yet) leave the screen where it
+     * opened, which is the same place it would have been without the deep link.
+     *
+     * The scroll runs as a short convergence loop rather than a single jump because scrolling
+     * can change the layout it was aimed at — groups that size themselves against the viewport,
+     * and rows whose content only measures once visible. Each pass re-reads the row's freshly
+     * measured position, so a second pass corrects whatever the first one disturbed.
+     */
+    suspend fun scrollToKey(
+        key: String?,
+        scrollState: ScrollableState,
+    ) {
+        if (key.isNullOrBlank()) return
+        if (!awaitMeasurement(key, scrollState)) return
+
+        repeat(SCROLL_PASSES) {
+            val rowTop = positions[key] ?: return@repeat
+            val delta = rowTop - (viewportTop ?: 0f)
+            if (abs(delta) < SETTLED_THRESHOLD_PX) return@repeat
+            scrollState.animateScrollBy(delta)
         }
+
+        highlightedKey = key
+        animate(0f, 1f, animationSpec = tween(HighlightFadeInMs)) { value, _ -> highlightAlpha = value }
+        delay(HighlightHoldMs)
+        animate(1f, 0f, animationSpec = tween(HighlightFadeOutMs)) { value, _ -> highlightAlpha = value }
+        highlightedKey = null
+    }
+
+    /**
+     * Waits until the row for [key] has reported a position, returning false when it never does.
+     *
+     * Two reasons a row can be unmeasured. In a `verticalScroll` column every row is composed
+     * whether or not it is visible, so it only needs a few frames to lay out — the poll loop
+     * covers that. A `LazyColumn` screen, though, never composes rows that are far below the
+     * viewport, so waiting alone would time out on exactly the deep targets that need scrolling
+     * the most. Stepping down the list a viewport at a time brings those into composition; the
+     * walk stops as soon as the row registers, leaving the convergence loop to land it precisely.
+     *
+     * A walk that finds nothing rewinds itself, so an unanchored key leaves the screen at the
+     * top rather than parked at the bottom of a list the user never asked to scroll.
+     */
+    private suspend fun awaitMeasurement(
+        key: String,
+        scrollState: ScrollableState,
+    ): Boolean {
+        repeat(MEASURE_TIMEOUT_STEPS) {
+            if (positions[key] != null) return true
+            delay(MEASURE_POLL_MS)
+        }
+
+        val step = viewportHeight * SEARCH_STEP_FRACTION
+        if (step <= 0f) return false
+        var walked = 0f
+        var steps = 0
+        while (positions[key] == null && steps < SEARCH_STEPS && scrollState.canScrollForward) {
+            walked += scrollState.animateScrollBy(step)
+            // One poll interval is enough for the newly revealed rows to report positions.
+            delay(MEASURE_POLL_MS)
+            steps++
+        }
+        if (positions[key] != null) return true
+        if (walked > 0f) scrollState.animateScrollBy(-walked)
+        return false
+    }
+
+    private companion object {
+        /** Poll interval and budget while waiting for the target row's first measurement. */
+        const val MEASURE_POLL_MS = 50L
+        const val MEASURE_TIMEOUT_STEPS = 16
+
+        /** How many corrective passes to make. Two is enough in practice; three is headroom. */
+        const val SCROLL_PASSES = 3
+
+        /** Anything smaller than this is already on target — sub-pixel jitter, not a miss. */
+        const val SETTLED_THRESHOLD_PX = 2f
+
+        /** How far to walk per step, and how many steps, when hunting an uncomposed row. */
+        const val SEARCH_STEP_FRACTION = 0.8f
+        const val SEARCH_STEPS = 24
     }
 }
+
+private val HighlightCornerRadius = 18.dp
+private val HighlightInset = 1.dp
+private const val HighlightFadeInMs = 220
+private const val HighlightHoldMs = 1_100L
+private const val HighlightFadeOutMs = 450

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
@@ -69,7 +69,7 @@ import kotlin.math.abs
  * reproduces the old overshooting behaviour rather than failing outright.
  */
 @Composable
-internal fun rememberPreferencePositions(): PreferencePositions {
+fun rememberPreferencePositions(): PreferencePositions {
     val highlightColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
     val positions = remember { PreferencePositions() }
     // Re-read every composition instead of capturing once: Appearance settings is itself one of
@@ -79,12 +79,12 @@ internal fun rememberPreferencePositions(): PreferencePositions {
 }
 
 @Stable
-internal class PreferencePositions {
+class PreferencePositions {
     private val positions = mutableMapOf<String, Float>()
     private var viewportTop: Float? = null
     private var viewportHeight: Float = 0f
 
-    internal var highlightColor: Color = Color.Transparent
+    var highlightColor: Color = Color.Transparent
 
     /** Read at draw time, so a change repaints without recomposing the whole screen. */
     private var highlightedKey by mutableStateOf<String?>(null)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsAutoScroll.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AlbumCanvasEnabledKey
 import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
 import moe.rukamori.archivetune.constants.SpotifyCanvasKey
 import moe.rukamori.archivetune.constants.AudioNormalizationKey
@@ -159,6 +160,7 @@ fun buildSettingsGroups(
                 SettingsChild("Use system font", "use_system_font", listOf("system font", "default font", "roboto")) { SearchResultSwitch(UseSystemFontKey, false) },
                 SettingsChild("Thumbnail corner radius", "thumbnail_corner_radius", listOf("thumbnail corner", "corner radius", "rounded thumbnail", "thumbnail shape")),
                 SettingsChild("Crop thumbnail to square", "crop_thumbnail_to_square", listOf("crop thumbnail", "square thumbnail", "thumbnail crop")) { SearchResultSwitch(CropThumbnailToSquareKey, false) },
+                SettingsChild("Enable canvas in albums page", "album_canvas_enabled", listOf("album canvas", "canvas in album", "album motion artwork", "album animated cover", "album header video")) { SearchResultSwitch(AlbumCanvasEnabledKey, true) },
                 SettingsChild("Player design style", "player_design_style", listOf("player design", "player layout", "player style")),
                 SettingsChild("Player background style", "player_background_style", listOf("player background", "player bg", "background style")),
                 SettingsChild("Lyrics background style", "lyrics_background_style", listOf("lyrics background", "lyrics bg")),
@@ -312,6 +314,7 @@ fun buildSettingsGroups(
                 SettingsChild("Auto start on Bluetooth", "bluetooth_auto_start", listOf("bluetooth", "auto start", "auto play", "connect")) { SearchResultSwitch(AutoStartOnBluetoothKey, false) },
                 SettingsChild("ArchiveTune Canvas", "archive_tune_canvas", listOf("canvas", "animated artwork", "motion artwork", "live artwork")) { SearchResultSwitch(ArchiveTuneCanvasKey, true) },
                 SettingsChild("Spotify Canvas", "spotify_canvas", listOf("spotify", "canvas", "spotify canvas", "looping video", "music video", "video artwork")) { SearchResultSwitch(SpotifyCanvasKey, false) },
+                SettingsChild("Canvas resolvers", "canvas_resolvers", listOf("canvas resolver", "canvas resolvers", "canvas endpoint", "canvas fallback", "spotify canvas resolver")),
                 SettingsChild("Tidal artwork fallback", "tidal_artwork_fallback", listOf("tidal artwork", "artwork fallback", "tidal cover", "hi-res artwork")) { SearchResultSwitch(TidalArtworkFallbackEnabledKey, true) },
                 SettingsChild("Persistent queue", "persistent_queue", listOf("queue", "persistent", "save queue", "resume")) { SearchResultSwitch(PersistentQueueKey, true) },
                 SettingsChild("Permanent shuffle", "permanent_shuffle", listOf("shuffle", "random", "permanent")) { SearchResultSwitch(PermanentShuffleKey, false) },
@@ -510,6 +513,7 @@ fun buildSettingsGroups(
                 SettingsChild("Paxsenix API stats", "paxsenix_stats", listOf("paxsenix stats", "paxsenix usage", "paxsenix quota")),
                 SettingsChild("Paxsenix API key", "paxsenix_api_key", listOf("paxsenix api key", "paxsenix key")),
                 SettingsChild("Paxsenix endpoint", "paxsenix_endpoint", listOf("paxsenix endpoint", "paxsenix url")),
+                SettingsChild("Check Paxsenix endpoints", "paxsenix_check_endpoints", listOf("check paxsenix", "paxsenix endpoints", "test paxsenix", "paxsenix status", "endpoint check")),
                 SettingsChild("Preferred lyrics provider", "set_first_lyrics_provider", listOf("preferred lyrics provider", "first lyrics provider", "lyrics priority")),
             ),
         )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -183,6 +183,108 @@ fun buildSettingsGroups(
                 SettingsChild("Grid layout", "grid_layout", listOf("grid", "layout", "list view", "artist grid")),
                 SettingsChild("Show home category chips", "show_home_category_chips", listOf("home chips", "category chips", "home category", "chips")) { SearchResultSwitch(ShowHomeCategoryChipsKey, false) },
                 SettingsChild("Language", "app_language", listOf("language", "app language", "locale")),
+                SettingsChild("UI scale", "ui_scale", listOf("ui scale", "scale", "zoom", "interface size", "display size", "bigger", "smaller")),
+                SettingsChild("Custom font", "custom_font", listOf("custom font", "font file", "typeface", "own font")),
+                SettingsChild("Backdrop blur amount", "backdrop_blur_amount", listOf("backdrop blur amount", "backdrop intensity", "background blur amount")),
+                SettingsChild("Customized background", "customized_background", listOf("customized background", "custom background", "background image", "wallpaper")),
+                SettingsChild("Tablet mode", "tablet_mode", listOf("tablet mode", "tablet", "large screen", "landscape layout")),
+                SettingsChild("Minimal mode", "minimal_home_mode", listOf("minimal mode", "minimal home", "simple home", "clean home")),
+                SettingsChild("Change default library chip", "default_lib_chips", listOf("library chip", "default chip", "library filter", "default library tab")),
+                SettingsChild("Liquid Glass effects", "liquid_glass_effects", listOf("liquid glass", "glass effects", "header glass", "mini player glass")),
+                SettingsChild("Theme creator", "theme_creator", listOf("theme creator", "create theme", "custom theme", "make theme")),
+                SettingsChild("Palette picker", "palette_picker", listOf("palette picker", "pick palette", "choose palette", "custom palette")),
+                SettingsChild("Extras", "extras", listOf("extras", "appearance extras", "home cards", "hide cards", "more appearance")),
+            ),
+        )
+    // Appearance → Extras sub-page. Hidden from the main list (it is reached through
+    // Appearance) but every toggle on it stays searchable.
+    val appearanceExtras =
+        SettingsItem(
+            key = "appearance_extras",
+            icon = painterResource(R.drawable.palette),
+            title = "Appearance extras",
+            subtitle = "Home and library card visibility",
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("extras", "appearance extras", "home cards", "hide cards", "library cards", "quick picks cards"),
+            onClick = { navController.navigate("settings/appearance/extras") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Show home category chips", "show_home_category_chips", listOf("home chips", "category chips", "home category", "chips")) { SearchResultSwitch(ShowHomeCategoryChipsKey, false) },
+                SettingsChild("Show tags in library", "show_tags_in_library", listOf("tags", "library tags", "show tags")),
+                SettingsChild("Hide Liked songs card", "hide_liked_songs_card", listOf("hide liked songs", "liked songs card", "favourites card", "hide card")),
+                SettingsChild("Hide Offline card", "hide_offline_card", listOf("hide offline", "offline card", "downloaded card", "hide card")),
+                SettingsChild("Hide Cached card", "hide_cached_card", listOf("hide cached", "cached card", "cache card", "hide card")),
+                SettingsChild("Hide Local Files card", "hide_local_files_card", listOf("hide local files", "local files card", "local card", "hide card")),
+                SettingsChild("Hide My top 50 card", "hide_top50_card", listOf("hide top 50", "top 50 card", "my top 50", "hide card")),
+            ),
+        )
+    // Appearance → AOD customization. Entirely absent from the search index before,
+    // so none of these 17 settings could be found by name.
+    val aodCustomization =
+        SettingsItem(
+            key = "aod",
+            icon = painterResource(R.drawable.palette),
+            title = "AOD customization",
+            subtitle = "Always-on display layout and style",
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("aod", "always on display", "always-on display", "lockscreen", "screensaver", "idle screen", "ambient display"),
+            onClick = { navController.navigate("settings/appearance/aod_customized") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Show thumbnail", "aod_customize_show_thumbnail", listOf("aod thumbnail", "always on display artwork", "aod cover", "aod show thumbnail")),
+                SettingsChild("Show artist", "aod_customize_show_artist", listOf("aod artist", "always on display artist", "aod show artist")),
+                SettingsChild("Show album", "aod_customize_show_album", listOf("aod album", "always on display album", "aod show album")),
+                SettingsChild("Show progress", "aod_customize_show_progress", listOf("aod progress", "aod progress bar", "always on display progress")),
+                SettingsChild("Show time labels", "aod_customize_show_time_labels", listOf("aod time", "aod timestamps", "aod time labels", "always on display time")),
+                SettingsChild("Show controls", "aod_customize_show_controls", listOf("aod controls", "aod buttons", "always on display controls")),
+                SettingsChild("Show exit button", "aod_customize_show_exit_button", listOf("aod exit", "aod close button", "leave aod")),
+                SettingsChild("Show lyrics", "aod_customize_show_lyrics", listOf("aod lyrics", "always on display lyrics", "aod show lyrics")),
+                SettingsChild("Background style", "aod_customize_background_style", listOf("aod background", "aod background style", "always on display background")),
+                SettingsChild("Accent style", "aod_customize_accent_style", listOf("aod accent", "aod accent style", "aod color")),
+                SettingsChild("Content position", "aod_customize_content_position", listOf("aod position", "aod content position", "aod layout")),
+                SettingsChild("Text alignment", "aod_customize_text_alignment", listOf("aod text alignment", "aod align", "aod centre", "aod center")),
+                SettingsChild("Slider style", "aod_customize_slider_style", listOf("aod slider", "aod slider style", "aod progress style")),
+                SettingsChild("Artwork glow", "aod_customize_artwork_glow", listOf("aod glow", "artwork glow", "aod artwork glow", "ambient glow")),
+                SettingsChild("Control style", "aod_customize_control_style", listOf("aod control style", "aod button style")),
+                SettingsChild("Enter AOD when screen dims", "aod_customize_auto_on_screen_dim", listOf("auto aod", "aod on dim", "automatic aod", "screen dim aod")),
+            ),
+        )
+    // Appearance → Navigation bar customization.
+    val navigationBar =
+        SettingsItem(
+            key = "navigation_bar",
+            icon = painterResource(R.drawable.palette),
+            title = "Navigation bar",
+            subtitle = "Navigation bar style and dimensions",
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("navigation bar", "nav bar", "bottom bar", "tab bar", "navbar"),
+            onClick = { navController.navigate("settings/appearance/navigation_bar") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Navigation bar style", "navigation_bar_style", listOf("navigation bar style", "nav bar style", "bottom bar style")),
+                SettingsChild("Frosted navigation bar", "navigation_bar_frosted_blur", listOf("frosted nav", "frosted navigation", "frosted blur")) { SearchResultSwitch(NavigationBarFrostedBlurKey, false) },
+                SettingsChild("Tint frosted navigation bar", "navigation_bar_tint_frosted_blur", listOf("tint frosted", "tint nav bar", "frosted tint", "coloured nav bar")),
+                SettingsChild("Liquid Glass navigation bar", "liquid_glass_nav_bar", listOf("liquid glass nav", "glass navigation", "liquid nav")) { SearchResultSwitch(LiquidGlassNavBarEnabledKey, false) },
+                SettingsChild("Hide labels in navigation bar", "hide_navigation_bar_labels", listOf("hide labels", "navigation labels", "nav labels", "icons only")) { SearchResultSwitch(HideNavigationBarLabelsKey, false) },
+                SettingsChild("Navigation bar dimensions", "navigation_bar_dimensions", listOf("nav bar height", "nav bar width", "nav bar opacity", "nav bar corner radius", "nav bar label spacing", "nav bar size")),
+            ),
+        )
+    // Appearance → Lyrics animations.
+    val lyricsAnimations =
+        SettingsItem(
+            key = "lyrics_animations",
+            icon = painterResource(R.drawable.lyrics),
+            title = "Lyrics animations",
+            subtitle = "Lyrics motion and transitions",
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("lyrics animation", "lyrics animations", "lyrics motion", "lyrics transition", "karaoke animation"),
+            onClick = { navController.navigate("settings/appearance/lyrics_animations") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Lyrics animation style", "lyrics_animation_style", listOf("lyrics animation style", "lyrics motion", "lyrics transition")),
+                SettingsChild("Lyrics scale animation", "lyrics_scale_animation", listOf("lyrics scale", "lyrics zoom", "lyrics grow")),
+                SettingsChild("Lyrics glow animation", "lyrics_glow_animation", listOf("lyrics glow", "lyrics shine", "lyrics highlight")),
+                SettingsChild("Lyrics fade animation", "lyrics_fade_animation", listOf("lyrics fade", "lyrics opacity animation")),
             ),
         )
     val playback =
@@ -218,6 +320,87 @@ fun buildSettingsGroups(
                 SettingsChild("Wakelock", "wakelock", listOf("wakelock", "wake lock", "keep awake", "cpu")) { SearchResultSwitch(WakelockKey, false) },
                 SettingsChild("Artist separators", "artist_separators", listOf("artist", "separator", "split", "featuring")),
                 SettingsChild("Manage playlist tags", "manage_playlist_tags", listOf("playlist tags", "tag management", "organize playlists")),
+                SettingsChild("Audio quality", "audio_quality", listOf("audio quality", "quality", "bitrate", "sound quality", "streaming quality", "high quality")),
+                SettingsChild("Artwork priority", "artwork_priority", listOf("artwork priority", "artwork order", "cover priority", "artwork provider order", "artwork source order")),
+                SettingsChild("Preferred sources", "preferred_sources", listOf("preferred sources", "source priority", "source order", "audio source order", "which source first")),
+                SettingsChild("Auto choose playback client", "auto_choose_playback_client", listOf("auto choose client", "playback client auto", "automatic client", "client selection")),
+                SettingsChild("Playback client", "player_stream_client", listOf("playback client", "stream client", "player client", "innertube client", "android vr", "ios client", "web client")),
+                SettingsChild("Skip gapless albums", "crossfade_gapless_title", listOf("skip gapless albums", "gapless album", "gapless")),
+                SettingsChild("Progressive seek", "seek_seconds_addup", listOf("progressive seek", "seek add up", "seek accumulate", "double tap seek")),
+                SettingsChild("Enable swipe to change song", "enable_swipe_thumbnail", listOf("swipe thumbnail", "swipe to change song", "swipe artwork", "swipe track")),
+                SettingsChild("Mini player swipe sensitivity", "swipe_sensitivity", listOf("swipe sensitivity", "mini player swipe", "gesture sensitivity")),
+                SettingsChild("Check source", "check_source", listOf("check source", "source health", "test source", "source diagnostics", "verify source", "source status")),
+                SettingsChild("Spotify catalog", "spotify_catalog_source", listOf("spotify catalog", "spotify metadata", "spotify source")),
+                SettingsChild("Enable Tidal source", "tidal_enable", listOf("tidal", "enable tidal", "tidal source", "lossless", "hifi")),
+                SettingsChild("Use my Tidal account first", "tidal_account_first", listOf("tidal account first", "my tidal account", "prefer my account")),
+                SettingsChild("Tidal audio quality", "tidal_audio_quality", listOf("tidal quality", "tidal audio quality", "tidal hifi", "tidal max", "mqa")),
+                SettingsChild("Tidal animated covers", "tidal_animated_covers", listOf("tidal animated covers", "tidal canvas", "tidal video cover", "animated cover")),
+                SettingsChild("Manage Tidal instances", "tidal_manage_instances", listOf("tidal instances", "tidal server", "tidal endpoint", "manage instances")),
+                SettingsChild("Enable Qobuz source", "qobuz_enable", listOf("qobuz", "enable qobuz", "qobuz source", "hi-res", "flac")),
+                SettingsChild("Qobuz audio quality", "qobuz_audio_quality", listOf("qobuz quality", "qobuz audio quality", "hi-res", "flac", "cd quality", "24 bit")),
+                SettingsChild("Enable Qobuz backup server", "qobuz_backup_enable", listOf("qobuz backup", "backup server", "qobuz backup server", "lossless backup", "fallback server", "kouzu")),
+                SettingsChild("Manage Qobuz instances", "qobuz_manage_instances", listOf("qobuz instances", "qobuz server", "qobuz endpoint", "manage instances")),
+                SettingsChild("Enable Deezer source", "deezer_enable", listOf("deezer", "enable deezer", "deezer source", "flac")),
+                SettingsChild("Deezer audio quality", "deezer_audio_quality", listOf("deezer quality", "deezer audio quality", "deezer flac")),
+                SettingsChild("Enable JioSaavn source", "jiosaavn_enable", listOf("jiosaavn", "jio saavn", "saavn", "enable jiosaavn", "indian music")),
+                SettingsChild("JioSaavn audio quality", "jiosaavn_audio_quality", listOf("jiosaavn quality", "saavn quality", "jiosaavn audio quality")),
+                SettingsChild("yt-dlp runtime", "ytdlp", listOf("yt-dlp", "ytdlp", "youtube-dl", "extractor", "downloader runtime", "yt dlp version")),
+            ),
+        )
+    // Playback → yt-dlp runtime sub-page. Absent from the index before.
+    val ytDlp =
+        SettingsItem(
+            key = "ytdlp",
+            icon = painterResource(R.drawable.experiment),
+            title = "yt-dlp runtime",
+            subtitle = "Extractor version and updates",
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("yt-dlp", "ytdlp", "yt dlp", "youtube-dl", "extractor", "runtime", "signature", "deobfuscator"),
+            onClick = { navController.navigate("settings/player/ytdlp") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Active version", "ytdlp_active_version", listOf("yt-dlp active version", "ytdlp version", "current extractor version")),
+                SettingsChild("Bundled version", "ytdlp_bundled_version", listOf("yt-dlp bundled version", "ytdlp bundled", "shipped version")),
+                SettingsChild("Pending version", "ytdlp_pending_version", listOf("yt-dlp pending version", "ytdlp pending", "staged update")),
+                SettingsChild("Last checked", "ytdlp_last_checked", listOf("yt-dlp last checked", "ytdlp last checked", "update check time")),
+                SettingsChild("Last updated", "ytdlp_last_updated", listOf("yt-dlp last updated", "ytdlp last updated", "update time")),
+                SettingsChild("Check for updates", "ytdlp_check_for_updates", listOf("yt-dlp check for updates", "ytdlp update now", "update extractor")),
+                SettingsChild("Automatic updates", "ytdlp_automatic_updates", listOf("yt-dlp automatic updates", "ytdlp auto update", "auto update extractor")),
+            ),
+        )
+    // Sources → JioSaavn sub-page.
+    val jioSaavn =
+        SettingsItem(
+            key = "jiosaavn",
+            icon = painterResource(R.drawable.provider_tidal),
+            title = "JioSaavn",
+            subtitle = "JioSaavn audio source",
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("jiosaavn", "jio saavn", "saavn", "indian music", "bollywood", "vivimusic"),
+            onClick = { navController.navigate("settings/jiosaavn") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Enable JioSaavn source", "jiosaavn_enable", listOf("enable jiosaavn", "jiosaavn source", "turn on jiosaavn")),
+                SettingsChild("JioSaavn audio quality", "jiosaavn_audio_quality", listOf("jiosaavn quality", "saavn audio quality", "jiosaavn bitrate")),
+                SettingsChild("JioSaavn credit", "jiosaavn_credit", listOf("jiosaavn credit", "vivimusic", "jiosaavn about")),
+            ),
+        )
+    // Sources → Deezer sub-page.
+    val deezer =
+        SettingsItem(
+            key = "deezer",
+            icon = painterResource(R.drawable.provider_tidal),
+            title = "Deezer",
+            subtitle = "Deezer account and audio source",
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("deezer", "deezer account", "deezer login", "arl", "deezer premium", "flac"),
+            onClick = { navController.navigate("settings/deezer") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Sign in to Deezer", "deezer_login", listOf("deezer login", "deezer sign in", "connect deezer", "deezer arl")),
+                SettingsChild("Sign out of Deezer", "deezer_sign_out", listOf("deezer logout", "deezer sign out", "disconnect deezer")),
+                SettingsChild("Enable Deezer source", "deezer_enable", listOf("enable deezer", "deezer source", "turn on deezer")),
+                SettingsChild("Deezer audio quality", "deezer_audio_quality", listOf("deezer quality", "deezer audio quality", "deezer flac")),
             ),
         )
     val sources =
@@ -286,6 +469,67 @@ fun buildSettingsGroups(
                 SettingsChild("Paxsenix Lyrics", "paxsenix_lyrics", listOf("paxsenix", "paxsenix lyrics", "paxsenix provider")),
                 SettingsChild("Paxsenix Stats", "paxsenix_stats", listOf("paxsenix stats", "paxsenix statistics", "paxsenix analytics")),
                 SettingsChild("First lyrics provider", "first_lyrics_provider", listOf("first lyrics", "lyrics priority", "primary lyrics provider", "lyrics order")),
+                SettingsChild("Preferred lyrics provider", "set_first_lyrics_provider", listOf("preferred lyrics provider", "default lyrics provider", "lyrics priority")),
+                SettingsChild("Prioritize word synced lyrics", "prioritize_word_synced_lyrics", listOf("word synced", "word by word", "karaoke lyrics", "prioritize word synced")),
+                SettingsChild("Providers", "providers", listOf("lyrics providers", "providers", "lyrics sources", "which lyrics provider")),
+                SettingsChild("Romanization", "romanization", listOf("romanization", "romanisation", "romanize", "romaji", "transliteration")),
+                SettingsChild("Language packs", "language_packs", listOf("language pack", "language packs", "romanization data", "dictionary")),
+                SettingsChild("Enable Tidal lyrics", "enable_tidal_lyrics", listOf("tidal lyrics", "enable tidal lyrics", "tidal lyric provider")),
+                SettingsChild("Enable Deezer lyrics", "enable_deezer_lyrics", listOf("deezer lyrics", "enable deezer lyrics", "deezer lyric provider")),
+                SettingsChild("Musixmatch (experimental)", "enable_musixmatch_experimental", listOf("musixmatch", "musixmatch experimental", "musixmatch lyrics")),
+                SettingsChild("Paxsenix API key", "paxsenix_api_key", listOf("paxsenix api key", "paxsenix key", "paxsenix token")),
+                SettingsChild("Paxsenix endpoint", "paxsenix_endpoint", listOf("paxsenix endpoint", "paxsenix url", "paxsenix server")),
+                SettingsChild("Lyrics text size", "lyrics_text_size", listOf("lyrics text size", "lyrics font size", "lyrics size", "bigger lyrics")),
+            ),
+        )
+    // Lyrics → Providers sub-page.
+    val lyricsProviders =
+        SettingsItem(
+            key = "lyrics_providers",
+            icon = painterResource(R.drawable.lyrics),
+            title = "Lyrics providers",
+            subtitle = "Enable and prioritise lyrics sources",
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("lyrics provider", "lyrics providers", "lyrics source", "lrclib", "kugou", "musixmatch", "betterlyrics", "paxsenix", "youlyplus", "unison", "simpmusic", "megalobiz"),
+            onClick = { navController.navigate("settings/lyrics/providers") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Prioritize word synced lyrics", "prioritize_word_synced_lyrics", listOf("word synced", "word by word", "karaoke lyrics")),
+                SettingsChild("Enable BetterLyrics", "enable_betterlyrics", listOf("betterlyrics", "better lyrics", "enable betterlyrics")),
+                SettingsChild("Enable BetterLyrics Portato", "enable_betterlyrics_portato", listOf("portato", "betterlyrics portato", "portato lyrics")),
+                SettingsChild("Enable YouLyPlus lyrics", "enable_youlyplus_lyrics", listOf("youlyplus", "youly plus", "youlyplus lyrics")),
+                SettingsChild("Enable LrcLib lyrics provider", "enable_lrclib", listOf("lrclib", "lrc lib", "lrclib lyrics")),
+                SettingsChild("Enable KuGou lyrics provider", "enable_kugou", listOf("kugou", "kugou lyrics", "chinese lyrics")),
+                SettingsChild("Enable Unison lyrics", "enable_unison_lyrics", listOf("unison", "unison lyrics")),
+                SettingsChild("Enable SimpMusic lyrics", "enable_simpmusic_lyrics", listOf("simpmusic", "simp music", "simpmusic lyrics")),
+                SettingsChild("Enable Megalobiz lyrics", "enable_megalobiz_lyrics", listOf("megalobiz", "megalobiz lyrics")),
+                SettingsChild("Enable Paxsenix lyrics", "enable_paxsenix_lyrics", listOf("paxsenix", "paxsenix lyrics")),
+                SettingsChild("Enable Tidal lyrics", "enable_tidal_lyrics", listOf("tidal lyrics", "enable tidal lyrics")),
+                SettingsChild("Enable Deezer lyrics", "enable_deezer_lyrics", listOf("deezer lyrics", "enable deezer lyrics")),
+                SettingsChild("Musixmatch (experimental)", "enable_musixmatch_experimental", listOf("musixmatch", "musixmatch experimental")),
+                SettingsChild("Paxsenix API stats", "paxsenix_stats", listOf("paxsenix stats", "paxsenix usage", "paxsenix quota")),
+                SettingsChild("Paxsenix API key", "paxsenix_api_key", listOf("paxsenix api key", "paxsenix key")),
+                SettingsChild("Paxsenix endpoint", "paxsenix_endpoint", listOf("paxsenix endpoint", "paxsenix url")),
+                SettingsChild("Preferred lyrics provider", "set_first_lyrics_provider", listOf("preferred lyrics provider", "first lyrics provider", "lyrics priority")),
+            ),
+        )
+    // Lyrics → Romanisation sub-page.
+    val lyricsRomanisation =
+        SettingsItem(
+            key = "lyrics_romanisation",
+            icon = painterResource(R.drawable.translate),
+            title = "Lyrics romanization",
+            subtitle = "Transliterate non-Latin lyrics",
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("romanization", "romanisation", "romanize", "romaji", "pinyin", "transliteration", "furigana", "hangul"),
+            onClick = { navController.navigate("settings/lyrics/romanisation") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Romanize japanese lyrics", "lyrics_romanize_japanese", listOf("romanize japanese", "romaji", "furigana", "japanese lyrics")),
+                SettingsChild("Romanize korean lyrics", "lyrics_romanize_korean", listOf("romanize korean", "hangul", "korean lyrics")),
+                SettingsChild("Romanize chinese lyrics", "lyrics_romanize_chinese", listOf("romanize chinese", "pinyin", "chinese lyrics")),
+                SettingsChild("Romanize hindi lyrics", "lyrics_romanize_hindi", listOf("romanize hindi", "devanagari", "hindi lyrics")),
+                SettingsChild("Romanize other non-latin lyrics", "lyrics_romanize_other_languages", listOf("romanize other", "arabic", "thai", "cyrillic", "other languages")),
             ),
         )
     val content =
@@ -305,6 +549,13 @@ fun buildSettingsGroups(
                 SettingsChild("Enable video", "enable_video", listOf("video", "music video", "mv", "enable video")),
                 SettingsChild("Quick picks", "quick_picks", listOf("quick picks", "quick mix", "smart mix", "recommendations")),
                 SettingsChild("Progressive playback", "progressive_playback", listOf("progressive", "gapless", "seamless")),
+                SettingsChild("Allow age-restricted content", "allow_age_restricted", listOf("age restricted", "allow age restricted", "mature content", "18+", "restricted")),
+                SettingsChild("Playlist recommendation source", "you_might_like_source", listOf("recommendation source", "you might like", "playlist recommendation", "suggestions source")),
+                SettingsChild("AI content filter", "ai_content_filter", listOf("ai content filter", "ai filter", "ai generated", "aislist", "filter ai music")),
+                SettingsChild("Hide AI-generated content", "ai_content_filter_hide", listOf("hide ai generated", "hide ai music", "ai content hide", "block ai")),
+                SettingsChild("Include moderate-confidence channels", "ai_content_filter_moderate", listOf("moderate confidence", "ai filter moderate", "ai channels")),
+                SettingsChild("Update channel lists", "ai_content_filter_update", listOf("update channel lists", "refresh ai list", "aislist update")),
+                SettingsChild("About AiSList", "ai_content_filter_source", listOf("aislist", "about aislist", "ai list source")),
             ),
         )
     val languagePacks =
@@ -339,6 +590,9 @@ fun buildSettingsGroups(
                 SettingsChild("Disable screenshot", "disable_screenshot", listOf("screenshot", "screen capture", "privacy", "no screenshot")) { SearchResultSwitch(DisableScreenshotKey, false) },
                 SettingsChild("Network metered", "network_metered", listOf("metered", "mobile data", "cellular", "data saver")) { SearchResultSwitch(NetworkMeteredKey, false) },
                 SettingsChild("Show tags in library", "show_tags_in_library", listOf("tags", "library tags", "show tags")),
+                SettingsChild("Low data mode", "low_data_mode", listOf("low data", "data saver", "save data", "metered", "data mode")) { SearchResultSwitch(LowDataModeKey, true) },
+                SettingsChild("Force high refresh rate", "force_high_refresh_rate", listOf("refresh rate", "high refresh", "120hz", "90hz", "smooth")) { SearchResultSwitch(ForceHighRefreshRateKey, false) },
+                SettingsChild("Open supported links by default", "open_supported_links", listOf("open links", "supported links", "default links", "deep link", "default browser app")),
             ),
         )
     val integration =
@@ -378,6 +632,119 @@ fun buildSettingsGroups(
                 SettingsChild("Telegram lossless only", "telegram_lossless_only", listOf("lossless", "flac", "lossless only", "high quality")) { SearchResultSwitch(TelegramLosslessOnlyKey, false) },
                 SettingsChild("Telegram logout", "telegram_logout", listOf("logout", "log out", "sign out", "disconnect telegram")),
                 SettingsChild("Import playlist from another service", "cross_service_import", listOf("import", "import playlist", "cross service", "youtube music import", "apple music import", "amazon music import", "tidal import", "deezer import", "playlist url", "import url", "import from url", "playlist from url")),
+                SettingsChild("Enable scrobbling", "enable_scrobbling", listOf("enable scrobbling", "scrobble", "scrobbler", "lastfm scrobble")) { SearchResultSwitch(EnableLastFMScrobblingKey, false) },
+                SettingsChild("Now playing", "lastfm_now_playing", listOf("now playing", "lastfm now playing", "scrobble now playing", "update now playing")),
+                SettingsChild("Prefer YouTube thumbnails", "lastfm_prefer_yt_thumbnails", listOf("prefer youtube thumbnails", "lastfm thumbnails", "scrobble artwork")),
+                SettingsChild("Minimum track duration", "scrobble_min_track_duration", listOf("minimum track duration", "scrobble minimum", "min duration", "scrobble threshold")),
+                SettingsChild("Scrobble delay percent", "scrobble_delay_percent", listOf("scrobble delay percent", "scrobble percentage", "scrobble after percent")),
+                SettingsChild("Scrobble delay (seconds)", "scrobble_delay_minutes", listOf("scrobble delay", "scrobble seconds", "scrobble delay minutes")),
+                SettingsChild("Connect Last.fm", "lastfm_connect_button", listOf("connect lastfm", "lastfm login", "lastfm sign in")),
+                SettingsChild("Connect Libre.fm", "lastfm_connect_librefm_button", listOf("librefm", "libre.fm", "connect librefm", "librefm login")),
+                SettingsChild("Connect custom GNU FM server", "lastfm_connect_custom_button", listOf("custom scrobble server", "gnu fm", "custom lastfm server", "self hosted scrobbler")),
+                SettingsChild("Activity status", "activity_status", listOf("discord activity status", "activity status", "online status")),
+                SettingsChild("Platform", "platform_status", listOf("discord platform", "platform status", "desktop mobile status")),
+                SettingsChild("Activity name", "discord_activity_name", listOf("discord activity name", "activity name", "rpc name")),
+                SettingsChild("Activity details", "discord_activity_details", listOf("discord activity details", "activity details", "rpc details")),
+                SettingsChild("Activity state", "discord_activity_state", listOf("discord activity state", "activity state", "rpc state")),
+                SettingsChild("Activity type", "discord_activity_type", listOf("discord activity type", "activity type", "listening playing")),
+                SettingsChild("Show RPC when paused", "discord_show_when_paused", listOf("show when paused", "discord paused", "rpc paused")),
+                SettingsChild("Large image", "large_image", listOf("discord large image", "large image", "rpc large image")),
+                SettingsChild("Large text", "large_text", listOf("discord large text", "large text", "rpc large text")),
+                SettingsChild("Small image", "small_image", listOf("discord small image", "small image", "rpc small image")),
+                SettingsChild("Discord experimental options", "discord_experimental", listOf("discord experimental", "discord buttons", "rpc buttons", "discord translator")),
+                SettingsChild("Telegram bots", "telegram_bots_title", listOf("telegram bots", "telegram bot", "bot token", "music bot")),
+            ),
+        )
+    // Integration → Discord experimental sub-page.
+    val discordExperimental =
+        SettingsItem(
+            key = "discord_experimental",
+            icon = painterResource(R.drawable.auto_awesome),
+            title = "Discord experimental",
+            subtitle = "Rich presence buttons and translation",
+            accentColor = MaterialTheme.colorScheme.secondary,
+            keywords = listOf("discord experimental", "discord buttons", "rich presence buttons", "rpc buttons", "discord translator"),
+            onClick = { navController.navigate("settings/discord/experimental") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Enable translator", "enable_translator", listOf("discord translator", "enable translator", "translate presence")) { SearchResultSwitch(EnableTranslatorKey, false) },
+                SettingsChild("Target language", "target_language", listOf("target language", "translation language", "discord language")),
+                SettingsChild("Show button 1", "discord_show_button_1", listOf("discord button", "show button", "rpc button 1")),
+                SettingsChild("Button 1 URL source", "discord_activity_button_1_url", listOf("button 1 url", "discord button url", "rpc button link")),
+                SettingsChild("Show button 2", "discord_show_button_2", listOf("discord button 2", "show second button", "rpc button 2")),
+                SettingsChild("Button 2 URL source", "discord_activity_button_2_url", listOf("button 2 url", "discord second button url", "rpc button 2 link")),
+            ),
+        )
+    // Integration → Tidal account + instance management sub-page.
+    val tidalDetail =
+        SettingsItem(
+            key = "tidal",
+            icon = painterResource(R.drawable.provider_tidal),
+            title = "Tidal",
+            subtitle = "Tidal account and instances",
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("tidal", "tidal account", "tidal instances", "hifi", "mqa", "lossless", "flac", "tidal login"),
+            onClick = { navController.navigate("settings/tidal") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Tidal account", "tidal_account_connected", listOf("tidal account", "connected account", "tidal user")),
+                SettingsChild("Sign in with Tidal (web)", "tidal_login_web", listOf("tidal login", "tidal sign in", "tidal web login", "connect tidal")),
+                SettingsChild("Reconnect Tidal account", "tidal_reconnect", listOf("reconnect tidal", "refresh tidal", "tidal reconnect")),
+                SettingsChild("Disconnect Tidal account", "tidal_disconnect", listOf("disconnect tidal", "tidal logout", "tidal sign out")),
+                SettingsChild("Manage instances", "source_manage_instances", listOf("manage instances", "tidal instances", "tidal servers")),
+                SettingsChild("Add instance", "tidal_add_instance", listOf("add instance", "add tidal instance", "new tidal server")),
+                SettingsChild("Add many (paste)", "source_bulk_add", listOf("bulk add", "add many", "paste instances")),
+                SettingsChild("Copy online", "source_copy_online", listOf("copy online", "copy working instances", "share instances")),
+                SettingsChild("Remove dead", "source_remove_dead", listOf("remove dead", "remove dead instances", "clean instances")),
+                SettingsChild("Remove deprecated", "source_remove_deprecated", listOf("remove deprecated", "remove old instances")),
+                SettingsChild("Clear all instances", "tidal_reset_instances", listOf("clear instances", "reset instances", "delete all instances")),
+            ),
+        )
+    // Integration → Qobuz account, tokens and instance management sub-page.
+    val qobuzDetail =
+        SettingsItem(
+            key = "qobuz",
+            icon = painterResource(R.drawable.provider_tidal),
+            title = "Qobuz",
+            subtitle = "Qobuz account, tokens and instances",
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("qobuz", "qobuz account", "qobuz tokens", "qobuz instances", "hi-res", "flac", "cd quality", "24 bit", "qobuz login"),
+            onClick = { navController.navigate("settings/qobuz") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Enable Qobuz source", "qobuz_enable", listOf("enable qobuz", "qobuz source", "turn on qobuz")),
+                SettingsChild("Qobuz audio quality", "qobuz_audio_quality", listOf("qobuz quality", "hi-res", "flac", "cd quality", "24 bit")),
+                SettingsChild("Sign in with Qobuz (web)", "qobuz_login_web", listOf("qobuz login", "qobuz sign in", "qobuz web login", "connect qobuz")),
+                SettingsChild("Add tokens (paste)", "qobuz_add_tokens", listOf("add qobuz tokens", "qobuz token", "app secret", "app id", "paste tokens")),
+                SettingsChild("Manage accounts", "qobuz_manage_accounts", listOf("manage qobuz accounts", "qobuz accounts", "account pool")),
+                SettingsChild("Clear all tokens", "qobuz_reset_tokens", listOf("clear qobuz tokens", "reset tokens", "delete tokens")),
+                SettingsChild("Manage instances", "source_manage_instances", listOf("manage instances", "qobuz instances", "qobuz servers")),
+                SettingsChild("Add instance", "qobuz_add_instance", listOf("add instance", "add qobuz instance", "new qobuz server")),
+                SettingsChild("Add many (paste)", "source_bulk_add", listOf("bulk add", "add many", "paste instances")),
+                SettingsChild("Copy online", "source_copy_online", listOf("copy online", "copy working instances")),
+                SettingsChild("Remove dead", "source_remove_dead", listOf("remove dead", "remove dead instances")),
+                SettingsChild("Remove deprecated", "source_remove_deprecated", listOf("remove deprecated", "remove old instances")),
+                SettingsChild("Clear all instances", "qobuz_reset_instances", listOf("clear instances", "reset instances", "delete all instances")),
+            ),
+        )
+    // Integration → Telegram sub-page.
+    val telegramDetail =
+        SettingsItem(
+            key = "telegram",
+            icon = painterResource(R.drawable.provider_tidal),
+            title = "Telegram",
+            subtitle = "Telegram account and channels",
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("telegram", "telegram channel", "telegram login", "telegram music", "telegram bots", "channel sync"),
+            onClick = { navController.navigate("settings/telegram") },
+            hidden = true,
+            children = listOf(
+                SettingsChild("Signed in as", "telegram_logged_in_as", listOf("telegram account", "signed in as", "telegram user")),
+                SettingsChild("Sign in with Telegram", "telegram_login", listOf("telegram login", "telegram sign in", "connect telegram", "phone code")),
+                SettingsChild("Sign out", "telegram_logout", listOf("telegram logout", "telegram sign out", "disconnect telegram")),
+                SettingsChild("Browse channels", "telegram_browse_channels", listOf("browse channels", "telegram channels", "music channels", "add channel")),
+                SettingsChild("Lossless files only", "telegram_lossless_only", listOf("lossless only", "telegram lossless", "flac only", "high quality only")) { SearchResultSwitch(TelegramLosslessOnlyKey, false) },
+                SettingsChild("Telegram bots", "telegram_bots_title", listOf("telegram bots", "bot token", "music bot")),
             ),
         )
     val aiIntegration =
@@ -399,6 +766,15 @@ fun buildSettingsGroups(
                 SettingsChild("AI model", "ai_model", listOf("model", "ai model", "gpt", "gemini model", "claude model")),
                 SettingsChild("Test API", "ai_test_api", listOf("test", "test api", "verify", "test connection", "ai test")),
                 SettingsChild("Hide AI mix", "hide_ai_mix", listOf("hide ai", "ai mix", "smart mix", "hide mix")) { SearchResultSwitch(HideAiMixKey, false) },
+                SettingsChild("Automatic translation", "auto_translate_lyrics", listOf("automatic translation", "auto translate", "auto translate lyrics", "translate automatically")),
+                SettingsChild("Don't auto translate these languages", "auto_translate_excluded_languages", listOf("excluded languages", "skip translation", "do not translate", "translation exclusions")),
+                SettingsChild("Target language", "translate_language", listOf("target language", "translate to", "translation language")),
+                SettingsChild("Translation mode", "translate_mode", listOf("translation mode", "translate mode", "translation style")),
+                SettingsChild("DeepL API key", "deepl_api_key", listOf("deepl", "deepl api key", "deepl key", "deepl token")),
+                SettingsChild("DeepL formality", "deepl_formality", listOf("deepl formality", "formality", "formal informal")),
+                SettingsChild("OpenRouter API key", "openrouter_api_key", listOf("openrouter", "openrouter api key", "openrouter key")),
+                SettingsChild("Mistral API key", "mistral_api_key", listOf("mistral", "mistral api key", "mistral key")),
+                SettingsChild("Model", "ai_model", listOf("ai model", "model", "gpt", "gemini model", "claude model")),
             ),
         )
     val internet =
@@ -440,6 +816,22 @@ fun buildSettingsGroups(
             // Moved into the Accounts sub-page (Task 9). Kept in the search index so existing
             // search shortcuts still work.
             hidden = true,
+            children = listOf(
+                SettingsChild("Web Client PO Token", "web_client_po_token", listOf("po token", "potoken", "web client po token", "botguard", "playability", "youtube token")),
+            ),
+        )
+    // Listen Together lives on its own screen reached from the player, not from a
+    // settings sub-page — indexed here so searching "listen together" still finds it.
+    val musicTogether =
+        SettingsItem(
+            key = "music_together",
+            icon = painterResource(R.drawable.auto_awesome),
+            title = stringResource(R.string.music_together),
+            subtitle = "Listen in sync with friends",
+            accentColor = MaterialTheme.colorScheme.tertiary,
+            keywords = listOf("music together", "listen together", "listening party", "sync listening", "together", "room", "lan", "public room", "share session"),
+            onClick = { navController.navigate("settings/music_together") },
+            hidden = true,
         )
     val storage =
         SettingsItem(
@@ -461,6 +853,12 @@ fun buildSettingsGroups(
                 SettingsChild("Storage folder", "storage_folder", listOf("storage path", "storage location", "storage directory")),
                 SettingsChild("Download location", "download_location", listOf("download path", "location", "folder", "directory", "save to")),
                 SettingsChild("Smart trimmer", "smart_trimmer", listOf("smart trimmer", "trim cache", "auto clean cache")) { SearchResultSwitch(SmartTrimmerKey, false) },
+                SettingsChild("Max song cache size", "max_song_cache_size", listOf("max song cache", "song cache size", "cache limit", "cache size")),
+                SettingsChild("Max image cache size", "max_image_cache_size", listOf("max image cache", "image cache size", "thumbnail cache size")),
+                SettingsChild("Max canvas cache size", "max_cache_size", listOf("max canvas cache", "canvas cache size", "motion artwork cache size")),
+                SettingsChild("Clear lyrics cache", "clear_lyrics_cache", listOf("clear lyrics cache", "delete lyrics cache", "wipe lyrics cache")),
+                SettingsChild("Choose folder", "storage_folder_pick", listOf("choose folder", "pick folder", "storage folder", "select directory")),
+                SettingsChild("Storage used", "size_used", listOf("storage used", "space used", "size used", "disk usage")),
             ),
         )
     val downloads =
@@ -499,6 +897,14 @@ fun buildSettingsGroups(
                 SettingsChild("Restore", "restore", listOf("restore", "import", "recover")),
                 SettingsChild("Import online (m3u)", "import_online", listOf("import online", "m3u", "playlist import")),
                 SettingsChild("Import CSV", "import_csv", listOf("import csv", "csv", "playlist csv")),
+                SettingsChild("Enable scheduled backup", "scheduled_backup_enabled", listOf("enable scheduled backup", "auto backup", "automatic backup", "periodic backup")),
+                SettingsChild("Overwrite existing backup", "scheduled_backup_overwrite", listOf("overwrite backup", "replace backup", "overwrite existing")),
+                SettingsChild("Enable cloud sync", "google_drive_sync_enabled", listOf("cloud sync", "google drive", "drive sync", "enable cloud sync", "gdrive", "backup to drive")),
+                SettingsChild("Drive folder", "google_drive_sync_remote_folder", listOf("drive folder", "google drive folder", "remote folder", "cloud folder")),
+                SettingsChild("Clear Drive folder", "google_drive_sync_clear_folder", listOf("clear drive folder", "empty drive folder", "delete drive backups")),
+                SettingsChild("Overwrite existing Drive backup", "google_drive_sync_overwrite", listOf("overwrite drive backup", "replace drive backup", "drive overwrite")),
+                SettingsChild("Drive sync frequency", "google_drive_sync_frequency", listOf("drive sync frequency", "cloud sync frequency", "sync interval", "sync schedule")),
+                SettingsChild("Sync now", "google_drive_sync_run_now", listOf("sync now", "run sync", "backup now", "upload now")),
             ),
         )
     val developerOptions =
@@ -518,6 +924,10 @@ fun buildSettingsGroups(
                 SettingsChild("Manual source login", "manual_source_login", listOf("manual source login", "manual login", "dev source login")),
                 SettingsChild("YTM sync", "ytm_sync", listOf("ytm sync", "youtube music sync", "sync library")),
                 SettingsChild("Force sync on account switch", "force_sync_account_switch", listOf("force sync", "account switch sync", "sync on switch")),
+                SettingsChild("Show nerd stats", "show_nerd_stats", listOf("nerd stats", "show nerd stats", "debug stats", "playback stats", "technical info")),
+                SettingsChild("Display codec on player", "display_codec_on_player", listOf("display codec", "show codec", "codec on player", "bitrate on player")),
+                SettingsChild("Show Discord debug UI", "show_discord_debug_ui", listOf("discord debug", "show debug ui", "discord debug ui")),
+                SettingsChild("Debug logs", "debug_logs", listOf("debug logs", "verbose logs", "diagnostic logs")),
             ),
         )
     val defaultLinks =
@@ -619,7 +1029,25 @@ fun buildSettingsGroups(
         ),
         SettingsGroup(
             title = stringResource(R.string.settings_section_player_content),
-            items = listOf(appearance, playback, sources, lyrics, languagePacks, content, behavior),
+            items =
+                listOf(
+                    appearance,
+                    appearanceExtras,
+                    aodCustomization,
+                    navigationBar,
+                    lyricsAnimations,
+                    playback,
+                    ytDlp,
+                    sources,
+                    jioSaavn,
+                    deezer,
+                    lyrics,
+                    lyricsProviders,
+                    lyricsRomanisation,
+                    languagePacks,
+                    content,
+                    behavior,
+                ),
         ),
         SettingsGroup(
             title = stringResource(R.string.integration),
@@ -627,12 +1055,23 @@ fun buildSettingsGroups(
             // top-level items here — they live as children of `integration` (and
             // also under their respective `sources` / `integration` screens).
             // Surfacing them as separate rows on the main settings page was
-            // redundant noise per user feedback.
-            items = listOf(integration, aiIntegration, internet, poToken),
+            // redundant noise per user feedback. The `hidden = true` entries below
+            // exist purely so their own sub-page settings are searchable.
+            items =
+                listOf(
+                    integration,
+                    aiIntegration,
+                    discordExperimental,
+                    tidalDetail,
+                    qobuzDetail,
+                    telegramDetail,
+                    internet,
+                    poToken,
+                ),
         ),
         SettingsGroup(
             title = stringResource(R.string.storage),
-            items = listOf(storage, downloads, backupRestore),
+            items = listOf(storage, downloads, backupRestore, musicTogether),
         ),
         SettingsGroup(
             title = stringResource(R.string.about),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -68,9 +68,102 @@ import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.Updater
 
 
+/**
+ * Search-result children that are indexed under one page but physically live on another.
+ *
+ * The settings index grew section by section, so a number of children are still listed under the
+ * page that *used* to own them — every Discord activity field under "Integration", every lyrics
+ * provider toggle under "Lyrics", every streaming-source switch under "Playback". Navigating to
+ * the indexed parent opens a screen that does not contain the row at all, so `?scrollTo=` has
+ * nothing to find and the result silently lands at the top of the wrong page.
+ *
+ * Keyed by `"<indexedParent>/<scrollKey>"` rather than by the scroll key alone: several keys are
+ * legitimately indexed twice (`qobuz_enable` under both "Playback" and "Qobuz"), and only the
+ * out-of-place copy should be redirected.
+ *
+ * Fixing the index itself would be the deeper repair, but it would also change the result titles
+ * users see; re-pointing the navigation keeps the search results as they are and simply sends
+ * them somewhere the setting exists.
+ */
+private val CROSS_PAGE_SCROLL_OWNERS: Map<String, String> =
+    buildMap {
+        fun own(
+            owner: String,
+            parent: String,
+            vararg keys: String,
+        ) = keys.forEach { put("$parent/$it", owner) }
+
+        // Integration is a hub of links; the settings themselves live on the per-service screens.
+        own(
+            "discord", "integration",
+            "discord_options", "discord_connection", "discord_activity", "discord_images",
+            "activity_status", "platform_status", "discord_activity_name",
+            "discord_activity_details", "discord_activity_state", "discord_activity_type",
+            "discord_show_when_paused", "large_image", "large_text", "small_image",
+        )
+        own("discord_experimental", "integration", "discord_experimental")
+        own(
+            "lastfm", "integration",
+            "lastfm_options", "lastfm_scrobbling_config", "enable_scrobbling", "lastfm_now_playing",
+            "lastfm_prefer_yt_thumbnails", "scrobble_min_track_duration", "scrobble_delay_percent",
+            "scrobble_delay_minutes", "lastfm_connect_button", "lastfm_connect_librefm_button",
+            "lastfm_connect_custom_button",
+        )
+        own("tidal", "integration", "tidal_account", "tidal_instances")
+        own("qobuz", "integration", "qobuz_account", "qobuz_tokens", "qobuz_instances")
+        own(
+            "telegram", "integration",
+            "telegram_login", "telegram_browse_channels", "telegram_lossless_only",
+            "telegram_logout", "telegram_bots_title",
+        )
+
+        // Lyrics was split into Providers / Romanisation / Animations sub-pages.
+        own(
+            "lyrics_providers", "lyrics",
+            "first_lyrics_provider", "set_first_lyrics_provider", "prioritize_word_synced_lyrics",
+            "enable_tidal_lyrics", "enable_deezer_lyrics", "enable_musixmatch_experimental",
+            "paxsenix_api_key", "paxsenix_endpoint", "paxsenix_stats", "paxsenix_lyrics",
+            "betterlyrics", "betterlyrics_portato", "youlyplus_lyrics", "lrclib", "kugou",
+            "unison_lyrics", "simpmusic_lyrics", "megalobiz_lyrics",
+        )
+        own(
+            "lyrics_romanisation", "lyrics",
+            "lyrics_romanize_japanese", "lyrics_romanize_korean", "lyrics_romanize_chinese",
+            "lyrics_romanize_hindi", "lyrics_romanize_other",
+        )
+        own("lyrics_animations", "lyrics", "lyrics_animations")
+        own("appearance", "lyrics", "lyrics_background_style")
+        // The lyrics translator shipped alongside the Discord experiments and still lives there.
+        own("discord_experimental", "lyrics", "translate_lyrics", "enable_translator")
+
+        // Source enable/quality switches moved from Playback to the dedicated Sources page.
+        own(
+            "sources", "playback",
+            "preferred_sources", "auto_choose_playback_client", "player_stream_client",
+            "check_source", "spotify_catalog_source", "tidal_enable", "tidal_account_first",
+            "tidal_audio_quality", "tidal_animated_covers", "tidal_manage_instances",
+            "qobuz_enable", "qobuz_audio_quality", "qobuz_backup_enable", "qobuz_manage_instances",
+            "deezer_enable", "deezer_audio_quality", "jiosaavn_enable", "jiosaavn_audio_quality",
+        )
+        own("ytdlp", "playback", "ytdlp")
+        own("sources", "deezer", "deezer_enable", "deezer_audio_quality")
+        own("qobuz", "sources", "qobuz")
+        own("tidal", "sources", "tidal")
+
+        // Appearance rows that were moved out to their own pages.
+        own("navigation_bar", "appearance", "frosted_nav_bar", "liquid_glass_nav_bar", "hide_navigation_bar_labels")
+        own("appearance_extras", "appearance", "show_home_category_chips")
+        own("playback", "appearance", "swipe_sensitivity")
+        own("behavior", "appearance", "force_high_refresh_rate")
+        own("appearance_extras", "behavior", "show_tags_in_library")
+        own("downloads", "storage", "downloaded_songs", "download_location")
+    }
+
 private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): String? {
+    // A child indexed under the wrong page is navigated to the page that actually holds it.
+    val ownerKey = CROSS_PAGE_SCROLL_OWNERS["$parentKey/${scrollKey.orEmpty()}"] ?: parentKey
     val route =
-        when (parentKey) {
+        when (ownerKey) {
             "account" -> "settings/account"
             "appearance" -> "settings/appearance"
             "appearance_extras" -> "settings/appearance/extras"
@@ -90,6 +183,7 @@ private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): Stri
             "integration" -> "settings/integration"
             "internet" -> "settings/internet"
             "storage" -> "settings/storage"
+            "downloads" -> "settings/downloads"
             "backup_restore" -> "settings/backup_restore"
             "developer_options" -> "settings/misc"
             "logcat" -> "settings/logcat"
@@ -109,7 +203,7 @@ private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): Stri
     // About / developer-options screens intentionally don't participate in auto-scroll
     // (their contents are mostly static links). All other screens honor ?scrollTo=.
     val supportsScroll =
-        parentKey !in
+        ownerKey !in
             setOf(
                 "developer_options",
                 "about",

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -73,9 +73,18 @@ private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): Stri
         when (parentKey) {
             "account" -> "settings/account"
             "appearance" -> "settings/appearance"
+            "appearance_extras" -> "settings/appearance/extras"
+            "aod" -> "settings/appearance/aod_customized"
+            "navigation_bar" -> "settings/appearance/navigation_bar"
+            "lyrics_animations" -> "settings/appearance/lyrics_animations"
             "playback" -> "settings/player"
+            "ytdlp" -> "settings/player/ytdlp"
             "sources" -> "settings/sources"
+            "jiosaavn" -> "settings/jiosaavn"
+            "deezer" -> "settings/deezer"
             "lyrics" -> "settings/lyrics"
+            "lyrics_providers" -> "settings/lyrics/providers"
+            "lyrics_romanisation" -> "settings/lyrics/romanisation"
             "content" -> "settings/content"
             "behavior" -> "settings/privacy"
             "integration" -> "settings/integration"
@@ -83,8 +92,11 @@ private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): Stri
             "storage" -> "settings/storage"
             "backup_restore" -> "settings/backup_restore"
             "developer_options" -> "settings/misc"
+            "logcat" -> "settings/logcat"
+            "music_together" -> "settings/music_together"
             "about" -> "settings/about"
             "discord" -> "settings/discord"
+            "discord_experimental" -> "settings/discord/experimental"
             "tidal" -> "settings/tidal"
             "qobuz" -> "settings/qobuz"
             "telegram" -> "settings/telegram"
@@ -96,48 +108,17 @@ private fun searchableSettingsRoute(parentKey: String, scrollKey: String?): Stri
         }
     // About / developer-options screens intentionally don't participate in auto-scroll
     // (their contents are mostly static links). All other screens honor ?scrollTo=.
-    val supportsScroll = parentKey !in setOf("developer_options", "about", "po_token", "account")
-    return if (!supportsScroll || scrollKey.isNullOrBlank()) route else "$route?scrollTo=$scrollKey"
-}
-
-/**
- * Strict, deterministic settings search index. Only settings currently rendered by the
- * settings hierarchy are indexed; stale aliases and hidden/moved entries cannot surface.
- */
-private fun searchSettings(groups: List<SettingsGroup>, query: String): List<SearchResultItem> {
-    val terms = query.lowercase().trim().split(Regex("\\s+")).filter(String::isNotBlank)
-    if (terms.isEmpty()) return emptyList()
-    return groups.asSequence()
-        .flatMap { it.items.asSequence().filterNot(SettingsItem::hidden) }
-        .flatMap { parent ->
-            parent.children.asSequence().map { child -> parent to child }
-        }
-        .filter { (parent, child) ->
-            val searchable = buildList {
-                add(child.title.lowercase())
-                add(child.scrollKey.replace('_', ' ').lowercase())
-                addAll(child.keywords.map(String::lowercase))
-            }
-            // Every word must describe the setting itself. Parent category
-            // words are deliberately excluded so "video", for example, does
-            // not return every unrelated item in the Content category.
-            terms.all { term -> searchable.any { it.contains(term) } }
-        }
-        .map { (parent, child) ->
-            SearchResultItem(
-                title = child.title,
-                parentTitle = parent.title,
-                parentIcon = parent.icon,
-                parentKey = parent.key,
-                parentAccentColor = parent.accentColor,
-                parentRoute = searchableSettingsRoute(parent.key, child.scrollKey),
-                scrollKey = child.scrollKey,
-                onClick = parent.onClick,
-                switchControl = child.switchControl,
+    val supportsScroll =
+        parentKey !in
+            setOf(
+                "developer_options",
+                "about",
+                "po_token",
+                "account",
+                "logcat",
+                "music_together",
             )
-        }
-        .sortedWith(compareBy<SearchResultItem> { !it.title.lowercase().startsWith(query.trim().lowercase()) }.thenBy { it.title })
-        .toList()
+    return if (!supportsScroll || scrollKey.isNullOrBlank()) route else "$route?scrollTo=$scrollKey"
 }
 
 @OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
@@ -196,8 +177,28 @@ fun SettingsScreen(
             Updater.isUpdateAvailable(latestVersionName, BuildConfig.VERSION_NAME)
     var isUpdateDismissed by remember { mutableStateOf(false) }
     val allSettingsGroups = buildSettingsGroups(navController, isAndroid12OrLater, hasUpdate, context)
+    // When searching, flatten all individual SettingsChildren across every
+    // category so each matching setting is shown as a separate row.
+    //
+    // Per product decision: settings that ship with an inline switch control
+    // (boolean toggles like Dynamic theme, Pure black, Low data mode, Crossfade,
+    // Persistent queue, etc.) ARE included in search results — the switch is
+    // rendered inline so the user can toggle directly from the results.
+    // Switchless settings navigate to the parent screen and auto-scroll to
+    // the setting's position when tapped.
+    //
+    // The matching itself lives in [SettingsSearch] — see that file for why
+    // multi-word queries used to return nothing.
     val filteredChildResults = remember(searchQuery, allSettingsGroups) {
-        if (searchQuery.isBlank()) emptyList() else searchSettings(allSettingsGroups, searchQuery)
+        if (searchQuery.isBlank()) {
+            emptyList()
+        } else {
+            SettingsSearch.search(
+                groups = allSettingsGroups,
+                rawQuery = searchQuery,
+                routeFor = { parentKey, scrollKey -> searchableSettingsRoute(parentKey, scrollKey) },
+            )
+        }
     }
     val filteredGroups = remember(allSettingsGroups) {
         allSettingsGroups.map { group ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsSearch.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsSearch.kt
@@ -1,0 +1,417 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.screens.settings
+
+/**
+ * Matching engine behind the settings search bar.
+ *
+ * ## Why this exists
+ *
+ * The previous matcher required **every** query word to hit some field of a
+ * candidate. Any word the index didn't know about killed the whole query, so
+ * single words worked while two or more words returned nothing at all:
+ * `dark` found "Dark theme", but `dark mode` found nothing, because no field
+ * anywhere contained "mode". Same for `lyrics font`, `night mode`, and so on.
+ * That is the bug this file fixes.
+ *
+ * ## How matching works
+ *
+ * Every candidate (a [SettingsChild], or a [SettingsItem] with no matching
+ * children) is flattened into a [Haystack] of normalised text at three
+ * confidence levels — title, "strong" (title + keywords + scroll key), and
+ * everything including the parent category's text.
+ *
+ * Each query term is scored against the haystack independently
+ * ([termStrength]). Then:
+ *
+ *  - **strict** — every term matched something. These are the real answers.
+ *  - **relaxed** — at least half the terms matched. Used *only* when nothing
+ *    matched strictly, so `dark mode` still surfaces "Dark theme" instead of an
+ *    empty list.
+ *
+ * A term also matches through a small [SYNONYMS] table (`mode`→`theme`,
+ * `vibration`→`haptic`, …), through a separator-insensitive "squashed" form so
+ * `lastfm` finds "Last.fm" and `potoken` finds "PO Token", and through a
+ * one-edit fuzzy comparison so ordinary typos and plurals still land.
+ */
+internal object SettingsSearch {
+    private val SEPARATOR_REGEX = Regex("[^a-z0-9]+")
+
+    /**
+     * Query-side synonym expansion. Deliberately small: every entry here trades
+     * a little precision for recall, so it only covers words users actually type
+     * that the app's own vocabulary doesn't use.
+     */
+    private val SYNONYMS: Map<String, List<String>> =
+        mapOf(
+            "mode" to listOf("theme", "style"),
+            "colour" to listOf("color"),
+            "colours" to listOf("color"),
+            "customise" to listOf("customize"),
+            "organise" to listOf("organize"),
+            "night" to listOf("dark"),
+            "vibration" to listOf("haptic"),
+            "vibrate" to listOf("haptic"),
+            "vibrations" to listOf("haptic"),
+            "wallpaper" to listOf("background", "backdrop"),
+            "lockscreen" to listOf("aod", "always", "screen"),
+            "song" to listOf("track", "music"),
+            "songs" to listOf("track", "music"),
+            "pic" to listOf("thumbnail", "artwork", "image", "cover"),
+            "picture" to listOf("thumbnail", "artwork", "image", "cover"),
+            "art" to listOf("artwork", "thumbnail", "cover"),
+            "vol" to listOf("volume"),
+            "eq" to listOf("equalizer", "normalization"),
+            "lang" to listOf("language"),
+            "translate" to listOf("translation", "translator"),
+            "pass" to listOf("password"),
+            "pwd" to listOf("password"),
+            "login" to listOf("account", "sign"),
+            "signin" to listOf("account", "login"),
+            "hires" to listOf("lossless", "flac", "quality"),
+            "hifi" to listOf("lossless", "flac", "quality"),
+            "size" to listOf("scale", "font"),
+            "speed" to listOf("limit", "bandwidth"),
+            "net" to listOf("network", "internet"),
+            "wifi" to listOf("network", "internet"),
+            "data" to listOf("network", "internet"),
+            "notification" to listOf("notify"),
+            "delete" to listOf("clear", "remove"),
+            "reset" to listOf("clear", "remove"),
+            "folder" to listOf("directory", "location", "path"),
+            "toggle" to listOf("enable", "show"),
+            "sync" to listOf("synchronize", "synchronise"),
+        )
+
+    /** Result tier — see the class docs. */
+    private enum class Tier { STRICT, RELAXED }
+
+    private class Match(
+        val tier: Tier,
+        val score: Int,
+        val item: SearchResultItem,
+    )
+
+    /**
+     * Normalised text for one candidate.
+     *
+     * Only the candidate's **own** text ([titleTokens] / [strongTokens]) can
+     * qualify it as a match. The parent category's text lives in [contextText]
+     * and contributes ranking bonuses only — otherwise a query like `equalizer`,
+     * which appears solely in the Playback category's keyword list, would match
+     * all ~20 Playback children equally and return them in arbitrary order
+     * instead of just pointing at the Playback category.
+     *
+     * [squashed] is every own-token concatenated with no separators, which is
+     * what lets `lastfm` match "Last.fm", `potoken` match "PO Token" and `hires`
+     * match "hi-res" without needing an alias for each.
+     */
+    private class Haystack(
+        val titleTokens: List<String>,
+        val titleText: String,
+        val strongTokens: List<String>,
+        val strongText: String,
+        val squashed: String,
+        val contextText: String,
+    )
+
+    /**
+     * Runs [rawQuery] against [groups].
+     *
+     * @param routeFor maps a parent key + scroll key to the route that should be
+     *   opened when a result is tapped.
+     * @return matching results, best first. Empty only when nothing matched even
+     *   loosely.
+     */
+    fun search(
+        groups: List<SettingsGroup>,
+        rawQuery: String,
+        routeFor: (parentKey: String, scrollKey: String) -> String?,
+    ): List<SearchResultItem> {
+        val queryText = normalizeText(rawQuery)
+        val terms = queryText.split(' ').filter { it.isNotBlank() }
+        if (terms.isEmpty()) return emptyList()
+        val querySquashed = terms.joinToString("")
+
+        val matches = mutableListOf<Match>()
+
+        for (group in groups) {
+            for (item in group.items) {
+                val parentFields =
+                    buildList {
+                        add(item.title)
+                        item.subtitle?.let { subtitle -> add(subtitle) }
+                        addAll(item.keywords)
+                    }
+
+                // Children are the specific settings, so they are always the
+                // preferred answer for an item.
+                val childMatches =
+                    item.children.mapNotNull { child ->
+                        val haystack =
+                            buildHaystack(
+                                titleFields = listOf(child.title),
+                                strongFields = child.keywords + scrollKeyFields(child.scrollKey),
+                                contextFields = parentFields,
+                            )
+                        evaluate(
+                            haystack = haystack,
+                            terms = terms,
+                            queryText = queryText,
+                            querySquashed = querySquashed,
+                            isChild = true,
+                        )?.let { (tier, score) ->
+                            Match(
+                                tier = tier,
+                                score = score,
+                                item =
+                                    SearchResultItem(
+                                        title = child.title,
+                                        parentTitle = item.title,
+                                        parentIcon = item.icon,
+                                        parentKey = item.key,
+                                        parentAccentColor = item.accentColor,
+                                        parentRoute = routeFor(item.key, child.scrollKey),
+                                        scrollKey = child.scrollKey,
+                                        onClick = item.onClick,
+                                        switchControl = child.switchControl,
+                                    ),
+                            )
+                        }
+                    }
+
+                if (childMatches.isNotEmpty()) {
+                    matches += childMatches
+                    continue
+                }
+
+                // No child matched — fall back to offering the category itself, so
+                // top-level entries with no children (Statistics, PO Token, …) stay
+                // reachable.
+                val parentHaystack =
+                    buildHaystack(
+                        titleFields = listOf(item.title),
+                        strongFields = item.keywords + listOfNotNull(item.subtitle),
+                        contextFields = emptyList(),
+                    )
+                evaluate(
+                    haystack = parentHaystack,
+                    terms = terms,
+                    queryText = queryText,
+                    querySquashed = querySquashed,
+                    isChild = false,
+                )?.let { (tier, score) ->
+                    matches +=
+                        Match(
+                            tier = tier,
+                            score = score,
+                            item =
+                                SearchResultItem(
+                                    title = item.title,
+                                    parentTitle = item.subtitle ?: "",
+                                    parentIcon = item.icon,
+                                    parentKey = item.key,
+                                    parentAccentColor = item.accentColor,
+                                    parentRoute = null,
+                                    scrollKey = null,
+                                    onClick = item.onClick,
+                                    switchControl = item.switchControl,
+                                ),
+                        )
+                }
+            }
+        }
+
+        // Only fall back to partial matches when there is no exact answer at all.
+        val strict = matches.filter { it.tier == Tier.STRICT }
+        val chosen = strict.ifEmpty { matches }
+        return chosen
+            .sortedByDescending { it.score }
+            .map { it.item }
+    }
+
+    /**
+     * Scores one candidate. Returns null when too few terms matched to be worth
+     * showing.
+     */
+    private fun evaluate(
+        haystack: Haystack,
+        terms: List<String>,
+        queryText: String,
+        querySquashed: String,
+        isChild: Boolean,
+    ): Pair<Tier, Int>? {
+        var strengthSum = 0
+        var matchedTerms = 0
+        var bestOwnStrength = 0
+        val unmatched = mutableListOf<String>()
+        for (term in terms) {
+            val strength = termStrength(term, haystack)
+            if (strength > 0) {
+                matchedTerms++
+                strengthSum += strength
+                if (strength > bestOwnStrength) bestOwnStrength = strength
+            } else {
+                unmatched += term
+            }
+        }
+        if (matchedTerms == 0) return null
+
+        // Terms that named the parent category ("appearance dark", "playback
+        // crossfade") count — but only once the candidate has already earned the
+        // match on its own text. Without that guard, a word living solely in a
+        // category's keyword list (e.g. "equalizer" under Playback) would qualify
+        // every child of that category equally.
+        if (unmatched.isNotEmpty() && bestOwnStrength >= 3 && haystack.contextText.isNotEmpty()) {
+            for (term in unmatched) {
+                if (haystack.contextText.contains(term)) {
+                    matchedTerms++
+                    strengthSum += 1
+                }
+            }
+        }
+
+        val tier =
+            when {
+                matchedTerms == terms.size -> Tier.STRICT
+                // At least half the words landed — good enough to suggest.
+                matchedTerms * 2 >= terms.size -> Tier.RELAXED
+                else -> return null
+            }
+
+        var score = if (tier == Tier.STRICT) 1_000 else 300
+        score += strengthSum * 10
+
+        // Whole-query phrase bonuses, strongest first.
+        when {
+            haystack.titleText == queryText -> score += 400
+            haystack.titleText.startsWith(queryText) -> score += 250
+            haystack.titleText.contains(queryText) -> score += 180
+            haystack.strongText.contains(queryText) -> score += 90
+            haystack.squashed.contains(querySquashed) -> score += 30
+        }
+
+        // Naming the parent category ("appearance dark", "playback crossfade")
+        // is a ranking signal, but never enough on its own to qualify a match.
+        if (haystack.contextText.isNotEmpty()) {
+            val contextHits = terms.count { haystack.contextText.contains(it) }
+            score += contextHits * 15
+        }
+
+        // Prefer the specific setting over the category row.
+        if (isChild) score += 25
+
+        return tier to score
+    }
+
+    /**
+     * How strongly a single [term] matches [haystack]: 0 for no match, up to 6
+     * for an exact title-token hit.
+     */
+    private fun termStrength(
+        term: String,
+        haystack: Haystack,
+    ): Int {
+        val variants = buildList {
+            add(term)
+            SYNONYMS[term]?.let { synonyms -> addAll(synonyms) }
+        }
+        var best = 0
+        for (variant in variants) {
+            val strength =
+                when {
+                    haystack.titleTokens.any { it == variant } -> 6
+                    haystack.titleText.contains(variant) -> 5
+                    haystack.strongTokens.any { it == variant } -> 4
+                    haystack.strongText.contains(variant) -> 3
+                    haystack.strongTokens.any { it.startsWith(variant) } -> 3
+                    // Separator-insensitive: "lastfm" vs "last.fm".
+                    variant.length >= 3 && haystack.squashed.contains(variant) -> 2
+                    // Compound query word, e.g. "scrollbar" vs a "scroll" token.
+                    variant.length >= 4 &&
+                        haystack.strongTokens.any { it.length >= 3 && variant.startsWith(it) } -> 1
+                    // Typos and plurals.
+                    haystack.strongTokens.any { fuzzyEquals(variant, it) } -> 1
+                    else -> 0
+                }
+            if (strength > best) best = strength
+            if (best == 6) break
+        }
+        return best
+    }
+
+    /** True when [a] and [b] differ by at most one edit. Both must be reasonably long. */
+    private fun fuzzyEquals(
+        a: String,
+        b: String,
+    ): Boolean {
+        if (a.length < 5 || b.length < 5) return false
+        if (kotlin.math.abs(a.length - b.length) > 1) return false
+        if (a == b) return true
+
+        // Same length: allow a single substitution.
+        if (a.length == b.length) {
+            var diffs = 0
+            for (i in a.indices) {
+                if (a[i] != b[i]) {
+                    diffs++
+                    if (diffs > 1) return false
+                }
+            }
+            return true
+        }
+
+        // Lengths differ by one: allow a single insertion/deletion.
+        val shorter = if (a.length < b.length) a else b
+        val longer = if (a.length < b.length) b else a
+        var shortIndex = 0
+        var longIndex = 0
+        var skipped = false
+        while (shortIndex < shorter.length && longIndex < longer.length) {
+            if (shorter[shortIndex] == longer[longIndex]) {
+                shortIndex++
+                longIndex++
+            } else {
+                if (skipped) return false
+                skipped = true
+                longIndex++
+            }
+        }
+        return true
+    }
+
+    private fun buildHaystack(
+        titleFields: List<String>,
+        strongFields: List<String>,
+        contextFields: List<String>,
+    ): Haystack {
+        val titleTokens = tokenizeAll(titleFields)
+        val strongTokens = titleTokens + tokenizeAll(strongFields)
+        return Haystack(
+            titleTokens = titleTokens,
+            titleText = titleTokens.joinToString(" "),
+            strongTokens = strongTokens,
+            strongText = strongTokens.joinToString(" "),
+            squashed = strongTokens.joinToString(""),
+            contextText = tokenizeAll(contextFields).joinToString(" "),
+        )
+    }
+
+    /** Splits a scroll key ("scrobble_threshold") into searchable fields. */
+    private fun scrollKeyFields(scrollKey: String): List<String> =
+        listOf(scrollKey, scrollKey.replace('_', ' ').replace('-', ' '))
+
+    private fun tokenizeAll(fields: List<String>): List<String> =
+        fields.flatMap { field -> normalizeText(field).split(' ') }.filter { it.isNotBlank() }
+
+    private fun normalizeText(text: String): String =
+        text
+            .lowercase()
+            .replace(SEPARATOR_REGEX, " ")
+            .trim()
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceCheckService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceCheckService.kt
@@ -150,7 +150,7 @@ object SourceCheckService {
 
     private fun checkQobuzBackup(): SourceCheckResult {
         // The Qobuz backup is a two-step resolver: GET the resolver endpoint to
-        // get the actual stream URL on the CDN, then HEAD-probe the CDN URL.
+        // get the actual stream URL on the CDN, then range-probe the CDN URL.
         // NOTE: server addresses are intentionally hidden from the summary text.
         val resolverUrl = "https://mlc-ytify.kouzu.in/api/stream?id=$KOZU_PROBE_YT_ID"
         return runCatching {
@@ -183,46 +183,52 @@ object SourceCheckService {
                         summary = "Qobuz backup resolver returned a non-JSON response.",
                     )
                 }
-                val streamUrl = root.optString("url").takeIf { it.isNotBlank() }
-                    ?: root.optString("canvas_url").takeIf { it.isNotBlank() }
-                    ?: root.optString("video_url").takeIf { it.isNotBlank() }
-                if (streamUrl.isNullOrBlank()) {
+                // The resolver returns both a lossy `url` mirror and a `lossless`
+                // FLAC mirror. Report on the lossless one first, since that is the
+                // reason to use this source at all.
+                val losslessUrl = root.optString("lossless").takeIf { it.isNotBlank() }
+                val lossyUrl = root.optString("url").takeIf { it.isNotBlank() }
+                if (losslessUrl == null && lossyUrl == null) {
                     return@runCatching SourceCheckResult(
                         healthy = false,
                         summary = "Qobuz backup resolver returned a JSON envelope with no stream URL.",
                     )
                 }
-                // Step 2: HEAD-probe the resolved CDN URL.
-                val cdnRequest = Request.Builder()
-                    .url(streamUrl)
-                    .method("HEAD", null)
-                    .header("User-Agent", "ArchiveTune-Android")
-                    .build()
-                client.newCall(cdnRequest).execute().use { cdnResponse ->
-                    if (!cdnResponse.isSuccessful) {
-                        // Some CDNs reject HEAD but accept GET — report healthy=true
-                        // if the resolver returned a URL even if HEAD failed.
-                        return@runCatching SourceCheckResult(
+                // Step 2: range-probe the resolved CDN URL.
+                //
+                // Deliberately a ranged GET, not HEAD: the CDN answers HEAD with
+                // `405 Method Not Allowed` (`allow: GET`) for every object, so the
+                // old HEAD probe always reported a scary "HEAD probe got HTTP 405"
+                // even when the stream was perfectly playable. `Range: bytes=0-1`
+                // downloads two bytes and returns the real Content-Type.
+                val losslessProbe = losslessUrl?.let { probeCdn(it) }
+                val lossyProbe = if (losslessProbe?.ok == true) null else lossyUrl?.let { probeCdn(it) }
+                when {
+                    losslessProbe?.ok == true ->
+                        SourceCheckResult(
                             healthy = true,
-                            summary = "Qobuz backup resolver returned a stream URL but the CDN HEAD probe " +
-                                "got HTTP ${cdnResponse.code}. ExoPlayer's GET might still succeed. " +
+                            summary = "Qobuz backup is reachable and served a lossless stream " +
+                                "(${losslessProbe.contentType}${losslessProbe.sizeSuffix()}). " +
                                 "Qobuz backup is READY.",
                         )
+
+                    lossyProbe?.ok == true ->
+                        SourceCheckResult(
+                            healthy = true,
+                            summary = "Qobuz backup is reachable but only the lossy mirror served audio " +
+                                "(${lossyProbe.contentType}). The backup server has no lossless copy of the " +
+                                "probe track yet — lossless will still be used for tracks that have one.",
+                        )
+
+                    else -> {
+                        val failed = losslessProbe ?: lossyProbe
+                        SourceCheckResult(
+                            healthy = false,
+                            summary = "Qobuz backup resolver returned a stream URL but the CDN served " +
+                                "${failed?.describeFailure() ?: "no response"}. The backup server may be " +
+                                "rebuilding its cache — try again in a few minutes.",
+                        )
                     }
-                    val contentType = cdnResponse.header("Content-Type")?.lowercase().orEmpty()
-                    val ok = contentType.startsWith("audio/") ||
-                        contentType.startsWith("video/") ||
-                        contentType.contains("octet-stream")
-                    SourceCheckResult(
-                        healthy = ok || contentType.isBlank(),
-                        summary = if (ok || contentType.isBlank()) {
-                            "Qobuz backup is reachable and returned an audio stream ($contentType). " +
-                                "Qobuz backup is READY."
-                        } else {
-                            "Qobuz backup resolver succeeded but the CDN returned an unexpected content type: $contentType. " +
-                                "The backup server may be misconfigured."
-                        },
-                    )
                 }
             }
         }.getOrElse { e ->
@@ -232,6 +238,49 @@ object SourceCheckService {
             )
         }
     }
+
+    /** Outcome of a two-byte ranged GET against a Qobuz-backup CDN mirror. */
+    private data class CdnProbe(
+        val ok: Boolean,
+        val code: Int,
+        val contentType: String,
+        val totalBytes: Long?,
+    ) {
+        fun sizeSuffix(): String =
+            totalBytes?.let { ", ${it / 1_000_000}MB" }.orEmpty()
+
+        fun describeFailure(): String =
+            if (code in 200..299) "an unexpected content type: $contentType" else "HTTP $code"
+    }
+
+    private fun probeCdn(url: String): CdnProbe? =
+        runCatching {
+            val request = Request.Builder()
+                .url(url)
+                .get()
+                .header("User-Agent", "ArchiveTune-Android")
+                .header("Range", "bytes=0-1")
+                .build()
+            client.newCall(request).execute().use { response ->
+                val contentType = response.header("Content-Type")?.lowercase().orEmpty()
+                val isAudio =
+                    contentType.startsWith("audio/") ||
+                        contentType.startsWith("video/") ||
+                        contentType.contains("octet-stream")
+                val total =
+                    response
+                        .header("Content-Range")
+                        ?.substringAfter('/', "")
+                        ?.trim()
+                        ?.toLongOrNull()
+                CdnProbe(
+                    ok = response.isSuccessful && isAudio,
+                    code = response.code,
+                    contentType = contentType.ifBlank { "unknown" },
+                    totalBytes = total,
+                )
+            }
+        }.getOrNull()
 
     private suspend fun checkDeezer(context: Context): SourceCheckResult {
         PoolAccountManager.refresh(context, force = false)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
@@ -94,6 +94,8 @@ fun SourceSettings(navController: NavController, scrollTo: String? = null) {
                         WindowInsetsSides.Horizontal,
                     ),
                 )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -104,7 +106,10 @@ fun SourceSettings(navController: NavController, scrollTo: String? = null) {
 
             // Preferred-source picker, per-source enable toggles and quality. Account/instance
             // management remains in Integration (behind the manual-source-login toggle).
-            PlaybackSourceSections(navController = navController)
+            PlaybackSourceSections(
+                navController = navController,
+                positions = positions,
+            )
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -344,6 +344,8 @@ fun StorageSettings(
             Modifier
                 .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal))
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(
                     start = 12.dp,
@@ -367,6 +369,7 @@ fun StorageSettings(
             ) {
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("max_song_cache_size"),
                         title = { Text(stringResource(R.string.max_song_cache_size)) },
                         description =
                             if (maxSongCacheSize == -1) {
@@ -401,6 +404,7 @@ fun StorageSettings(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("clear_song_cache"),
                         title = { Text(stringResource(R.string.clear_song_cache)) },
                         onClick = { clearCacheDialog = true },
                     )
@@ -428,6 +432,7 @@ fun StorageSettings(
             ) {
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("max_image_cache_size"),
                         title = { Text(stringResource(R.string.max_image_cache_size)) },
                         description =
                             when {
@@ -470,6 +475,7 @@ fun StorageSettings(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("clear_image_cache"),
                         title = { Text(stringResource(R.string.clear_image_cache)) },
                         onClick = { clearImageCacheDialog = true },
                     )
@@ -497,6 +503,7 @@ fun StorageSettings(
             ) {
                 item {
                     ListPreference(
+                        modifier = positions.modifierFor("max_cache_size"),
                         title = { Text(stringResource(R.string.max_cache_size)) },
                         description =
                             when {
@@ -539,6 +546,7 @@ fun StorageSettings(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("clear_canvas_cache"),
                         title = { Text(stringResource(R.string.clear_canvas_cache)) },
                         onClick = { clearCanvasCacheDialog = true },
                     )
@@ -570,6 +578,7 @@ fun StorageSettings(
             ) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("clear_lyrics_cache"),
                         title = { Text(stringResource(R.string.clear_lyrics_cache)) },
                         onClick = { clearLyricsCacheDialog = true },
                     )
@@ -674,6 +683,7 @@ private fun StorageFolderSection(
 
         item {
             SwitchPreference(
+                modifier = positions.modifierFor("smart_trimmer"),
                 title = { Text(stringResource(R.string.smart_trimmer)) },
                 description = stringResource(R.string.smart_trimmer_description),
                 checked = smartTrimmer && isSmartTrimmerAvailable,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
@@ -58,7 +58,10 @@ import androidx.compose.foundation.layout.asPaddingValues
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TelegramSettings(navController: NavController) {
+fun TelegramSettings(
+    navController: NavController,
+    scrollTo: String? = null,
+) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
@@ -134,6 +137,9 @@ fun TelegramSettings(navController: NavController) {
                 .only(WindowInsetsSides.Bottom)
                 .asPaddingValues()
                 .calculateBottomPadding()
+        val scrollState = rememberScrollState()
+        val positions = rememberPreferencePositions()
+        androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, scrollState) }
         Column(
             Modifier
                 .padding(top = innerPadding.calculateTopPadding())
@@ -141,13 +147,17 @@ fun TelegramSettings(navController: NavController) {
                     LocalPlayerAwareWindowInsets.current.only(
                         WindowInsetsSides.Horizontal,
                     ),
-                ).verticalScroll(rememberScrollState())
+                )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
+                .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
             PreferenceGroup(title = stringResource(R.string.telegram_account)) {
                 if (isReady) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("telegram_logged_in_as"),
                             title = {
                                 Text(
                                     stringResource(
@@ -162,6 +172,7 @@ fun TelegramSettings(navController: NavController) {
                     }
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("telegram_logout"),
                             title = { Text(stringResource(R.string.telegram_logout)) },
                             icon = { Icon(painterResource(R.drawable.logout), contentDescription = null) },
                             onClick = { showLogoutDialog = true },
@@ -170,6 +181,7 @@ fun TelegramSettings(navController: NavController) {
                 } else {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("telegram_login"),
                             title = { Text(stringResource(R.string.telegram_login)) },
                             description = stringResource(R.string.telegram_login_summary),
                             icon = { Icon(painterResource(R.drawable.provider_telegram), contentDescription = null) },
@@ -185,6 +197,7 @@ fun TelegramSettings(navController: NavController) {
             PreferenceGroup(title = stringResource(R.string.telegram_browse_channels)) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("telegram_browse_channels"),
                         title = { Text(stringResource(R.string.telegram_browse_channels)) },
                         description =
                             if (isReady) {
@@ -199,6 +212,7 @@ fun TelegramSettings(navController: NavController) {
                 }
                 item {
                     SwitchPreference(
+                        modifier = positions.modifierFor("telegram_lossless_only"),
                         title = { Text(stringResource(R.string.telegram_lossless_only)) },
                         description = stringResource(R.string.telegram_lossless_only_description),
                         icon = { Icon(painterResource(R.drawable.graphic_eq), contentDescription = null) },
@@ -214,6 +228,7 @@ fun TelegramSettings(navController: NavController) {
             PreferenceGroup(title = stringResource(R.string.telegram_bots_title)) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("telegram_bots_title"),
                         title = { Text(stringResource(R.string.telegram_bots_title)) },
                         description =
                             if (isReady) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
@@ -440,6 +440,8 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
                         WindowInsetsSides.Horizontal,
                     ),
                 )
+                // Chained before verticalScroll so it measures the viewport, not the scrolling content.
+                .then(positions.containerModifier())
                 .verticalScroll(scrollState)
                 .padding(bottom = playerAwareBottomPadding + SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -450,6 +452,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
                 if (accountConfigured) {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("tidal_account_connected"),
                             title = {
                                 Text(stringResource(R.string.tidal_account_connected, accountName.ifBlank { "Tidal" }))
                             },
@@ -481,6 +484,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
                     if (needsRelogin) {
                         item {
                             PreferenceEntry(
+                                modifier = positions.modifierFor("tidal_reconnect"),
                                 title = { Text(stringResource(R.string.tidal_reconnect)) },
                                 icon = { Icon(painterResource(R.drawable.error), null) },
                                 onClick = { navController.navigate(TIDAL_LOGIN_ROUTE) },
@@ -490,6 +494,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
 
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("tidal_disconnect"),
                             title = { Text(stringResource(R.string.tidal_disconnect)) },
                             icon = { Icon(painterResource(R.drawable.logout), null) },
                             onClick = {
@@ -512,6 +517,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
                 } else {
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("tidal_login_web"),
                             title = { Text(stringResource(R.string.tidal_login_web)) },
                             icon = { Icon(painterResource(R.drawable.token), null) },
                             onClick = { navController.navigate(TIDAL_LOGIN_ROUTE) },
@@ -535,6 +541,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
                         healthStatus[it] == TidalAudioProvider.InstanceHealth.UNREACHABLE
                     }
                     PreferenceEntry(
+                        modifier = positions.modifierFor("source_manage_instances"),
                         title = { Text(stringResource(R.string.source_manage_instances)) },
                         description = stringResource(
                             R.string.source_health_summary,
@@ -624,6 +631,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("tidal_add_instance"),
                         title = { Text(stringResource(R.string.tidal_add_instance)) },
                         icon = { Icon(painterResource(R.drawable.add), null) },
                         onClick = { showAddDialog = true },
@@ -632,6 +640,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("source_bulk_add"),
                         title = { Text(stringResource(R.string.source_bulk_add)) },
                         description = stringResource(R.string.source_bulk_hint),
                         icon = { Icon(painterResource(R.drawable.playlist_add), null) },
@@ -641,6 +650,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("source_copy_online"),
                         title = { Text(stringResource(R.string.source_copy_online)) },
                         icon = { Icon(painterResource(R.drawable.copy), null) },
                         onClick = { copyOnlineInstances() },
@@ -649,6 +659,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("source_remove_dead"),
                         title = { Text(stringResource(R.string.source_remove_dead)) },
                         icon = { Icon(painterResource(R.drawable.delete), null) },
                         onClick = {
@@ -659,6 +670,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("source_remove_deprecated"),
                         title = { Text(stringResource(R.string.source_remove_deprecated)) },
                         icon = { Icon(painterResource(R.drawable.delete), null) },
                         onClick = {
@@ -669,6 +681,7 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
 
                 item(visible = showInstanceManagement) {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("tidal_reset_instances"),
                         title = { Text(stringResource(R.string.tidal_reset_instances)) },
                         icon = { Icon(painterResource(R.drawable.close), null) },
                         onClick = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/YtDlpSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/YtDlpSettings.kt
@@ -82,6 +82,7 @@ private val YtDlpMessageMaxWidth = 480.dp
 fun YtDlpSettings(
     navController: NavController,
     viewModel: YtDlpSettingsViewModel = hiltViewModel(),
+    scrollTo: String? = null,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -109,6 +110,7 @@ fun YtDlpSettings(
         onNavigateUp = onNavigateUp,
         onNavigateToMain = onNavigateToMain,
         onCheckForUpdates = onCheckForUpdates,
+        scrollTo = scrollTo,
     )
 }
 
@@ -119,6 +121,7 @@ private fun YtDlpSettingsContent(
     onNavigateUp: () -> Unit,
     onNavigateToMain: () -> Unit,
     onCheckForUpdates: () -> Unit,
+    scrollTo: String? = null,
 ) {
     val scrollBehavior = appBarScrollBehavior()
 
@@ -208,6 +211,7 @@ private fun YtDlpSettingsContent(
                                     WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                                 ),
                             ),
+                    scrollTo = scrollTo,
                 )
             }
         }
@@ -220,7 +224,11 @@ private fun YtDlpSettingsSuccess(
     onCheckForUpdates: () -> Unit,
     contentPadding: PaddingValues,
     modifier: Modifier = Modifier,
+    scrollTo: String? = null,
 ) {
+    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val positions = rememberPreferencePositions()
+    androidx.compose.runtime.LaunchedEffect(scrollTo) { positions.scrollToKey(scrollTo, listState) }
     val neverCheckedText = stringResource(R.string.ytdlp_never_checked)
     val bundledRuntimeText = stringResource(R.string.ytdlp_bundled_runtime)
     val lastCheckedText = rememberDateTime(data.lastCheckedAtMillis, neverCheckedText)
@@ -245,7 +253,9 @@ private fun YtDlpSettingsSuccess(
         }
 
     LazyColumn(
-        modifier = modifier.fillMaxSize(),
+        state = listState,
+        // A LazyColumn *is* its own viewport, so the position it reports is the one scrollToKey measures against.
+        modifier = modifier.fillMaxSize().then(positions.containerModifier()),
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(SettingsDimensions.SectionSpacing),
     ) {
@@ -272,6 +282,7 @@ private fun YtDlpSettingsSuccess(
             CenteredPreferenceGroup(title = stringResource(R.string.ytdlp_runtime_section)) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ytdlp_active_version"),
                         title = { Text(stringResource(R.string.ytdlp_active_version)) },
                         description = data.activeVersion,
                         icon = { Icon(painterResource(R.drawable.integration), null) },
@@ -279,6 +290,7 @@ private fun YtDlpSettingsSuccess(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ytdlp_bundled_version"),
                         title = { Text(stringResource(R.string.ytdlp_bundled_version)) },
                         description = data.bundledVersion,
                         icon = { Icon(painterResource(R.drawable.info), null) },
@@ -287,6 +299,7 @@ private fun YtDlpSettingsSuccess(
                 data.pendingVersion?.let { pendingVersion ->
                     item {
                         PreferenceEntry(
+                            modifier = positions.modifierFor("ytdlp_pending_version"),
                             title = { Text(stringResource(R.string.ytdlp_pending_version)) },
                             description = pendingVersion,
                             icon = { Icon(painterResource(R.drawable.sync), null) },
@@ -295,6 +308,7 @@ private fun YtDlpSettingsSuccess(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ytdlp_last_checked"),
                         title = { Text(stringResource(R.string.ytdlp_last_checked)) },
                         description = lastCheckedText,
                         icon = { Icon(painterResource(R.drawable.timer), null) },
@@ -302,6 +316,7 @@ private fun YtDlpSettingsSuccess(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ytdlp_last_updated"),
                         title = { Text(stringResource(R.string.ytdlp_last_updated)) },
                         description = lastUpdatedText,
                         icon = { Icon(painterResource(R.drawable.timer), null) },
@@ -314,6 +329,7 @@ private fun YtDlpSettingsSuccess(
             CenteredPreferenceGroup(title = stringResource(R.string.ytdlp_update_section)) {
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ytdlp_check_for_updates"),
                         title = { Text(stringResource(R.string.ytdlp_check_for_updates)) },
                         description = manualUpdateDescription,
                         icon = { Icon(painterResource(R.drawable.sync), null) },
@@ -328,6 +344,7 @@ private fun YtDlpSettingsSuccess(
                 }
                 item {
                     PreferenceEntry(
+                        modifier = positions.modifierFor("ytdlp_automatic_updates"),
                         title = { Text(stringResource(R.string.ytdlp_automatic_updates)) },
                         description = stringResource(R.string.ytdlp_automatic_updates_description),
                         icon = { Icon(painterResource(R.drawable.info), null) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/CanvasResolverEndpoints.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/CanvasResolverEndpoints.kt
@@ -1,0 +1,50 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.utils
+
+/**
+ * Parses the user's list of extra Spotify Canvas resolver endpoints.
+ *
+ * ## Why this is user-configurable
+ *
+ * Spotify's own Canvas endpoint (`spclient.wg.spotify.com/canvaz-cache`) is the only
+ * authoritative source, and it needs a Spotify session. Every community alternative on
+ * GitHub is a *self-hosted* wrapper around that same endpoint — they all require the
+ * operator's own `sp_dc` cookie, so there is no stable public instance to hardcode: the
+ * ones that exist come and go, and the app cannot ship a working default for a user with
+ * no Spotify login. Shipping a list the user controls means a resolver that appears (or a
+ * private one they run themselves) works immediately, with no app update.
+ *
+ * Entries are stored one per line. Anything that isn't an `http(s)` URL is dropped rather
+ * than being passed to the network layer, and duplicates are collapsed so a pasted list
+ * with repeats doesn't multiply the request count per song.
+ */
+object CanvasResolverEndpoints {
+    private const val MAX_ENDPOINTS = 8
+
+    /**
+     * Splits raw multi-line input into resolver base URLs, in the order given.
+     *
+     * The list is capped: each entry costs one network round trip per song with no canvas,
+     * and a runaway paste should not turn every track change into dozens of requests.
+     */
+    fun parse(raw: String?): List<String> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return raw
+            .split('\n', ',')
+            .map { it.trim().trimEnd('/') }
+            .filter { candidate ->
+                candidate.startsWith("http://", ignoreCase = true) ||
+                    candidate.startsWith("https://", ignoreCase = true)
+            }.distinct()
+            .take(MAX_ENDPOINTS)
+    }
+
+    /** Normalises for storage: one endpoint per line, blank/invalid entries removed. */
+    fun serialize(endpoints: List<String>): String = endpoints.joinToString("\n")
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/AlbumViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.canvas.AppleMusicProvider
 import moe.rukamori.archivetune.canvas.models.CanvasArtwork
+import moe.rukamori.archivetune.constants.AlbumCanvasEnabledKey
 import moe.rukamori.archivetune.constants.HideVideoKey
 import moe.rukamori.archivetune.db.MusicDatabase
 import moe.rukamori.archivetune.extensions.filterBlockedArtists
@@ -172,17 +173,15 @@ class AlbumViewModel
          */
         private fun fetchAlbumCanvas(context: Context) {
             viewModelScope.launch {
-                // Album-page animated art is fetched regardless of the
-                // player-level `ArchiveTuneCanvasKey` toggle. That toggle
-                // controls whether the *song player* mounts a canvas overlay
-                // over the now-playing thumbnail — but on the album page the
-                // user expects the album cover to animate the moment they
-                // open the page (matching Apple Music's behaviour), not only
-                // when they've flipped a separate switch in Player settings.
-                //
-                // We still respect LowDataMode (skip the network fetch on
-                // metered connections) since the canvas is a short video
-                // loop with non-trivial bandwidth.
+                // Gated on its own preference (Appearance → "Enable canvas in albums page")
+                // rather than the player-level `ArchiveTuneCanvasKey`: the album loop starts
+                // as soon as the page opens, whether or not anything is playing, so it is a
+                // separate cost and a separate choice. Default on, matching Apple Music.
+                if (!context.dataStore.get(AlbumCanvasEnabledKey, true)) return@launch
+
+                // Still respect LowDataMode (skip the network fetch on metered
+                // connections) since the canvas is a short video loop with non-trivial
+                // bandwidth.
                 if (context.isLowDataModeActive()) return@launch
 
                 // Wait for the album to load in the DB (it might not be
@@ -191,22 +190,71 @@ class AlbumViewModel
                 val loaded = albumWithSongs.first { it != null } ?: return@launch
                 val album = loaded.album
                 val firstArtist = loaded.artists.firstOrNull()?.name
+                val firstSongTitle = loaded.songs.firstOrNull()?.song?.title
 
-                val artwork = runCatching {
-                    AppleMusicProvider.getByAlbumId(album.id)
-                }.getOrNull()
-                    ?: runCatching {
-                        if (!firstArtist.isNullOrBlank()) {
-                            AppleMusicProvider.getByAlbumArtist(
-                                album = album.title,
-                                artist = firstArtist,
-                            )
-                        } else {
-                            null
-                        }
-                    }.getOrNull()
-
-                _canvasArtwork.value = artwork
+                _canvasArtwork.value = resolveAlbumCanvas(album.id, album.title, firstArtist, firstSongTitle)
             }
         }
+
+        /**
+         * Walks the Apple Music motion-artwork lookups from most to least specific and
+         * returns the first hit, or null when the album simply has no motion artwork.
+         *
+         * The ladder exists because the id we hold is almost never an Apple Music id — a
+         * YouTube album is an `MPREb…` browse id, so [AppleMusicProvider.getByAlbumId]
+         * only succeeds for the rare album that came from an Apple-shaped id, and
+         * everything else has to be matched by name. Each extra rung recovers a class of
+         * album the previous one misses:
+         *
+         *  - **exact title + artist** — the normal path.
+         *  - **title stripped of edition suffixes** — Apple's catalogue carries "1989"
+         *    where YouTube has "1989 (Taylor's Version) [Deluxe]", and an exact-name
+         *    search for the decorated form finds nothing.
+         *  - **a track from the album** — singles and EPs are frequently catalogued under
+         *    the track's own name, and a song lookup also picks up motion artwork attached
+         *    to the song rather than the album.
+         */
+        private suspend fun resolveAlbumCanvas(
+            albumId: String,
+            albumTitle: String,
+            artist: String?,
+            firstSongTitle: String?,
+        ): CanvasArtwork? {
+            runCatching { AppleMusicProvider.getByAlbumId(albumId) }
+                .getOrNull()
+                ?.let { return it }
+
+            if (artist.isNullOrBlank()) return null
+
+            val titleCandidates =
+                linkedSetOf(albumTitle, stripAlbumEditionSuffixes(albumTitle))
+                    .filter { it.isNotBlank() }
+            for (title in titleCandidates) {
+                runCatching { AppleMusicProvider.getByAlbumArtist(album = title, artist = artist) }
+                    .getOrNull()
+                    ?.let { return it }
+            }
+
+            if (!firstSongTitle.isNullOrBlank()) {
+                runCatching {
+                    AppleMusicProvider.getBySongArtist(
+                        song = firstSongTitle,
+                        artist = artist,
+                        album = albumTitle,
+                    )
+                }.getOrNull()?.let { return it }
+            }
+            return null
+        }
+
+        /**
+         * Drops the release-edition decoration YouTube album titles carry and Apple's
+         * catalogue titles usually do not: parenthesised/bracketed qualifiers
+         * ("(Deluxe Edition)", "[Remastered 2011]") and a trailing " - EP" / " - Single".
+         */
+        private fun stripAlbumEditionSuffixes(title: String): String =
+            title
+                .replace(Regex("\\s*[\\(\\[][^)\\]]*[\\)\\]]\\s*$"), "")
+                .replace(Regex("\\s*-\\s*(EP|Single|Deluxe|Remaster(ed)?)\\s*$", RegexOption.IGNORE_CASE), "")
+                .trim()
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ContentSettingsViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ContentSettingsViewModel.kt
@@ -46,6 +46,22 @@ sealed interface PaxsenixStatsState {
     data object Error : PaxsenixStatsState
 }
 
+/**
+ * Result of asking the configured Paxsenix endpoint which per-provider lyrics paths it
+ * still serves. Surfaced by the "Check Paxsenix endpoints" action so a user can tell a
+ * retired upstream route apart from a wrong endpoint or a bad API key — from inside the
+ * app both look identical (the provider simply returns no lyrics).
+ */
+sealed interface PaxsenixEndpointCheckState {
+    data object Idle : PaxsenixEndpointCheckState
+
+    data object Running : PaxsenixEndpointCheckState
+
+    data class Success(
+        val results: List<PaxsenixLyrics.PathCheck>,
+    ) : PaxsenixEndpointCheckState
+}
+
 sealed interface AiContentFilterSettingsState {
     data object Loading : AiContentFilterSettingsState
 
@@ -92,6 +108,10 @@ class ContentSettingsViewModel
     ) : ViewModel() {
         private val _paxsenixStatsState = MutableStateFlow<PaxsenixStatsState>(PaxsenixStatsState.Loading)
         val paxsenixStatsState = _paxsenixStatsState.asStateFlow()
+        private val _paxsenixEndpointCheckState =
+            MutableStateFlow<PaxsenixEndpointCheckState>(PaxsenixEndpointCheckState.Idle)
+        val paxsenixEndpointCheckState = _paxsenixEndpointCheckState.asStateFlow()
+        private var paxsenixEndpointCheckJob: Job? = null
         private val refreshingAiContentFilter = MutableStateFlow(false)
         private val _aiContentFilterEffects = MutableSharedFlow<AiContentFilterSettingsEffect>(extraBufferCapacity = 1)
         val aiContentFilterEffects = _aiContentFilterEffects.asSharedFlow()
@@ -134,6 +154,21 @@ class ContentSettingsViewModel
                     .onSuccess { _paxsenixStatsState.value = PaxsenixStatsState.Success(it) }
                     .onFailure { _paxsenixStatsState.value = PaxsenixStatsState.Error }
             }
+        }
+
+        /**
+         * Probes every per-provider Paxsenix path against the endpoint currently configured
+         * in settings. Re-tapping while a check is running restarts it rather than queueing a
+         * second sweep.
+         */
+        fun checkPaxsenixEndpoints() {
+            paxsenixEndpointCheckJob?.cancel()
+            _paxsenixEndpointCheckState.value = PaxsenixEndpointCheckState.Running
+            paxsenixEndpointCheckJob =
+                viewModelScope.launch(Dispatchers.IO) {
+                    val results = PaxsenixLyrics.checkProviderPaths()
+                    _paxsenixEndpointCheckState.value = PaxsenixEndpointCheckState.Success(results)
+                }
         }
 
         fun clearLyricsCache() {

--- a/app/src/main/res/values/fork_strings.xml
+++ b/app/src/main/res/values/fork_strings.xml
@@ -130,4 +130,26 @@
     <string name="lastfm_search_placeholder">Search scrobbles</string>
     <string name="lastfm_no_search_results">No matching tracks.</string>
     <string name="lastfm_player_unavailable">Player not ready. Try again in a moment.</string>
+
+    <!-- Album page appearance -->
+    <string name="album_page">Album page</string>
+    <string name="album_canvas_enabled">Enable canvas in albums page</string>
+    <string name="album_canvas_enabled_desc">Play the album\'s looping motion artwork behind the album header, the way Apple Music does. Turn off to always show the static cover.</string>
+
+    <!-- Qobuz backup source search -->
+    <string name="source_qobuz_backup_search_hint">Search the kouzu.in backup catalogue</string>
+
+    <!-- Spotify Canvas resolvers -->
+    <string name="canvas_resolvers">Canvas resolvers</string>
+    <string name="canvas_resolvers_description">Extra Spotify Canvas resolver endpoints, one per line. Tried in order after Spotify\'s own Canvas endpoint. Each must answer GET &lt;base&gt;?id=&lt;youtube video id&gt; with JSON containing a canvas video URL.</string>
+    <string name="canvas_resolvers_count">%1$d configured</string>
+    <string name="canvas_resolvers_none">Built-in resolver only</string>
+
+    <!-- Paxsenix endpoint check -->
+    <string name="paxsenix_check_endpoints">Check Paxsenix endpoints</string>
+    <string name="paxsenix_check_endpoints_description">Ask the configured endpoint which per-provider lyrics paths it actually serves.</string>
+    <string name="paxsenix_check_running">Checking…</string>
+    <string name="paxsenix_check_result_ok">%1$s: available</string>
+    <string name="paxsenix_check_result_retired">%1$s: retired upstream (403)</string>
+    <string name="paxsenix_check_result_failed">%1$s: unreachable</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -760,6 +760,8 @@
     <string name="paxsenix_api_key_not_set">Not set — using anonymous access</string>
     <string name="paxsenix_endpoint">Paxsenix Endpoint</string>
     <string name="paxsenix_endpoint_default">Default: https://lyrics.paxsenix.org/</string>
+    <string name="paxsenix_endpoint_retired">Retired upstream — this endpoint now returns 403. Only Paxsenix: Apple Music still works.</string>
+    <string name="paxsenix_endpoint_hint">Service root only, e.g. https://lyrics.paxsenix.org/ — the per-provider path is added automatically.</string>
     <string name="uptime">Uptime</string>
     <string name="total_requests">Total Requests</string>
     <string name="success_rate">Success Rate</string>

--- a/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/AppleMusicProvider.kt
+++ b/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/AppleMusicProvider.kt
@@ -22,6 +22,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.KotlinxSerializationConverter
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
@@ -100,26 +101,31 @@ object AppleMusicProvider {
 
     // Fallback Apple Music web player JWT — publicly distributed by Apple in
     // their web player JavaScript bundle. Apple rotates it roughly every ~6
-    // months; the previous hardcoded value expired on 2026-06-17, which
-    // caused every AMP API request to silently 401 (and produced the
-    // `D/CanvasArtwork: No playable canvas resolved for <mediaId>` log lines).
+    // months, so this value WILL go stale; [ensureTokenFresh] scrapes a live
+    // one and only falls back to this when scraping fails (e.g. offline).
     //
-    // We now scrape a fresh token on first use (and on 401) from the Apple
-    // Music web player JS bundle via [ensureTokenFresh]. The hardcoded value
-    // is kept only as a last-resort fallback in case scraping fails (e.g.
-    // offline) so we don't NPE on the very first call.
+    // The previous value here expired on 2026-06-17 and, because the scraper
+    // was also broken (see [jsBundleRegex]), every AMP request 401'd — which is
+    // what made "ArchiveTune Canvas" silently resolve nothing and log
+    // `No playable canvas resolved for <mediaId>`. This value expires
+    // 2026-10-22.
     private val fallbackAppleMusicToken: String =
-        "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ" +
-            ".eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNzc0NDU2MzgyLCJleHAiOjE3ODE3" +
-            "MTM5ODIsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ" +
-            ".4n8qYF4qa18sL1E0G9A3qX35cD8wQ-IJcS9Bh8ZT8JV_yLBtVq46B-9-2ZS3EvWHuw3yK9BYFYAhAdTaDm38vQ"
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6IldlYlBsYXlLaWQifQ" +
+            ".eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNzg2NjMyOTI0LCJleHAiOjE3OTI2" +
+            "ODA5MjQsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ" +
+            ".hBgj61sZf-y7bmuvT-joXAUAcf7TVJ51732xnH5vFkLHOmsQHxVqGMYUuI4h8c0-RX3fRY3moylhLW8fewFJyw"
 
     @Volatile
     private var appleMusicToken: String = fallbackAppleMusicToken
 
     // JWT decoded `exp` epoch seconds, or 0 if unknown / unparseable.
+    //
+    // Seeded from the fallback token rather than left at 0. When this was 0,
+    // [ensureTokenFresh] hit its "expiry unknown — serve what we have" branch on
+    // the very first call and handed out the fallback token without ever trying
+    // to refresh, so a stale fallback guaranteed a 401 on the first lookup.
     @Volatile
-    private var appleMusicTokenExpAtSec: Long = 0L
+    private var appleMusicTokenExpAtSec: Long = decodeJwtExpSec(fallbackAppleMusicToken)
 
     // Last time we attempted to refresh the token, used to throttle retries
     // when the Apple Music web player is unreachable.
@@ -179,19 +185,20 @@ object AppleMusicProvider {
      */
     private suspend fun ensureTokenFresh(): String {
         val nowSec = System.currentTimeMillis() / 1000L
+        val isExpired = appleMusicTokenExpAtSec == 0L || appleMusicTokenExpAtSec <= nowSec
         val needsRefresh =
             appleMusicTokenExpAtSec == 0L || appleMusicTokenExpAtSec - nowSec < 60L * 60L * 24L
         if (!needsRefresh) return appleMusicToken
 
-        // Throttle: don't hammer music.apple.com more than once a minute.
+        // Throttle: don't hammer music.apple.com more than once a minute — but
+        // never throttle away the *first* refresh of an already-expired token,
+        // otherwise we'd knowingly hand out a token that is guaranteed to 401.
         val sinceLast = System.currentTimeMillis() - appleMusicTokenLastRefreshAtMs
-        if (sinceLast in 1..60_000L) return appleMusicToken
+        if (!isExpired && sinceLast in 1..60_000L) return appleMusicToken
 
-        // If the current token is still strictly valid, serve it and let the
+        // Token is merely nearing expiry (not expired yet) — serve it and let the
         // 401 handler in [searchAndFetchMotion] force a refresh on rejection.
-        if (appleMusicTokenExpAtSec == 0L || appleMusicTokenExpAtSec > nowSec) {
-            return appleMusicToken
-        }
+        if (!isExpired) return appleMusicToken
 
         return refreshToken() ?: appleMusicToken
     }
@@ -199,36 +206,35 @@ object AppleMusicProvider {
     private suspend fun scrapeTokenFromWeb(): String? =
         try {
             val homeResponse = tokenClient.get(APPLE_MUSIC_WEB_HOME)
-            if (homeResponse.status != HttpStatusCode.OK) {
+            // music.apple.com/ now 301s to a localised landing page (e.g. /us/new).
+            // Ktor follows that for us, so only a genuine error status is fatal here.
+            if (!homeResponse.status.isSuccess()) {
                 Log.w("Apple Music home fetch failed: ${homeResponse.status}")
                 return null
             }
             val html = homeResponse.bodyAsText()
 
-            directJwtRegex.find(html)?.let { return it.value }
+            pickAmpToken(html)?.let { return it }
 
-            val jsBundleMatch = jsBundleRegex.find(html) ?: run {
+            val bundleUrls = jsBundleUrls(html)
+            if (bundleUrls.isEmpty()) {
                 Log.w("Apple Music token: no JS bundle URL found in home HTML")
                 return null
             }
-            val rawJsUrl = jsBundleMatch.groupValues[1]
-            val jsBundleUrl =
-                when {
-                    rawJsUrl.startsWith("http") -> rawJsUrl
-                    rawJsUrl.startsWith("//") -> "https:$rawJsUrl"
-                    rawJsUrl.startsWith("/") -> "https://music.apple.com$rawJsUrl"
-                    else -> "https://music.apple.com/$rawJsUrl"
-                }
 
-            val jsResponse = tokenClient.get(jsBundleUrl)
-            if (jsResponse.status != HttpStatusCode.OK) {
-                Log.w("Apple Music token: JS bundle fetch failed: ${jsResponse.status}")
-                return null
+            // Try each candidate bundle until one yields a usable AMP token. The
+            // main bundle is normally first, but Apple occasionally splits the
+            // token into a vendor chunk.
+            for (jsBundleUrl in bundleUrls) {
+                val jsResponse = tokenClient.get(jsBundleUrl)
+                if (!jsResponse.status.isSuccess()) {
+                    Log.w("Apple Music token: JS bundle fetch failed: ${jsResponse.status} ($jsBundleUrl)")
+                    continue
+                }
+                pickAmpToken(jsResponse.bodyAsText())?.let { return it }
+                Log.w("Apple Music token: no usable JWT found in JS bundle $jsBundleUrl")
             }
-            val js = jsResponse.bodyAsText()
-            directJwtRegex.find(js)?.value.also {
-                if (it == null) Log.w("Apple Music token: no JWT found in JS bundle $jsBundleUrl")
-            }
+            null
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -236,25 +242,100 @@ object AppleMusicProvider {
             null
         }
 
+    /**
+     * Extracts every JWT-shaped string from [text] and returns the best AMP web
+     * player token: an unexpired one issued by `AMPWebPlay`, else any unexpired
+     * one, else null.
+     *
+     * The bundle embeds several JWTs (the AMP web player token plus MusicKit
+     * developer tokens for other Apple properties). Taking the regex's first
+     * match — what the old code did — could pick one the AMP catalog API
+     * rejects, so match on the `iss` claim instead of on document order.
+     */
+    private fun pickAmpToken(text: String): String? {
+        val nowSec = System.currentTimeMillis() / 1000L
+        val candidates = directJwtRegex.findAll(text).map { it.value }.distinct().toList()
+        if (candidates.isEmpty()) return null
+
+        fun unexpired(jwt: String): Boolean {
+            val exp = decodeJwtExpSec(jwt)
+            return exp == 0L || exp > nowSec
+        }
+
+        return candidates.firstOrNull { jwt ->
+            unexpired(jwt) && decodeJwtIssuer(jwt) == AMP_WEB_PLAY_ISSUER
+        } ?: candidates.firstOrNull { unexpired(it) }
+    }
+
+    /**
+     * Collects candidate JS bundle URLs from the web player HTML, most likely
+     * first (`index~<hash>.js` / `index-<hash>.js`, then any other module script).
+     */
+    private fun jsBundleUrls(html: String): List<String> {
+        val indexBundles =
+            jsBundleRegex
+                .findAll(html)
+                .map { it.groupValues[1] }
+                .toList()
+        val anyBundles =
+            anyJsAssetRegex
+                .findAll(html)
+                .map { it.groupValues[1] }
+                .toList()
+        return (indexBundles + anyBundles)
+            .distinct()
+            .map(::absoluteAppleMusicUrl)
+            .take(4)
+    }
+
+    private fun absoluteAppleMusicUrl(rawUrl: String): String =
+        when {
+            rawUrl.startsWith("http") -> rawUrl
+            rawUrl.startsWith("//") -> "https:$rawUrl"
+            rawUrl.startsWith("/") -> "https://music.apple.com$rawUrl"
+            else -> "https://music.apple.com/$rawUrl"
+        }
+
     // Apple Music web player JWTs are ES256-signed with 3 base64url segments.
     private val directJwtRegex: Regex =
         Regex("""eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}""")
 
+    // Apple's Vite build names the entry chunk `index~<hash>.js`. This pattern
+    // previously only accepted `index-<hash>.js`, so once Apple switched the
+    // separator to `~` no bundle was ever found, the scrape returned null, and
+    // the provider fell back to the (expired) hardcoded token forever. Accept
+    // both separators.
     private val jsBundleRegex: Regex =
-        Regex("""(?:src|href)=["']([^"']*index-[A-Za-z0-9._-]+\.js)["']""")
+        Regex("""(?:src|href)=["']([^"']*index[~\-][A-Za-z0-9._~-]+\.js)["']""")
+
+    // Last-resort: any module script asset, used when the entry chunk is renamed
+    // to something that doesn't contain "index" at all.
+    private val anyJsAssetRegex: Regex =
+        Regex("""(?:src|data-src)=["']([^"']*/assets/[^"']+\.js)["']""")
+
+    private const val AMP_WEB_PLAY_ISSUER = "AMPWebPlay"
 
     /** Decodes the `exp` claim of a JWT without verifying the signature. */
     private fun decodeJwtExpSec(jwt: String): Long {
-        val parts = jwt.split(".")
-        if (parts.size != 3) return 0L
-        val payload =
-            runCatching {
-                val normalized = parts[1].replace('-', '+').replace('_', '/')
-                val padded = normalized + "=".repeat((4 - normalized.length % 4) % 4)
-                String(java.util.Base64.getDecoder().decode(padded))
-            }.getOrNull() ?: return 0L
+        val payload = decodeJwtPayload(jwt) ?: return 0L
         val expMatch = """"exp"\s*:\s*(\d+)"""".toRegex().find(payload) ?: return 0L
         return expMatch.groupValues[1].toLongOrNull() ?: 0L
+    }
+
+    /** Decodes the `iss` claim of a JWT without verifying the signature. */
+    private fun decodeJwtIssuer(jwt: String): String? {
+        val payload = decodeJwtPayload(jwt) ?: return null
+        return """"iss"\s*:\s*"([^"]+)"""".toRegex().find(payload)?.groupValues?.get(1)
+    }
+
+    private fun decodeJwtPayload(jwt: String): String? {
+        val parts = jwt.split(".")
+        if (parts.size != 3) return null
+        return runCatching {
+            val normalized = parts[1].replace('-', '+').replace('_', '/')
+            val padded = normalized + "=".repeat((4 - normalized.length % 4) % 4)
+            String(java.util.Base64.getDecoder().decode(padded))
+        }.getOrNull()
     }
 
     // ── Networking ───────────────────────────────────────────────────────────────────

--- a/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/SpotifyCanvasProvider.kt
+++ b/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/SpotifyCanvasProvider.kt
@@ -18,6 +18,8 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
@@ -30,38 +32,68 @@ import moe.rukamori.archivetune.canvas.models.CanvasArtwork
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Fetches Spotify Canvas looping videos for songs by their YouTube Music video ID.
+ * Fetches Spotify Canvas looping videos for the currently playing song.
  *
- * The provider delegates to the third-party `mlc-ytify.kouzu.in` resolver, which maps a
- * YouTube Music video ID → the song's Spotify Canvas URL. The resolver endpoint is
- * `https://mlc-ytify.kouzu.in/api/canvas?id=<videoId>` (same resolver pattern as the Qobuz
- * backup server) — it returns a JSON envelope with the actual canvas video URL on the
- * `velamhere-img.hf.space` CDN.
+ * Two sources are tried, in order:
  *
- * The resolver also returns the matched song name and artist name, which we surface in the
- * resulting [CanvasArtwork] for identity verification by the caller.
+ * 1. **Spotify's own Canvas endpoint** (`spclient.wg.spotify.com/canvaz-cache`).
+ *    This is the authoritative source — it is the same endpoint the Spotify
+ *    clients use, and it returns the real canvas mp4. It needs a Spotify access
+ *    token and the song's `spotify:track:<id>` URI, both supplied by the host app
+ *    through [tokenProvider] / [trackUriResolver] (the canvas module deliberately
+ *    has no dependency on the app's Spotify or player code). When the user has no
+ *    Spotify session this source is simply unavailable.
  *
- * The `x-request-source: muzo` header is required on every kouzu.in request — without it
- * the server rate-limits the client. The header is injected centrally by the
- * `MusicService.mediaOkHttpClient` interceptor for any kouzu.in host request, but the canvas
- * provider uses its own Ktor client (with OkHttp engine) — so we add the header manually
- * here via the `defaultRequest` block.
+ * 2. **The `mlc-ytify.kouzu.in` resolver**, keyed by YouTube Music video ID.
+ *    Kept as a fallback for users without a Spotify login. Note that this
+ *    resolver serves canvases only out of its own cache and currently reports
+ *    zero cached canvases (`/api/stats` → `"canvas": 0`), answering every lookup
+ *    with `404 {"detail":"No cached canvas"}` — which is why Spotify Canvas
+ *    appeared completely broken when it was the *only* source.
  *
- * The response shape is tolerant — we accept any of the common field names seen across
- * resolvers of this kind (`url` / `canvas_url` / `video_url`, `song` / `name` / `title`,
- * `artist` / `artists`).
+ * The `x-request-source: muzo` header is required on every kouzu.in request —
+ * without it the server rate-limits the client. It is injected centrally by the
+ * `MusicService.mediaOkHttpClient` interceptor for kouzu.in hosts, but this
+ * provider uses its own Ktor client, so the header is added here via
+ * `defaultRequest`.
  *
- * Results are cached in-memory for 1 hour per video ID to avoid hammering the resolver
- * on every recomposition / replay.
+ * Results are cached in-memory for 1 hour per video ID to avoid hammering either
+ * source on every recomposition / replay. A negative result is cached too, so a
+ * song with no canvas doesn't re-query on every replay.
  */
 object SpotifyCanvasProvider {
     /**
-     * Resolver base URL. The full URL is `$BASE_URL?id=<videoId>` — the video ID is passed
-     * as a query parameter. The `x-request-source: muzo` header is added to every request
-     * to bypass the server's rate-limiting.
+     * Fallback resolver base URL. The full URL is `$BASE_URL?id=<videoId>`.
      */
     private const val BASE_URL = "https://mlc-ytify.kouzu.in/api/canvas"
+
+    /** Spotify's Canvas endpoint. Speaks protobuf — see [SpotifyCanvazProtocol]. */
+    private const val CANVAZ_URL = "https://spclient.wg.spotify.com/canvaz-cache/v0/canvases"
+
     private const val CACHE_TTL_MS = 60L * 60 * 1000 // 1 hour
+
+    /**
+     * Supplies a Spotify access token, or null when the user has no Spotify
+     * session. Set by the host app (see `App.kt`); left null in tests and in
+     * standalone use of this module.
+     */
+    @Volatile
+    var tokenProvider: (suspend () -> String?)? = null
+
+    /**
+     * Maps the currently playing song to a `spotify:track:<id>` URI, or null when
+     * it can't be identified on Spotify. Set by the host app.
+     */
+    @Volatile
+    var trackUriResolver: (suspend (videoId: String, title: String?, artist: String?) -> String?)? = null
+
+    /** Optional diagnostic sink, mirroring [AppleMusicProvider.logger]. */
+    @Volatile
+    var logger: ((message: String) -> Unit)? = null
+
+    private fun log(message: String) {
+        logger?.invoke(message)
+    }
 
     private val json =
         Json {
@@ -85,12 +117,29 @@ object SpotifyCanvasProvider {
             install(HttpCache)
             // The x-request-source: muzo header is REQUIRED on every kouzu.in
             // request — without it the server rate-limits the client aggressively.
-            // Adding it here via defaultRequest means every request the client makes
-            // to the resolver includes the header.
             defaultRequest {
                 header("x-request-source", "muzo")
                 header("User-Agent", "ArchiveTune-Android")
                 header("Accept", "application/json")
+            }
+            expectSuccess = false
+        }
+    }
+
+    /**
+     * Separate client for Spotify's Canvas endpoint.
+     *
+     * Deliberately not [client]: that one's `defaultRequest` block pins
+     * `x-request-source: muzo` and `Accept: application/json` for the kouzu.in
+     * resolver. Sending the muzo header to Spotify would be wrong, and the JSON
+     * Accept header would fight the protobuf one this endpoint needs.
+     */
+    private val spotifyClient by lazy {
+        HttpClient(OkHttp) {
+            install(HttpTimeout) {
+                connectTimeoutMillis = 10_000
+                requestTimeoutMillis = 15_000
+                socketTimeoutMillis = 15_000
             }
             expectSuccess = false
         }
@@ -104,16 +153,19 @@ object SpotifyCanvasProvider {
     private val cache = ConcurrentHashMap<String, CacheEntry>()
 
     /**
-     * Looks up the Spotify Canvas for [videoId] (the YouTube Music video ID of the
-     * currently playing song). Returns `null` if the resolver has no canvas for the
-     * song, the song isn't on Spotify, or the request fails.
+     * Looks up the Spotify Canvas for the song identified by [videoId] (the
+     * YouTube Music video ID of the currently playing song). [songTitle] and
+     * [artistName] are used only to identify the song on Spotify for the official
+     * endpoint; the fallback resolver keys off [videoId] alone.
      *
-     * The returned [CanvasArtwork] has its [CanvasArtwork.videoUrl] /
-     * [CanvasArtwork.videoUrlVertical] populated with the canvas URL so the player
-     * can loop it as artwork. `name` and `artist` are populated from the resolver
-     * response when available so the caller can do identity verification.
+     * Returns `null` if neither source has a canvas for the song, the song isn't
+     * on Spotify, or both requests fail.
      */
-    suspend fun getByVideoId(videoId: String): CanvasArtwork? {
+    suspend fun getByVideoId(
+        videoId: String,
+        songTitle: String? = null,
+        artistName: String? = null,
+    ): CanvasArtwork? {
         if (videoId.isBlank()) return null
 
         cache[videoId]?.let { entry ->
@@ -121,14 +173,27 @@ object SpotifyCanvasProvider {
             cache.remove(videoId)
         }
 
+        // Source 1: Spotify's own Canvas endpoint.
+        val official =
+            try {
+                fetchOfficialCanvas(videoId, songTitle, artistName)
+            } catch (throwable: Throwable) {
+                if (throwable is CancellationException) throw throwable
+                log("Official Spotify Canvas lookup failed for $videoId: ${throwable.message}")
+                null
+            }
+        if (official != null) {
+            cache[videoId] = CacheEntry(official, System.currentTimeMillis() + CACHE_TTL_MS)
+            return official
+        }
+
+        // Source 2: the kouzu.in resolver.
         val artwork =
             try {
-                // The resolver URL pattern: `https://mlc-ytify.kouzu.in/api/canvas?id=<videoId>`.
-                // The video ID is passed as a query parameter. The x-request-source: muzo
-                // header is added to every request by the client's defaultRequest block.
-                val response = client.get(BASE_URL) {
-                    parameter("id", videoId)
-                }
+                val response =
+                    client.get(BASE_URL) {
+                        parameter("id", videoId)
+                    }
                 if (response.status != HttpStatusCode.OK) {
                     cache[videoId] = CacheEntry(null, System.currentTimeMillis() + CACHE_TTL_MS)
                     return null
@@ -145,7 +210,65 @@ object SpotifyCanvasProvider {
         return artwork
     }
 
-    private fun parseCanvasArtwork(body: JsonObject, videoId: String): CanvasArtwork? {
+    /**
+     * Asks Spotify directly for the canvas of the current song.
+     *
+     * Returns null (without caching) when the host app hasn't wired up a token /
+     * track resolver, when the user has no Spotify session, when the song can't
+     * be matched on Spotify, or when Spotify has no canvas for the track.
+     */
+    private suspend fun fetchOfficialCanvas(
+        videoId: String,
+        songTitle: String?,
+        artistName: String?,
+    ): CanvasArtwork? {
+        val resolveTrackUri = trackUriResolver ?: return null
+        val provideToken = tokenProvider ?: return null
+
+        val token = provideToken()?.takeIf { it.isNotBlank() } ?: return null
+        val trackUri =
+            resolveTrackUri(videoId, songTitle, artistName)?.takeIf { it.isNotBlank() } ?: return null
+
+        val response =
+            spotifyClient.post(CANVAZ_URL) {
+                header("Authorization", "Bearer $token")
+                header("Accept", "application/x-protobuf")
+                header("Content-Type", "application/x-protobuf")
+                header("User-Agent", "ArchiveTune-Android")
+                setBody(SpotifyCanvazProtocol.encodeRequest(listOf(trackUri)))
+            }
+        if (response.status != HttpStatusCode.OK) {
+            log("Spotify canvaz returned ${response.status.value} for $trackUri")
+            return null
+        }
+
+        val entries = SpotifyCanvazProtocol.decodeResponse(response.body<ByteArray>())
+        val canvasUrl =
+            entries
+                .firstOrNull { it.entityUri == trackUri && !it.url.isNullOrBlank() }
+                ?.url
+                ?: entries.firstNotNullOfOrNull { entry -> entry.url?.takeIf { it.isNotBlank() } }
+                ?: return null
+
+        log("Spotify canvaz resolved $trackUri → $canvasUrl")
+        return CanvasArtwork(
+            name = songTitle,
+            artist = artistName,
+            // Stable placeholder so CanvasArtworkPlaybackCache dedupes correctly.
+            albumId = "yt:$videoId",
+            albumName = null,
+            static = null,
+            animated = null,
+            animatedVertical = null,
+            videoUrl = canvasUrl,
+            videoUrlVertical = canvasUrl,
+        )
+    }
+
+    private fun parseCanvasArtwork(
+        body: JsonObject,
+        videoId: String,
+    ): CanvasArtwork? {
         // The resolver may either return the canvas fields at the top level or nested
         // under a `data` / `result` envelope. Handle both.
         val payload = body["data"]?.jsonObject ?: body["result"]?.jsonObject ?: body

--- a/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/SpotifyCanvasProvider.kt
+++ b/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/SpotifyCanvasProvider.kt
@@ -87,6 +87,19 @@ object SpotifyCanvasProvider {
     @Volatile
     var trackUriResolver: (suspend (videoId: String, title: String?, artist: String?) -> String?)? = null
 
+    /**
+     * Supplies extra community/self-hosted resolver base URLs to try after Spotify's own
+     * endpoint and before the built-in one. Set by the host app from the user's
+     * preference; left null in tests and standalone use.
+     *
+     * Every public Canvas resolver on GitHub is a self-hosted wrapper that needs the
+     * operator's own Spotify cookie, so there is no additional instance worth hardcoding —
+     * what makes the fallback chain extensible is letting the user name the instances they
+     * can actually reach.
+     */
+    @Volatile
+    var extraResolverEndpointsProvider: (suspend () -> List<String>)? = null
+
     /** Optional diagnostic sink, mirroring [AppleMusicProvider.logger]. */
     @Volatile
     var logger: ((message: String) -> Unit)? = null
@@ -187,27 +200,57 @@ object SpotifyCanvasProvider {
             return official
         }
 
-        // Source 2: the kouzu.in resolver.
-        val artwork =
+        // Source 2..N: JSON resolvers, keyed by YouTube video id. The user's own
+        // endpoints come first (they are the ones that might actually have data — see
+        // [extraResolverEndpointsProvider]), then the built-in kouzu.in resolver.
+        val extraEndpoints =
             try {
-                val response =
-                    client.get(BASE_URL) {
-                        parameter("id", videoId)
-                    }
-                if (response.status != HttpStatusCode.OK) {
-                    cache[videoId] = CacheEntry(null, System.currentTimeMillis() + CACHE_TTL_MS)
-                    return null
-                }
-                val body: JsonObject = response.body()
-                parseCanvasArtwork(body, videoId)
+                extraResolverEndpointsProvider?.invoke().orEmpty()
             } catch (throwable: Throwable) {
                 if (throwable is CancellationException) throw throwable
-                // Network/parse failure — don't cache, allow a retry next time.
-                return null
+                log("Failed to read extra canvas resolvers: ${throwable.message}")
+                emptyList()
             }
+        val resolverEndpoints = (extraEndpoints + BASE_URL).distinct()
 
-        cache[videoId] = CacheEntry(artwork, System.currentTimeMillis() + CACHE_TTL_MS)
-        return artwork
+        var anyResolverReachable = false
+        for (endpoint in resolverEndpoints) {
+            val artwork =
+                try {
+                    val response =
+                        client.get(endpoint) {
+                            parameter("id", videoId)
+                        }
+                    if (response.status != HttpStatusCode.OK) {
+                        // A clean "no canvas for this track" answer — the resolver works, it
+                        // just has nothing. Keep going, but remember that it answered so a
+                        // negative result can be cached at the end.
+                        anyResolverReachable = true
+                        log("Canvas resolver $endpoint returned ${response.status.value} for $videoId")
+                        continue
+                    }
+                    anyResolverReachable = true
+                    val body: JsonObject = response.body()
+                    parseCanvasArtwork(body, videoId)
+                } catch (throwable: Throwable) {
+                    if (throwable is CancellationException) throw throwable
+                    // Unreachable / unparseable: try the next resolver, and do not cache a
+                    // negative result on its account.
+                    log("Canvas resolver $endpoint failed for $videoId: ${throwable.message}")
+                    null
+                }
+            if (artwork != null) {
+                cache[videoId] = CacheEntry(artwork, System.currentTimeMillis() + CACHE_TTL_MS)
+                return artwork
+            }
+        }
+
+        // Only cache "no canvas" when at least one source actually answered; otherwise a
+        // transient outage would suppress lookups for the next hour.
+        if (anyResolverReachable) {
+            cache[videoId] = CacheEntry(null, System.currentTimeMillis() + CACHE_TTL_MS)
+        }
+        return null
     }
 
     /**

--- a/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/SpotifyCanvazProtocol.kt
+++ b/canvas/src/main/kotlin/moe/rukamori/archivetune/canvas/SpotifyCanvazProtocol.kt
@@ -1,0 +1,222 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.canvas
+
+import java.io.ByteArrayOutputStream
+
+/**
+ * Minimal, dependency-free protobuf codec for Spotify's Canvas endpoint
+ * (`POST https://spclient.wg.spotify.com/canvaz-cache/v0/canvases`).
+ *
+ * Spotify serves Canvas metadata as protobuf, not JSON, so this module needs to
+ * speak just enough of the wire format to build the request and pull the video
+ * URL back out. Only two messages are involved and each needs a single field,
+ * so hand-rolling the two varint/length-delimited paths is far cheaper than
+ * adding a protobuf runtime + codegen to a pure-JVM module:
+ *
+ * ```proto
+ * message EntityCanvazRequest {
+ *   repeated Entity entities = 1;
+ *   message Entity { string entity_uri = 1; }
+ * }
+ *
+ * message EntityCanvazResponse {
+ *   repeated Canvaz canvases = 1;
+ *   message Canvaz {
+ *     string id         = 1;
+ *     string url        = 2;   // the looping canvas video (mp4)
+ *     string file_id    = 3;
+ *     Type   type       = 4;
+ *     string entity_uri = 5;   // spotify:track:<id> this canvas belongs to
+ *   }
+ *   string ttl_in_seconds = 2;
+ * }
+ * ```
+ *
+ * Unknown fields are skipped rather than rejected, so Spotify adding fields to
+ * either message is a no-op here.
+ */
+internal object SpotifyCanvazProtocol {
+    private const val WIRE_VARINT = 0
+    private const val WIRE_64BIT = 1
+    private const val WIRE_LENGTH_DELIMITED = 2
+    private const val WIRE_START_GROUP = 3
+    private const val WIRE_END_GROUP = 4
+    private const val WIRE_32BIT = 5
+
+    /** `EntityCanvazRequest.entities` / `EntityCanvazResponse.canvases`. */
+    private const val FIELD_ENTITIES = 1
+
+    /** `EntityCanvazRequest.Entity.entity_uri`. */
+    private const val FIELD_ENTITY_URI = 1
+
+    /** `EntityCanvazResponse.Canvaz.url`. */
+    private const val FIELD_CANVAZ_URL = 2
+
+    /** `EntityCanvazResponse.Canvaz.entity_uri`. */
+    private const val FIELD_CANVAZ_ENTITY_URI = 5
+
+    /** A single canvas entry decoded out of an `EntityCanvazResponse`. */
+    data class CanvazEntry(
+        val entityUri: String?,
+        val url: String?,
+    )
+
+    /**
+     * Encodes an `EntityCanvazRequest` asking for the canvas of each of
+     * [trackUris] (full `spotify:track:<id>` URIs).
+     */
+    fun encodeRequest(trackUris: List<String>): ByteArray {
+        val out = ByteArrayOutputStream()
+        for (uri in trackUris) {
+            if (uri.isBlank()) continue
+            val entity = ByteArrayOutputStream()
+            writeStringField(entity, FIELD_ENTITY_URI, uri)
+            writeBytesField(out, FIELD_ENTITIES, entity.toByteArray())
+        }
+        return out.toByteArray()
+    }
+
+    /**
+     * Decodes an `EntityCanvazResponse` into its canvas entries. Returns an empty
+     * list for a well-formed response with no canvases, and also for a truncated
+     * or unexpected body — a malformed response is treated as "no canvas" rather
+     * than an error, since a missing canvas is the common case.
+     */
+    fun decodeResponse(bytes: ByteArray): List<CanvazEntry> {
+        val reader = Reader(bytes)
+        val entries = mutableListOf<CanvazEntry>()
+        while (reader.hasRemaining()) {
+            val tag = reader.readTag() ?: break
+            if (tag.field == FIELD_ENTITIES && tag.wire == WIRE_LENGTH_DELIMITED) {
+                val payload = reader.readLengthDelimited() ?: break
+                entries += decodeCanvaz(payload)
+            } else if (!reader.skip(tag.wire)) {
+                break
+            }
+        }
+        return entries
+    }
+
+    private fun decodeCanvaz(bytes: ByteArray): CanvazEntry {
+        val reader = Reader(bytes)
+        var url: String? = null
+        var entityUri: String? = null
+        while (reader.hasRemaining()) {
+            val tag = reader.readTag() ?: break
+            if (tag.wire == WIRE_LENGTH_DELIMITED) {
+                val payload = reader.readLengthDelimited() ?: break
+                when (tag.field) {
+                    FIELD_CANVAZ_URL -> url = payload.decodeToString()
+                    FIELD_CANVAZ_ENTITY_URI -> entityUri = payload.decodeToString()
+                    else -> Unit
+                }
+            } else if (!reader.skip(tag.wire)) {
+                break
+            }
+        }
+        return CanvazEntry(entityUri = entityUri, url = url)
+    }
+
+    // ── Writing ──────────────────────────────────────────────────────────────
+
+    private fun writeStringField(
+        out: ByteArrayOutputStream,
+        field: Int,
+        value: String,
+    ) = writeBytesField(out, field, value.encodeToByteArray())
+
+    private fun writeBytesField(
+        out: ByteArrayOutputStream,
+        field: Int,
+        value: ByteArray,
+    ) {
+        writeVarint(out, ((field.toLong() shl 3) or WIRE_LENGTH_DELIMITED.toLong()))
+        writeVarint(out, value.size.toLong())
+        out.write(value)
+    }
+
+    private fun writeVarint(
+        out: ByteArrayOutputStream,
+        value: Long,
+    ) {
+        var remaining = value
+        while (true) {
+            val chunk = (remaining and 0x7F).toInt()
+            remaining = remaining ushr 7
+            if (remaining == 0L) {
+                out.write(chunk)
+                return
+            }
+            out.write(chunk or 0x80)
+        }
+    }
+
+    // ── Reading ──────────────────────────────────────────────────────────────
+
+    private data class Tag(
+        val field: Int,
+        val wire: Int,
+    )
+
+    private class Reader(
+        private val bytes: ByteArray,
+    ) {
+        private var position = 0
+
+        fun hasRemaining(): Boolean = position < bytes.size
+
+        fun readTag(): Tag? {
+            val raw = readVarint() ?: return null
+            val field = (raw ushr 3).toInt()
+            val wire = (raw and 0x07).toInt()
+            if (field <= 0) return null
+            return Tag(field = field, wire = wire)
+        }
+
+        fun readVarint(): Long? {
+            var result = 0L
+            var shift = 0
+            while (shift < 64) {
+                if (position >= bytes.size) return null
+                val byte = bytes[position++].toInt() and 0xFF
+                result = result or ((byte and 0x7F).toLong() shl shift)
+                if (byte and 0x80 == 0) return result
+                shift += 7
+            }
+            return null
+        }
+
+        fun readLengthDelimited(): ByteArray? {
+            val length = readVarint()?.toInt() ?: return null
+            if (length < 0 || position + length > bytes.size) return null
+            val slice = bytes.copyOfRange(position, position + length)
+            position += length
+            return slice
+        }
+
+        /** Advances past a field of [wire] type. Returns false if unrecoverable. */
+        fun skip(wire: Int): Boolean =
+            when (wire) {
+                WIRE_VARINT -> readVarint() != null
+                WIRE_64BIT -> advance(8)
+                WIRE_LENGTH_DELIMITED -> readLengthDelimited() != null
+                WIRE_32BIT -> advance(4)
+                // Groups are deprecated and never appear in these messages; an
+                // end-group marker here means we are out of sync.
+                WIRE_START_GROUP, WIRE_END_GROUP -> false
+                else -> false
+            }
+
+        private fun advance(count: Int): Boolean {
+            if (position + count > bytes.size) return false
+            position += count
+            return true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Eight requested changes, plus the submodule bump that carries the Paxsenix work.

| # | Area | Change |
|---|------|--------|
| 1 | Qobuz backup | Searchable + selectable in the "Play from" popup, with thumbnail and quality tag |
| 2 | Telegram | Private channels populate on first sync; long lossless files no longer stall near the end |
| 3 | Settings search | Results scroll to and highlight the setting they name |
| 4 | Play-from popup | Real per-track stream details instead of one identical figure for every lossless song |
| 5 | Lyrics | Animation restarts when a song repeats with the Apple-Music-style view open |
| 6 | Album page | Looping canvas behind a new "enable canvas in albums page" switch |
| 7 | Spotify canvas | User-editable resolver endpoint list as fallbacks |
| 8 | Paxsenix | Correct default endpoint, per-provider paths, endpoint check action |

## Notes on the less obvious parts

**Stream details (4).** Sources that hand over a bare file URL report no technical metadata, so `persistDirectStreamFormat` fell back to a tier heuristic keyed off the stream's label — every "lossless" track became 44.1 kHz / 1411 kbps. `FlacStreamInfo` reads the mandatory 34-byte `STREAMINFO` block from the first 42 bytes, which yields the true sample rate, bit depth and channel count without decoding anything.

**Canvas resolvers (7).** Every community Spotify Canvas resolver on GitHub is a self-hosted wrapper around Spotify's own endpoint and needs the operator's `sp_dc` cookie, so there is no stable public instance to hardcode. The list is user-owned instead: a resolver that appears, or a private one the user runs, works with no app update. Entries are capped at 8 and non-`http(s)` lines are dropped before they reach the network layer.

**Paxsenix (8).** Upstream has retired most provider sub-paths — they answer 403 regardless of API key, while `apple-music` still works. From inside the app that was indistinguishable from a wrong endpoint or a bad key. `checkProviderPaths()` probes each path and reports AVAILABLE / RETIRED / UNREACHABLE against whatever endpoint is configured. No API key is embedded; the working endpoint needs none.

**Settings deep links (3)** were four independent defects:
- Scroll targets were measured in root coordinates, which include the status bar and top app bar, so every jump overshot by the app bar's height and landed on the row below. Now viewport-relative (`rowTop - viewportTop`), which needs a `containerModifier()` chained *before* `verticalScroll` on each screen.
- Routes that never declared a `scrollTo` argument dropped it silently; `settings/downloads` had no branch in the route resolver at all.
- Roughly 150 indexed rows had no on-screen anchor. Coverage is now **392/413**.
- Dozens of children are indexed under a page that no longer contains them (Discord activity fields under Integration, lyrics providers under Lyrics, source switches under Playback). `CROSS_PAGE_SCROLL_OWNERS` re-points navigation to the owning page without renaming index entries users may already be searching for.

The ~21 uncovered keys are harmless: index entries with no corresponding row anywhere (`color_source`, `grid_layout`, `theme_creator`, …), section links where the top of the target screen *is* the right destination (`ytdlp`, `sources/qobuz`, `lyrics_animations`, …), and `check_source`, which is one row repeated per source and so cannot be identified by a single key.

## Testing

**Not built or run.** This environment has no JDK and no Android SDK, so neither `./gradlew assembleGmsMobileUniversalDebug` nor `:app:testGmsMobileUniversalDebugUnitTest` could be executed — CI is the first real compile.

Verified by reading and by scripted structural checks over all 54 changed files:
- delimiter balance with comments and strings stripped — 0 unbalanced
- every `positions.modifierFor(...)` resolves in a scope that owns a `positions` — 0 out of scope
- no duplicate `modifier =` argument in any call (two duplicated lines from a batch insert were found and removed this way)
- every `R.string.*` and `R.drawable.*` added by the diff exists; every `*Key` added resolves in `PreferenceKeys.kt`
- search-index keys resolved through route registrations to on-screen anchors, transitively through extracted section composables

## Submodule

`lyrics` advances to `4nx3b/lyrics@31705a8` (`feat(paxsenix): probe per-provider endpoint paths`), pushed before this branch so the pointer resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
