### PR TITLE
Apple Music blur + lyrics perf, landscape quality sheet, account persistence, Qobuz backup search

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -410,11 +410,15 @@ jobs:
             echo "## Commits"
           } >> nightly_notes.md
           if [ -n "${LAST_TAG:-}" ] && [ "$LAST_TAG" != "null" ] && git rev-parse "$LAST_TAG" >/dev/null 2>&1; then
-            git log --pretty=format:'- %s (%h)' "${LAST_TAG}..HEAD" >> nightly_notes.md || true
+            # -n 500 caps the list: after a large sync jump the range can contain thousands of
+            # commits and the release body would exceed GitHub's 125k-character limit.
+            git log --pretty=format:'- %s (%h)' -n 500 "${LAST_TAG}..HEAD" >> nightly_notes.md || true
           else
             git log --pretty=format:'- %s (%h)' -n 30 >> nightly_notes.md || true
           fi
           echo "" >> nightly_notes.md
+          # Hard guarantee against GitHub's 125k-character release-body limit.
+          head -c 120000 nightly_notes.md > nightly_notes.tmp && mv nightly_notes.tmp nightly_notes.md
 
       - name: Create nightly prerelease
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,13 @@ core.*
 /android_resource_cleaner.py
 # Local Claude Code config
 .claude/
+
+# Agent session state — never commit
+/.swarm/
+/.opencode/
+/.jcode/
+/ARCHIVETUNE_SESSION_NOTES.md
+/ARCHIVETUNE_CODE_MAP.md
+/.env
+/.cursor/
+/.windsurf/

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ core.*
 /string_cleaner.py
 /.codexignore
 /android_resource_cleaner.py
+# Local Claude Code config
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,42 @@
-# AGENTS.md — vossgraves/ArchiveTune (fork)
+# AGENTS.md — ArchiveTune (vossgraves fork of 4nx3b/ArchiveTune)
 
-This is a fork of [rukamori/ArchiveTune](https://github.com/rukamori/ArchiveTune)
-with substantial custom features. Any agent working in this repo MUST preserve
-the fork invariants below — especially when merging upstream changes.
+Active development on `dev`, tracking `4nx3b/ArchiveTune@dev`. Any agent working
+here must preserve the invariants below.
 
-## Fork invariants (never break these)
+## Fork invariants — never break
 
-1. **Tidal music source** — `app/src/main/kotlin/moe/rukamori/archivetune/tidal/`
-   (`TidalAudioProvider`, `TidalInstanceHealthManager`, `TidalAccountManager`,
-   `TidalDns`, `TidalArtworkProvider`), settings UI
-   `ui/screens/settings/TidalSettings.kt` + `TidalLoginScreen.kt`,
-   `utils/tidal/TidalCookieUtils.kt`. Concurrent instance racing documented in
-   `INSTANCE_RACING.md`.
-2. **Multi-source audio framework** —
-   `app/src/main/kotlin/moe/rukamori/archivetune/audiosource/` (Deezer/Amazon
-   providers, ISRC resolver, source priority config). Playback resolution goes
-   through `resolveMultiSourceDataSpec` in
-   `playback/MusicService.kt` — YouTube is the final fallback. Do not rewire
-   playback around this.
-3. **Spotify catalog source** — `spotifycore/` plus the app's `spotify/` repository/resolver and search UI provide authenticated Spotify metadata, artwork, search and track-to-YouTube identification. Spotify remains a catalog source, not an `AudioSourceType`; resolved playback continues through `MusicService.resolveMultiSourceDataSpec` and its configured audio providers.
-4. **Playback client policy** — `AutoChoosePlaybackClientKey` and `YTPlayerUtils` own bounded YouTube client selection/fallback. Manual mode must remain available and must not be replaced by an automatic-only path.
-5. **Telegram channel streaming** —
-   `app/src/main/kotlin/moe/rukamori/archivetune/telegram/` (`TelegramClient`
-   TDLib wrapper, `TelegramDataSource` Media3 streaming source, media-id codec
-   + models), UI `ui/screens/TelegramBrowseScreen.kt` +
-   `ui/screens/settings/TelegramSettings.kt` + `TelegramLoginScreen.kt`.
-   Playback is routed by the `telegram://` scheme branch in `MusicService`'s
-   `SchemeRoutingDataSource` (independent of the multi-source resolver chain).
-   Depends on the prebuilt TDLib AAR `com.github.tdlibx:td` (JitPack group
-   allow-listed in `settings.gradle.kts`). Login is phone + code only — the
-   app's api_id/api_hash are baked in via `BuildConfig.TELEGRAM_API_ID`/`_HASH`
-   (`buildConfigField` in `app/build.gradle.kts`, overridable through
-   local.properties / env, with the public Telegram Desktop credentials as the
-   fallback); users never enter developer credentials. Opening a channel
-   **materialises it into a real local playlist** (`TelegramChannelSync`,
-   deterministic id `LPtg<chatId>`) so it reuses the normal playlist UI; there
-   is no bespoke channel screen. Artwork resolves lazily through the Coil
-   `tgart://` fetcher (`TelegramThumbnailFetcher`) — HQ catalogue cover by
-   title/artist (`TelegramCoverProvider`, iTunes), falling back to the embedded
-   Telegram cover. Downloads route `telegram://` through TDLib via
-   `DownloadUtil`'s `DownloadSchemeRoutingDataSource`.
-6. **Fork CI signing patch** — workflows sign with the committed
-   `app/persistent-debug.keystore` when the `KEYSTORE` secret is absent
-   (forks have no release keystore). Upstream's workflows must not overwrite
-   this logic (see `build.yml`, `release.yml`).
-7. **Listen Together runs on LAN + the vivimusic public servers only** —
-   there is no koiverse REST/WS path and no `*.koiiverse.cloud` or
-   `raw.githubusercontent.com/koiverse/*` network call anywhere in the tree.
-   Public rooms connect via `TogetherPublicServers` (vivimusic WSS endpoints)
-   and `TogetherPublicClient`; LAN rooms via `TogetherServer`/`TogetherClient`.
-8. **Protected files** — the `applicationId` (`moe.rukamori.archivetune`) in
-   `app/build.gradle.kts` is a fork-identity file: do not adopt upstream
-   changes to it without explicit instruction. (`Koiverse.jks`,
-   `Koiverse.jks.base64`, `ArchiveTuneKoiverseServer.txt` and `DataServer.txt`
-   were removed as part of the koiverse phone-home cleanup and must never be
-   restored.)
+- **Tidal source**: `app/src/main/kotlin/moe/rukamori/archivetune/tidal/` (`TidalAudioProvider`, `TidalAccountManager`, `TidalInstanceHealthManager`, `TidalDns`, `TidalArtworkProvider`), Tidal settings/login UI, `utils/tidal/`; instance racing documented in `INSTANCE_RACING.md`. Live progressive-DASH streams use the `tidal-dash://` scheme routed in `MusicService`.
+- **Multi-source audio**: providers live in top-level packages `tidal/`, `deezer/` (DeezerCrypto + Media3 decrypting DataSource), `qobuz/` (+ `QobuzBackupProvider` via the kouzu.in mirror), `spotify/`; shared contract (`DirectStream`, `TitleMatch`, source priority) in `audiosource/`. Playback resolution goes through `resolveMultiSourceDataSpec` in `playback/MusicService.kt`; YouTube is the final fallback. Do not rewire playback around this.
+- **Spotify is catalog-only**: `spotifycore/` + app `spotify/` provide metadata, artwork, search, playlist import and track-to-YouTube identification. Spotify is never an `AudioSourceType`.
+- **Playback client policy**: `AutoChoosePlaybackClientKey` + `YTPlayerUtils` own bounded YouTube client selection/fallback (incl. video-scoped PO tokens and the yt-dlp layer). Manual mode must remain available.
+- **Telegram streaming**: `telegram/` (TDLib wrapper + `TelegramDataSource`), browse/settings/login UI. Playback routed by the `telegram://` branch in `MusicService`'s `SchemeRoutingDataSource`, independent of the multi-source chain. Channels materialise as local playlists (`LPtg<chatId>`); artwork via the Coil `tgart://` fetcher. api_id/hash via `BuildConfig` with public Telegram Desktop fallback.
+- **CI signing**: workflows sign with the committed `app/persistent-debug.keystore` when the `KEYSTORE` secret is absent. Do not let upstream workflows overwrite this.
+- **Listen Together**: LAN + vivimusic public servers only. No koiverse REST/WS path and no `*.koiverse.cloud` / `raw.githubusercontent.com/koiverse/*` call anywhere in the tree.
+- **Protected files**: `applicationId` (`moe.rukamori.archivetune`) is fork identity — never adopt upstream changes to it. `Koiverse.jks*`, `ArchiveTuneKoiverseServer.txt`, `DataServer.txt` were removed and must never be restored.
 
-## Submodules
+## Modules & submodules
 
-- `core` → **vossgraves/core** (our fork of rukamori/core). Sync strategy:
-  merge `rukamori/core` into `vossgraves/core` first, then pin the gitlink to
-  the merged commit — never blindly adopt upstream's gitlink.
-- `lyrics`, `IconPack`, `morideobfuscator` → rukamori-owned;
-  always adopt upstream's recorded pointers.
+- Gradle modules: `:app :core :spotifycore :canvas :jiosaavn :lastfm :musixmatch :shazamkit :morideobfuscator :lyrics:*`.
+- Submodules: `core` → **4nx3b/core** (NewPipeExtractor-based InnerTube client), `lyrics` → **4nx3b/lyrics**, `IconPack` → rukamori, `morideobfuscator` → rukamori. Commit + push inside a submodule first, then pin the gitlink; never leave a dirty or unpushed pointer.
+
+## Build & test
+
+- JDK 21, Android SDK (compileSdk 37), Gradle wrapper 9.6.1.
+- Flavor matrix: gms/foss × mobile/tv × universal/arm64/x86_64. Debug check: `./gradlew assembleGmsMobileUniversalDebug`.
+- Fork contract tests (palette/crossfade/artwork/multi-source/presence/telegram — sources in `app/src/test/`): `./gradlew :app:testGmsMobileUniversalDebugUnitTest`. Run after any merge or feature change.
+- Keep the GPL header banner on new `.kt` files. No formatter task — match surrounding style.
+
+## Dependency gotchas
+
+- `settings.gradle.kts` declares a GCS mirror of Maven Central **before** `mavenCentral()` — do not reorder (Maven Central 429-rate-limits CI).
+- JitPack is scoped via `exclusiveContent` to an allow-list of `com.github.*` groups (TeamNewPipe, tdlibx, PRDownloader, jaudiotagger, MetrolistGroup…). A new `com.github.*` dependency fails until its group is added.
+- Chaquopy/Python (yt-dlp runtime) requires Python 3.11 on CI and is restricted to arm64-v8a + x86_64 ABIs.
 
 ## Automated upstream sync
 
-`.github/workflows/upstream-sync.yml` runs hourly and merges
-`rukamori/ArchiveTune@dev` into `dev`, using `scripts/upstream_sync.sh` +
-`scripts/ai_resolve.py` (LLM conflict resolution following the invariants
-above). Full documentation: `docs/UPSTREAM_SYNC.md`. If you modify fork
-features or protected files, update the invariants in **both** this file and
-the verification section of `scripts/upstream_sync.sh`.
+`.github/workflows/upstream-sync.yml` merges hourly via `scripts/upstream_sync.sh` + `scripts/ai_resolve.py`, following these invariants. If you change a fork feature or protected file, update the invariants in **both** this file and the script's verification section.
 
-## Build
+## Agent hygiene
 
-JDK 21, Android SDK. Debug build check:
-`./gradlew assembleGmsMobileUniversalDebug`
-
-Fork contract tests (palette/crossfade/artwork/multi-source/presence — run
-after any upstream merge or feature change):
-`./gradlew :app:testGmsMobileUniversalDebugUnitTest`
+- Never commit credentials, tokens, keystores or agent session state (`.swarm/`, `.opencode/`, `.jcode/` stay untracked).
+- Local working notes (`ARCHIVETUNE_SESSION_NOTES.md`, `ARCHIVETUNE_CODE_MAP.md`) are scratch memory — never ship them.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -255,10 +255,16 @@ class App :
                 prefs[ContentLanguageKey]?.takeIf { it != SYSTEM_DEFAULT }?.let { lang ->
                     YouTube.locale = YouTube.locale.copy(hl = lang)
                 }
-                prefs[YouTubeMusicRegionKey]?.let { regionValue ->
-                    if (regionValue != SYSTEM_DEFAULT) {
-                        YouTube.locale = YouTube.locale.copy(gl = regionValue)
-                    }
+                // Restore the YouTube Music region override. BOTH halves have to come back: the
+                // `gl` locale override *and* `regionSpooferActive`, which is what forces the
+                // region-sensitive endpoints (home, search, charts, explore, moods, new releases)
+                // to go out anonymously so `gl` is authoritative. Restoring only `gl` — as this
+                // used to — meant spoofing silently stopped working after the very first restart,
+                // including the automatic one that picking a region triggers: the account context
+                // came back and YouTube went on serving the account's home country.
+                prefs[YouTubeMusicRegionKey]?.takeIf { it != SYSTEM_DEFAULT }?.let { regionValue ->
+                    YouTube.locale = YouTube.locale.copy(gl = regionValue)
+                    YouTube.regionSpooferActive = true
                 }
 
                 LastFmServiceConfig.fromPreferences(prefs).apply(prefs[LastFMSessionKey])
@@ -272,6 +278,17 @@ class App :
                     password = prefs[ProxyPasswordKey],
                 )
                 YouTube.streamBypassProxy = YouTube.proxy != null && prefs[StreamBypassProxyKey] == true
+
+                // Re-install the rotating proxy pool when the user left IP rotation on. Without
+                // this the toggle in Internet Settings read as ON after every restart while no
+                // proxy was actually installed, so rotation appeared to do nothing. Fetching and
+                // validating the pool is network-bound, so it runs here in the deferred IO block
+                // and not on the startup critical path. A pool that validates to nothing leaves
+                // rotation off; requests then go out directly, exactly as before.
+                if (prefs[IpRotationEnabledKey] == true) {
+                    runCatching { YouTube.enableIpRotation() }
+                        .onFailure { Timber.w(it, "IP rotation restore failed") }
+                }
 
                 if (prefs[UseLoginForBrowse] != false) {
                     YouTube.useLoginForBrowse = true

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -81,6 +81,7 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -1029,6 +1030,11 @@ class MainActivity : ComponentActivity() {
                 customFontUri = customFontUri,
             ) {
                 val navController = rememberNavController()
+                // Keep top-level list state outside destination content. MainActivity unbinds the
+                // music service in onStop; HomeScreen otherwise disappears while the connection is
+                // null and is recreated at offset zero when the app returns to the foreground.
+                val homeListState = rememberLazyListState()
+                val searchListState = rememberLazyListState()
                 val onboardingViewModel: OnboardingViewModel = hiltViewModel()
                 val onboardingState by onboardingViewModel.screenState.collectAsStateWithLifecycle()
                 var showOnboardingLogin by rememberSaveable { mutableStateOf(false) }
@@ -2970,6 +2976,8 @@ class MainActivity : ComponentActivity() {
                                         onClearUpdateBadge = { latestVersionName = BuildConfig.VERSION_NAME },
                                         onSearchQuery = onSearch,
                                         onVoiceSearch = launchVoiceSearch,
+                                        homeListState = homeListState,
+                                        searchListState = searchListState,
                                         homeScrollConnection = homeScrollBehavior.nestedScrollConnection,
                                         searchScrollConnection = searchScrollBehavior.nestedScrollConnection,
                                         onlineSearchSort = onlineSearchSort,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
@@ -173,22 +173,32 @@ object TitleMatch {
 
         val titleScore = ratio(wantedTitle, candidateTitle)
         val durationScore = durationScore(wantedDurationMs, stream.matchedDurationMs)
-        if (durationScore == 0.0) {
-            return Result(false, 0.0, titleScore, null, durationScore, "duration differs by more than 15s")
-        }
 
         val wantedArtist = wantedArtists.joinToString(", ").takeIf { it.isNotBlank() }
         val candidateArtist = stream.matchedArtist?.takeIf { it.isNotBlank() }
         val artistScore =
             if (wantedArtist != null && candidateArtist != null) artistRatio(wantedArtist, candidateArtist) else null
 
+        // Artist is gated before duration. Both gates reject, so this does not change
+        // WHETHER a stream is accepted — only the reason reported for it. That matters
+        // because "duration differs" was actively misleading for the exact case this
+        // matcher exists to catch: a same-title recording by a different artist almost
+        // always has a different length too, so the wrong-artist rejection was being
+        // blamed on the length instead of the artist.
+        if (artistScore != null && artistScore < MIN_ARTIST) {
+            return Result(false, 0.0, titleScore, artistScore, durationScore, "artist mismatch")
+        }
+        if (durationScore == 0.0) {
+            return Result(false, 0.0, titleScore, artistScore, durationScore, "duration differs by more than 15s")
+        }
+
+        // Deliberately AFTER the duration gate: with no artist to compare against, the
+        // duration is the only independent signal left, so a title-only acceptance must
+        // never be allowed to override an implausible length.
         if (artistScore == null) {
             val accepted = titleScore >= TITLE_ONLY_THRESHOLD
             val score = titleScore * 0.8 + (durationScore ?: 0.5) * 0.2
             return Result(accepted, score, titleScore, null, durationScore, if (accepted) "strict title fallback" else "artist metadata unavailable")
-        }
-        if (artistScore < MIN_ARTIST) {
-            return Result(false, 0.0, titleScore, artistScore, durationScore, "artist mismatch")
         }
         if (titleScore < MIN_TITLE_WITH_METADATA && !containsTokenRun(candidateTitle, wantedTitle)) {
             return Result(false, 0.0, titleScore, artistScore, durationScore, "title mismatch")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -15,6 +15,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import java.util.Locale
 
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
 val CustomThemeColorKey = stringPreferencesKey("customThemeColor")
@@ -271,6 +272,14 @@ enum class DownloadSource {
     AUTO,
 
     QOBUZ,
+
+    /**
+     * Community-hosted Qobuz mirror (mlc-ytify.kouzu.in), keyed by YouTube video id
+     * rather than a Qobuz catalogue id, so it needs no Source Pool account at all.
+     * Mirrors [AudioSourceType.QOBUZ_BACKUP] on the playback side and is gated by the
+     * same `QobuzBackupEnabledKey` toggle. Not in [DownloadSourceConfig.REQUIRES_POOL].
+     */
+    QOBUZ_BACKUP,
     TIDAL,
 
     /**
@@ -311,6 +320,7 @@ object DownloadSourceConfig {
     val DEFAULT_ORDER: List<DownloadSource> =
         listOf(
             DownloadSource.QOBUZ,
+            DownloadSource.QOBUZ_BACKUP,
             DownloadSource.TIDAL,
             DownloadSource.DEEZER,
             DownloadSource.JIOSAAVN,
@@ -320,6 +330,28 @@ object DownloadSourceConfig {
     /** Sources that need a Source Pool account configured to be usable for downloads. */
     val REQUIRES_POOL: Set<DownloadSource> =
         setOf(DownloadSource.QOBUZ, DownloadSource.TIDAL, DownloadSource.DEEZER)
+
+    /**
+     * Cache-key prefix a source's downloaded bytes are stored under, e.g. `"qobuz_backup:"`.
+     *
+     * `DownloadUtil` namespaces each source's cache entries so bytes from one source can never be
+     * served for another, then has to check every prefix when deciding whether a song is already
+     * fully cached. Deriving the list here rather than writing it out at each of those call sites
+     * is what keeps a newly added source from being silently skipped by the cache lookups — which
+     * is exactly what happened to [DownloadSource.QOBUZ_BACKUP] and [DownloadSource.JIOSAAVN]: they
+     * resolved and downloaded fine, but their cached bytes were invisible to the completeness check
+     * and to the purge-on-failure path, so a download that had already succeeded was fetched again.
+     *
+     * [DownloadSource.AUTO] and [DownloadSource.YOUTUBE_MUSIC] are excluded: neither ever writes a
+     * prefixed key (the YouTube fallback uses the bare media id).
+     *
+     * `Locale.US` matters — `TIDAL` and `JIOSAAVN` both contain `I`, which lowercases to a dotless
+     * `ı` under a Turkish locale and would not match the key that was written.
+     */
+    val CACHE_KEY_PREFIXES: List<String> =
+        DownloadSource.entries
+            .filterNot { it == DownloadSource.AUTO || it == DownloadSource.YOUTUBE_MUSIC }
+            .map { "${it.name.lowercase(Locale.US)}:" }
 
     private fun parseType(name: String): DownloadSource? =
         runCatching { DownloadSource.valueOf(name.trim().uppercase()) }.getOrNull()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -1175,6 +1175,11 @@ val PoTokenKey = stringPreferencesKey("poToken")
 val AccountNameKey = stringPreferencesKey("accountName")
 val AccountEmailKey = stringPreferencesKey("accountEmail")
 val AccountChannelHandleKey = stringPreferencesKey("accountChannelHandle")
+
+// Avatar that goes with AccountNameKey. Persisted for the same reason the name is: the visible
+// account identity has to survive a cold start (including the one the region picker triggers)
+// without waiting on, or depending on, a live accountMenu call.
+val AccountImageUrlKey = stringPreferencesKey("accountImageUrl")
 val SavedAccountsKey = stringPreferencesKey("savedAccounts")
 val UseLoginForBrowse = booleanPreferencesKey("useLoginForBrowse")
 val SpotifySpDcKey = stringPreferencesKey("spotify_sp_dc")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -1556,6 +1556,11 @@ val CountryCodeToName =
 // App rating / star prompt preferences
 val LaunchCountKey = intPreferencesKey("launch_count")
 val OnboardingCompletedKey = booleanPreferencesKey("onboarding_completed")
+
+// Last onboarding page the user was on. The onboarding ViewModel's page index is plain
+// in-memory state; without persisting it, process death or activity recreation resets the
+// flow to page 1 even though the user was mid-way through.
+val OnboardingCurrentPageKey = intPreferencesKey("onboarding_current_page")
 val HasPressedStarKey = booleanPreferencesKey("has_pressed_star")
 val RemindAfterKey = intPreferencesKey("remind_after")
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingRepository.kt
@@ -16,10 +16,12 @@ import androidx.datastore.preferences.core.edit
 import com.google.common.collect.ImmutableList
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.constants.LaunchCountKey
 import moe.rukamori.archivetune.constants.OnboardingCompletedKey
+import moe.rukamori.archivetune.constants.OnboardingCurrentPageKey
 import moe.rukamori.archivetune.utils.dataStore
 import javax.inject.Inject
 
@@ -56,6 +58,16 @@ class OnboardingRepository
         suspend fun markCompleted() {
             context.dataStore.edit { preferences ->
                 preferences[OnboardingCompletedKey] = true
+                preferences[OnboardingCurrentPageKey] = 0
+            }
+        }
+
+        suspend fun currentPage(): Int = context.dataStore.data.first()[OnboardingCurrentPageKey] ?: 0
+
+        suspend fun setCurrentPage(page: Int) {
+            if (page <= 0) return
+            context.dataStore.edit { preferences ->
+                preferences[OnboardingCurrentPageKey] = page
             }
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/onboarding/OnboardingViewModel.kt
@@ -31,11 +31,29 @@ class OnboardingViewModel
         observeOnboardingDataUseCase: ObserveOnboardingDataUseCase,
         private val buildOnboardingUiStateUseCase: BuildOnboardingUiStateUseCase,
         private val completeOnboardingUseCase: CompleteOnboardingUseCase,
+        private val onboardingRepository: OnboardingRepository,
     ) : ViewModel() {
         private val currentPage = MutableStateFlow(0)
         private val refreshSignals = MutableStateFlow(0)
         private val mutableEvents = MutableSharedFlow<OnboardingEvent>(extraBufferCapacity = 1)
         private var completionJob: Job? = null
+
+        init {
+            // Seed the page from DataStore so process death / activity recreation /
+            // app restart resumes the onboarding where the user left it instead of
+            // resetting to page 1.
+            viewModelScope.launch {
+                val restored = onboardingRepository.currentPage()
+                if (restored > 0 && currentPage.value == 0) {
+                    currentPage.value = restored
+                }
+            }
+        }
+
+        private fun goToPage(page: Int) {
+            currentPage.value = page
+            viewModelScope.launch { onboardingRepository.setCurrentPage(page) }
+        }
 
         val events = mutableEvents.asSharedFlow()
 
@@ -59,7 +77,7 @@ class OnboardingViewModel
             val success = screenState.value as? OnboardingScreenState.Success ?: return
             val lastPage = success.uiState.pages.lastIndex
             if (success.uiState.currentPage < lastPage) {
-                currentPage.value = success.uiState.currentPage + 1
+                goToPage(success.uiState.currentPage + 1)
             } else {
                 complete()
             }
@@ -67,7 +85,7 @@ class OnboardingViewModel
 
         fun onBack() {
             val success = screenState.value as? OnboardingScreenState.Success ?: return
-            currentPage.value = (success.uiState.currentPage - 1).coerceAtLeast(0)
+            goToPage((success.uiState.currentPage - 1).coerceAtLeast(0))
         }
 
         fun onPermissionAction(action: OnboardingPermissionAction) {
@@ -100,7 +118,7 @@ class OnboardingViewModel
             val success = screenState.value as? OnboardingScreenState.Success ?: return
             val currentPageIndex = success.uiState.currentPage
             if (success.uiState.pages.getOrNull(currentPageIndex)?.id == OnboardingPageId.LOGIN) {
-                currentPage.value = currentPageIndex + 1
+                goToPage(currentPageIndex + 1)
             }
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -46,6 +46,8 @@ import moe.rukamori.archivetune.constants.DownloadSourceKey
 import moe.rukamori.archivetune.constants.DownloadSourceOrderKey
 import moe.rukamori.archivetune.constants.QobuzAudioQuality
 import moe.rukamori.archivetune.constants.QobuzAudioQualityKey
+import moe.rukamori.archivetune.constants.SaavnAudioQuality
+import moe.rukamori.archivetune.constants.SaavnAudioQualityKey
 import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalAudioQualityKey
 import moe.rukamori.archivetune.constants.toFormatId
@@ -114,6 +116,7 @@ class DownloadUtil
             get() = DownloadSourceConfig.parseOrder(downloadSourceOrderCsv)
         private val qobuzAudioQuality by enumPreference(context, QobuzAudioQualityKey, QobuzAudioQuality.FLAC)
         private val tidalAudioQuality by enumPreference(context, TidalAudioQualityKey, TidalAudioQuality.FLAC)
+        private val saavnAudioQuality by enumPreference(context, SaavnAudioQualityKey, SaavnAudioQuality.QUALITY_320)
         private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
 
@@ -188,13 +191,19 @@ class DownloadUtil
                         // that we want a binary stream and disable any transparent
                         // gzip/br compression — compressed audio is already efficiently
                         // encoded and re-compressing it just wastes CPU.
-                        return@addInterceptor chain.proceed(
+                        val patched =
                             request
                                 .newBuilder()
                                 .header("Accept-Encoding", "identity")
                                 .header("Connection", "keep-alive")
-                                .build(),
-                        )
+                        // The Qobuz backup mirror rate-limits aggressively unless every request
+                        // carries this header — including the byte fetch, not just the resolve.
+                        // MusicService's client does the same for the playback path; without it
+                        // here the pre-warm fetch for a Qobuz-backup download gets throttled.
+                        if (host.endsWith("kouzu.in") && request.header("x-request-source").isNullOrEmpty()) {
+                            patched.header("x-request-source", "muzo")
+                        }
+                        return@addInterceptor chain.proceed(patched.build())
                     }
 
                     val requestProfile = StreamClientUtils.resolveRequestProfile(request.url)
@@ -328,7 +337,7 @@ class DownloadUtil
                 }
                 // Same check for source-prefixed cache keys — only return
                 // when we actually have the full file, not on partial cache.
-                for (sourcePrefix in listOf("qobuz:", "tidal:", "deezer:")) {
+                for (sourcePrefix in DownloadSourceConfig.CACHE_KEY_PREFIXES) {
                     val sourceKey = "$sourcePrefix$mediaId"
                     val sourceExpected = expectedLength // same expected length across sources
                     if (sourceExpected > 0L) {
@@ -434,13 +443,14 @@ class DownloadUtil
                                 // subsequent playback attempts.
                                 //
                                 // Both the bare mediaId key and the
-                                // source-prefixed keys (qobuz:/tidal:/deezer:)
+                                // source-prefixed keys (see
+                                // DownloadSourceConfig.CACHE_KEY_PREFIXES)
                                 // are purged so a failed pre-warm under one
                                 // source doesn't poison the next attempt via
                                 // a different source.
                                 val mediaId = download.request.id
                                 runCatching { playerCache.removeResource(mediaId) }
-                                for (sourcePrefix in listOf("qobuz:", "tidal:", "deezer:")) {
+                                for (sourcePrefix in DownloadSourceConfig.CACHE_KEY_PREFIXES) {
                                     runCatching { playerCache.removeResource("$sourcePrefix$mediaId") }
                                 }
                             }
@@ -462,7 +472,7 @@ class DownloadUtil
                             // playback attempt.
                             val mediaId = download.request.id
                             runCatching { playerCache.removeResource(mediaId) }
-                            for (sourcePrefix in listOf("qobuz:", "tidal:", "deezer:")) {
+                            for (sourcePrefix in DownloadSourceConfig.CACHE_KEY_PREFIXES) {
                                 runCatching { playerCache.removeResource("$sourcePrefix$mediaId") }
                             }
                             downloads.update { map -> map - download.request.id }
@@ -547,7 +557,7 @@ class DownloadUtil
             // When expected is unknown, we fall through to the resolver and
             // fetch a fresh copy, which writes the authoritative contentLength
             // to FormatEntity for next time.
-            for (key in listOf("qobuz:$mediaId", "tidal:$mediaId", "deezer:$mediaId", mediaId)) {
+            for (key in DownloadSourceConfig.CACHE_KEY_PREFIXES.map { "$it$mediaId" } + mediaId) {
                 val spans = runCatching { playerCache.getCachedSpans(key) }.getOrNull().orEmpty()
                 if (spans.isNotEmpty()) {
                     val expected = database.getSongByIdBlocking(mediaId)?.format?.contentLength ?: 0L
@@ -765,6 +775,11 @@ class DownloadUtil
                 return dataSpec.buildUpon()
                     .setUri(resolved.uri.toUri())
                     .setKey("${source.name.lowercase(java.util.Locale.US)}:$mediaId")
+                    // The DownloadManager fetches these bytes through PRDownloader, not through
+                    // mediaOkHttpClient, so the mirror's required header has to ride on the
+                    // DataSpec — the interceptor above never sees this request. Merged rather than
+                    // replaced so nothing Media3 already put on the spec is dropped.
+                    .setHttpRequestHeaders(dataSpec.httpRequestHeaders + requiredHeadersFor(resolved.uri))
                     .build()
             }
             return null
@@ -813,6 +828,14 @@ class DownloadUtil
                     cacheDir = appContext.cacheDir,
                 )?.let { ResolvedStreamData(it.uri, it.mimeType, it.codecs, it.contentLength) }
             }
+            DownloadSource.QOBUZ_BACKUP -> {
+                // Keyed by the YouTube video id, so it needs neither a Source Pool account nor a
+                // catalogue search — which makes it the one lossless source that works on a fresh
+                // install with nothing configured.
+                LosslessStreamResolver
+                    .resolveQobuzBackup(mediaId)
+                    ?.let { ResolvedStreamData(it.uri, it.mimeType, it.codecs, it.contentLength) }
+            }
             DownloadSource.DEEZER -> {
                 // Public Deezer API only exposes 30-second previews — full
                 // streaming requires Premium credentials. Return null so the
@@ -822,15 +845,32 @@ class DownloadUtil
                 null
             }
             DownloadSource.JIOSAAVN -> {
-                // The JioSaavn public API exposes 96/160/320 kbps AAC stream URLs at runtime,
-                // but the download path needs a stable, contentLength-bearing resolver like
-                // LosslessStreamResolver.resolveQobuz/resolveTidal. Until that's added, return
-                // null so the AUTO chain falls through to the next source. The runtime playback
-                // path (MusicService.resolveJioSaavnStream) is unaffected and still works.
-                null
+                LosslessStreamResolver.resolveJioSaavn(
+                    mediaId = mediaId,
+                    title = title,
+                    artists = artists,
+                    album = album,
+                    durationMs = durationMs,
+                    qualityApiValue = saavnAudioQuality.toApiValue(),
+                )?.let { ResolvedStreamData(it.uri, it.mimeType, it.codecs, it.contentLength) }
             }
             DownloadSource.AUTO, DownloadSource.YOUTUBE_MUSIC -> null
         }
+
+        /**
+         * Headers a resolved stream URL cannot be fetched without.
+         *
+         * Only the Qobuz backup mirror needs one today: `mlc-ytify.kouzu.in` rate-limits any
+         * request that arrives without `x-request-source`, and that applies to the byte fetch as
+         * much as to the resolve call. Every other source serves plain authenticated-by-URL CDN
+         * links, so the map stays empty for them.
+         */
+        private fun requiredHeadersFor(uri: String): Map<String, String> =
+            if (runCatching { uri.toUri().host }.getOrNull()?.endsWith("kouzu.in") == true) {
+                mapOf("x-request-source" to "muzo")
+            } else {
+                emptyMap()
+            }
 
         private data class ResolvedStreamData(
             val uri: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/LosslessStreamResolver.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/LosslessStreamResolver.kt
@@ -22,7 +22,9 @@ import moe.rukamori.archivetune.constants.TidalAccountFirstKey
 import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalCountryCodeKey
 import moe.rukamori.archivetune.constants.TidalInstancesKey
+import moe.rukamori.archivetune.jiosaavn.SaavnService
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
+import moe.rukamori.archivetune.qobuz.QobuzBackupProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
 import moe.rukamori.archivetune.tidal.TidalAccountManager
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
@@ -312,6 +314,175 @@ object LosslessStreamResolver {
             )
         }
     }
+
+    /**
+     * Resolves a **Qobuz backup** stream for [mediaId] — the community-hosted `mlc-ytify.kouzu.in`
+     * mirror, keyed by YouTube video id.
+     *
+     * Needs no Source Pool account and no credentials at all, which makes it the one lossless
+     * source that works on a fresh install. That is also why it belongs in the download priority
+     * list: before it was added there, a user with no pool accounts had every lossless entry in the
+     * chain return null and every download fall through to the lossy YouTube fallback, even for
+     * tracks the mirror had in FLAC.
+     *
+     * Delegates to [QobuzBackupProvider.resolveStream], the same resolver the playback path uses,
+     * so mirror selection and FLAC detection cannot drift between playing a song and downloading
+     * it. The mirror serves plain HTTPS with no decryption step, so the resolved URL is directly
+     * usable by the downloader's HTTP data source.
+     *
+     * Deliberately NOT gated on the `QobuzBackupEnabledKey` playback toggle: the download priority
+     * list is the control for downloads, exactly as it is for Qobuz, Tidal and Deezer — none of
+     * which consult their playback switches here either. A user who drags this source to the top of
+     * the download list means it.
+     *
+     * @param mediaId the song's YouTube video id. Anything that is not an 11-character video id is
+     *   rejected by the provider, which is the normal outcome for a local or imported track.
+     */
+    fun resolveQobuzBackup(mediaId: String): DirectStream? =
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                QobuzBackupProvider.resolveStream(mediaId)?.let { resolved ->
+                    DirectStream(
+                        uri = resolved.uri,
+                        mimeType = resolved.mimeType,
+                        codecs = resolved.codecs,
+                        contentLength = resolved.contentLength,
+                        label = resolved.label,
+                        source = AudioSourceType.QOBUZ_BACKUP,
+                        // The mirror is keyed by the YouTube id we asked for, so the match is
+                        // authoritative by construction — there is no catalogue search to verify.
+                        trustedDirectId = true,
+                        sampleRate = resolved.sampleRate,
+                        bitDepth = resolved.bitDepth,
+                        matchedDurationMs = resolved.durationMs,
+                    )
+                }
+            }
+        }.onFailure { error ->
+            Timber.tag("LosslessResolver").w(error, "Qobuz backup resolve failed for %s", mediaId)
+        }.getOrNull()
+
+    /**
+     * Resolves a **JioSaavn** stream for [mediaId].
+     *
+     * JioSaavn is unauthenticated — no account, no pool, no decryption — and returns a plain HTTPS
+     * AAC URL, so the download path can use it exactly as playback does. It was previously a
+     * hard-coded `null` in the download chain with a comment saying a "stable, contentLength-bearing
+     * resolver" was still needed; that requirement turned out to be unnecessary. The downloader
+     * derives the length from the response itself (see `PRDownloaderDataSource`), which is how the
+     * YouTube fallback already works — every YouTube stream URL arrives without a declared length
+     * too.
+     *
+     * Mirrors `MusicService.resolveJioSaavnStream`, including the candidate scoring, so a track
+     * downloads as the same recording it plays as.
+     */
+    fun resolveJioSaavn(
+        mediaId: String,
+        title: String,
+        artists: List<String>,
+        album: String?,
+        durationMs: Long?,
+        qualityApiValue: String,
+    ): DirectStream? {
+        val artistHint = artists.firstOrNull()?.takeIf { it.isNotBlank() }.orEmpty()
+        val albumHint = album?.takeIf { it.isNotBlank() }.orEmpty()
+        val searchQuery =
+            buildString {
+                append(title)
+                if (artistHint.isNotBlank()) append(' ').append(artistHint)
+                if (albumHint.isNotBlank()) append(' ').append(albumHint)
+            }.trim()
+
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                val results = SaavnService.searchSongs(searchQuery).getOrNull().orEmpty()
+                if (results.isEmpty()) return@runBlocking null
+                val wantedDurationSec = durationMs?.let { it / 1000 }
+                val candidate =
+                    results
+                        // Pro-only tracks answer with a 30-second preview, which would silently
+                        // download as a truncated file.
+                        .filter { !it.isProOnly && it.downloadUrl.isNotEmpty() }
+                        .minByOrNull { song ->
+                            saavnMatchPenalty(
+                                candidateTitle = song.name,
+                                candidateArtist = song.artists.primary.firstOrNull()?.name,
+                                candidateDurationSec = song.duration?.toLong(),
+                                wantedTitle = title,
+                                wantedArtist = artistHint,
+                                wantedDurationSec = wantedDurationSec,
+                            )
+                        } ?: return@runBlocking null
+                val streamUrl =
+                    SaavnService.selectBestUrl(candidate.downloadUrl, qualityApiValue)
+                        ?: return@runBlocking null
+                DirectStream(
+                    uri = streamUrl,
+                    mimeType = "audio/mp4",
+                    codecs = "mp4a.40.2",
+                    contentLength = null,
+                    label = "JioSaavn $qualityApiValue",
+                    source = AudioSourceType.JIOSAAVN,
+                    matchedTitle = candidate.name,
+                    matchedArtist = candidate.artists.primary.firstOrNull()?.name,
+                    matchedAlbum = candidate.album?.name,
+                    matchedDurationMs = candidate.duration?.toLong()?.times(1000L),
+                )
+            }
+        }.onFailure { error ->
+            Timber.tag("LosslessResolver").w(error, "JioSaavn resolve failed for %s", mediaId)
+        }.getOrNull()
+    }
+
+    /**
+     * Scores how badly a JioSaavn search hit matches what we asked for — lower is better.
+     *
+     * Same weighting as `MusicService.resolveJioSaavnStream`: an exact title is free, a substring
+     * match costs a little, anything else costs a lot; artist is weighted lower than title because
+     * JioSaavn credits features inconsistently; duration is the tie-breaker that catches remixes
+     * and extended edits sharing a title.
+     */
+    private fun saavnMatchPenalty(
+        candidateTitle: String,
+        candidateArtist: String?,
+        candidateDurationSec: Long?,
+        wantedTitle: String,
+        wantedArtist: String,
+        wantedDurationSec: Long?,
+    ): Int {
+        var penalty = 0
+        val normTitle = candidateTitle.lowercase().replace(SAAVN_NORMALIZE_REGEX, "")
+        val normWanted = wantedTitle.lowercase().replace(SAAVN_NORMALIZE_REGEX, "")
+        penalty +=
+            when {
+                normTitle == normWanted -> 0
+                normTitle.contains(normWanted) || normWanted.contains(normTitle) -> 1
+                else -> 5
+            }
+        val normArtist = candidateArtist?.lowercase()?.replace(SAAVN_NORMALIZE_REGEX, "").orEmpty()
+        val normWantedArtist = wantedArtist.lowercase().replace(SAAVN_NORMALIZE_REGEX, "")
+        if (normWantedArtist.isNotBlank() && normArtist.isNotBlank()) {
+            penalty +=
+                when {
+                    normArtist == normWantedArtist -> 0
+                    normArtist.contains(normWantedArtist) || normWantedArtist.contains(normArtist) -> 1
+                    else -> 3
+                }
+        }
+        if (wantedDurationSec != null && candidateDurationSec != null) {
+            val delta = kotlin.math.abs(candidateDurationSec - wantedDurationSec)
+            penalty +=
+                when {
+                    delta <= 3 -> 0
+                    delta <= 10 -> 2
+                    else -> 6
+                }
+        }
+        return penalty
+    }
+
+    /** Strips punctuation and whitespace so titles compare on their words alone. */
+    private val SAAVN_NORMALIZE_REGEX = Regex("[^a-z0-9]")
 
     /**
      * Returns the cache key prefix for [source], matching

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -220,10 +220,10 @@ import moe.rukamori.archivetune.deezer.DeezerCrypto
 import moe.rukamori.archivetune.deezer.DeezerDecryptingDataSource
 import moe.rukamori.archivetune.jiosaavn.SaavnService
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
+import moe.rukamori.archivetune.qobuz.QobuzBackupProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
 import moe.rukamori.archivetune.audiosource.AudioSourceConfig
 import moe.rukamori.archivetune.audiosource.DirectStream
-import moe.rukamori.archivetune.audiosource.FlacStreamInfo
 import moe.rukamori.archivetune.audiosource.SongSourceOverride
 import moe.rukamori.archivetune.audiosource.SongSourceQobuzBackupVideoId
 import moe.rukamori.archivetune.audiosource.SongSourceQobuzTrackId
@@ -9709,258 +9709,70 @@ class MusicService :
     }
 
     /**
-     * Backup Qobuz stream resolver: https://mlc-ytify.kouzu.in/api/stream?id=<youtube_id>
+     * Resolves a **Qobuz backup** stream — the community-hosted `mlc-ytify.kouzu.in` mirror, which
+     * serves a FLAC per YouTube video id.
      *
-     * Two-step flow:
-     *   1. GET the resolver endpoint — returns a small JSON envelope:
-     *        { "id": "<yt_id>", "url": "https://velamhere-img.hf.space/song/<yt_id>", ... }
-     *      The `url` field points at the actual lossless audio stream on the CDN.
-     *   2. ExoPlayer streams from the resolved CDN URL — the same mediaOkHttpClient
-     *      is used, so the x-request-source: muzo header (injected for kouzu.in hosts
-     *      by the interceptor) is applied to the resolver call. The CDN host
-     *      (velamhere-img.hf.space) doesn't need the header.
+     * The two-step resolve (envelope → mirror probe) lives in
+     * [QobuzBackupProvider.resolveStream], shared with the download path
+     * (`LosslessStreamResolver.resolveQobuzBackup`). It used to be duplicated here, which is how
+     * the two drifted: the playback copy was fixed to prefer the `lossless` mirror over the lossy
+     * `url` one while the download path had no Qobuz-backup support at all.
      *
-     * The `x-request-source: muzo` header MUST be sent on every kouzu.in request —
-     * without it the server rate-limits the client aggressively. The header is
-     * injected centrally by the [mediaOkHttpClient] interceptor for any kouzu.in
-     * host request.
+     * [mediaOkHttpClient] is passed in so the probe goes out through the same proxy-aware client
+     * that will fetch the bytes, and so the interceptor adds `x-request-source: muzo` — without
+     * that header kouzu.in rate-limits aggressively.
      *
-     * Returns null when:
-     *   - mediaId is blank or not a YouTube video id (not 11 chars)
-     *   - the resolver is unreachable / returns a non-2xx
-     *   - the JSON envelope has no `url` field
+     * Returns null when the id is not a YouTube video id, the mirror has nothing for it, or no
+     * candidate mirror serves audio.
      *
-     * Marked [trustedDirectId] = true because the user has explicitly chosen the
-     * Qobuz backup source — the YouTube mediaId IS the authoritative identity for
-     * the song the user is playing, so we skip the title/artist metadata gate.
+     * Marked [DirectStream.trustedDirectId] because the mirror is keyed by the very id we asked
+     * for: the YouTube media id IS the authoritative identity here, so the title/artist gate that
+     * guards catalogue-search sources has nothing to check.
      */
     private fun resolveQobuzBackupStream(query: SourceQuery): DirectStream? {
-        // An explicit pick from the "Play from" popup addresses a specific mirror entry,
-        // which is usually NOT the playing song's own id — honour it when present and
-        // fall back to the media id for the automatic path.
+        // An explicit pick from the "Play from" popup addresses a specific mirror entry, which is
+        // usually NOT the playing song's own id — honour it when present and fall back to the media
+        // id for the automatic path.
         val ytId = (query.directQobuzBackupVideoId ?: query.mediaId).trim()
-        // YouTube video ids are 11 characters. Anything else isn't a valid id for
-        // the kouzu.in endpoint — bail early so we don't waste a network call.
-        if (ytId.length != 11 || ytId.any { !it.isLetterOrDigit() && it != '_' && it != '-' }) {
-            Timber.tag("MusicService").d("Qobuz backup skip: mediaId=%s is not a valid YT id", ytId)
-            return null
-        }
-        return runCatching {
-            runBlocking(Dispatchers.IO) {
-                // Step 1: call the resolver endpoint. It returns a small JSON envelope
-                // with the actual stream URL on the velamhere-img.hf.space CDN.
-                val resolverUrl = "https://mlc-ytify.kouzu.in/api/stream?id=$ytId"
-                // NOTE: GET (not HEAD) — the endpoint returns 405 Method Not Allowed
-                // for HEAD. We only need the first chunk of the response to parse the
-                // JSON envelope (the body is ~150 bytes), so we use a small byte range
-                // to avoid downloading the full envelope unnecessarily.
-                val resolverRequest =
-                    okhttp3.Request
-                        .Builder()
-                        .url(resolverUrl)
-                        .get()
-                        .header("User-Agent", "ArchiveTune-Android")
-                        .header("Accept", "application/json")
-                        .build()
-                val resolvedCandidates = mediaOkHttpClient.newCall(resolverRequest).execute().use { response ->
-                    if (!response.isSuccessful) {
-                        Timber.tag("MusicService").d(
-                            "Qobuz backup resolver miss for %s: HTTP %d",
-                            ytId,
-                            response.code,
-                        )
-                        return@runBlocking null
-                    }
-                    val body = response.body?.string().orEmpty()
-                    if (body.isBlank()) {
-                        Timber.tag("MusicService").d("Qobuz backup resolver miss for %s: empty body", ytId)
-                        return@runBlocking null
-                    }
-                    val root = runCatching { org.json.JSONObject(body) }.getOrNull()
-                    if (root == null) {
-                        Timber.tag("MusicService").d(
-                            "Qobuz backup resolver miss for %s: body is not JSON (first 100 chars: %s)",
-                            ytId,
-                            body.take(100),
-                        )
-                        return@runBlocking null
-                    }
-                    // The resolver envelope carries TWO mirrors for the same track:
-                    //   "url"      → https://…/song/<id>     lossy AAC-in-MP4 transcode
-                    //   "lossless" → https://…/lossless/<id> the real FLAC
-                    // Reading only `url` is why "Qobuz backup" never actually played
-                    // lossless: the lossy mirror was picked every time and the FLAC
-                    // mirror was ignored. Try lossless first and keep the lossy
-                    // mirror as a fallback for entries that have no FLAC yet.
-                    val candidates =
-                        buildList {
-                            root.optString("lossless").takeIf { it.isNotBlank() }?.let(::add)
-                            root.optString("flac").takeIf { it.isNotBlank() }?.let(::add)
-                            root.optString("url").takeIf { it.isNotBlank() }?.let(::add)
-                            root.optString("canvas_url").takeIf { it.isNotBlank() }?.let(::add)
-                            root.optString("video_url").takeIf { it.isNotBlank() }?.let(::add)
-                        }.distinct()
-                    if (candidates.isEmpty()) {
-                        Timber.tag("MusicService").d(
-                            "Qobuz backup resolver miss for %s: no url field in response (first 200 chars: %s)",
-                            ytId,
-                            body.take(200),
-                        )
-                        return@runBlocking null
-                    }
-                    candidates
-                } ?: return@runBlocking null
-
-                // Step 2: probe each candidate mirror with a two-byte ranged GET and
-                // take the first that answers with real audio.
-                //
-                // This used to be a HEAD probe, which could never succeed: the CDN
-                // answers HEAD with `405 Method Not Allowed` and `allow: GET`. The
-                // old code papered over that by falling through to the URL anyway
-                // and hardcoding `audio/mp4`, so a FLAC mirror would have been
-                // mislabelled as AAC even if it had been selected. A ranged GET is
-                // honoured (206 + Content-Type + Content-Range) so we learn the real
-                // container and the real length, and we can tell a genuine 404 for
-                // this track apart from a method-not-allowed.
-                val probe =
-                    resolvedCandidates.firstNotNullOfOrNull { candidate ->
-                        probeQobuzBackupMirror(candidate)
-                    }
-                if (probe == null) {
-                    Timber.tag("MusicService").d(
-                        "Qobuz backup CDN miss for %s: no candidate mirror served audio (tried %d)",
-                        ytId,
-                        resolvedCandidates.size,
-                    )
-                    return@runBlocking null
+        val resolved =
+            runCatching {
+                runBlocking(Dispatchers.IO) {
+                    QobuzBackupProvider.resolveStream(ytId, mediaOkHttpClient)
                 }
-                Timber.tag("MusicService").i(
-                    "Qobuz backup resolved \"%s\" via mlc-ytify.kouzu.in → %s [%s%s%s]",
-                    query.title,
-                    probe.url.take(80),
-                    probe.contentType,
-                    if (probe.isLossless) ", lossless" else "",
-                    probe.sampleRate?.let { rate ->
-                        ", ${probe.bitDepth?.toString() ?: "?"}bit/${rate / 1000f}kHz"
-                    }.orEmpty(),
-                )
-                DirectStream(
-                    uri = probe.url,
-                    mimeType = probe.mimeType,
-                    codecs = probe.codecs,
-                    contentLength = probe.contentLength,
-                    label = if (probe.isLossless) "Qobuz backup (lossless)" else "Qobuz backup (kouzu.in)",
-                    source = AudioSourceType.QOBUZ_BACKUP,
-                    sampleRate = probe.sampleRate,
-                    bitDepth = probe.bitDepth,
-                    // The YouTube mediaId is the authoritative identity of the
-                    // song the user is playing — we trust it without requiring
-                    // the backup server to echo back matching metadata.
-                    trustedDirectId = true,
-                    matchedTitle = query.title,
-                    matchedArtist = query.artists.joinToString(", ").ifBlank { null },
-                    matchedAlbum = query.album,
-                    // The FLAC header's own sample count is the exact length of the file
-                    // being served; prefer it over the catalogue duration so the Details
-                    // card and the measured bitrate are both computed from the real file.
-                    matchedDurationMs = probe.durationMs ?: query.durationMs,
-                )
-            }
-        }.onFailure { error ->
-            Timber.tag("MusicService").w(error, "Qobuz backup resolution failed for %s", ytId)
-        }.getOrNull()
+            }.onFailure { error ->
+                Timber.tag("MusicService").w(error, "Qobuz backup resolution failed for %s", ytId)
+            }.getOrNull() ?: return null
+
+        Timber.tag("MusicService").i(
+            "Qobuz backup resolved \"%s\" via mlc-ytify.kouzu.in → %s [%s%s%s]",
+            query.title,
+            resolved.uri.take(80),
+            resolved.contentType,
+            if (resolved.isLossless) ", lossless" else "",
+            resolved.sampleRate?.let { rate ->
+                ", ${resolved.bitDepth?.toString() ?: "?"}bit/${rate / 1000f}kHz"
+            }.orEmpty(),
+        )
+        return DirectStream(
+            uri = resolved.uri,
+            mimeType = resolved.mimeType,
+            codecs = resolved.codecs,
+            contentLength = resolved.contentLength,
+            label = resolved.label,
+            source = AudioSourceType.QOBUZ_BACKUP,
+            sampleRate = resolved.sampleRate,
+            bitDepth = resolved.bitDepth,
+            trustedDirectId = true,
+            matchedTitle = query.title,
+            matchedArtist = query.artists.joinToString(", ").ifBlank { null },
+            matchedAlbum = query.album,
+            // The FLAC header's own sample count is the exact length of the file being served;
+            // prefer it over the catalogue duration so the Details card and the measured bitrate
+            // are both computed from the real file.
+            matchedDurationMs = resolved.durationMs ?: query.durationMs,
+        )
     }
 
-    /**
-     * A Qobuz-backup CDN mirror that answered a probe with real audio bytes.
-     *
-     * [contentLength] is the *full* resource size taken from the `Content-Range`
-     * total (`bytes 0-1/40802970`), not the two bytes the probe actually asked
-     * for — ExoPlayer wants the whole-resource length.
-     */
-    private data class QobuzBackupProbe(
-        val url: String,
-        val mimeType: String,
-        val codecs: String,
-        val contentLength: Long?,
-        val contentType: String,
-        val isLossless: Boolean,
-        /**
-         * Real stream properties read out of the FLAC STREAMINFO block that the probe
-         * already downloads. Null for the lossy mirror (and for any FLAC whose header
-         * did not parse), in which case the Details card falls back to its tier
-         * heuristic rather than inventing precision.
-         */
-        val sampleRate: Int? = null,
-        val bitDepth: Int? = null,
-        val durationMs: Long? = null,
-    )
-
-    /**
-     * Issues a 2-byte ranged GET against a Qobuz-backup CDN mirror and maps the
-     * response to a [QobuzBackupProbe], or null when the mirror doesn't exist
-     * (404) or doesn't serve audio.
-     *
-     * HEAD is deliberately not used: the CDN replies `405 Method Not Allowed`
-     * with `allow: GET` for HEAD on every object, so a HEAD probe can only ever
-     * fail. The range is sized to exactly cover a FLAC `STREAMINFO` block
-     * ([FlacStreamInfo.REQUIRED_BYTES]) so the same round trip that establishes
-     * reachability also yields the track's real sample rate, bit depth and length —
-     * that is what stops every lossless track from showing the same numbers in the
-     * player's Details card.
-     */
-    private fun probeQobuzBackupMirror(url: String): QobuzBackupProbe? =
-        runCatching {
-            val request =
-                okhttp3.Request
-                    .Builder()
-                    .url(url)
-                    .get()
-                    .header("User-Agent", "ArchiveTune-Android")
-                    .header("Range", "bytes=0-${FlacStreamInfo.REQUIRED_BYTES - 1}")
-                    .build()
-            mediaOkHttpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return@use null
-                val headerBytes = runCatching { response.body?.bytes() }.getOrNull()
-                val contentType = response.header("Content-Type")?.lowercase().orEmpty()
-                // A JSON body here is the CDN's {"detail":"Not Found"} envelope for a
-                // mirror that hasn't been populated for this track yet.
-                if (contentType.contains("json") || contentType.contains("html")) return@use null
-                if (contentType.isNotBlank() &&
-                    !contentType.startsWith("audio/") &&
-                    !contentType.startsWith("video/") &&
-                    !contentType.contains("octet-stream")
-                ) {
-                    return@use null
-                }
-                // Prefer the Content-Range total ("bytes 0-1/40802970") — Content-Length
-                // on a 206 is just the two probed bytes.
-                val totalLength =
-                    response
-                        .header("Content-Range")
-                        ?.substringAfter('/', "")
-                        ?.trim()
-                        ?.toLongOrNull()
-                        ?: response.header("Content-Length")?.toLongOrNull()?.takeIf { response.code != 206 }
-                // Trust the bytes over the labels: a mirror that serves FLAC is FLAC even
-                // if the CDN mislabels the Content-Type, and the header is already here.
-                val streamInfo = headerBytes?.let(FlacStreamInfo::parse)
-                val isFlac = streamInfo != null || contentType.contains("flac") || url.contains("/lossless/")
-                QobuzBackupProbe(
-                    url = url,
-                    mimeType = if (isFlac) "audio/flac" else "audio/mp4",
-                    codecs = if (isFlac) "flac" else "mp4a.40.2",
-                    contentLength = totalLength?.takeIf { it > 0 },
-                    contentType = contentType.ifBlank { "unknown" },
-                    isLossless = isFlac,
-                    sampleRate = streamInfo?.sampleRate,
-                    bitDepth = streamInfo?.bitDepth,
-                    durationMs = streamInfo?.durationMs,
-                )
-            }
-        }.onFailure { error ->
-            Timber.tag("MusicService").d(error, "Qobuz backup mirror probe failed for %s", url.take(80))
-        }.getOrNull()
 
     private fun parseQobuzInstances(): List<String> =
         dataStore

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -568,6 +568,15 @@ class MusicService :
     private var lastLoginRecoveryPrompt: Pair<String, Long>? = null
     private val playbackStreamRecoveryTracker = PlaybackStreamRecoveryTracker()
 
+    // Initial-buffer-stall recovery (ported from Metrolist's "fix: playback once again").
+    // A stream can stall in STATE_BUFFERING forever without surfacing an HTTP error the
+    // onPlayerError recovery paths can act on — the player just spins, then the user skips.
+    // Watchdog: if playback is BUFFERING with playWhenReady at the very start of a track for
+    // longer than INITIAL_BUFFER_STALL_DELAY_MS, invalidate the resolved stream caches and
+    // re-prepare so the resolver picks a fresh (possibly different-client) stream URL.
+    private var initialBufferRecoveryJob: Job? = null
+    private var initialBufferRecoveryAttemptedMediaId: String? = null
+
     // Codec-state recovery counter, SEPARATE from PlaybackStreamRecoveryTracker.
     //
     // Background: when an ALAC (.m4a) stream is backgrounded + paused for a few minutes,
@@ -3833,6 +3842,47 @@ class MusicService :
         player.prepare()
         if (shouldResume) player.play()
         return true
+    }
+
+    private fun updateInitialBufferRecovery(@Player.State playbackState: Int) {
+        val mediaId = player.currentMediaItem?.mediaId
+        val shouldWatch =
+            playbackState == Player.STATE_BUFFERING &&
+                player.playWhenReady &&
+                player.currentPosition < INITIAL_BUFFER_STALL_POSITION_MS &&
+                mediaId != null &&
+                initialBufferRecoveryAttemptedMediaId != mediaId
+
+        if (!shouldWatch) {
+            initialBufferRecoveryJob?.cancel()
+            initialBufferRecoveryJob = null
+            return
+        }
+        if (initialBufferRecoveryJob?.isActive == true) return
+
+        initialBufferRecoveryJob =
+            scope.launch {
+                delay(INITIAL_BUFFER_STALL_DELAY_MS)
+                if (player.playbackState != Player.STATE_BUFFERING ||
+                    !player.playWhenReady ||
+                    player.currentPosition >= INITIAL_BUFFER_STALL_POSITION_MS ||
+                    player.currentMediaItem?.mediaId != mediaId
+                ) {
+                    return@launch
+                }
+
+                initialBufferRecoveryAttemptedMediaId = mediaId
+                Timber.tag(TAG).w(
+                    "Initial buffer stalled for %s; invalidating stream caches and re-preparing",
+                    mediaId,
+                )
+                playbackUrlCache.remove(mediaId)
+                YTPlayerUtils.invalidateCachedStreamUrls(mediaId)
+                if (playbackStreamRecoveryTracker.registerRetryAttempt(mediaId)) {
+                    player.prepare()
+                    if (player.playWhenReady) player.play()
+                }
+            }
     }
 
 
@@ -7343,6 +7393,12 @@ class MusicService :
         super.onMediaItemTransition(mediaItem, reason)
         mediaItem?.metadata?.let { queuedMetadataByMediaId[mediaItem.mediaId] = it }
 
+        // New item: reset the initial-buffer-stall watchdog for the next track.
+        initialBufferRecoveryJob?.cancel()
+        initialBufferRecoveryJob = null
+        initialBufferRecoveryAttemptedMediaId = null
+        updateInitialBufferRecovery(player.playbackState)
+
         // Catch-all for user-initiated skips that bypass PlayerConnection (notification, lock
         // screen, Bluetooth, Android Auto): a SEEK transition while a crossfade fade loop is still
         // running — but NOT the crossfade's own handoff seek (crossfadeHandoffInProgress) — means
@@ -7596,6 +7652,7 @@ class MusicService :
         super.onPlaybackStateChanged(playbackState)
 
         updateHistoryTrackingPlaybackState()
+        updateInitialBufferRecovery(playbackState)
         if (playbackState == Player.STATE_ENDED || playbackState == Player.STATE_IDLE) {
             enqueueCurrentHistorySessionForFinalization()
             if (!isCrossfading || playbackState == Player.STATE_IDLE) {
@@ -7695,6 +7752,7 @@ class MusicService :
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
         super.onIsPlayingChanged(isPlaying)
+        updateInitialBufferRecovery(player.playbackState)
         secondaryCrossfadePlayer?.let { secondaryPlayer ->
             if (isCrossfading && !crossfadeHandoffInProgress) {
                 if (isPlaying) {
@@ -8463,6 +8521,7 @@ class MusicService :
             }
         val directFactory = createResolvedUpstreamDataSourceFactory()
         val telegramFactory = TelegramDataSource.Factory()
+        val tidalProgressiveDashFactory = TidalProgressiveDashDataSource.Factory(mediaOkHttpClient)
         // Deezer needs its own chain rather than cachedFactory's: that one runs the YouTube
         // resolver over the dataSpec, which would rewrite our deezer:// URI. Decryption sits below
         // the cache so what gets cached is already-decrypted audio, letting a replay skip both the
@@ -8483,6 +8542,7 @@ class MusicService :
                 directFactory = directFactory,
                 telegramFactory = telegramFactory,
                 deezerFactory = deezerFactory,
+                tidalProgressiveDashFactory = tidalProgressiveDashFactory,
             )
         }
     }
@@ -8493,13 +8553,28 @@ class MusicService :
                 this,
                 OkHttpDataSource.Factory(mediaOkHttpClient),
             )
-        val routingFactory = youtubeMediaFactory
+        // Resolved source URIs pass through this factory a second time after the outer resolver has
+        // selected a provider. Route those private schemes here instead of asking DefaultDataSource
+        // to handle an unknown `deezer://` or `tidal-dash://` URI.
+        val routingFactory =
+            DataSource.Factory {
+                ResolvedSchemeRoutingDataSource(
+                    defaultFactory = youtubeMediaFactory,
+                    deezerFactory = DeezerDecryptingDataSource.Factory(OkHttpDataSource.Factory(mediaOkHttpClient)),
+                    tidalProgressiveDashFactory = TidalProgressiveDashDataSource.Factory(mediaOkHttpClient),
+                )
+            }
 
         return ResolvingDataSource.Factory(routingFactory) { dataSpec ->
-            resolvePlaybackDataSpec(
-                dataSpec = dataSpec,
-                allowCacheShortCircuit = false,
-            )
+            val scheme = dataSpec.uri.scheme?.lowercase(Locale.US)
+            if (scheme == DeezerCrypto.SCHEME || scheme == TidalAudioProvider.PROGRESSIVE_DASH_SCHEME) {
+                dataSpec
+            } else {
+                resolvePlaybackDataSpec(
+                    dataSpec = dataSpec,
+                    allowCacheShortCircuit = false,
+                )
+            }
         }
     }
 
@@ -9626,7 +9701,7 @@ class MusicService :
                         ),
                     cacheDir = cacheDir,
                     preferAtmos = false,
-                    preferLiveDash = false,
+                    preferLiveDash = true,
                     audioQuality = quality,
                 )
             }.onFailure { error ->
@@ -10607,6 +10682,8 @@ class MusicService :
             normalizedScheme == "file" ||
             normalizedScheme == "android.resource" ||
             normalizedScheme == "telegram" ||
+            normalizedScheme == DeezerCrypto.SCHEME ||
+            normalizedScheme == TidalAudioProvider.PROGRESSIVE_DASH_SCHEME ||
             normalizedScheme == "http" ||
             normalizedScheme == "https"
     }
@@ -10643,6 +10720,7 @@ class MusicService :
         private val directFactory: DataSource.Factory,
         private val telegramFactory: DataSource.Factory,
         private val deezerFactory: DataSource.Factory,
+        private val tidalProgressiveDashFactory: DataSource.Factory,
     ) : DataSource {
         private val transferListeners = mutableListOf<TransferListener>()
         private var delegate: DataSource? = null
@@ -10662,6 +10740,10 @@ class MusicService :
                 } else if (normalizedScheme == DeezerCrypto.SCHEME) {
                     // Carries its own cache; the YouTube resolver would rewrite the URI.
                     deezerFactory
+                } else if (normalizedScheme == TidalAudioProvider.PROGRESSIVE_DASH_SCHEME) {
+                    // Streams through its own progressive-DASH source; the YouTube resolver
+                    // would rewrite the URI.
+                    tidalProgressiveDashFactory
                 } else if (
                     normalizedScheme == "content" ||
                     normalizedScheme == "file" ||
@@ -10693,7 +10775,49 @@ class MusicService :
         }
     }
 
+    /** Routes provider URIs after the resolving/cache layers have already selected a stream. */
+    private class ResolvedSchemeRoutingDataSource(
+        private val defaultFactory: DataSource.Factory,
+        private val deezerFactory: DataSource.Factory,
+        private val tidalProgressiveDashFactory: DataSource.Factory,
+    ) : DataSource {
+        private val transferListeners = mutableListOf<TransferListener>()
+        private var delegate: DataSource? = null
 
+        override fun addTransferListener(transferListener: TransferListener) {
+            transferListeners += transferListener
+            delegate?.addTransferListener(transferListener)
+        }
+
+        override fun open(dataSpec: DataSpec): Long {
+            val scheme = dataSpec.uri.scheme?.lowercase(Locale.US)
+            val factory =
+                when (scheme) {
+                    DeezerCrypto.SCHEME -> deezerFactory
+                    TidalAudioProvider.PROGRESSIVE_DASH_SCHEME -> tidalProgressiveDashFactory
+                    else -> defaultFactory
+                }
+            val selected = factory.createDataSource()
+            transferListeners.forEach(selected::addTransferListener)
+            delegate = selected
+            return selected.open(dataSpec)
+        }
+
+        override fun read(
+            buffer: ByteArray,
+            offset: Int,
+            length: Int,
+        ): Int = checkNotNull(delegate).read(buffer, offset, length)
+
+        override fun getUri(): Uri? = delegate?.uri
+
+        override fun getResponseHeaders(): Map<String, List<String>> = delegate?.responseHeaders ?: emptyMap()
+
+        override fun close() {
+            delegate?.close()
+            delegate = null
+        }
+    }
 
     private fun updateAudioOffload(enabled: Boolean) {
         val effectiveEnabled = enabled && !crossfadeEnabled
@@ -11223,6 +11347,7 @@ class MusicService :
             localPlayer.removeListener(audioEffectPlayerListener)
             player.removeListener(this)
             player.removeListener(sleepTimer)
+            initialBufferRecoveryJob?.cancel()
             player.release()
             castPlaybackRepository.releasePlayer(player)
         } catch (_: Exception) {
@@ -11458,6 +11583,8 @@ class MusicService :
         const val ERROR_CODE_NO_STREAM = 1000001
         const val CHUNK_LENGTH = 8 * 1024 * 1024L
         val RETRYABLE_STREAM_RESPONSE_CODES = setOf(403, 404, 410, 416)
+        private const val INITIAL_BUFFER_STALL_DELAY_MS = 15_000L
+        private const val INITIAL_BUFFER_STALL_POSITION_MS = 5_000L
         const val PERSISTENT_QUEUE_FILE = "persistent_queue.data"
         const val PERSISTENT_AUTOMIX_FILE = "persistent_automix.data"
         const val PERSISTENT_PLAYER_STATE_FILE = "persistent_player_state.data"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/TidalProgressiveDashDataSource.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/TidalProgressiveDashDataSource.kt
@@ -1,0 +1,194 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playback
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import kotlinx.coroutines.CancellationException
+import moe.rukamori.archivetune.tidal.TidalAudioProvider
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+
+/**
+ * Presents TIDAL's fragmented FLAC DASH stream as a progressive FLAC stream.
+ *
+ * Media3 chooses a media-source type before a ResolvingDataSource can rewrite the URI. A DASH URI
+ * returned from the resolver would therefore be treated as progressive audio and fail to parse. The
+ * resolver stores the MPD and returns a private `tidal-dash://` URI instead; this source emits a
+ * normal FLAC header and pulls one fMP4 media segment at a time. It preserves progressive playback
+ * without downloading the entire lossless track before the first sample is available.
+ */
+internal class TidalProgressiveDashDataSource(
+    private val httpClient: OkHttpClient,
+) : BaseDataSource(true) {
+    private var currentUri: Uri? = null
+    private var segmentUrls: List<String> = emptyList()
+    private var nextSegmentIndex = 0
+    private var pendingBytes = ByteArray(0)
+    private var pendingOffset = 0
+    private var bytesRemaining = C.LENGTH_UNSET.toLong()
+    private var opened = false
+
+    override fun open(dataSpec: DataSpec): Long {
+        val manifestPath =
+            dataSpec.uri.getQueryParameter("manifest")
+                ?.takeIf(String::isNotBlank)
+                ?: throw IOException("TIDAL progressive stream did not include a manifest")
+        val manifestFile = File(manifestPath)
+        if (!manifestFile.isFile) throw IOException("TIDAL progressive manifest is unavailable")
+
+        val urls =
+            runCatching {
+                TidalAudioProvider.progressiveDashSegmentUrls(
+                    manifestFile.readText(Charsets.UTF_8),
+                )
+            }.getOrElse { error ->
+                throw IOException("TIDAL progressive manifest could not be parsed", error)
+            }
+        if (urls.size < 2 || urls.any { !it.startsWith("http://") && !it.startsWith("https://") }) {
+            throw IOException("TIDAL progressive manifest did not contain absolute FLAC segments")
+        }
+
+        currentUri = dataSpec.uri
+        segmentUrls = urls
+        nextSegmentIndex = 1
+        pendingBytes =
+            byteArrayOf(
+                'f'.code.toByte(),
+                'L'.code.toByte(),
+                'a'.code.toByte(),
+                'C'.code.toByte(),
+            ) + fetchSegment(urls.first(), 0)
+        pendingOffset = 0
+        bytesRemaining = C.LENGTH_UNSET.toLong()
+        opened = true
+        transferStarted(dataSpec)
+
+        try {
+            if (dataSpec.position > 0L) skipFully(dataSpec.position)
+            bytesRemaining = dataSpec.length
+            return bytesRemaining
+        } catch (error: CancellationException) {
+            close()
+            throw error
+        } catch (error: Throwable) {
+            close()
+            if (error is IOException) throw error
+            throw IOException("TIDAL progressive stream seek failed", error)
+        }
+    }
+
+    override fun read(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Int {
+        if (length == 0) return 0
+        if (!opened) throw IOException("TIDAL progressive stream is not open")
+        if (bytesRemaining == 0L) return C.RESULT_END_OF_INPUT
+
+        if (pendingOffset >= pendingBytes.size && !loadNextSegment()) {
+            return C.RESULT_END_OF_INPUT
+        }
+
+        var available = pendingBytes.size - pendingOffset
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) {
+            available = minOf(available.toLong(), bytesRemaining).toInt()
+        }
+        if (available <= 0) return C.RESULT_END_OF_INPUT
+
+        val count = minOf(length, available)
+        pendingBytes.copyInto(buffer, offset, pendingOffset, pendingOffset + count)
+        pendingOffset += count
+        if (bytesRemaining != C.LENGTH_UNSET.toLong()) bytesRemaining -= count
+        bytesTransferred(count)
+        return count
+    }
+
+    private fun loadNextSegment(): Boolean {
+        if (nextSegmentIndex >= segmentUrls.size) return false
+        val segmentIndex = nextSegmentIndex
+        val payload = fetchSegment(segmentUrls[segmentIndex], segmentIndex)
+        nextSegmentIndex++
+        pendingBytes = payload
+        pendingOffset = 0
+        return pendingBytes.isNotEmpty()
+    }
+
+    private fun fetchSegment(
+        url: String,
+        segmentIndex: Int,
+    ): ByteArray {
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .header("Accept", "audio/flac,audio/*,*/*;q=0.8")
+                .header("Accept-Encoding", "identity")
+                .header("User-Agent", "ArchiveTune-Android")
+                .get()
+                .build()
+        return try {
+            httpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("TIDAL FLAC segment ${segmentIndex + 1} HTTP ${response.code}")
+                }
+                val bytes = response.body?.bytes() ?: throw IOException("TIDAL FLAC segment was empty")
+                if (segmentIndex == 0) {
+                    TidalAudioProvider.progressiveDashFlacMetadata(bytes)
+                } else {
+                    TidalAudioProvider.progressiveDashAudioPayload(bytes)
+                }
+            }
+        } catch (error: IOException) {
+            throw error
+        } catch (error: Throwable) {
+            throw IOException("TIDAL FLAC segment ${segmentIndex + 1} failed", error)
+        }
+    }
+
+    private fun skipFully(bytesToSkip: Long) {
+        var remaining = bytesToSkip
+        val scratch = ByteArray(16 * 1024)
+        while (remaining > 0L) {
+            val read = read(scratch, 0, minOf(remaining, scratch.size.toLong()).toInt())
+            if (read == C.RESULT_END_OF_INPUT) {
+                throw IOException("TIDAL progressive stream ended before the requested position")
+            }
+            remaining -= read
+        }
+    }
+
+    override fun getUri(): Uri? = currentUri
+
+    override fun getResponseHeaders(): Map<String, List<String>> = emptyMap()
+
+    override fun close() {
+        segmentUrls = emptyList()
+        nextSegmentIndex = 0
+        pendingBytes = ByteArray(0)
+        pendingOffset = 0
+        bytesRemaining = C.LENGTH_UNSET.toLong()
+        currentUri = null
+        if (opened) {
+            opened = false
+            transferEnded()
+        }
+    }
+
+    class Factory(
+        private val httpClient: OkHttpClient,
+    ) : DataSource.Factory {
+        override fun createDataSource(): DataSource = TidalProgressiveDashDataSource(httpClient)
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/stream/ResolveAudioStreamUseCase.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/stream/ResolveAudioStreamUseCase.kt
@@ -139,7 +139,19 @@ class ResolveAudioStreamUseCase
                 } catch (cancellation: CancellationException) {
                     throw cancellation
                 } catch (loginRequired: YTPlayerUtils.LoginRequiredForPlaybackException) {
-                    throw loginRequired
+                    // An age-gated track fails here with "Sign in to confirm your age". That is
+                    // only a dead end when the user has NOT opted in: with Content Settings →
+                    // "Allow age-restricted content" on, the native resolver's client order ends
+                    // with the embedded players YouTube does serve age-gated streams to, so let it
+                    // try rather than surfacing a sign-in prompt the user cannot satisfy.
+                    if (!YTPlayerUtils.isAgeRestrictedPlaybackFallbackAllowed(loginRequired)) {
+                        throw loginRequired
+                    }
+                    Timber.tag(TAG).i(
+                        "yt-dlp hit the age gate for %s; trying the native embedded-player path",
+                        request.mediaId,
+                    )
+                    loginRequired
                 } catch (invalidLogin: YTPlayerUtils.InvalidPlaybackLoginContextException) {
                     throw invalidLogin
                 } catch (ytDlpFailure: YtDlpExtractionException) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzBackupProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzBackupProvider.kt
@@ -7,10 +7,12 @@
 
 package moe.rukamori.archivetune.qobuz
 
+import moe.rukamori.archivetune.audiosource.FlacStreamInfo
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
+import org.json.JSONObject
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -19,9 +21,13 @@ import java.util.concurrent.TimeUnit
  * Catalogue lookups for the **Qobuz backup** source (the community-hosted
  * `mlc-ytify.kouzu.in` mirror, which serves a FLAC per YouTube video id).
  *
- * Streaming itself lives in `MusicService.resolveQobuzBackupStream` — this object
- * only covers the parts the *UI* needs, which the resolver has no use for:
+ * Covers everything that talks to the mirror:
  *
+ *  - [resolveStream] turns a YouTube video id into a playable stream. Both the playback path
+ *    (`MusicService.resolveQobuzBackupStream`) and the download path
+ *    (`LosslessStreamResolver.resolveQobuzBackup`) call it, so a fix to mirror selection or
+ *    format detection reaches both. Callers pass their own [OkHttpClient] when they need one —
+ *    playback streams the resolved bytes through the service's proxy-aware client.
  *  - [searchCandidates] backs the player's "Play from" search popup. The popup
  *    used to hard-exclude this source with a "search backend not yet available"
  *    empty state, on the assumption that the mirror could only be addressed by
@@ -182,6 +188,214 @@ object QobuzBackupProvider {
         }
         return out
     }
+
+    /**
+     * A mirror that answered a probe with real audio bytes.
+     *
+     * [contentLength] is the *full* resource size taken from the `Content-Range` total
+     * (`bytes 0-41/40802970`), not the 42 bytes the probe asked for — ExoPlayer and the downloader
+     * both want the whole-resource length.
+     *
+     * [sampleRate], [bitDepth] and [durationMs] come from the FLAC STREAMINFO block that the probe
+     * already downloads, so they describe the actual file rather than a tier guess. All three are
+     * null for the lossy mirror.
+     */
+    data class ResolvedStream(
+        val uri: String,
+        val mimeType: String,
+        val codecs: String,
+        val contentLength: Long?,
+        val contentType: String,
+        val isLossless: Boolean,
+        val sampleRate: Int? = null,
+        val bitDepth: Int? = null,
+        val durationMs: Long? = null,
+    ) {
+        /** Label for logs and the media-info card. */
+        val label: String
+            get() = if (isLossless) "Qobuz backup (lossless)" else "Qobuz backup (kouzu.in)"
+    }
+
+    /**
+     * Resolves a playable stream for [videoId] (a YouTube video id — the mirror's primary key).
+     *
+     * Two steps, because the mirror is a resolver in front of a CDN:
+     *  1. `GET /api/stream?id=<videoId>` returns a small JSON envelope naming the mirrors for the
+     *     track. GET, not HEAD — the endpoint answers HEAD with `405 Method Not Allowed`.
+     *  2. Each candidate mirror is probed with a ranged GET and the first that serves real audio
+     *     wins. Also a GET: the CDN rejects HEAD the same way. The probe reads
+     *     [FlacStreamInfo.REQUIRED_BYTES] bytes, which is both cheap and exactly enough to read the
+     *     FLAC header, so the container is determined from the bytes rather than from a
+     *     `Content-Type` the CDN often gets wrong.
+     *
+     * Returns null when the id is not a video id, the mirror has nothing indexed for it, or no
+     * candidate serves audio. Blocking — call from `Dispatchers.IO`.
+     *
+     * @param client the HTTP client to use. Defaults to this object's own; pass a proxy-aware one
+     *   to route the probe the same way the resolved bytes will be fetched.
+     */
+    fun resolveStream(
+        videoId: String,
+        client: OkHttpClient = this.client,
+    ): ResolvedStream? {
+        val id = videoId.trim()
+        if (!VIDEO_ID_REGEX.matches(id)) {
+            Timber.tag("QobuzBackup").d("skip: \"%s\" is not a YouTube video id", id)
+            return null
+        }
+
+        val candidates = fetchMirrorCandidates(id, client)
+        if (candidates.isEmpty()) return null
+
+        val resolved = candidates.firstNotNullOfOrNull { candidate -> probeMirror(candidate, client) }
+        if (resolved == null) {
+            Timber.tag("QobuzBackup").d(
+                "CDN miss for %s: no candidate mirror served audio (tried %d)",
+                id,
+                candidates.size,
+            )
+            return null
+        }
+        Timber.tag("QobuzBackup").i(
+            "resolved %s → %s [%s%s]",
+            id,
+            resolved.uri.take(80),
+            resolved.contentType,
+            if (resolved.isLossless) ", lossless" else "",
+        )
+        return resolved
+    }
+
+    /**
+     * Reads the resolver envelope and returns its mirror URLs, best first.
+     *
+     * The envelope carries more than one mirror for the same track:
+     *   `"lossless"` → `…/lossless/<id>`, the real FLAC
+     *   `"url"`      → `…/song/<id>`, a lossy AAC-in-MP4 transcode
+     * Reading only `url` is why "Qobuz backup" used to never actually play lossless. The FLAC
+     * mirrors are listed first and the lossy one is kept as a fallback for entries that have no
+     * FLAC yet.
+     */
+    private fun fetchMirrorCandidates(
+        videoId: String,
+        client: OkHttpClient,
+    ): List<String> {
+        val url =
+            "$BASE_URL/api/stream"
+                .toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("id", videoId)
+                .build()
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .get()
+                .header("User-Agent", USER_AGENT)
+                .header("Accept", "application/json")
+                .header("x-request-source", "muzo")
+                .build()
+        return runCatching {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Timber.tag("QobuzBackup").d("resolver miss for %s: HTTP %d", videoId, response.code)
+                    return@use emptyList()
+                }
+                val body = response.body?.string().orEmpty()
+                if (body.isBlank()) {
+                    Timber.tag("QobuzBackup").d("resolver miss for %s: empty body", videoId)
+                    return@use emptyList()
+                }
+                val root = runCatching { JSONObject(body) }.getOrNull()
+                if (root == null) {
+                    Timber.tag("QobuzBackup").d(
+                        "resolver miss for %s: body is not JSON (first 100 chars: %s)",
+                        videoId,
+                        body.take(100),
+                    )
+                    return@use emptyList()
+                }
+                buildList {
+                    root.optString("lossless").takeIf { it.isNotBlank() }?.let(::add)
+                    root.optString("flac").takeIf { it.isNotBlank() }?.let(::add)
+                    root.optString("url").takeIf { it.isNotBlank() }?.let(::add)
+                    root.optString("canvas_url").takeIf { it.isNotBlank() }?.let(::add)
+                    root.optString("video_url").takeIf { it.isNotBlank() }?.let(::add)
+                }.distinct().also { mirrors ->
+                    if (mirrors.isEmpty()) {
+                        Timber.tag("QobuzBackup").d(
+                            "resolver miss for %s: no url field in response (first 200 chars: %s)",
+                            videoId,
+                            body.take(200),
+                        )
+                    }
+                }
+            }
+        }.onFailure { error ->
+            Timber.tag("QobuzBackup").d(error, "resolver call failed for %s", videoId)
+        }.getOrDefault(emptyList())
+    }
+
+    /**
+     * Probes one mirror with a ranged GET and describes it, or returns null when it does not serve
+     * audio for this track.
+     */
+    private fun probeMirror(
+        url: String,
+        client: OkHttpClient,
+    ): ResolvedStream? =
+        runCatching {
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .get()
+                    .header("User-Agent", USER_AGENT)
+                    .header("x-request-source", "muzo")
+                    .header("Range", "bytes=0-${FlacStreamInfo.REQUIRED_BYTES - 1}")
+                    .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@use null
+                val headerBytes = runCatching { response.body?.bytes() }.getOrNull()
+                val contentType = response.header("Content-Type")?.lowercase().orEmpty()
+                // A JSON body here is the CDN's {"detail":"Not Found"} envelope for a mirror that
+                // has not been populated for this track yet.
+                if (contentType.contains("json") || contentType.contains("html")) return@use null
+                if (contentType.isNotBlank() &&
+                    !contentType.startsWith("audio/") &&
+                    !contentType.startsWith("video/") &&
+                    !contentType.contains("octet-stream")
+                ) {
+                    return@use null
+                }
+                // Prefer the Content-Range total ("bytes 0-41/40802970") — Content-Length on a 206
+                // is just the probed bytes.
+                val totalLength =
+                    response
+                        .header("Content-Range")
+                        ?.substringAfter('/', "")
+                        ?.trim()
+                        ?.toLongOrNull()
+                        ?: response.header("Content-Length")?.toLongOrNull()?.takeIf { response.code != 206 }
+                // Trust the bytes over the labels: a mirror that serves FLAC is FLAC even when the
+                // CDN mislabels the Content-Type, and the header is already in hand.
+                val streamInfo = headerBytes?.let(FlacStreamInfo::parse)
+                val isFlac = streamInfo != null || contentType.contains("flac") || url.contains("/lossless/")
+                ResolvedStream(
+                    uri = url,
+                    mimeType = if (isFlac) "audio/flac" else "audio/mp4",
+                    codecs = if (isFlac) "flac" else "mp4a.40.2",
+                    contentLength = totalLength?.takeIf { it > 0 },
+                    contentType = contentType.ifBlank { "unknown" },
+                    isLossless = isFlac,
+                    sampleRate = streamInfo?.sampleRate,
+                    bitDepth = streamInfo?.bitDepth,
+                    durationMs = streamInfo?.durationMs,
+                )
+            }
+        }.onFailure { error ->
+            Timber.tag("QobuzBackup").d(error, "mirror probe failed for %s", url.take(80))
+        }.getOrNull()
 
     /** Drops cached search results. Called when the user clears app caches. */
     fun clearCaches() {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzBackupProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/qobuz/QobuzBackupProvider.kt
@@ -48,6 +48,11 @@ object QobuzBackupProvider {
     /** YouTube video ids are exactly 11 chars of `[A-Za-z0-9_-]`. */
     private val VIDEO_ID_REGEX = Regex("^[A-Za-z0-9_-]{11}$")
 
+    private val WHITESPACE_REGEX = Regex("\\s+")
+
+    /** Ceiling on the requests one [searchCandidates] call may make. See [queryVariants]. */
+    private const val MAX_QUERY_VARIANTS = 6
+
     private val client =
         OkHttpClient
             .Builder()
@@ -109,11 +114,85 @@ object QobuzBackupProvider {
         val now = System.currentTimeMillis()
         searchCache[cacheKey]?.takeIf { it.expiresAt > now }?.let { return it.candidates }
 
+        // Over-fetch, then rank locally: the mirror returns its matches in primary-key order, not
+        // by relevance, so the first 8 rows for a broad term ("sabrina carpenter") are an
+        // arbitrary 8 of however many it has.
+        val fetchLimit = limit.coerceAtLeast(24).coerceAtMost(60)
+        val candidates =
+            queryVariants(trimmed)
+                .firstNotNullOfOrNull { variant -> fetchSearch(variant, fetchLimit).takeIf { it.isNotEmpty() } }
+                .orEmpty()
+                .let { rows -> rankByQueryCoverage(rows, trimmed).take(limit) }
+
+        // Cache successes only: a transient network failure should not pin an
+        // empty result for the next ten minutes.
+        if (candidates.isNotEmpty()) {
+            searchCache[cacheKey] = CachedSearch(candidates, now + SEARCH_CACHE_MS)
+        }
+        return candidates
+    }
+
+    /**
+     * Query forms to try, in order, until one returns rows.
+     *
+     * The mirror's search is a single `name LIKE %q% OR artists LIKE %q%` — it never tokenizes and
+     * never matches across the two fields. So "Die With A Smile Lady Gaga" returns nothing even
+     * though both "die with a smile" and "lady gaga" return that exact track, which means *every*
+     * query naming both a track and its artist came back empty. That is what "nothing shows when I
+     * search Qobuz backup" was: the query reached the mirror intact and no single field contained
+     * all of it.
+     *
+     * Words are dropped a pair at a time — tail first ("Title Artist" is the common shape), then
+     * head ("Artist - Title") — so both orderings get tried before the query is whittled far down.
+     * Capped at [MAX_QUERY_VARIANTS] so one search can never fan out into a dozen round trips.
+     */
+    private fun queryVariants(query: String): List<String> {
+        val words = query.split(WHITESPACE_REGEX).filter { it.isNotBlank() }
+        if (words.size < 2) return listOf(query)
+        return buildList {
+            add(query)
+            for (kept in words.size - 1 downTo 1) {
+                add(words.take(kept).joinToString(" "))
+                add(words.takeLast(kept).joinToString(" "))
+            }
+        }.distinct()
+            .filter { it.length >= 2 }
+            .take(MAX_QUERY_VARIANTS)
+    }
+
+    /**
+     * Sorts [rows] by how much of the *original* query each one covers, so dropping words to get a
+     * hit does not also cost the ranking: "espresso sabrina carpenter" falls back to "espresso",
+     * and the row whose artist is Sabrina Carpenter still comes first.
+     *
+     * Ties break on the shorter title, which puts the plain track above the remixes, mashups and
+     * "(On Vacation Version)" entries that share its name. [List.sortedWith] is stable, so rows
+     * that tie on both keep the mirror's own order.
+     */
+    private fun rankByQueryCoverage(
+        rows: List<Candidate>,
+        query: String,
+    ): List<Candidate> {
+        val tokens = query.lowercase().split(WHITESPACE_REGEX).filter { it.length > 1 }
+        if (tokens.isEmpty()) return rows
+        return rows.sortedWith(
+            compareByDescending<Candidate> { candidate ->
+                val haystack = "${candidate.title} ${candidate.artist.orEmpty()}".lowercase()
+                tokens.count { token -> token in haystack }
+            }.thenBy { candidate -> candidate.title.length },
+        )
+    }
+
+    /** One `GET /api/search` call. Empty on any failure — callers treat it as "no rows". */
+    private fun fetchSearch(
+        query: String,
+        limit: Int,
+    ): List<Candidate> {
         val url =
             "$BASE_URL/api/search"
                 .toHttpUrl()
                 .newBuilder()
-                .addQueryParameter("q", trimmed)
+                .addQueryParameter("q", query)
                 .addQueryParameter("limit", limit.toString())
                 .build()
         val request =
@@ -126,29 +205,21 @@ object QobuzBackupProvider {
                 .header("x-request-source", "muzo")
                 .build()
 
-        val candidates =
-            runCatching {
-                client.newCall(request).execute().use { response ->
-                    if (!response.isSuccessful) {
-                        Timber.tag("QobuzBackup").d(
-                            "search \"%s\" failed: HTTP %d",
-                            trimmed,
-                            response.code,
-                        )
-                        return@use emptyList()
-                    }
-                    parseSearchResponse(response.body?.string().orEmpty(), limit)
+        return runCatching {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    Timber.tag("QobuzBackup").d(
+                        "search \"%s\" failed: HTTP %d",
+                        query,
+                        response.code,
+                    )
+                    return@use emptyList()
                 }
-            }.onFailure { error ->
-                Timber.tag("QobuzBackup").d(error, "search \"%s\" failed", trimmed)
-            }.getOrDefault(emptyList())
-
-        // Cache successes only: a transient network failure should not pin an
-        // empty result for the next ten minutes.
-        if (candidates.isNotEmpty()) {
-            searchCache[cacheKey] = CachedSearch(candidates, now + SEARCH_CACHE_MS)
-        }
-        return candidates
+                parseSearchResponse(response.body?.string().orEmpty(), limit)
+            }
+        }.onFailure { error ->
+            Timber.tag("QobuzBackup").d(error, "search \"%s\" failed", query)
+        }.getOrDefault(emptyList())
     }
 
     /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
@@ -163,7 +163,10 @@ class SpotifyLibraryRepository
                         prefs.remove(SpotifyAccessTokenExpiresAtKey)
                     }
                 }
-                if (credentialsChanged) Spotify.accessToken = null
+                if (credentialsChanged) {
+                    Spotify.accessToken = null
+                    clearCatalogCaches()
+                }
                 _playlists.value = emptyList()
                 _errorMessage.value = null
                 refreshAccessToken(spDc = spDc, spKey = spKey).getOrThrow()
@@ -189,6 +192,7 @@ class SpotifyLibraryRepository
                 _playlists.value = emptyList()
                 _errorMessage.value = null
                 Spotify.accessToken = null
+                clearCatalogCaches()
                 runCatching { clearWebAuthSession(context) }
                     .onFailure(::reportException)
             }
@@ -379,6 +383,11 @@ class SpotifyLibraryRepository
                 }
                 enriched
             }
+
+        private fun clearCatalogCaches() {
+            synchronized(searchCache) { searchCache.clear() }
+            synchronized(metadataCache) { metadataCache.clear() }
+        }
 
 
         /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
@@ -277,6 +277,27 @@ class SpotifyLibraryRepository
                 tracks
             }
 
+        suspend fun likedSongs(): List<SpotifyTrack> =
+            withContext(Dispatchers.IO) {
+                ensureAuthenticated()
+                val tracks = ArrayList<SpotifyTrack>()
+                var offset = 0
+                val limit = 50
+
+                while (true) {
+                    val page =
+                        spotifyCallWithTokenRetry {
+                            Spotify.likedSongs(limit = limit, offset = offset).getOrThrow()
+                        }
+                    if (page.items.isEmpty()) break
+                    tracks += page.items.mapNotNull { it.track.takeUnless(SpotifyTrack::isLocal) }
+                    offset += page.items.size
+                    if (offset >= page.total || page.items.size < limit) break
+                }
+
+                tracks
+            }
+
         /**
          * Searches Spotify's catalog after restoring/refreshing the persisted Web Player session.
          * Results are cached briefly because the Search page and metadata enrichment can ask for

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyPlaybackResolver.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyPlaybackResolver.kt
@@ -46,12 +46,24 @@ object SpotifyPlaybackResolver {
                 cache[cacheKey]?.let { return@withContext it }
             }
 
+            val youtubeQuery = SpotifyMapper.buildSearchQuery(track)
+            // Spotify catalog playback is intentionally resolved through the existing audio-source
+            // chain, so identifying the matching YouTube item must also work without a YouTube
+            // login. Try anonymous search first; a stale account context must not make Spotify
+            // playlist tracks appear unplayable for signed-out users.
             val searchResult =
                 YouTube
                     .search(
-                        query = SpotifyMapper.buildSearchQuery(track),
+                        query = youtubeQuery,
                         filter = YouTube.SearchFilter.FILTER_SONG,
-                    ).getOrNull() ?: return@withContext null
+                        useAccountContext = false,
+                    ).getOrNull()
+                    ?: YouTube
+                        .search(
+                            query = youtubeQuery,
+                            filter = YouTube.SearchFilter.FILTER_SONG,
+                        ).getOrNull()
+                    ?: return@withContext null
 
             val candidates =
                 searchResult.items

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyPlaylistQueue.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyPlaylistQueue.kt
@@ -17,6 +17,8 @@ import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.playback.queues.Queue
 import moe.rukamori.archivetune.spotify.models.SpotifyTrack
 
+internal const val SPOTIFY_LIKED_SONGS_ID = "__spotify_liked_songs__"
+
 class SpotifyPlaylistQueue(
     private val playlistId: String,
     private val title: String? = null,
@@ -108,6 +110,14 @@ class SpotifyPlaylistQueue(
 
     private suspend fun fetchNextApiPage() {
         if (!apiHasMore) return
+        if (playlistId == SPOTIFY_LIKED_SONGS_ID) {
+            val page = Spotify.likedSongs(limit = SPOTIFY_PAGE_SIZE, offset = apiFetchOffset).getOrThrow()
+            apiTotal = page.total
+            allTracks += page.items.mapNotNull { it.track.takeUnless(SpotifyTrack::isLocal) }
+            apiFetchOffset += page.items.size
+            apiHasMore = apiFetchOffset < apiTotal
+            return
+        }
         val result =
             Spotify
                 .playlistTracks(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyPlaylistViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyPlaylistViewModel.kt
@@ -7,12 +7,14 @@
 
 package moe.rukamori.archivetune.spotify
 
+import android.content.Context
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.common.collect.ImmutableList
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -23,7 +25,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.spotify.models.SpotifyPlaylist
+import moe.rukamori.archivetune.spotify.models.SpotifyPlaylistTracksRef
 import moe.rukamori.archivetune.spotify.models.SpotifyTrack
 import moe.rukamori.archivetune.utils.reportException
 import javax.inject.Inject
@@ -35,6 +39,7 @@ class SpotifyPlaylistViewModel
         savedStateHandle: SavedStateHandle,
         private val repository: SpotifyLibraryRepository,
         private val resolveSpotifyPlaylistDownloads: ResolveSpotifyPlaylistDownloadsUseCase,
+        @ApplicationContext private val context: Context,
     ) : ViewModel() {
         private val playlistId: String = savedStateHandle.get<String>("playlistId").orEmpty()
 
@@ -69,8 +74,17 @@ class SpotifyPlaylistViewModel
             }
             reloadJob = viewModelScope.launch(Dispatchers.IO) {
                 try {
-                    val playlist = repository.playlist(playlistId)
-                    val tracks = repository.playlistTracks(playlistId)
+                    val (playlist, tracks) =
+                        if (playlistId == SPOTIFY_LIKED_SONGS_ID) {
+                            val likedTracks = repository.likedSongs()
+                            SpotifyPlaylist(
+                                id = playlistId,
+                                name = context.getString(R.string.liked_songs),
+                                tracks = SpotifyPlaylistTracksRef(total = likedTracks.size),
+                            ) to likedTracks
+                        } else {
+                            repository.playlist(playlistId) to repository.playlistTracks(playlistId)
+                        }
                     _uiState.value =
                         SpotifyPlaylistUiState(
                             playlist = playlist,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAccountManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAccountManager.kt
@@ -374,12 +374,20 @@ object TidalAccountManager {
         durationMs: Long?,
         audioQuality: String,
         cacheDir: File,
+        preferLiveDash: Boolean = false,
         countryCode: String = COUNTRY_CODE,
     ): DirectStream? =
         withContext(Dispatchers.IO) {
             val country = countryCode.ifBlank { COUNTRY_CODE }
             val match = searchTrack(accessToken, title, artists, durationMs, country) ?: return@withContext null
-            resolvePlaybackInfo(accessToken, match.id, audioQuality, durationMs, cacheDir)?.copy(
+            resolvePlaybackInfo(
+                accessToken = accessToken,
+                trackId = match.id,
+                audioQuality = audioQuality,
+                durationMs = durationMs,
+                cacheDir = cacheDir,
+                preferLiveDash = preferLiveDash,
+            )?.copy(
                 matchedTitle = match.title,
                 matchedArtist = match.artist,
                 matchedAlbum = match.album,
@@ -475,6 +483,7 @@ object TidalAccountManager {
         audioQuality: String,
         durationMs: Long?,
         cacheDir: File,
+        preferLiveDash: Boolean,
     ): DirectStream? {
         val url =
             "$API_BASE/tracks/$trackId/playbackinfopostpaywall" +
@@ -509,6 +518,7 @@ object TidalAccountManager {
                     quality = audioQuality,
                     durationMs = durationMs,
                     cacheDir = cacheDir,
+                    preferLiveDash = preferLiveDash,
                 )
             }
         }.getOrElse {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
@@ -7,10 +7,13 @@ package moe.rukamori.archivetune.tidal
 
 import android.net.Uri
 import moe.rukamori.archivetune.BuildConfig
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.supervisorScope
 import moe.rukamori.archivetune.audiosource.DirectStream
 import moe.rukamori.archivetune.constants.AudioSourceType
 import android.util.Base64
@@ -36,6 +39,7 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 
 object TidalAudioProvider {
+    internal const val PROGRESSIVE_DASH_SCHEME = "tidal-dash"
     private const val API_BASE_URL = "https://tidal.com/v1"
     private const val SONG_LINK_API_URL = "https://api.song.link/v1-alpha.1/links"
     private const val PUBLIC_TOKEN = "49YxDN9a2aFV6RTG"
@@ -224,12 +228,16 @@ object TidalAudioProvider {
 
     /** Finds a real catalog track for a first-run health check when no successful stream is cached. */
     fun findHealthProbeTrackId(): String? =
-        runCatching {
-            val items = searchTracks("adele hello") ?: return@runCatching null
-            (0 until items.length())
-                .firstNotNullOfOrNull { items.optJSONObject(it)?.toMatchedTrack()?.trackId }
-                ?.also { lastResolvedTrackId = it }
-        }.getOrNull()
+        if (activeEndpoints.isEmpty()) {
+            null
+        } else {
+            runCatching {
+                val items = searchTracks("adele hello") ?: return@runCatching null
+                (0 until items.length())
+                    .firstNotNullOfOrNull { items.optJSONObject(it)?.toMatchedTrack()?.trackId }
+                    ?.also { lastResolvedTrackId = it }
+            }.getOrNull()
+        }
 
     /**
      * Deep health probe for a single instance. Unlike [checkInstance] (reachability only), this
@@ -699,6 +707,11 @@ object TidalAudioProvider {
         preferLiveDash: Boolean = true,
         audioQuality: TidalAudioQuality = TidalAudioQuality.AAC_320,
     ): Resolved {
+        // The public catalog search endpoint is not a playback backend. Avoid a needless network
+        // lookup (and song.link fallback) when no configured/discovered instance can serve audio.
+        if (activeEndpoints.isEmpty()) {
+            throw TidalAudioResolutionException("TIDAL playback has no configured instance")
+        }
         val now = System.currentTimeMillis()
         val cooldownRemainingMs = resolverRateLimitedUntilMs - now
         if (cooldownRemainingMs > 0L) {
@@ -994,14 +1007,40 @@ object TidalAudioProvider {
 
     // endregion
 
-    fun isLiveManifestUri(value: String?): Boolean =
-        value
-            ?.let(Uri::parse)
-            ?.path
-            ?.replace('\\', '/')
-            ?.let { path ->
-                path.contains("/tidal-temp/") && path.endsWith(".mpd", ignoreCase = true)
-            } == true
+    fun isLiveManifestUri(value: String?): Boolean {
+        val uri = value?.let(Uri::parse) ?: return false
+        if (uri.scheme.equals(PROGRESSIVE_DASH_SCHEME, ignoreCase = true)) return true
+        val path = uri.path?.replace('\\', '/') ?: return false
+        return path.contains("/tidal-temp/") && path.endsWith(".mpd", ignoreCase = true)
+    }
+
+    /**
+     * Builds a private URI consumed by [TidalProgressiveDashDataSource]. The manifest remains in the
+     * app cache; only its path is carried in the URI so playback can fetch FLAC media segments lazily
+     * instead of downloading the complete track before ExoPlayer starts.
+     */
+    internal fun progressiveDashUri(manifestFile: File): String =
+        Uri.Builder()
+            .scheme(PROGRESSIVE_DASH_SCHEME)
+            .authority("stream")
+            .appendQueryParameter("manifest", manifestFile.absolutePath)
+            .build()
+            .toString()
+
+    /** Reads the segment list used by the progressive FLAC data source. */
+    internal fun progressiveDashSegmentUrls(manifestText: String): List<String> =
+        runCatching { extractDashSegmentUrls(manifestText.sanitizeXmlEntities()) }
+            .getOrDefault(emptyList())
+
+    /** Converts the fMP4 initialization segment into a normal FLAC header. */
+    internal fun progressiveDashFlacMetadata(initBytes: ByteArray): ByteArray = extractFlacMetadataBlocks(initBytes)
+
+    /** Extracts FLAC frames from one fMP4 media segment without buffering the rest of the track. */
+    internal fun progressiveDashAudioPayload(segmentBytes: ByteArray): ByteArray =
+        java.io.ByteArrayOutputStream(segmentBytes.size).use { output ->
+            writeMdatPayloads(segmentBytes, output)
+            output.toByteArray()
+        }
 
     fun normalizeIsrc(value: String?): String? {
         val compact = value
@@ -1299,59 +1338,86 @@ object TidalAudioProvider {
         // Healthy instances first; instances on cooldown are only reached if all are down.
         val endpoints = orderedEndpoints()
         
-        // Race all instances concurrently: first to return successfully wins.
+        // Race all instances concurrently. A successful full-quality result returns immediately;
+        // waiting for every mirror here made one dead endpoint delay playback even when another
+        // mirror had already produced a valid stream. Downgraded AAC results are retained while we
+        // wait for a possible full-quality result from another mirror.
         return runBlocking(Dispatchers.IO) {
-            val tasks = endpoints.map { endpoint ->
-                async {
-                    runCatching {
-                        requestDirectFlacFromEndpoint(
-                            endpoint = endpoint,
-                            isAtmosRequest = isAtmosRequest,
-                            manifestFormats = manifestFormats,
-                            track = track,
-                            quality = quality,
-                            durationMs = durationMs,
-                            now = now,
-                            cacheDir = cacheDir,
-                            preferLiveDash = preferLiveDash,
-                            audioQuality = audioQuality,
-                        )
-                    }.also { result ->
-                        result.getOrNull()?.let {
-                            markInstanceHealthy(endpoint.baseUrl)
-                            // Remember this track as a health-probe for future instance scans.
-                            lastResolvedTrackId = track.trackId
-                        }
-                        result.exceptionOrNull()?.let { error ->
-                            if (error is TidalRateLimitedException) {
-                                rateLimitCount += 1
-                                longestRetryAfterMs = maxOf(longestRetryAfterMs, error.retryAfterMs)
-                            } else {
-                                val hardFailure =
-                                    error is java.net.UnknownHostException || error is java.net.ConnectException
-                                markInstanceFailed(endpoint.baseUrl, hardFailure = hardFailure)
+            supervisorScope {
+                val results = Channel<Pair<TidalDownloadEndpoint, Result<Resolved>>>(endpoints.size.coerceAtLeast(1))
+                val jobs = endpoints.map { endpoint ->
+                    launch {
+                        val result: Result<Resolved> =
+                            try {
+                                runInterruptible(Dispatchers.IO) {
+                                    Result.success(
+                                        requestDirectFlacFromEndpoint(
+                                            endpoint = endpoint,
+                                            isAtmosRequest = isAtmosRequest,
+                                            manifestFormats = manifestFormats,
+                                            track = track,
+                                            quality = quality,
+                                            durationMs = durationMs,
+                                            now = now,
+                                            cacheDir = cacheDir,
+                                            preferLiveDash = preferLiveDash,
+                                            audioQuality = audioQuality,
+                                        ),
+                                    )
+                                }
+                            } catch (cancel: CancellationException) {
+                                throw cancel
+                            } catch (error: Throwable) {
+                                Result.failure(error)
                             }
-                            errors += "${endpoint.name}: ${error.message ?: error.javaClass.simpleName}"
-                            Timber.tag("TidalAudio").w(error, "TIDAL resolver ${endpoint.name} failed for ${track.trackId}")
-                        }
+                        results.send(endpoint to result)
                     }
                 }
-            }
-            
-            // Await all tasks and find the first success.
-            val results = tasks.awaitAll()
-            results.forEach { result ->
-                result.getOrNull()?.let { return@runBlocking it }
-            }
-            
+
+                var deferredAacFallback: Resolved? = null
+                try {
+                    repeat(endpoints.size) {
+                        val (endpoint, result) = results.receive()
+                        val resolved = result.getOrNull()
+                        if (resolved != null) {
+                            markInstanceHealthy(endpoint.baseUrl)
+                            lastResolvedTrackId = track.trackId
+                            if (resolved.losslessDowngradedBitrateKbps == null) {
+                                jobs.forEach { it.cancel() }
+                                return@supervisorScope resolved
+                            }
+                            if (deferredAacFallback == null) deferredAacFallback = resolved
+                            return@repeat
+                        }
+
+                        val error = result.exceptionOrNull() ?: TidalAudioResolutionException("unknown mirror failure")
+                        if (error is TidalRateLimitedException) {
+                            rateLimitCount += 1
+                            longestRetryAfterMs = maxOf(longestRetryAfterMs, error.retryAfterMs)
+                        } else {
+                            val hardFailure =
+                                error is java.net.UnknownHostException || error is java.net.ConnectException
+                            markInstanceFailed(endpoint.baseUrl, hardFailure = hardFailure)
+                        }
+                        errors += "${endpoint.name}: ${error.message ?: error.javaClass.simpleName}"
+                        Timber.tag("TidalAudio").w(error, "TIDAL resolver ${endpoint.name} failed for ${track.trackId}")
+                    }
+                } finally {
+                    jobs.forEach { it.cancel() }
+                    results.close()
+                }
+
+                deferredAacFallback?.let { return@supervisorScope it }
+
             // All failed; check if rate-limited.
-            if (rateLimitCount == endpoints.size && longestRetryAfterMs > 0L) {
-                resolverRateLimitedUntilMs = System.currentTimeMillis() + longestRetryAfterMs
-                throw TidalRateLimitedException(longestRetryAfterMs)
+                if (rateLimitCount == endpoints.size && longestRetryAfterMs > 0L) {
+                    resolverRateLimitedUntilMs = System.currentTimeMillis() + longestRetryAfterMs
+                    throw TidalRateLimitedException(longestRetryAfterMs)
+                }
+                throw TidalAudioResolutionException(
+                    "TIDAL resolver failed on all mirrors for ${track.title}: ${errors.joinToString(" | ").take(720)}",
+                )
             }
-            throw TidalAudioResolutionException(
-                "TIDAL resolver failed on all mirrors for ${track.title}: ${errors.joinToString(" | ").take(720)}",
-            )
         }
     }
 
@@ -1573,25 +1639,34 @@ object TidalAudioProvider {
                 )
             }
 
-            val localFile = if (manifest.isDash && manifestLooksFlac && cacheDir != null) {
+            val progressiveDashFile = if (preferLiveDash && manifest.isDash && manifestLooksFlac && cacheDir != null) {
+                // Keep only the manifest for playback; the progressive DataSource fetches FLAC
+                // segments on demand and can start after the init segment arrives.
+                writeDashManifestToTempFile(track.trackId, quality, manifest, cacheDir)
+            } else {
+                null
+            }
+            val localFile = if (progressiveDashFile == null && manifest.isDash && manifestLooksFlac && cacheDir != null) {
                 downloadDashFlacToTempFile(track.trackId, quality, manifest, cacheDir)
-            } else if (!preferLiveDash && manifest.isDash && cacheDir != null) {
+            } else if (progressiveDashFile == null && manifest.isDash && cacheDir != null) {
                 downloadManifestToTempFile(track.trackId, quality, manifest, cacheDir)
             } else {
                 null
             }
-            val liveManifestFile = if (localFile == null && preferLiveDash && manifest.isDash && cacheDir != null) {
-                writeDashManifestToTempFile(track, quality, manifest, cacheDir)
+            val liveManifestFile = if (progressiveDashFile == null && localFile == null && preferLiveDash && manifest.isDash && cacheDir != null) {
+                writeDashManifestToTempFile(track.trackId, quality, manifest, cacheDir)
             } else {
                 null
             }
-            val streamUri = liveManifestFile
+            val streamUri = progressiveDashFile
+                ?.let { progressiveDashUri(it) }
+                ?: liveManifestFile
                 ?.let { Uri.fromFile(it).toString() }
                 ?: localFile?.let { Uri.fromFile(it).toString() }
                 ?: manifest.url
             val playbackStreamInfo = localFile
                 ?.let { inspectLocalPlaybackFile(it, manifest) }
-                ?: if (liveManifestFile == null && !manifest.isDash) {
+                ?: if (progressiveDashFile == null && liveManifestFile == null && !manifest.isDash) {
                     inspectRemotePlaybackUrl(manifest.url, manifest)
                 } else {
                     null
@@ -1603,7 +1678,9 @@ object TidalAudioProvider {
                     isAtmosManifest -> "ec-3"
                     else -> "mp4a.40.2"
                 }
-            val playbackMimeType = if (liveManifestFile != null) {
+            val playbackMimeType = if (progressiveDashFile != null) {
+                AUDIO_FLAC_MIME_TYPE
+            } else if (liveManifestFile != null) {
                 DASH_MIME_TYPE
             } else {
                 playbackStreamInfo?.mimeType ?: manifest.mimeType.coerceDirectPlaybackMimeType(manifest.url)
@@ -1618,6 +1695,7 @@ object TidalAudioProvider {
                 )
             }
             val streamMetadata = when {
+                progressiveDashFile != null -> StreamMetadata(AUDIO_FLAC_MIME_TYPE, null)
                 liveManifestFile != null -> StreamMetadata(playbackMimeType, null)
                 playbackStreamInfo != null -> StreamMetadata(
                     playbackStreamInfo.mimeType,
@@ -1641,7 +1719,7 @@ object TidalAudioProvider {
             val losslessDowngradedBitrateKbps =
                 if (isLosslessDowngrade) ((bitrate ?: 320_000) / 1000).coerceAtLeast(1) else null
             Timber.tag("TidalAudio").i(
-                "Resolved TIDAL ${resolvedQuality.ifBlank { quality }} stream for ${track.trackId}: label=$resolvedLabel, local=${localFile != null}, dash=${manifest.isDash}, bitrate=$bitrate, sampleRate=$sampleRate",
+                "Resolved TIDAL ${resolvedQuality.ifBlank { quality }} stream for ${track.trackId}: label=$resolvedLabel, local=${localFile != null}, progressive=${progressiveDashFile != null}, dash=${manifest.isDash}, bitrate=$bitrate, sampleRate=$sampleRate",
             )
 
             return Resolved(
@@ -1653,10 +1731,10 @@ object TidalAudioProvider {
                 bitrate = bitrate ?: if (isLosslessDowngrade) 320_000 else 0,
                 sampleRate = sampleRate,
                 contentLength = streamMetadata.contentLength,
-                expiresAtMs = (localFile ?: liveManifestFile)?.let { now + STREAM_CACHE_MS }
+                expiresAtMs = (progressiveDashFile ?: localFile ?: liveManifestFile)?.let { now + STREAM_CACHE_MS }
                     ?: extractExpiryMs(manifest.expiryUrl ?: manifest.url, now),
                 losslessDowngradedBitrateKbps = losslessDowngradedBitrateKbps,
-                isLiveManifest = liveManifestFile != null,
+                isLiveManifest = progressiveDashFile != null || liveManifestFile != null,
             )
         }
     }
@@ -1720,7 +1798,8 @@ object TidalAudioProvider {
      * Resolves a directly-playable [DirectStream] from an official-API `playbackinfopostpaywall`
      * manifest, reusing the same BTS/DASH handling as the public-instance path. This is what makes
      * the signed-in account path work for lossless/HiRes: Tidal returns a segmented DASH manifest
-     * there (not a BTS direct URL), so the segments are stitched into a temp FLAC in [cacheDir].
+     * there (not a BTS direct URL), so playback can use the progressive FLAC data source while
+     * downloads still stitch the segments into a temp file in [cacheDir].
      *
      * Returns null if the manifest can't be turned into a playable stream, so the caller can fall
      * back to the public instances and then YouTube.
@@ -1732,6 +1811,7 @@ object TidalAudioProvider {
         quality: String,
         durationMs: Long?,
         cacheDir: File,
+        preferLiveDash: Boolean = false,
     ): DirectStream? =
         runCatching {
             val manifest = parseManifest(manifestB64, declaredMimeType, durationMs)
@@ -1751,6 +1831,20 @@ object TidalAudioProvider {
             val looksFlac =
                 manifest.mimeType.contains("flac", ignoreCase = true) ||
                     manifest.codecs.contains("flac", ignoreCase = true)
+            if (preferLiveDash && looksFlac) {
+                // Do not make playback wait for a complete FLAC download. The progressive data
+                // source writes the FLAC header from the init segment and fetches media segments as
+                // ExoPlayer consumes them. Downloads keep using the full remux below.
+                val manifestFile = writeDashManifestToTempFile(trackId, quality, manifest, cacheDir)
+                return@runCatching DirectStream(
+                    uri = progressiveDashUri(manifestFile),
+                    mimeType = AUDIO_FLAC_MIME_TYPE,
+                    codecs = manifest.codecs.takeIf { it.isNotBlank() } ?: "flac",
+                    contentLength = null,
+                    label = "account $quality",
+                    source = AudioSourceType.TIDAL,
+                )
+            }
             val localFile =
                 if (looksFlac && manifest.segmentUrls.size >= 2) {
                     downloadDashFlacToTempFile(trackId, quality, manifest, cacheDir)
@@ -2298,7 +2392,7 @@ object TidalAudioProvider {
     }
 
     private fun writeDashManifestToTempFile(
-        track: MatchedTrack,
+        trackId: String,
         quality: String,
         manifest: ParsedManifest,
         cacheDir: File,
@@ -2308,7 +2402,7 @@ object TidalAudioProvider {
         val tidalDir = File(cacheDir, "tidal-temp").apply { mkdirs() }
         val outputFile = File(
             tidalDir,
-            "${track.trackId}-${quality.lowercase(Locale.US)}-${System.currentTimeMillis()}.mpd",
+            "${trackId}-${quality.lowercase(Locale.US)}-${System.currentTimeMillis()}.mpd",
         )
         runCatching {
             outputFile.writeText(manifestText, Charsets.UTF_8)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalAudioProvider.kt
@@ -75,6 +75,37 @@ object TidalAudioProvider {
     // This list is intentionally empty so nothing is ever baked into the app or silently used.
     private val DEFAULT_DOWNLOAD_API_ENDPOINTS = emptyList<TidalDownloadEndpoint>()
 
+    /**
+     * Well-known public HiFi/QQDL hostnames offered to the startup health scan as *probe
+     * candidates* only.
+     *
+     * These are NOT active endpoints: nothing here is ever streamed from until
+     * [TidalInstanceHealthManager] has probed it and recorded it as
+     * [InstanceHealth.HEALTHY], at which point it reaches the resolver the same way a
+     * pool-discovered instance does (via `TidalInstanceHealthManager.healthyUrls`). So the
+     * "empty user list = public streaming disabled" contract still holds for anything that
+     * cannot actually serve a full track, and a user who clears their list does not silently
+     * get these back as endpoints.
+     *
+     * The reason they exist: the Source Pool discovery feed is often down to one entry (or
+     * zero), which left the scan with nothing to probe and the instance list permanently at
+     * "0 healthy" even on a correctly-configured install. Seeding the scan gives it something
+     * to find. Dead hosts cost one probe each and are then skipped via the cooldown map.
+     */
+    val SEED_INSTANCE_CANDIDATES: List<String> =
+        listOf(
+            "https://eu-central.monochrome.tf",
+            "https://us-west.monochrome.tf",
+            "https://api.monochrome.tf",
+            "https://hot.monochrome.tf",
+            "https://monochrome-api.samidy.com",
+            "https://wolf.qqdl.site",
+            "https://maus.qqdl.site",
+            "https://vogel.qqdl.site",
+            "https://katze.qqdl.site",
+            "https://hund.qqdl.site",
+        )
+
     // Live uptime feed used by the official monochrome.tf frontend to discover currently-healthy
     // instances. Best-effort only: it rotates and may be unreachable, so discovery is allowed to
     // fail and callers keep the manual/default list. The payload is a JSON object of the form
@@ -206,6 +237,12 @@ object TidalAudioProvider {
      * track or only a PREVIEW (unsubscribed backing account). When [probeTrackId] is blank it
      * degrades to a reachability check (HEALTHY/UNREACHABLE). Runs blocking network I/O, so callers
      * must invoke it off the main thread.
+     *
+     * Both API dialects are probed, newest first — `/trackManifests/` (HiFi-RestAPI 3.x /
+     * Monochrome) and then `/track/` (HiFi-RestAPI 2.x), mirroring the fallback in
+     * [requestDirectFlacFromEndpoint]. Probing only the newer path classified every 2.x instance as
+     * UNREACHABLE even when it streamed fine, which is what left the instance list permanently at
+     * "0 healthy".
      */
     fun verifyInstance(
         baseUrl: String,
@@ -222,7 +259,21 @@ object TidalAudioProvider {
                 TidalAudioQuality.AAC_320 -> "HIGH"
             }
         val manifestFormats = qualityString.tidalManifestFormats()
-            ?: return if (checkInstance(normalized) != null) InstanceHealth.HEALTHY else InstanceHealth.UNREACHABLE
+            ?: return probeTrackDialect(normalized, trackId, qualityString)
+        val viaManifests = probeTrackManifestsDialect(normalized, trackId, manifestFormats)
+        // Only a hard "this instance doesn't speak that dialect" result is worth a second probe. A
+        // PREVIEW_ONLY answer is authoritative (the backing account has no subscription), so the
+        // older endpoint would report the same thing.
+        if (viaManifests != InstanceHealth.UNREACHABLE) return viaManifests
+        return probeTrackDialect(normalized, trackId, qualityString)
+    }
+
+    /** Probes `/trackManifests/` (HiFi-RestAPI 3.x / Monochrome). */
+    private fun probeTrackManifestsDialect(
+        normalized: String,
+        trackId: String,
+        manifestFormats: List<String>,
+    ): InstanceHealth {
         val url =
             normalized
                 .toHttpUrl()
@@ -236,16 +287,8 @@ object TidalAudioProvider {
                 .addQueryParameter("uriScheme", "HTTPS")
                 .addQueryParameter("usage", "PLAYBACK")
                 .build()
-        val request =
-            Request
-                .Builder()
-                .url(url)
-                .get()
-                .header("Accept", "application/json")
-                .header("User-Agent", DOWNLOAD_USER_AGENT)
-                .build()
         return runCatching {
-            healthClient.newCall(request).execute().use { response ->
+            healthClient.newCall(buildProbeRequest(url)).execute().use { response ->
                 val body = response.body?.string().orEmpty()
                 if (!response.isSuccessful || body.isBlank()) return@use InstanceHealth.UNREACHABLE
                 val attributes =
@@ -265,6 +308,52 @@ object TidalAudioProvider {
             }
         }.getOrElse { InstanceHealth.UNREACHABLE }
     }
+
+    /**
+     * Probes `/track/?id=&quality=` (HiFi-RestAPI 2.x), which returns the base64 manifest inline
+     * under `data.manifest` rather than a manifest document URL.
+     */
+    private fun probeTrackDialect(
+        normalized: String,
+        trackId: String,
+        qualityString: String,
+    ): InstanceHealth {
+        val url =
+            normalized
+                .toHttpUrl()
+                .newBuilder()
+                .addPathSegment("track")
+                .addPathSegment("")
+                .addQueryParameter("id", trackId)
+                .addQueryParameter("quality", qualityString)
+                .build()
+        return runCatching {
+            healthClient.newCall(buildProbeRequest(url)).execute().use { response ->
+                val body = response.body?.string().orEmpty()
+                if (!response.isSuccessful || body.isBlank()) return@use InstanceHealth.UNREACHABLE
+                val data = JSONObject(body).optJSONObject("data") ?: return@use InstanceHealth.UNREACHABLE
+                if (data.optString("assetPresentation").equals("PREVIEW", ignoreCase = true)) {
+                    return@use InstanceHealth.PREVIEW_ONLY
+                }
+                // No inline manifest means the instance answered but cannot actually stream (e.g.
+                // its backing Tidal account is dead and it returns an upstream error payload).
+                if (data.stringOrNull("manifest").isNullOrBlank()) {
+                    InstanceHealth.UNREACHABLE
+                } else {
+                    InstanceHealth.HEALTHY
+                }
+            }
+        }.getOrElse { InstanceHealth.UNREACHABLE }
+    }
+
+    private fun buildProbeRequest(url: HttpUrl): Request =
+        Request
+            .Builder()
+            .url(url)
+            .get()
+            .header("Accept", "application/json")
+            .header("User-Agent", DOWNLOAD_USER_AGENT)
+            .build()
 
     /**
      * Feeds an externally-obtained health result (e.g. from the startup scan) into the same runtime
@@ -425,6 +514,13 @@ object TidalAudioProvider {
     class TidalRateLimitedException(
         val retryAfterMs: Long,
     ) : TidalAudioResolutionException("TIDAL FLAC resolver is rate limited; cooling down for ${retryAfterMs / 1000L}s")
+
+    /**
+     * An instance answered 404 for the requested API dialect (i.e. it does not implement
+     * `/trackManifests/`). Internal signal only: [requestDirectFlacFromEndpoint] catches it and
+     * retries the same instance on the older `/track/` dialect, so it never reaches callers.
+     */
+    private class TidalDialectUnsupportedException(message: String) : TidalAudioResolutionException(message)
 
     private data class CachedTrack(
         val track: MatchedTrack,
@@ -1259,7 +1355,66 @@ object TidalAudioProvider {
         }
     }
 
+    /**
+     * Requests a direct stream from one instance, transparently retrying on the older API dialect.
+     *
+     * Public HiFi/QQDL instances come in two flavours:
+     *  - **HiFi-RestAPI 3.x / Monochrome** expose `/trackManifests/`, which returns a manifest
+     *    *document URL* under `data.data.attributes.uri`.
+     *  - **HiFi-RestAPI 2.x** only expose `/track/?id=&quality=`, which returns the base64 manifest
+     *    inline under `data.manifest`.
+     *
+     * The 2.x instances answer `/trackManifests/` with HTTP 404. Before this fallback existed, every
+     * such instance was written off as broken for lossless playback even though `/track/` would have
+     * served the exact same FLAC — which is why perfectly working mirrors reported as unusable.
+     */
     private fun requestDirectFlacFromEndpoint(
+        endpoint: TidalDownloadEndpoint,
+        isAtmosRequest: Boolean,
+        manifestFormats: List<String>?,
+        track: MatchedTrack,
+        quality: String,
+        durationMs: Long?,
+        now: Long,
+        cacheDir: File?,
+        preferLiveDash: Boolean,
+        audioQuality: TidalAudioQuality,
+    ): Resolved =
+        try {
+            requestDirectFlacFromEndpointDialect(
+                endpoint = endpoint,
+                isAtmosRequest = isAtmosRequest,
+                manifestFormats = manifestFormats,
+                track = track,
+                quality = quality,
+                durationMs = durationMs,
+                now = now,
+                cacheDir = cacheDir,
+                preferLiveDash = preferLiveDash,
+                audioQuality = audioQuality,
+            )
+        } catch (unsupported: TidalDialectUnsupportedException) {
+            Timber.tag("TidalAudio").d(
+                "%s has no /trackManifests/ (%s); retrying on the /track/ dialect",
+                endpoint.name,
+                unsupported.message,
+            )
+            requestDirectFlacFromEndpointDialect(
+                endpoint = endpoint,
+                isAtmosRequest = isAtmosRequest,
+                // null selects the `/track/?id=&quality=` request shape below.
+                manifestFormats = null,
+                track = track,
+                quality = quality,
+                durationMs = durationMs,
+                now = now,
+                cacheDir = cacheDir,
+                preferLiveDash = preferLiveDash,
+                audioQuality = audioQuality,
+            )
+        }
+
+    private fun requestDirectFlacFromEndpointDialect(
         endpoint: TidalDownloadEndpoint,
         isAtmosRequest: Boolean,
         manifestFormats: List<String>?,
@@ -1330,9 +1485,14 @@ object TidalAudioProvider {
                 throw TidalRateLimitedException(retryAfterMs)
             }
             if (!response.isSuccessful) {
-                throw TidalAudioResolutionException(
-                    "TIDAL ${endpoint.name} HTTP ${response.code}: ${responseBody.take(180)}",
-                )
+                val detail = "TIDAL ${endpoint.name} HTTP ${response.code}: ${responseBody.take(180)}"
+                // HiFi-RestAPI 2.x instances only implement `/track/`; they answer
+                // `/trackManifests/` with 404. Signal the caller so it retries this same
+                // instance on the older dialect rather than marking it failed.
+                if (response.code == 404 && manifestFormats != null) {
+                    throw TidalDialectUnsupportedException(detail)
+                }
+                throw TidalAudioResolutionException(detail)
             }
             val root = JSONObject(responseBody)
             val data = root.optJSONObject("data")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalInstanceHealthManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalInstanceHealthManager.kt
@@ -102,6 +102,11 @@ object TidalInstanceHealthManager {
                     // count at 0 regardless of how many public mirrors were actually up.
                     candidates += TidalAudioProvider.SEED_INSTANCE_CANDIDATES
 
+                    if (candidates.isEmpty()) {
+                        Timber.tag("TidalHealth").d("No TIDAL instances configured or discovered; skipping health scan")
+                        return@withLock emptyList()
+                    }
+
                     val probeTrackId =
                         TidalAudioProvider.lastResolvedTrackId
                             ?: context.dataStore.get(TidalLastProbeTrackKey)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalInstanceHealthManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/tidal/TidalInstanceHealthManager.kt
@@ -94,6 +94,13 @@ object TidalInstanceHealthManager {
                         Timber.tag("TidalHealth").d("Discovery returned %d instance(s)", discovered.size)
                         candidates += discovered
                     }
+                    // Seed the scan with the well-known public hostnames. Probing them is the only
+                    // way any of them can ever become usable: the resolver reads its fallback list
+                    // from healthyUrls(), so a seed that fails verification never gets streamed
+                    // from. Without this the scan had nothing to probe whenever the Source Pool
+                    // discovery feed was empty or unreachable, which pinned the reported instance
+                    // count at 0 regardless of how many public mirrors were actually up.
+                    candidates += TidalAudioProvider.SEED_INSTANCE_CANDIDATES
 
                     val probeTrackId =
                         TidalAudioProvider.lastResolvedTrackId

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -308,29 +308,42 @@ fun LyricsEnhanced(
     val isSynced = remember(lyrics) { lyrics != null && (isLineSyncedLrc(lyrics!!) || isTtml(lyrics!!)) }
     val isTtmlFormat = remember(lyrics) { lyrics != null && isTtml(lyrics!!) }
 
-    val lyricsEntries: List<LyricsEntry> =
-        remember(lyrics) {
-            if (lyrics == null || lyrics == LYRICS_NOT_FOUND) return@remember emptyList()
-            when {
-                isTtml(lyrics!!) -> {
-                    parseTtml(lyrics!!)
-                }
-
-                isLineSyncedLrc(lyrics!!) -> {
-                    parseLyrics(lyrics!!)
-                }
-
-                else -> {
-                    lyrics!!
-                        .lines()
-                        .filter { it.isNotBlank() }
-                        .map { line -> LyricsEntry(time = -1L, text = line.trim()) }
+    // Parsed off the composition thread. `null` means "not parsed yet" — the render `when` below
+    // keeps the shimmer up on that state instead of falling through to "lyrics not found".
+    //
+    // parseTtml/parseLyrics used to run right here, synchronously, and buildSyncedLyrics below
+    // walked the result again in the same composition. For word-synced TTML that is an XML parse
+    // plus one object per syllable, twice — landing on the exact frame the Apple Music
+    // COVER->LYRICS morph starts, which is what made switching to the lyrics page stutter. Both
+    // now run on Dispatchers.Default, the dispatcher the romanization pass below already uses.
+    var parsedEntries by remember(lyrics) { mutableStateOf<List<LyricsEntry>?>(null) }
+    LaunchedEffect(lyrics) {
+        val text = lyrics
+        if (text == null || text == LYRICS_NOT_FOUND) {
+            parsedEntries = emptyList()
+            return@LaunchedEffect
+        }
+        parsedEntries =
+            withContext(Dispatchers.Default) {
+                when {
+                    isTtml(text) -> parseTtml(text)
+                    isLineSyncedLrc(text) -> parseLyrics(text)
+                    else ->
+                        text
+                            .lines()
+                            .filter { it.isNotBlank() }
+                            .map { line -> LyricsEntry(time = -1L, text = line.trim()) }
                 }
             }
-        }
+    }
+    val lyricsEntries: List<LyricsEntry> = parsedEntries.orEmpty()
 
-    var syncedLyrics by remember(lyricsEntries, isTtmlFormat) {
-        mutableStateOf(buildSyncedLyrics(lyricsEntries, isTtmlFormat, emptyMap()))
+    // Keyed on the raw lyrics text, not on lyricsEntries: the entries now arrive a beat after the
+    // first composition, and re-keying on them would put a synchronous buildSyncedLyrics straight
+    // back on the main thread the moment the parse lands. The effect below publishes the real
+    // build from Default, so this only ever supplies the empty starting value.
+    var syncedLyrics by remember(lyrics, isTtmlFormat) {
+        mutableStateOf(SyncedLyrics(emptyList()))
     }
 
     LaunchedEffect(lyricsEntries, romanizationPreferences) {
@@ -877,7 +890,10 @@ fun LyricsEnhanced(
                 }
             }
 
-            lyrics == null -> {
+            // parsedEntries == null means the off-thread parse above hasn't published yet.
+            // Shimmer on that state — without it the two "lyrics not found" branches below
+            // would flash for the frames the parse takes.
+            lyrics == null || parsedEntries == null -> {
                 ShimmerHost {
                     repeat(6) { TextPlaceholder() }
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -18,6 +18,8 @@ import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
@@ -79,6 +81,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -185,6 +188,11 @@ private const val SMOOTH_PLAYBACK_DRIFT_CORRECTION = 0.55f
 // short enough to settle before the next line change in almost all songs,
 // while still looking smooth rather than instant.
 private const val LYRIC_FOCUS_SCROLL_DURATION_MS = 280
+// The lines stay transparent until the active one has been placed, then fade in
+// over this long. See `awaitingFirstFocus`.
+private const val LYRIC_FIRST_FOCUS_FADE_MS = 200
+// Hard ceiling on how long the lines may stay hidden waiting for that placement.
+private const val LYRIC_FIRST_FOCUS_TIMEOUT_MS = 400L
 private const val MIN_KARAOKE_SYLLABLE_DURATION_MS = 1
 // Minimum backward position jump (in ms) that we treat as a "reset" trigger —
 // large enough to ride through ExoPlayer's normal position jitter (which is
@@ -466,6 +474,44 @@ fun LyricsEnhanced(
     // observe the live state.
     val listState = key(lyricsSessionKey, positionResetCounter) { rememberLazyListState() }
 
+    // ── First-frame placement ──
+    // A fresh LazyListState starts at line 0 and the auto-scroll collector below
+    // walks it to the active line. Drawing during that trip is what made the
+    // lyrics visibly reposition themselves every time the view was opened — most
+    // obvious in the Apple Music player, which composes this view from scratch on
+    // every open, so the user saw the first verse for a frame and then a jump
+    // plus a 280ms settle to wherever the song actually is.
+    //
+    // So: keep the lines invisible until the active one has been placed (the
+    // first placement snaps instead of animating, since nothing is on screen to
+    // animate), then fade them in. Re-armed when the number of lines changes so
+    // lyrics that arrive after the view is already open — a slow provider, a
+    // translation — get the same treatment instead of jumping.
+    var awaitingFirstFocus by
+        remember(lyricsSessionKey, positionResetCounter, syncedLyrics.lines.size) {
+            mutableStateOf(isSynced && syncedLyrics.lines.isNotEmpty())
+        }
+    // Safety net: nothing may keep the lyrics hidden. If the placement hasn't
+    // happened by the time this fires (no viewport, auto-scroll preference off,
+    // an index that never lands in range) the lines are shown as they are.
+    LaunchedEffect(awaitingFirstFocus) {
+        if (!awaitingFirstFocus) return@LaunchedEffect
+        delay(LYRIC_FIRST_FOCUS_TIMEOUT_MS)
+        awaitingFirstFocus = false
+    }
+    // Read only from the draw phase (graphicsLayer), so the fade never
+    // recomposes the karaoke view.
+    val firstFocusAlpha =
+        animateFloatAsState(
+            targetValue = if (awaitingFirstFocus) 0f else 1f,
+            animationSpec =
+                tween(
+                    durationMillis = if (awaitingFirstFocus) 0 else LYRIC_FIRST_FOCUS_FADE_MS,
+                    easing = LinearEasing,
+                ),
+            label = "lyrics-first-focus-alpha",
+        )
+
     LaunchedEffect(lyricsSessionKey) {
         playbackPositionMs.longValue = player.currentPosition.coerceAtLeast(0L)
         isManualScrolling = false
@@ -693,7 +739,10 @@ fun LyricsEnhanced(
     // observes the first new active line. Keeping listState stable means the
     // collector always targets the list currently on screen.
     LaunchedEffect(lyricsSessionKey, isSynced, positionResetCounter) {
-        if (!isSynced || latestSyncedLyricsForScroll.value.lines.isEmpty()) return@LaunchedEffect
+        if (!isSynced || latestSyncedLyricsForScroll.value.lines.isEmpty()) {
+            awaitingFirstFocus = false
+            return@LaunchedEffect
+        }
         snapshotFlow {
             listState.layoutInfo.viewportEndOffset > listState.layoutInfo.viewportStartOffset
         }.first { it }
@@ -713,12 +762,19 @@ fun LyricsEnhanced(
                     return@collectLatest
                 }
 
+                // The first placement of a session is a snap: the list is still
+                // transparent, so animating it would only spend frames on a
+                // motion nobody can see — and it is the animation that used to
+                // read as the lyrics repositioning themselves.
+                val isFirstFocus = awaitingFirstFocus
                 listState.scrollLyricIntoFocus(
                     index = index,
                     animateToNearbyItem = !forceNextScroll,
                     force = forceNextScroll,
+                    snap = isFirstFocus,
                 )
                 forceNextScroll = false
+                if (isFirstFocus) awaitingFirstFocus = false
             }
     }
 
@@ -950,7 +1006,11 @@ fun LyricsEnhanced(
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .nestedScroll(nestedScrollConnection),
+                            .nestedScroll(nestedScrollConnection)
+                            // Draw-phase read: holds the lines back until the
+                            // active one is in place (see awaitingFirstFocus),
+                            // then fades them in without recomposing anything.
+                            .graphicsLayer { alpha = firstFocusAlpha.value },
                 ) {
                     val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.08f }
 
@@ -1388,6 +1448,9 @@ private suspend fun LazyListState.scrollLyricIntoFocus(
     index: Int,
     animateToNearbyItem: Boolean,
     force: Boolean,
+    // Placement for a view that isn't visible yet: skip both animations so the
+    // active line is already in place on the frame the lyrics fade in.
+    snap: Boolean = false,
 ) {
     val itemCount = layoutInfo.totalItemsCount
     if (itemCount == 0) return
@@ -1396,7 +1459,7 @@ private suspend fun LazyListState.scrollLyricIntoFocus(
     var itemInfo = layoutInfo.visibleItemsInfo.firstOrNull { item -> item.index == targetIndex }
     if (itemInfo == null) {
         val distance = abs(targetIndex - firstVisibleItemIndex)
-        if (animateToNearbyItem && distance <= LYRIC_FOCUS_ANIMATED_DISTANCE) {
+        if (!snap && animateToNearbyItem && distance <= LYRIC_FOCUS_ANIMATED_DISTANCE) {
             animateScrollToItem(targetIndex)
         } else {
             scrollToItem(targetIndex)
@@ -1430,7 +1493,7 @@ private suspend fun LazyListState.scrollLyricIntoFocus(
         // Larger deltas (return from manual scroll, large seeks) still
         // animate so the motion stays smooth over long distances.
         val instantThreshold = (viewportHeight * LYRIC_FOCUS_INSTANT_SCROLL_RATIO).roundToInt()
-        if (abs(scrollDelta) <= instantThreshold && !force) {
+        if (snap || (abs(scrollDelta) <= instantThreshold && !force)) {
             scrollBy(scrollDelta.toFloat())
         } else {
             animateScrollBy(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -14,8 +14,10 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -64,6 +66,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -102,6 +105,7 @@ import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -181,6 +185,11 @@ private const val V2_POSITION_RESET_BACKWARD_THRESHOLD_MS = 1_000L
 
 /** Seconds to wait before auto-scroll resumes after manual scroll. */
 private const val MANUAL_SCROLL_TIMEOUT_MS = 3000L
+// The lines stay transparent until the active one has been placed, then fade
+// in over this long. See `awaitingFirstFocus`.
+private const val V2_FIRST_FOCUS_FADE_MS = 200
+// Hard ceiling on how long the lines may stay hidden waiting for that placement.
+private const val V2_FIRST_FOCUS_TIMEOUT_MS = 400L
 
 /** Sentinel entry prepended so auto-scroll has headroom above the first line. */
 private val HEAD_LYRICS_ENTRY = LyricsEntry(time = 0L, text = "")
@@ -498,6 +507,40 @@ fun LyricsV2(
     var isManualScrolling by remember { mutableStateOf(false) }
     var lastManualScrollTime by remember { mutableLongStateOf(0L) }
 
+    // ── First-frame placement ──
+    // A fresh LazyListState starts at line 0 and the auto-scroll effect below
+    // animates it to the active line, so opening the view showed the first verse
+    // for a moment and then scrolled itself to wherever the song actually is.
+    // That is the "lyrics reposition themselves every time I open lyrics"
+    // report; it is most obvious in the Apple Music player, which composes this
+    // view from scratch on every open.
+    //
+    // Hold the list transparent until the active line is placed — the first
+    // placement is an instant scroll, since there is nothing on screen to
+    // animate — then fade in. Keyed on the line count so lyrics that land after
+    // the view is already open (slow provider, translation) are placed the same
+    // way instead of jumping.
+    var awaitingFirstFocus by
+        remember(playbackResetTick, entriesWithWords.size) {
+            mutableStateOf(isSynced && entriesWithWords.isNotEmpty())
+        }
+    // Safety net: never leave the lyrics hidden because a placement never came.
+    LaunchedEffect(awaitingFirstFocus) {
+        if (!awaitingFirstFocus) return@LaunchedEffect
+        delay(V2_FIRST_FOCUS_TIMEOUT_MS)
+        awaitingFirstFocus = false
+    }
+    val firstFocusAlpha =
+        androidx.compose.animation.core.animateFloatAsState(
+            targetValue = if (awaitingFirstFocus) 0f else 1f,
+            animationSpec =
+                tween(
+                    durationMillis = if (awaitingFirstFocus) 0 else V2_FIRST_FOCUS_FADE_MS,
+                    easing = LinearEasing,
+                ),
+            label = "lyrics-v2-first-focus-alpha",
+        )
+
     // Detect manual scrolling
     val nestedScrollConnection =
         remember {
@@ -532,8 +575,26 @@ fun LyricsV2(
 
     // Auto-scroll to active line
     LaunchedEffect(currentLineIndex, isManualScrolling, lyricsScroll) {
-        if (!lyricsScroll || isManualScrolling || !isSynced) return@LaunchedEffect
+        if (!lyricsScroll || isManualScrolling || !isSynced) {
+            awaitingFirstFocus = false
+            return@LaunchedEffect
+        }
         if (currentLineIndex < 0 || currentLineIndex >= entriesWithWords.size) return@LaunchedEffect
+
+        if (awaitingFirstFocus) {
+            // Wait for the first measure so the 35% anchor is computed against a
+            // real viewport, then jump straight there while the list is still
+            // transparent.
+            val viewportHeight =
+                listState.layoutInfo.viewportSize.height.takeIf { it > 0 }
+                    ?: snapshotFlow { listState.layoutInfo.viewportSize.height }.first { it > 0 }
+            listState.scrollToItem(
+                index = currentLineIndex,
+                scrollOffset = -(viewportHeight * 0.35f).toInt(),
+            )
+            awaitingFirstFocus = false
+            return@LaunchedEffect
+        }
 
         val visibleInfo = listState.layoutInfo
         val viewportHeight = visibleInfo.viewportSize.height
@@ -635,7 +696,12 @@ fun LyricsV2(
                     .fillMaxSize()
                     .nestedScroll(nestedScrollConnection)
                     .smoothFadingEdge(vertical = 80.dp)
-                    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen },
+                    .graphicsLayer {
+                        compositingStrategy = CompositingStrategy.Offscreen
+                        // Draw-phase read — holds the lines back until the active
+                        // one has been placed (see awaitingFirstFocus).
+                        alpha = firstFocusAlpha.value
+                    },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             itemsIndexed(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -318,35 +318,38 @@ fun LyricsV2(
     val isSynced = remember(lyrics) { lyrics != null && (isLineSyncedLrc(lyrics!!) || isTtml(lyrics!!)) }
     val isTtmlFormat = remember(lyrics) { lyrics != null && isTtml(lyrics!!) }
 
-    val lyricsEntries: List<LyricsEntry> =
-        remember(lyrics) {
-            if (lyrics == null || lyrics == LYRICS_NOT_FOUND) return@remember emptyList()
-            val parsed =
-                when {
-                    isTtml(lyrics!!) -> {
-                        parseTtml(lyrics!!)
-                    }
-
-                    isLineSyncedLrc(lyrics!!) -> {
-                        val dur = player.duration.takeIf { it > 0L } ?: 0L
-                        insertInstrumentalBreaks(parseLyrics(lyrics!!), dur)
-                    }
-
-                    else -> {
-                        lyrics!!
-                            .lines()
-                            .filter { it.isNotBlank() }
-                            .mapIndexed { index, line ->
-                                LyricsEntry(time = -1L, text = line.trim())
-                            }
-                    }
-                }
-            if (parsed.isNotEmpty() && parsed.first().time >= 0) {
-                listOf(HEAD_LYRICS_ENTRY) + parsed
-            } else {
-                parsed
-            }
+    // Parsed off the composition thread — same reason as LyricsEnhanced: a word-synced TTML file
+    // is an XML parse plus one object per syllable, and running it in composition put the whole
+    // cost on the frame the Apple Music COVER->LYRICS morph starts. `null` means "not parsed yet",
+    // which the render path below shows as the shimmer rather than "lyrics not found".
+    var parsedEntries by remember(lyrics) { mutableStateOf<List<LyricsEntry>?>(null) }
+    LaunchedEffect(lyrics) {
+        val text = lyrics
+        if (text == null || text == LYRICS_NOT_FOUND) {
+            parsedEntries = emptyList()
+            return@LaunchedEffect
         }
+        val dur = player.duration.takeIf { it > 0L } ?: 0L
+        parsedEntries =
+            withContext(Dispatchers.Default) {
+                val parsed =
+                    when {
+                        isTtml(text) -> parseTtml(text)
+                        isLineSyncedLrc(text) -> insertInstrumentalBreaks(parseLyrics(text), dur)
+                        else ->
+                            text
+                                .lines()
+                                .filter { it.isNotBlank() }
+                                .map { line -> LyricsEntry(time = -1L, text = line.trim()) }
+                    }
+                if (parsed.isNotEmpty() && parsed.first().time >= 0) {
+                    listOf(HEAD_LYRICS_ENTRY) + parsed
+                } else {
+                    parsed
+                }
+            }
+    }
+    val lyricsEntries: List<LyricsEntry> = parsedEntries.orEmpty()
 
     val entriesWithWords: List<LyricsEntry> = lyricsEntries
 
@@ -599,7 +602,9 @@ fun LyricsV2(
             return@BoxWithConstraints
         }
 
-        if (lyrics == null) {
+        // parsedEntries == null: the off-thread parse hasn't published yet. Shimmer on that
+        // state so the "lyrics not found" branch below doesn't flash while it runs.
+        if (lyrics == null || parsedEntries == null) {
             ShimmerHost {
                 repeat(6) {
                     TextPlaceholder()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
@@ -29,6 +29,7 @@ import moe.rukamori.archivetune.constants.ThumbnailCornerRadius
 import moe.rukamori.archivetune.db.entities.Playlist
 import moe.rukamori.archivetune.db.entities.PlaylistEntity
 import moe.rukamori.archivetune.spotify.SpotifyMapper
+import moe.rukamori.archivetune.spotify.SPOTIFY_LIKED_SONGS_ID
 import moe.rukamori.archivetune.spotify.models.SpotifyPlaylist
 import moe.rukamori.archivetune.spotify.models.SpotifyTrack
 import moe.rukamori.archivetune.ui.utils.resize
@@ -64,6 +65,24 @@ fun SpotifyLibraryPlaylistListItem(
                 .fillMaxWidth()
                 .focusable()
                 .clickable(onClick = openPlaylist),
+    )
+}
+
+@Composable
+fun SpotifyLikedSongsListItem(
+    navController: NavController,
+    modifier: Modifier = Modifier,
+) {
+    LibraryPinnedCollectionTile(
+        title = stringResource(R.string.liked_songs),
+        iconRes = R.drawable.favorite,
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable {
+                    navController.navigate("spotify_playlist/$SPOTIFY_LIKED_SONGS_ID")
+                },
+        accentColor = MaterialTheme.colorScheme.primary,
     )
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -150,7 +150,7 @@ fun LyricsMenu(
     val context = LocalContext.current
     val showPlayerControls = showPlayerControlsState?.value ?: true
     val (autoHidePlayerControls, onAutoHidePlayerControlsPreferenceChange) =
-        rememberPreference(AutoHideLyricsPlayerControlsKey, false)
+        rememberPreference(AutoHideLyricsPlayerControlsKey, true)
 
     var showEditDialog by rememberSaveable {
         mutableStateOf(false)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
@@ -117,6 +117,10 @@ fun YouTubeSongMenu(
     val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val librarySong by database.song(song.id).collectAsStateWithLifecycle(initialValue = null)
+    // "Don't recommend this song again" state. Kept here (rather than inside the item lambda) so
+    // the label flips as soon as the DB write lands.
+    val blockedSongIds by database.blockedSongIds().collectAsStateWithLifecycle(initialValue = emptyList())
+    val isSongBlocked = remember(blockedSongIds, song.id) { song.id in blockedSongIds }
     val downloadUtil = LocalDownloadUtil.current
     val download by downloadUtil.getDownload(song.id).collectAsStateWithLifecycle(initialValue = null)
     val coroutineScope = rememberCoroutineScope()
@@ -790,6 +794,73 @@ fun YouTubeSongMenu(
                             )
                         }
                     }
+                }
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        // "Don't recommend this song again" — the counterpart of the same item in SongMenu.
+        // It matters most here: this is the menu shown for catalogue results (home feed,
+        // search, related), which is exactly where a recommendation the user wants gone
+        // comes from. SongMenu only ever opens for rows that are already in the library.
+        item {
+            MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
+                Column {
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text =
+                                    stringResource(
+                                        if (isSongBlocked) {
+                                            R.string.undo_dont_recommend_song_again
+                                        } else {
+                                            R.string.dont_recommend_song_again
+                                        },
+                                    ),
+                            )
+                        },
+                        leadingContent = {
+                            Icon(
+                                painter = painterResource(R.drawable.block),
+                                contentDescription = null,
+                            )
+                        },
+                        modifier =
+                            Modifier.clickable {
+                                coroutineScope.launch {
+                                    database.withTransaction {
+                                        // `setSongBlockedAt` is an UPDATE, so it silently does
+                                        // nothing when the song has no local row — which is the
+                                        // normal case for a catalogue result the user has never
+                                        // played. Materialise the row first so the block sticks.
+                                        if (getSongById(song.id) == null) {
+                                            insert(song.toMediaMetadata())
+                                        }
+                                        setSongBlockedAt(
+                                            songId = song.id,
+                                            blockedAt = if (isSongBlocked) null else LocalDateTime.now(),
+                                        )
+                                    }
+                                    android.widget.Toast
+                                        .makeText(
+                                            context,
+                                            context.getString(
+                                                if (isSongBlocked) {
+                                                    R.string.song_unblocked_success
+                                                } else {
+                                                    R.string.song_blocked_success
+                                                },
+                                            ),
+                                            android.widget.Toast.LENGTH_SHORT,
+                                        ).show()
+                                    onDismiss()
+                                }
+                            },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -182,6 +182,21 @@ private val AppleMusicBottomIconSize = 26.dp
 private val AppleMusicBottomButtonSize = 48.dp
 private val AppleMusicMiniArtworkSize = 56.dp
 
+// ─── Lyrics backdrop "moving blur" drift ─────────────────────────────────────
+// Kept in sync with MovingBlurBackground in LyricsScreen.kt so both lyrics
+// surfaces pan at the same Apple-Music-like rate. Amplitudes are in dp and are
+// applied as graphicsLayer translations (see driftGraphicsLayer below).
+//
+// AmLyricsBlurDriftScale must satisfy
+//     (scale - 1) / 2 * screenWidthDp  >=  driftX + blurRadius
+// or the blurred artwork stops covering the parent at max drift and the blur
+// samples transparent pixels, which shows up as a dark band on the trailing
+// edge. For the narrowest common phone (360dp) that means
+//     (2.4 - 1) / 2 * 360 = 252dp  >=  160 + 64 = 224dp.  ✔
+private const val AmLyricsBlurDriftXDp = 160f
+private const val AmLyricsBlurDriftYDp = 120f
+private const val AmLyricsBlurDriftScale = 2.4f
+
 /**
  * A [Shape] that interpolates the corner radius based on the element's size.
  * At [smallSize], the corner radius is [smallRadius]; at [largeSize], it's
@@ -457,16 +472,21 @@ fun AppleMusicPlayerContent(
     // trailing edge was INSIDE the parent's bounds (0.2*W - 80 < 0 for W=360),
     // so the blur sampled transparent areas at the trailing edge — appearing
     // as a flickering dark band at the screen corners/edges. Now using scale
-    // 1.9 with drift ±60/±45 and blur 64dp: the image extends 0.45*W beyond
-    // each edge (162dp for W=360), which is > drift(60) + blur(64) = 124dp,
+    // 2.4 with drift ±160/±120 and blur 64dp: the image extends 0.7*W beyond
+    // each edge (252dp for W=360), which is > drift(160) + blur(64) = 224dp,
     // so the image always covers the parent with a comfortable safety margin.
     //
-    // SPEED: uses LinearEasing instead of FastOutSlowInEasing. The previous
-    // FastOutSlowInEasing made the drift feel fast at the start but slow at
-    // the turnaround points (the easing decelerates into each endpoint then
-    // accelerates back out). LinearEasing gives a constant, uniform speed
-    // throughout the entire cycle — no perceived "slowdown" at the edges.
-    // Duration kept at 14s/20s (already increased from the original 19s/27s).
+    // SPEED: amplitude and period now match [MovingBlurBackground] in
+    // LyricsScreen.kt — 4s/6s half-cycles over ±160/±120 dp, the Apple Music
+    // "breathing" pan. The previous 14s/20s over ±60/±45 covered 120dp in 14s
+    // and 90dp in 20s — ~9 dp/s on X and ~5 dp/s on Y; against a 64dp blur
+    // (which masks any motion under ~16dp) that read as a still image. 4s/6s
+    // over the wider range covers 320dp in 4s and 240dp in 6s — 80 dp/s on X
+    // and 40 dp/s on Y, a clearly visible drift.
+    //
+    // LinearEasing (rather than FastOutSlowInEasing) keeps the speed constant
+    // through the whole cycle, so there is no perceived "stall" at the
+    // turnaround points where the easing would otherwise decelerate.
     //
     // CRITICAL PERF: we keep the State<Float> objects (NOT `by` delegation) so
     // the animation values are read ONLY inside Modifier.graphicsLayer { }
@@ -480,19 +500,19 @@ fun AppleMusicPlayerContent(
     // drift lives in a separate MovingBlurBackground composable.
     val blurTransition = rememberInfiniteTransition(label = "am-lyrics-blur-drift")
     val blurDriftXState = blurTransition.animateFloat(
-        initialValue = -60f,
-        targetValue = 60f,
+        initialValue = -AmLyricsBlurDriftXDp,
+        targetValue = AmLyricsBlurDriftXDp,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 14_000, easing = LinearEasing),
+            animation = tween(durationMillis = 4_000, easing = LinearEasing),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "am-lyrics-drift-x",
     )
     val blurDriftYState = blurTransition.animateFloat(
-        initialValue = -45f,
-        targetValue = 45f,
+        initialValue = -AmLyricsBlurDriftYDp,
+        targetValue = AmLyricsBlurDriftYDp,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 20_000, easing = LinearEasing),
+            animation = tween(durationMillis = 6_000, easing = LinearEasing),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "am-lyrics-drift-y",
@@ -727,13 +747,14 @@ fun AppleMusicPlayerContent(
                 // lyricsOpen is a stable Boolean state — reading it here is a
                 // deferred read that only triggers a layer update on toggle.
                 val active = lyricsOpen
-                // Scale 1.9 (lyricsOpen) ensures the image extends 0.45*W beyond
-                // each edge — enough to cover drift(±60) + blur(64dp) = 124dp
-                // even on a 360dp-wide screen (162dp > 124dp). The old 1.4f scale
-                // only extended 72dp, which was less than drift(80) alone —
-                // causing the trailing edge to expose transparent areas at max
-                // drift, which the blur then sampled as a flickering dark band.
-                val scale = if (active) 1.9f else 1.2f
+                // Scale [AmLyricsBlurDriftScale] (lyricsOpen) ensures the image
+                // extends 0.7*W beyond each edge — enough to cover
+                // drift(±160) + blur(64dp) = 224dp even on a 360dp-wide screen
+                // (252dp > 224dp). The old 1.4f scale only extended 72dp, which
+                // was less than drift alone — causing the trailing edge to
+                // expose transparent areas at max drift, which the blur then
+                // sampled as a flickering dark band.
+                val scale = if (active) AmLyricsBlurDriftScale else 1.2f
                 scaleX = scale
                 scaleY = scale
                 if (active) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -91,6 +91,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -108,6 +109,7 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import kotlin.math.abs
+import kotlin.math.sin
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -182,21 +184,50 @@ private val AppleMusicBottomIconSize = 26.dp
 private val AppleMusicBottomButtonSize = 48.dp
 private val AppleMusicMiniArtworkSize = 56.dp
 
-// ─── Lyrics backdrop "moving blur" drift ─────────────────────────────────────
+// ─── Lyrics backdrop "moving blur" wander ────────────────────────────
 // Kept in sync with MovingBlurBackground in LyricsScreen.kt so both lyrics
-// surfaces pan at the same Apple-Music-like rate. Amplitudes are in dp and are
-// applied as graphicsLayer translations (see driftGraphicsLayer below).
+// surfaces move at the same rate. Offsets are in dp and are applied as
+// graphicsLayer translations (see driftGraphicsLayer below).
 //
-// AmLyricsBlurDriftScale must satisfy
-//     (scale - 1) / 2 * screenWidthDp  >=  driftX + blurRadius
+// This used to be two independent tweens with RepeatMode.Reverse (±160dp / 4s on
+// X, ±120dp / 6s on Y). Reverse turns around at full speed the instant it hits an
+// endpoint, so the artwork swept one way and then visibly snapped back the other
+// — which is what read as the backdrop "rotating back really fast".
+//
+// Instead each axis is now the sum of two sines of a single ever-advancing phase.
+// The result is a closed Lissajous path: the offset wanders without ever
+// reversing abruptly, and because the harmonics are whole numbers the phase can
+// wrap from 1 back to 0 with no discontinuity.
+//
+// Amplitudes still sum to the old peaks (160dp X / 120dp Y) so
+// [AmLyricsBlurDriftScale] keeps covering drift + blur. It must satisfy
+//     (scale - 1) / 2 * screenWidthDp  >=  maxDriftX + blurRadius
 // or the blurred artwork stops covering the parent at max drift and the blur
 // samples transparent pixels, which shows up as a dark band on the trailing
 // edge. For the narrowest common phone (360dp) that means
 //     (2.4 - 1) / 2 * 360 = 252dp  >=  160 + 64 = 224dp.  ✔
-private const val AmLyricsBlurDriftXDp = 160f
-private const val AmLyricsBlurDriftYDp = 120f
+//
+// Rate: peak speed is (2π / period) × Σ(amplitude × harmonic) — 82 dp/s on X and
+// 50 dp/s on Y, averaging ~52 and ~32 dp/s over a cycle. The old tweens ran at a
+// constant 80 and 40 dp/s, so this is the slightly slower drift that was asked
+// for while still being clearly in motion behind a 64dp blur.
+internal const val AmBlurWanderPeriodMs = 20_000
 private const val AmLyricsBlurDriftScale = 2.4f
 private const val AppleMusicLyricsContentDeferMs = 350L
+
+/** Horizontal wander offset in dp. [phase] advances 0→1 once per [AmBlurWanderPeriodMs]. */
+internal fun blurWanderXDp(phase: Float): Float =
+    110f * sin(TwoPi * phase) + 50f * sin(TwoPi * (3f * phase + 0.25f))
+
+/** Vertical wander offset in dp. Quarter-turn out of phase with X so the path orbits. */
+internal fun blurWanderYDp(phase: Float): Float =
+    80f * sin(TwoPi * (phase + 0.27f)) + 40f * sin(TwoPi * (2f * phase + 0.61f))
+
+private const val TwoPi = (2.0 * Math.PI).toFloat()
+
+// How far above the bottom of the artwork stage the blurred canvas starts dissolving into the
+// still blurred album art beneath it. See canvasSeamFade in AppleMusicPlayerContent.
+private val AmCanvasSeamFadeDp = 88.dp
 
 /**
  * A [Shape] that interpolates the corner radius based on the element's size.
@@ -486,60 +517,44 @@ fun AppleMusicPlayerContent(
         { sliderPositionState.value }
     }
 
-    // === Moving blur drift for the backdrop when lyrics is open ===
+    // === Moving blur wander for the backdrop when lyrics is open ===
     // Mirrors the MovingBlurBackground from LyricsScreen: the blurred artwork
-    // slowly drifts horizontally and vertically, creating an ambient motion
-    // behind the lyrics. Only active when lyricsOpen = true.
+    // wanders behind the lyrics. Only active when lyricsOpen = true. See
+    // [blurWanderXDp] for why this is one advancing phase rather than two
+    // reversing tweens, and for the amplitude/rate budget.
     //
     // FLICKER FIX: the previous scale (1.4f) was too small for the drift range
     // (±80dp X / ±60dp Y) + blur radius (64dp). At max drift, the image's
     // trailing edge was INSIDE the parent's bounds (0.2*W - 80 < 0 for W=360),
     // so the blur sampled transparent areas at the trailing edge — appearing
     // as a flickering dark band at the screen corners/edges. Now using scale
-    // 2.4 with drift ±160/±120 and blur 64dp: the image extends 0.7*W beyond
+    // 2.4 with peaks ±160/±120 and blur 64dp: the image extends 0.7*W beyond
     // each edge (252dp for W=360), which is > drift(160) + blur(64) = 224dp,
     // so the image always covers the parent with a comfortable safety margin.
     //
-    // SPEED: amplitude and period now match [MovingBlurBackground] in
-    // LyricsScreen.kt — 4s/6s half-cycles over ±160/±120 dp, the Apple Music
-    // "breathing" pan. The previous 14s/20s over ±60/±45 covered 120dp in 14s
-    // and 90dp in 20s — ~9 dp/s on X and ~5 dp/s on Y; against a 64dp blur
-    // (which masks any motion under ~16dp) that read as a still image. 4s/6s
-    // over the wider range covers 320dp in 4s and 240dp in 6s — 80 dp/s on X
-    // and 40 dp/s on Y, a clearly visible drift.
+    // RepeatMode.Restart, not Reverse: the wander functions are periodic in the
+    // phase, so wrapping 1→0 is continuous. Reverse would replay the path
+    // backwards, reintroducing the very snap this replaced.
     //
-    // LinearEasing (rather than FastOutSlowInEasing) keeps the speed constant
-    // through the whole cycle, so there is no perceived "stall" at the
-    // turnaround points where the easing would otherwise decelerate.
-    //
-    // CRITICAL PERF: we keep the State<Float> objects (NOT `by` delegation) so
-    // the animation values are read ONLY inside Modifier.graphicsLayer { }
-    // lambdas (draw-phase deferred reads). Reading them during composition —
-    // e.g. `val backdropDriftX = if (lyricsOpen) blurDriftX else 0f` — would
-    // invalidate the ENTIRE AppleMusicPlayerContent composable every frame
+    // CRITICAL PERF: we keep the State<Float> object (NOT `by` delegation) so
+    // the animation value is read ONLY inside Modifier.graphicsLayer { }
+    // lambdas (draw-phase deferred reads). Reading it during composition —
+    // e.g. `val backdropDriftX = if (lyricsOpen) blurWanderXDp(phase) else 0f` —
+    // would invalidate the ENTIRE AppleMusicPlayerContent composable every frame
     // (SharedTransitionLayout, AnimatedContent, ControlsColumn, and the inline
     // LyricsEnhanced all recompose at ~60fps), stealing the frame budget from
     // the karaoke syllable sweep. This was the root cause of the Apple-Music-
     // style-only lyrics jank — LyricsScreen.kt doesn't have it because its
     // drift lives in a separate MovingBlurBackground composable.
     val blurTransition = rememberInfiniteTransition(label = "am-lyrics-blur-drift")
-    val blurDriftXState = blurTransition.animateFloat(
-        initialValue = -AmLyricsBlurDriftXDp,
-        targetValue = AmLyricsBlurDriftXDp,
+    val blurPhaseState = blurTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 4_000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse,
+            animation = tween(durationMillis = AmBlurWanderPeriodMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
         ),
-        label = "am-lyrics-drift-x",
-    )
-    val blurDriftYState = blurTransition.animateFloat(
-        initialValue = -AmLyricsBlurDriftYDp,
-        targetValue = AmLyricsBlurDriftYDp,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 6_000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = "am-lyrics-drift-y",
+        label = "am-lyrics-blur-phase",
     )
     // Pre-compute dp→px once (graphicsLayer.translationX is in pixels). Density
     // doesn't change per-frame so this is a one-time composition-phase read.
@@ -710,6 +725,12 @@ fun AppleMusicPlayerContent(
                     .background(Color.Black),
         )
 
+        // Height of the artwork stage (the weight(1f) morph area). Captured here so the backdrop —
+        // which is composed before the Column and so cannot see its layout — knows where the
+        // bottom controls begin. Read only from a draw-phase lambda, so a change costs a redraw
+        // rather than a recomposition.
+        var morphAreaHeightPx by remember { mutableIntStateOf(0) }
+
         val videoShowing =
             LocalVideoArtworkState.current != null &&
                 mediaMetadata.isMusicVideo &&
@@ -791,9 +812,10 @@ fun AppleMusicPlayerContent(
                 scaleX = scale
                 scaleY = scale
                 if (active) {
-                    // State.value reads are deferred to the draw phase.
-                    translationX = blurDriftXState.value * driftDpToPx
-                    translationY = blurDriftYState.value * driftDpToPx
+                    // State.value read is deferred to the draw phase.
+                    val phase = blurPhaseState.value
+                    translationX = blurWanderXDp(phase) * driftDpToPx
+                    translationY = blurWanderYDp(phase) * driftDpToPx
                 }
                 // Force an offscreen compositing layer so the (expensive)
                 // Modifier.blur RenderEffect applied to this same node is
@@ -807,6 +829,43 @@ fun AppleMusicPlayerContent(
                 // its own syllables and is less sensitive to GPU pressure).
                 compositingStrategy = CompositingStrategy.Offscreen
             }
+
+            // ── Canvas → still-art seam ──
+            // The blurred canvas layer used to run the full height of the player, so a
+            // BetterLyrics/Spotify canvas kept playing — blurred — behind the bottom controls.
+            // Apple Music ends the animated artwork at the artwork stage and carries the same
+            // colours on underneath the controls as a still gradient.
+            //
+            // This dissolves the canvas over the last [AmCanvasSeamFadeDp] of the artwork stage
+            // using the same DstIn trick AppleMusicSharpArtwork's fadeBottom uses. Below the seam
+            // what shows is the blurred album art already rendered underneath the canvas — same
+            // 72dp blur, same 1.2x scale, same scrim on top — so the colours continue across the
+            // join with nothing to give the seam away, and nothing moves behind the controls.
+            //
+            // Portrait only: in landscape the controls sit beside the artwork, not below it, so
+            // there is no seam to hide.
+            val canvasSeamFade: Modifier =
+                if (landscape) {
+                    Modifier
+                } else {
+                    Modifier
+                        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                        .drawWithContent {
+                            drawContent()
+                            val seam = morphAreaHeightPx.toFloat()
+                            // Before the stage has been measured there is nothing to fade to.
+                            if (seam <= 0f || seam >= size.height) return@drawWithContent
+                            val fadeStart = ((seam - AmCanvasSeamFadeDp.toPx()) / size.height).coerceIn(0f, 1f)
+                            drawRect(
+                                brush =
+                                    Brush.verticalGradient(
+                                        fadeStart to Color.Black,
+                                        (seam / size.height) to Color.Transparent,
+                                    ),
+                                blendMode = androidx.compose.ui.graphics.BlendMode.DstIn,
+                            )
+                        }
+                }
             if (useCanvasBackdrop) {
                 // Fallback: blurred album art BEHIND the canvas. Visible while
                 // the canvas video is loading (isVideoReady = false → canvas
@@ -862,6 +921,8 @@ fun AppleMusicPlayerContent(
                     modifier =
                         Modifier
                             .matchParentSize()
+                            // Outside the blur so the mask is applied to the blurred result.
+                            .then(canvasSeamFade)
                             .blur(72.dp)
                             .graphicsLayer {
                                 // Fixed 1.2x scale (no drift) — the canvas is
@@ -1104,7 +1165,10 @@ fun AppleMusicPlayerContent(
                             }
                         },
             ) {
-                BoxWithConstraints(modifier = Modifier.weight(1f)) {
+                BoxWithConstraints(
+                    // Reports the artwork stage height to canvasSeamFade above.
+                    modifier = Modifier.weight(1f).onSizeChanged { morphAreaHeightPx = it.height },
+                ) {
                 // Mini header height = artwork size + vertical padding (8.dp top + 8.dp bottom)
                 // + top system bar inset (status bar / notch). The overlay must start
                 // BELOW this height so it doesn't intercept taps on the mini header's

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -196,6 +196,7 @@ private val AppleMusicMiniArtworkSize = 56.dp
 private const val AmLyricsBlurDriftXDp = 160f
 private const val AmLyricsBlurDriftYDp = 120f
 private const val AmLyricsBlurDriftScale = 2.4f
+private const val AppleMusicLyricsContentDeferMs = 350L
 
 /**
  * A [Shape] that interpolates the corner radius based on the element's size.
@@ -434,6 +435,19 @@ fun AppleMusicPlayerContent(
         } else {
             canvasVisibleForLyrics = true
         }
+    }
+    var lyricsContentReady by remember { mutableStateOf(false) }
+    LaunchedEffect(lyricsOpen) {
+        if (!lyricsOpen) {
+            lyricsContentReady = false
+            return@LaunchedEffect
+        }
+        // Parse/building a large TTML/LRC model is synchronous during the first composition of
+        // LyricsEnhanced/LyricsV2. Let the artwork morph and canvas handoff render first so that
+        // this one-time CPU burst cannot land on the same frame as the shared-bounds animation.
+        lyricsContentReady = false
+        delay(AppleMusicLyricsContentDeferMs)
+        lyricsContentReady = true
     }
     val pokePlayerControlsVisibility = remember(lyricsOpen, queueOpen) {
         {
@@ -763,9 +777,9 @@ fun AppleMusicPlayerContent(
             // animation State<Float> inside the lambda (draw phase) so the
             // parent composable is NOT invalidated every frame.
             val driftGraphicsLayer: GraphicsLayerScope.() -> Unit = {
-                // lyricsOpen is a stable Boolean state — reading it here is a
-                // deferred read that only triggers a layer update on toggle.
-                val active = lyricsOpen
+                // These are stable state reads — deferred inside the graphics-layer lambda so
+                // the backdrop only updates when the lyrics transition reaches its ready point.
+                val active = lyricsOpen && lyricsContentReady
                 // Scale [AmLyricsBlurDriftScale] (lyricsOpen) ensures the image
                 // extends 0.7*W beyond each edge — enough to cover
                 // drift(±160) + blur(64dp) = 224dp even on a 360dp-wide screen
@@ -859,7 +873,7 @@ fun AppleMusicPlayerContent(
                 // Static image overlay for lyrics — rendered ON TOP of the
                 // (paused) canvas so the user sees the moving-blur aesthetic.
                 // Without this, the paused canvas's last frame would show.
-                if (lyricsOpen) {
+                if (lyricsOpen && lyricsContentReady) {
                     if (isPreS && preBlurredBitmap != null) {
                         Image(
                             bitmap = preBlurredBitmap!!.asImageBitmap(),
@@ -894,7 +908,7 @@ fun AppleMusicPlayerContent(
                         )
                     }
                 }
-            } else if (lyricsOpen) {
+            } else if (lyricsOpen && lyricsContentReady) {
                 // Non-canvas backdrop, LYRICS state: static image with blur + drift.
                 if (isPreS && preBlurredBitmap != null) {
                     Image(
@@ -1451,21 +1465,23 @@ fun AppleMusicPlayerContent(
                         // allowed to extend into the empty padded area and only gets
                         // clipped by the physical screen edge if truly necessary.
                         val lyricsHorizontalPadding = AppleMusicContentPadding - 16.dp
-                        when (lyricsMode) {
-                            LyricsMode.V2 -> LyricsV2(
-                                sliderPositionProvider = lyricsPosProvider,
-                                lyricsSyncOffset = lyricsSyncOffset,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = lyricsHorizontalPadding),
-                            )
-                            LyricsMode.ENHANCED -> LyricsEnhanced(
-                                sliderPositionProvider = lyricsPosProvider,
-                                lyricsSyncOffset = lyricsSyncOffset,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = lyricsHorizontalPadding),
-                            )
+                        if (lyricsContentReady) {
+                            when (lyricsMode) {
+                                LyricsMode.V2 -> LyricsV2(
+                                    sliderPositionProvider = lyricsPosProvider,
+                                    lyricsSyncOffset = lyricsSyncOffset,
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = lyricsHorizontalPadding),
+                                )
+                                LyricsMode.ENHANCED -> LyricsEnhanced(
+                                    sliderPositionProvider = lyricsPosProvider,
+                                    lyricsSyncOffset = lyricsSyncOffset,
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = lyricsHorizontalPadding),
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -326,8 +326,9 @@ fun AppleMusicPlayerContent(
     // forces an extra layout pass on top of whatever the lyrics view is already
     // spending its frame budget on.
     val animationsDisabled = LocalAnimationsDisabled.current
-    val showLyricsPlayerControls by rememberPreference(ShowLyricsPlayerControlsKey, defaultValue = true)
-    val autoHideLyricsPlayerControls by rememberPreference(AutoHideLyricsPlayerControlsKey, defaultValue = false)
+    val showLyricsPlayerControlsState = rememberPreference(ShowLyricsPlayerControlsKey, defaultValue = true)
+    val showLyricsPlayerControls by showLyricsPlayerControlsState
+    val autoHideLyricsPlayerControls by rememberPreference(AutoHideLyricsPlayerControlsKey, defaultValue = true)
 
     // Toggling one closes the other — queue and lyrics are mutually exclusive
     // (only one morph target can be active at a time).
@@ -362,17 +363,20 @@ fun AppleMusicPlayerContent(
         lyricsOpen = false
     }
 
-    // Copied from main branch: simple auto-hide that always shows controls
-    // for 4 seconds when lyrics or queue opens, then hides them.
-    // No preference checks — the controls ALWAYS show first, then auto-hide.
+    // Auto-hide follows the shared Lyrics settings (AutoHideLyricsPlayerControlsKey),
+    // matching Apple Music's lyrics view: the controls are shown when the lyrics or
+    // queue opens, then clear after five seconds so the lyrics own the full screen —
+    // "Initially, you'll see other controls on the screen. But after five seconds,
+    // the lyrics will automatically start showing on the full screen." Tapping
+    // anywhere brings them back (see the pointerInput on the content Column/Row).
     var playerControlsExpanded by remember(mediaMetadata.id) { mutableStateOf(true) }
     var playerControlsVisibilityTick by remember(mediaMetadata.id) { mutableIntStateOf(0) }
-    val autoHideDelayMs = 4_000L
+    val autoHideDelayMs = 5_000L
 
     LaunchedEffect(lyricsOpen) {
         if (lyricsOpen) {
             playerControlsExpanded = true
-            playerControlsVisibilityTick++
+            if (autoHideLyricsPlayerControls) playerControlsVisibilityTick++
         } else {
             playerControlsExpanded = true
         }
@@ -380,7 +384,7 @@ fun AppleMusicPlayerContent(
     LaunchedEffect(queueOpen) {
         if (queueOpen) {
             playerControlsExpanded = true
-            playerControlsVisibilityTick++
+            if (autoHideLyricsPlayerControls) playerControlsVisibilityTick++
         } else {
             playerControlsExpanded = true
         }
@@ -394,8 +398,14 @@ fun AppleMusicPlayerContent(
     DisposableEffect(Unit) {
         onDispose { onLyricsVisibilityChange(false) }
     }
-    // Auto-hide: show controls for 4s, then hide. Fires for both lyrics and queue.
-    LaunchedEffect(lyricsOpen, queueOpen, playerControlsVisibilityTick) {
+    // Auto-hide timer: show controls for 5s, then hide. Fires for both lyrics and queue,
+    // but ONLY when the Auto-hide controls preference is on. Turning the preference off
+    // mid-session immediately restores the controls and keeps them.
+    LaunchedEffect(lyricsOpen, queueOpen, playerControlsVisibilityTick, autoHideLyricsPlayerControls) {
+        if (!autoHideLyricsPlayerControls) {
+            playerControlsExpanded = true
+            return@LaunchedEffect
+        }
         if (!lyricsOpen && !queueOpen) return@LaunchedEffect
         playerControlsExpanded = true
         delay(autoHideDelayMs)
@@ -618,16 +628,25 @@ fun AppleMusicPlayerContent(
     }
     val onMoreClick = {
         if (lyricsOpen) {
-            // When lyrics is open, the overflow menu shows lyric actions. Control visibility is governed
-            // by the shared Lyrics settings, so the Apple Music style does not duplicate those toggles.
+            // When lyrics is open, the overflow menu shows lyric actions plus the
+            // player-control toggles, identical to the standalone lyrics screen.
             menuState.show {
                 LyricsMenu(
                     lyricsProvider = { currentLyrics },
                     mediaMetadataProvider = { mediaMetadata },
                     lyricsSyncOffset = lyricsSyncOffset,
                     onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
+                    showPlayerControlsState = showLyricsPlayerControlsState,
+                    onShowPlayerControlsChange = { showLyricsPlayerControlsState.value = it },
+                    onAutoHidePlayerControlsChange = { enabled ->
+                        if (enabled) {
+                            playerControlsVisibilityTick++
+                        } else {
+                            playerControlsExpanded = true
+                        }
+                    },
                     onDismiss = menuState::dismiss,
-                    showControlsToggles = false,
+                    showControlsToggles = true,
                 )
             }
         } else {
@@ -955,7 +974,22 @@ fun AppleMusicPlayerContent(
         }
 
         if (landscape) {
-            Row(Modifier.fillMaxSize()) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        // Tap ANYWHERE to bring the auto-hidden controls back (Apple Music
+                        // lyrics behaviour). A parent-level handler observes every tap in the
+                        // subtree regardless of which child consumes the gesture, so the whole
+                        // screen — lyrics, queue list, controls — is one large tap target.
+                        .pointerInput(lyricsOpen, queueOpen) {
+                            if (!lyricsOpen && !queueOpen) return@pointerInput
+                            awaitEachGesture {
+                                awaitFirstDown(requireUnconsumed = false)
+                                pokePlayerControlsVisibility()
+                            }
+                        },
+            ) {
                 AppleMusicSharpArtwork(
                     artworkRequest = artworkRequest,
                     artworkUrl = artworkUrl,
@@ -1039,7 +1073,22 @@ fun AppleMusicPlayerContent(
             //    weighted Box, and the controls live in a separate AnimatedVisibility
             //    below the Box — touches on the controls go directly to the controls.
             Column(
-                modifier = Modifier.fillMaxSize(),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        // Tap ANYWHERE to bring the auto-hidden controls back (Apple Music
+                        // lyrics behaviour). A parent-level handler observes every tap in the
+                        // subtree regardless of which child consumes the gesture, so the whole
+                        // player — lyrics overlay, queue sheet, controls — is one large tap
+                        // target. This also covers the controls themselves: an interaction on
+                        // the seekbar or transport restarts the auto-hide timer.
+                        .pointerInput(lyricsOpen, queueOpen) {
+                            if (!lyricsOpen && !queueOpen) return@pointerInput
+                            awaitEachGesture {
+                                awaitFirstDown(requireUnconsumed = false)
+                                pokePlayerControlsVisibility()
+                            }
+                        },
             ) {
                 BoxWithConstraints(modifier = Modifier.weight(1f)) {
                 // Mini header height = artwork size + vertical padding (8.dp top + 8.dp bottom)
@@ -1353,14 +1402,7 @@ fun AppleMusicPlayerContent(
                             Modifier
                                 .fillMaxWidth()
                                 .height(maxHeight - miniHeaderHeight)
-                                .offset(y = miniHeaderHeight)
-                                .pointerInput(lyricsOpen) {
-                                    if (!lyricsOpen) return@pointerInput
-                                    awaitEachGesture {
-                                        awaitFirstDown(requireUnconsumed = false)
-                                        pokePlayerControlsVisibility()
-                                    }
-                                },
+                                .offset(y = miniHeaderHeight),
                     ) {
                         // HORIZONTAL PADDING — compensate for the mocharealm
                         // KaraokeLineText library's INTERNAL 16dp horizontal padding
@@ -1440,7 +1482,10 @@ fun AppleMusicPlayerContent(
                 // animations are reduced so the auto-hide/show cycle doesn't compete with
                 // the karaoke lyrics view for frame budget on lower-end devices.
                 AnimatedVisibility(
-                    visible = (!lyricsOpen && !queueOpen) || playerControlsExpanded,
+                    visible =
+                        (!lyricsOpen && !queueOpen) ||
+                            (queueOpen && playerControlsExpanded) ||
+                            (lyricsOpen && showLyricsPlayerControls && playerControlsExpanded),
                     enter = if (animationsDisabled) {
                         fadeIn(tween(120))
                     } else {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -25,13 +25,8 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.SharedTransitionScope.OverlayClip
 import androidx.compose.animation.BoundsTransform
 import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -109,7 +104,6 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import kotlin.math.abs
-import kotlin.math.sin
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -185,45 +179,37 @@ private val AppleMusicBottomButtonSize = 48.dp
 private val AppleMusicMiniArtworkSize = 56.dp
 
 // ─── Lyrics backdrop "moving blur" wander ────────────────────────────
-// Kept in sync with MovingBlurBackground in LyricsScreen.kt so both lyrics
-// surfaces move at the same rate. Offsets are in dp and are applied as
-// graphicsLayer translations (see driftGraphicsLayer below).
+// The drift itself lives in [BlurWanderDrift], shared with MovingBlurBackground
+// in LyricsScreen.kt so both lyrics surfaces move identically. Offsets are in dp
+// and are applied as graphicsLayer translations (see driftGraphicsLayer below).
 //
-// This used to be two independent tweens with RepeatMode.Reverse (±160dp / 4s on
-// X, ±120dp / 6s on Y). Reverse turns around at full speed the instant it hits an
-// endpoint, so the artwork swept one way and then visibly snapped back the other
-// — which is what read as the backdrop "rotating back really fast".
-//
-// Instead each axis is now the sum of two sines of a single ever-advancing phase.
-// The result is a closed Lissajous path: the offset wanders without ever
-// reversing abruptly, and because the harmonics are whole numbers the phase can
-// wrap from 1 back to 0 with no discontinuity.
-//
-// Amplitudes still sum to the old peaks (160dp X / 120dp Y) so
-// [AmLyricsBlurDriftScale] keeps covering drift + blur. It must satisfy
-//     (scale - 1) / 2 * screenWidthDp  >=  maxDriftX + blurRadius
-// or the blurred artwork stops covering the parent at max drift and the blur
+// [AmLyricsBlurDriftScale] has to cover the drift plus the blur radius:
+//     (scale - 1) / 2 * screenWidthDp  >=  maxDrift + blurRadius
+// or the blurred artwork stops covering the parent at maximum drift and the blur
 // samples transparent pixels, which shows up as a dark band on the trailing
 // edge. For the narrowest common phone (360dp) that means
-//     (2.4 - 1) / 2 * 360 = 252dp  >=  160 + 64 = 224dp.  ✔
-//
-// Rate: peak speed is (2π / period) × Σ(amplitude × harmonic) — 82 dp/s on X and
-// 50 dp/s on Y, averaging ~52 and ~32 dp/s over a cycle. The old tweens ran at a
-// constant 80 and 40 dp/s, so this is the slightly slower drift that was asked
-// for while still being clearly in motion behind a 64dp blur.
-internal const val AmBlurWanderPeriodMs = 20_000
+//     (2.4 - 1) / 2 * 360 = 252dp  >=  150 + 64 = 214dp.  ✔
 private const val AmLyricsBlurDriftScale = 2.4f
+
+// Scale of the blurred backdrop in the COVER/QUEUE states. The LYRICS state
+// zooms from here to [AmLyricsBlurDriftScale] over [AmLyricsBackdropMorphMs].
+private const val AmCoverBlurScale = 1.2f
+
+// How long the backdrop takes to travel between the COVER look (no drift, 1.2x)
+// and the LYRICS look (drifting, 2.4x). Also the duration of the canvas →
+// still-artwork cross-dissolve, and the delay before the canvas TextureView is
+// torn down, so the video surface only disappears once the still artwork that
+// replaces it is fully opaque.
+private const val AmLyricsBackdropMorphMs = 650
+
+// Blur radius of the artwork backdrop. Applied INSIDE the drift/zoom transform
+// (see driftGraphicsLayer), so the on-screen radius is this times the current
+// scale: ~77dp in COVER, ~154dp with lyrics open. Keeping the radius itself
+// constant means the RenderEffect is built once instead of being rebuilt on
+// every frame of the zoom.
+private val AmBackdropBlurRadius = 64.dp
+
 private const val AppleMusicLyricsContentDeferMs = 350L
-
-/** Horizontal wander offset in dp. [phase] advances 0→1 once per [AmBlurWanderPeriodMs]. */
-internal fun blurWanderXDp(phase: Float): Float =
-    110f * sin(TwoPi * phase) + 50f * sin(TwoPi * (3f * phase + 0.25f))
-
-/** Vertical wander offset in dp. Quarter-turn out of phase with X so the path orbits. */
-internal fun blurWanderYDp(phase: Float): Float =
-    80f * sin(TwoPi * (phase + 0.27f)) + 40f * sin(TwoPi * (2f * phase + 0.61f))
-
-private const val TwoPi = (2.0 * Math.PI).toFloat()
 
 // How far above the bottom of the artwork stage the blurred canvas starts dissolving into the
 // still blurred album art beneath it. See canvasSeamFade in AppleMusicPlayerContent.
@@ -445,26 +431,41 @@ fun AppleMusicPlayerContent(
     }
 
     // Deferred canvas-visible state: when lyrics opens, the canvas
-    // TextureView teardown (visible = false) + ExoPlayer pause are delayed by
-    // 250ms so they don't compete with the COVER→LYRICS sharedBounds morph
-    // for the main thread on the same frame. Without this deferral, the
-    // TextureView teardown + static image overlay composition + lyrics
-    // composable initialization + morph animation all fire simultaneously,
-    // causing a visible stutter in the thumbnail transition (issue 3).
-    // 250ms is enough for the morph spring to get past its initial phase
-    // (the non-bouncy StiffnessMediumLow spring reaches ~70% of target in
-    // ~250ms); the canvas teardown then happens smoothly behind the
-    // already-moving overlay. When lyrics closes, the canvas restores
-    // immediately (no delay) so there's no visible gap.
+    // TextureView teardown (visible = false) + ExoPlayer pause are delayed so
+    // they don't compete with the COVER→LYRICS sharedBounds morph for the main
+    // thread on the same frame. Without this deferral, the TextureView
+    // teardown + static image composition + lyrics composable initialization
+    // AND the morph animation all fire simultaneously, causing a visible
+    // stutter in the thumbnail transition (issue 3).
+    //
+    // The delay is [AmLyricsBackdropMorphMs] — the length of the backdrop
+    // cross-dissolve — so the canvas surface is only removed once the still
+    // blurred artwork underneath has faded up to full opacity. Shorter delays
+    // (this used to be 250ms while the still artwork appeared at 350ms) left a
+    // window where the canvas was already gone and the still artwork had not
+    // arrived, which is what made the backdrop visibly jump. When lyrics
+    // closes, the canvas restores immediately so there's no visible gap.
     var canvasVisibleForLyrics by remember { mutableStateOf(true) }
     LaunchedEffect(lyricsOpen) {
         if (lyricsOpen) {
-            // Keep canvas visible briefly while the morph starts
+            // Keep canvas visible while the backdrop cross-dissolve runs.
             canvasVisibleForLyrics = true
-            delay(250)
+            delay(AmLyricsBackdropMorphMs.toLong())
             canvasVisibleForLyrics = false
         } else {
             canvasVisibleForLyrics = true
+        }
+    }
+    // True while the lyrics backdrop (zoom + drift) is on screen OR still
+    // animating back out. Gates the wander frame loop so it isn't burning a
+    // frame callback every 16ms while the player sits in the COVER state.
+    var lyricsBackdropActive by remember { mutableStateOf(false) }
+    LaunchedEffect(lyricsOpen) {
+        if (lyricsOpen) {
+            lyricsBackdropActive = true
+        } else {
+            delay(AmLyricsBackdropMorphMs.toLong())
+            lyricsBackdropActive = false
         }
     }
     var lyricsContentReady by remember { mutableStateOf(false) }
@@ -519,46 +520,67 @@ fun AppleMusicPlayerContent(
 
     // === Moving blur wander for the backdrop when lyrics is open ===
     // Mirrors the MovingBlurBackground from LyricsScreen: the blurred artwork
-    // wanders behind the lyrics. Only active when lyricsOpen = true. See
-    // [blurWanderXDp] for why this is one advancing phase rather than two
-    // reversing tweens, and for the amplitude/rate budget.
+    // wanders behind the lyrics. See [BlurWanderDrift] for the path itself —
+    // random waypoints joined by eased legs, so the colours always finish the
+    // leg they are on, settle, and then set off again somewhere new, instead of
+    // suddenly doubling back the way a closed periodic path does.
     //
-    // FLICKER FIX: the previous scale (1.4f) was too small for the drift range
-    // (±80dp X / ±60dp Y) + blur radius (64dp). At max drift, the image's
-    // trailing edge was INSIDE the parent's bounds (0.2*W - 80 < 0 for W=360),
-    // so the blur sampled transparent areas at the trailing edge — appearing
-    // as a flickering dark band at the screen corners/edges. Now using scale
-    // 2.4 with peaks ±160/±120 and blur 64dp: the image extends 0.7*W beyond
-    // each edge (252dp for W=360), which is > drift(160) + blur(64) = 224dp,
-    // so the image always covers the parent with a comfortable safety margin.
+    // The offsets are bounded by BlurWanderDrift.WanderRadiusDp (150dp), which
+    // is what [AmLyricsBlurDriftScale] is sized against: at 2.4x the artwork
+    // overhangs 0.7*W per edge (252dp on a 360dp screen), covering the 150dp of
+    // drift plus the 64dp blur with margin to spare. A smaller scale would let
+    // the trailing edge pull inside the parent at maximum drift, and the blur
+    // would sample transparent pixels — the flickering dark band at the screen
+    // edges that an earlier 1.4x scale produced.
     //
-    // RepeatMode.Restart, not Reverse: the wander functions are periodic in the
-    // phase, so wrapping 1→0 is continuous. Reverse would replay the path
-    // backwards, reintroducing the very snap this replaced.
-    //
-    // CRITICAL PERF: we keep the State<Float> object (NOT `by` delegation) so
-    // the animation value is read ONLY inside Modifier.graphicsLayer { }
-    // lambdas (draw-phase deferred reads). Reading it during composition —
-    // e.g. `val backdropDriftX = if (lyricsOpen) blurWanderXDp(phase) else 0f` —
-    // would invalidate the ENTIRE AppleMusicPlayerContent composable every frame
+    // CRITICAL PERF: the offsets stay wrapped in FloatState and are read ONLY
+    // inside Modifier.graphicsLayer { } lambdas (draw-phase deferred reads).
+    // Reading them during composition — e.g.
+    // `val driftX = if (lyricsOpen) wander.xDp.floatValue else 0f` — would
+    // invalidate the ENTIRE AppleMusicPlayerContent composable every frame
     // (SharedTransitionLayout, AnimatedContent, ControlsColumn, and the inline
     // LyricsEnhanced all recompose at ~60fps), stealing the frame budget from
     // the karaoke syllable sweep. This was the root cause of the Apple-Music-
-    // style-only lyrics jank — LyricsScreen.kt doesn't have it because its
-    // drift lives in a separate MovingBlurBackground composable.
-    val blurTransition = rememberInfiniteTransition(label = "am-lyrics-blur-drift")
-    val blurPhaseState = blurTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = AmBlurWanderPeriodMs, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart,
-        ),
-        label = "am-lyrics-blur-phase",
-    )
+    // style-only lyrics jank.
+    //
+    // Gated on lyricsBackdropActive: the walk is driven by a frame loop, and
+    // leaving it running while the player sits on the cover (which is what
+    // rememberInfiniteTransition did) keeps the choreographer — and with it the
+    // whole Compose frame pipeline — awake for a value nothing is reading.
+    val blurWander = rememberBlurWanderDrift(active = lyricsBackdropActive)
     // Pre-compute dp→px once (graphicsLayer.translationX is in pixels). Density
     // doesn't change per-frame so this is a one-time composition-phase read.
     val driftDpToPx = with(LocalDensity.current) { 1.dp.toPx() }
+
+    // === COVER ↔ LYRICS backdrop hand-off ===
+    // The backdrop used to be built from two different nodes: 72dp blur at 1.2x
+    // for COVER/QUEUE, and a separate "64dp blur at 2.4x with drift" node that
+    // replaced it the instant `lyricsContentReady` flipped, 350ms after the
+    // morph began. Swapping nodes is what made the background change abruptly:
+    //
+    //  • the effective on-screen blur more than doubled in one frame (64dp
+    //    applied inside a 2.4x zoom reads as ~154dp, against 72dp at 1.2x),
+    //  • the artwork jumped from 1.2x to 2.4x — a 2x zoom with no in-between,
+    //  • and the drift snapped straight to wherever the always-running wander
+    //    had got to, i.e. up to 150dp of instant translation,
+    //  • while on canvas songs the video surface had already been pulled 100ms
+    //    earlier, so the un-drifted fallback flashed in between.
+    //
+    // Now there is ONE backdrop node whose graphicsLayer interpolates between
+    // the two looks off this progress value: scale 1.2 → 2.4, drift amplitude
+    // 0 → 1, and (for canvas songs) the video's opacity 1 → 0 underneath it.
+    // Both endpoints look exactly as they did before; only the trip between
+    // them changed, from one frame to [AmLyricsBackdropMorphMs].
+    val lyricsBackdropProgress =
+        animateFloatAsState(
+            targetValue = if (lyricsOpen) 1f else 0f,
+            animationSpec =
+                tween(
+                    durationMillis = AmLyricsBackdropMorphMs,
+                    easing = FastOutSlowInEasing,
+                ),
+            label = "am-lyrics-backdrop-progress",
+        )
 
     // Hoist the thumbnail corner radius preference so it can be used both
     // for the COVER state's artwork clip AND for the sharedBounds overlay
@@ -748,7 +770,14 @@ fun AppleMusicPlayerContent(
         val context = LocalContext.current
         val imageLoader = context.imageLoader
         val preBlurredBitmap by produceState<Bitmap?>(null, artworkUrl) {
-            if (!isPreS || artworkUrl.isNullOrBlank() || videoShowing || canvasActive) {
+            // Pre-S has no RenderEffect, so Modifier.blur is a no-op there and the
+            // blur has to be baked into a bitmap off the main thread instead.
+            // Gated on useCanvasBackdrop rather than canvasActive: pre-S never
+            // uses the canvas as its backdrop (blurring a video surface without
+            // RenderEffect isn't possible), so a canvas song still needs the
+            // blurred artwork — without this it fell through to an unblurred
+            // AsyncImage and showed a sharp backdrop.
+            if (!isPreS || artworkUrl.isNullOrBlank() || videoShowing || useCanvasBackdrop) {
                 value = null
                 return@produceState
             }
@@ -775,47 +804,61 @@ fun AppleMusicPlayerContent(
         }
 
         if (!videoShowing) {
-            // Backdrop rendering — keeps the canvas ExoPlayer alive across
-            // lyrics open/close to avoid the multi-second reload delay that
-            // left a black gap behind the bottom controls.
+            // Backdrop rendering — one blurred-artwork node for every state,
+            // plus (on canvas songs) the live canvas video composited over it.
             //
-            // • COVER / QUEUE state (canvas) — render the live canvas with
-            //   heavy blur (72.dp), fixed 1.2x scale, no drift. The canvas
-            //   keeps playing continuously across COVER↔QUEUE morphs because
-            //   it lives outside the SharedTransitionLayout / AnimatedContent.
+            // • COVER / QUEUE state — the artwork sits at [AmCoverBlurScale]
+            //   with no drift. On canvas songs the canvas video covers it
+            //   completely, so what the user sees is the blurred canvas; the
+            //   artwork underneath is the fallback for while the canvas video
+            //   is still buffering.
             //
-            // • LYRICS state (canvas) — the canvas is PAUSED (isPlaying=false)
-            //   to free GPU for the karaoke syllable sweep, but the ExoPlayer
-            //   instance is retained (no disposal). A static AsyncImage with
-            //   blur + drift is overlaid ON TOP of the paused canvas so the
-            //   user sees the moving-blur aesthetic. When lyrics closes, the
-            //   canvas resumes instantly — no reload delay.
+            // • LYRICS state — the same artwork node zooms to
+            //   [AmLyricsBlurDriftScale] and starts drifting, and the canvas
+            //   fades out over it before its TextureView is torn down (the
+            //   ExoPlayer instance is retained either way, so closing lyrics
+            //   resumes the canvas instantly instead of reloading it).
             //
-            // • Non-canvas backdrop (no Spotify Canvas) — same as before:
-            //   static album art with blur, drift enabled during lyrics.
-            //
-            // Helper: deferred-read graphicsLayer for the drift. Reads the
-            // animation State<Float> inside the lambda (draw phase) so the
-            // parent composable is NOT invalidated every frame.
+            // Everything animates off `lyricsBackdropProgress`, and every read
+            // of it happens inside a graphicsLayer lambda — i.e. in the draw
+            // phase — so the zoom/drift/fade costs a redraw of an
+            // already-rasterized blur layer per frame and NOT a recomposition.
             val driftGraphicsLayer: GraphicsLayerScope.() -> Unit = {
-                // These are stable state reads — deferred inside the graphics-layer lambda so
-                // the backdrop only updates when the lyrics transition reaches its ready point.
-                val active = lyricsOpen && lyricsContentReady
-                // Scale [AmLyricsBlurDriftScale] (lyricsOpen) ensures the image
-                // extends 0.7*W beyond each edge — enough to cover
-                // drift(±160) + blur(64dp) = 224dp even on a 360dp-wide screen
-                // (252dp > 224dp). The old 1.4f scale only extended 72dp, which
-                // was less than drift alone — causing the trailing edge to
+                // Deferred state reads: draw phase only. See the comment on
+                // lyricsBackdropProgress for why this is a continuous ramp
+                // rather than the `if (lyricsOpen && lyricsContentReady)` step
+                // it replaced.
+                val progress = lyricsBackdropProgress.value
+                // Scale [AmLyricsBlurDriftScale] (lyrics fully open) ensures the
+                // image extends 0.7*W beyond each edge — enough to cover
+                // drift(±150) + blur(64dp) = 214dp even on a 360dp-wide screen
+                // (252dp > 214dp). A smaller scale would let the trailing edge
                 // expose transparent areas at max drift, which the blur then
                 // sampled as a flickering dark band.
-                val scale = if (active) AmLyricsBlurDriftScale else 1.2f
+                //
+                // Drift amplitude scales with the same progress, so the drift
+                // never outruns the zoom that has to cover it: at progress p
+                // the image overhangs (0.2 + 1.2p) / 2 * W while the drift asks
+                // for 150p + 64. On a 360dp screen those cross at p ≈ 0.42 and
+                // the margin only widens from there to the 252 vs 214 above.
+                //
+                // Below p ≈ 0.42 the overhang is short of the *blur radius*
+                // alone (36dp vs 64dp at p = 0) — but that is the COVER state,
+                // which has zero drift and looked exactly this way before the
+                // ramp existed (it was a 72dp blur at a fixed 1.2x, i.e. a
+                // slightly larger shortfall). What the ramp has to avoid is
+                // translation outrunning the zoom, and it does.
+                val scale = AmCoverBlurScale + (AmLyricsBlurDriftScale - AmCoverBlurScale) * progress
                 scaleX = scale
                 scaleY = scale
-                if (active) {
-                    // State.value read is deferred to the draw phase.
-                    val phase = blurPhaseState.value
-                    translationX = blurWanderXDp(phase) * driftDpToPx
-                    translationY = blurWanderYDp(phase) * driftDpToPx
+                if (progress > 0f) {
+                    // Ramping the amplitude with `progress` is what keeps the
+                    // wander from snapping in: the phase advances the whole
+                    // time lyrics is open, so without the multiplier the very
+                    // first drifted frame would teleport the artwork by
+                    // however far along the path the phase already was.
+                    translationX = blurWander.xDp.floatValue * driftDpToPx * progress
+                    translationY = blurWander.yDp.floatValue * driftDpToPx * progress
                 }
                 // Force an offscreen compositing layer so the (expensive)
                 // Modifier.blur RenderEffect applied to this same node is
@@ -839,8 +882,8 @@ fun AppleMusicPlayerContent(
             // This dissolves the canvas over the last [AmCanvasSeamFadeDp] of the artwork stage
             // using the same DstIn trick AppleMusicSharpArtwork's fadeBottom uses. Below the seam
             // what shows is the blurred album art already rendered underneath the canvas — same
-            // 72dp blur, same 1.2x scale, same scrim on top — so the colours continue across the
-            // join with nothing to give the seam away, and nothing moves behind the controls.
+            // scrim on top, colours continuing across the join with nothing to give the seam
+            // away, and nothing moving behind the controls.
             //
             // Portrait only: in landscape the controls sit beside the artwork, not below it, so
             // there is no seam to hide.
@@ -866,13 +909,23 @@ fun AppleMusicPlayerContent(
                             )
                         }
                 }
-            if (useCanvasBackdrop) {
-                // Fallback: blurred album art BEHIND the canvas. Visible while
-                // the canvas video is loading (isVideoReady = false → canvas
-                // alpha = 0). Without this, the user sees a black gap behind
-                // the bottom controls during the initial song load (when the
-                // canvas ExoPlayer is first created and buffering). Once the
-                // canvas is ready, it covers this fallback entirely.
+
+            // The artwork backdrop. Composed in every state so there is no node
+            // swap (and so no re-decode, no new RenderEffect, no one-frame
+            // discontinuity) when lyrics opens or closes.
+            if (isPreS && preBlurredBitmap != null) {
+                // Pre-Android-12 has no RenderEffect, so the blur was baked
+                // into the bitmap on a background thread instead.
+                Image(
+                    bitmap = preBlurredBitmap!!.asImageBitmap(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier =
+                        Modifier
+                            .matchParentSize()
+                            .graphicsLayer(driftGraphicsLayer),
+                )
+            } else {
                 AsyncImage(
                     model = artworkRequest ?: artworkUrl,
                     contentDescription = null,
@@ -880,38 +933,42 @@ fun AppleMusicPlayerContent(
                     modifier =
                         Modifier
                             .matchParentSize()
+                            // graphicsLayer OUTSIDE blur: the blur is applied to
+                            // the centered image (inside the layer), then the
+                            // scale + translation is applied to the blurred
+                            // result. Blurring after the transform would sample
+                            // the translated image's edges instead.
+                            .graphicsLayer(driftGraphicsLayer)
                             .then(
                                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                    Modifier.blur(72.dp)
+                                    Modifier.blur(AmBackdropBlurRadius)
                                 } else {
                                     Modifier
                                 },
-                            ).graphicsLayer {
-                                scaleX = 1.2f
-                                scaleY = 1.2f
-                            },
+                            ),
                 )
+            }
+
+            if (useCanvasBackdrop) {
                 // Canvas backdrop — the ExoPlayer is ALWAYS retained (never
                 // disposed across lyrics open/close) so the canvas resumes
                 // instantly when lyrics closes — no multi-second reload delay.
                 //
                 // PERFORMANCE (lyrics lag fix): the TextureView is HIDDEN
-                // (`visible = canvasVisibleForLyrics`) when lyrics is open. A
-                // paused TextureView with Modifier.blur(72.dp) still costs a
-                // full per-frame GPU composite + blur pass because the
-                // RenderEffect is re-applied every frame even when the surface
-                // content hasn't changed. This steals the frame budget from
-                // the karaoke syllable sweep, causing the "lyrics lag after
-                // ~20s" symptom. Hiding the TextureView entirely frees that
-                // budget. The static image overlay below visually replaces the
-                // canvas so the user still sees the moving-blur aesthetic.
+                // (`visible = canvasVisibleForLyrics`) once lyrics is open. A
+                // paused TextureView with Modifier.blur still costs a full
+                // per-frame GPU composite + blur pass because the RenderEffect
+                // is re-applied every frame even when the surface content
+                // hasn't changed. This steals the frame budget from the karaoke
+                // syllable sweep, causing the "lyrics lag after ~20s" symptom.
+                // Hiding the TextureView entirely frees that budget; the
+                // blurred artwork behind it has already faded up by then.
                 //
-                // STUTTER FIX (issue 3): canvasVisibleForLyrics is deferred
-                // by 250ms when lyrics opens (see the LaunchedEffect above).
-                // This prevents the TextureView teardown, ExoPlayer pause,
-                // static image composition, lyrics init, AND the sharedBounds
-                // morph from all firing on the same frame — which was causing
-                // a visible stutter in the thumbnail transition.
+                // The alpha ramp (draw phase) is what makes that hand-off
+                // invisible: the canvas dissolves into the artwork over
+                // [AmLyricsBackdropMorphMs] while the artwork zooms, instead of
+                // the surface being yanked out from under a hard-swapped
+                // overlay.
                 CanvasArtworkPlayer(
                     primaryUrl = canvasPrimaryUrl,
                     fallbackUrl = canvasFallbackUrl,
@@ -925,109 +982,12 @@ fun AppleMusicPlayerContent(
                             .then(canvasSeamFade)
                             .blur(72.dp)
                             .graphicsLayer {
-                                // Fixed 1.2x scale (no drift) — the canvas is
-                                // paused during lyrics so drift would be wasted.
-                                scaleX = 1.2f
-                                scaleY = 1.2f
+                                // Fixed scale (no drift) — the canvas is on its
+                                // way out by the time the drift matters.
+                                scaleX = AmCoverBlurScale
+                                scaleY = AmCoverBlurScale
+                                alpha = 1f - lyricsBackdropProgress.value
                             },
-                )
-                // Static image overlay for lyrics — rendered ON TOP of the
-                // (paused) canvas so the user sees the moving-blur aesthetic.
-                // Without this, the paused canvas's last frame would show.
-                if (lyricsOpen && lyricsContentReady) {
-                    if (isPreS && preBlurredBitmap != null) {
-                        Image(
-                            bitmap = preBlurredBitmap!!.asImageBitmap(),
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier =
-                                Modifier
-                                    .matchParentSize()
-                                    .graphicsLayer(driftGraphicsLayer),
-                        )
-                    } else {
-                        AsyncImage(
-                            model = artworkRequest ?: artworkUrl,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier =
-                                Modifier
-                                    .matchParentSize()
-                                    // graphicsLayer OUTSIDE blur: the blur is applied
-                                    // to the centered image (inside graphicsLayer), then
-                                    // the scale + translation is applied to the blurred
-                                    // result. This prevents the blur from sampling
-                                    // transparent areas at the translated image's edges.
-                                    .graphicsLayer(driftGraphicsLayer)
-                                    .then(
-                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                            Modifier.blur(64.dp)
-                                        } else {
-                                            Modifier
-                                        },
-                                    ),
-                        )
-                    }
-                }
-            } else if (lyricsOpen && lyricsContentReady) {
-                // Non-canvas backdrop, LYRICS state: static image with blur + drift.
-                if (isPreS && preBlurredBitmap != null) {
-                    Image(
-                        bitmap = preBlurredBitmap!!.asImageBitmap(),
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier =
-                            Modifier
-                                .matchParentSize()
-                                .graphicsLayer(driftGraphicsLayer),
-                    )
-                } else {
-                    AsyncImage(
-                        model = artworkRequest ?: artworkUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier =
-                            Modifier
-                                .matchParentSize()
-                                // graphicsLayer OUTSIDE blur: see canvas+lyrics path
-                                // above for the full rationale.
-                                .graphicsLayer(driftGraphicsLayer)
-                                .then(
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                        Modifier.blur(64.dp)
-                                    } else {
-                                        Modifier
-                                    },
-                                ),
-                    )
-                }
-            } else if (isPreS && preBlurredBitmap != null) {
-                // Non-canvas backdrop, COVER/QUEUE state, pre-S with pre-blurred bitmap.
-                Image(
-                    bitmap = preBlurredBitmap!!.asImageBitmap(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .matchParentSize()
-                            .graphicsLayer(driftGraphicsLayer),
-                )
-            } else {
-                // Non-canvas backdrop, COVER/QUEUE state, S+ or loading.
-                AsyncImage(
-                    model = artworkRequest ?: artworkUrl,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .matchParentSize()
-                            .then(
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                    Modifier.blur(72.dp)
-                                } else {
-                                    Modifier
-                                },
-                            ).graphicsLayer(driftGraphicsLayer),
                 )
             }
             val preBlurLoading = isPreS && preBlurredBitmap == null && !canvasActive

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/BlurWanderDrift.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/BlurWanderDrift.kt
@@ -1,0 +1,186 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.FloatState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.isActive
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Drift for the heavily blurred artwork behind lyrics — shared by the
+ * Apple-Music-style player's inline lyrics backdrop and the standalone lyrics
+ * screen's [moe.rukamori.archivetune.ui.player.LyricsScreen] backdrop, so both
+ * surfaces move identically.
+ *
+ * ### Why a random walk and not a formula
+ *
+ * The first version was a pair of `RepeatMode.Reverse` tweens: the artwork swept
+ * to one extreme and turned around at full speed, which read as the colours
+ * whipping back. Replacing it with a Lissajous path (two sines per axis off one
+ * ever-advancing phase) removed the hard turnaround but not the underlying
+ * problem — a closed periodic path still spends half its cycle travelling back
+ * the way it came, so the colours were still seen "suddenly travelling in the
+ * opposite direction", just more smoothly.
+ *
+ * This drives the drift as a walk between random waypoints instead:
+ *
+ *  * each leg carries the artwork from where it currently rests to a new
+ *    waypoint drawn at random inside a disc of [WanderRadiusDp],
+ *  * the interpolation is a raised cosine, so speed starts and ends at zero —
+ *    the artwork *finishes its path*, settles, and only then sets off again,
+ *    which means no reversal ever happens while it is moving,
+ *  * the next waypoint is at least [MinTurnRadians] away in angle from the leg
+ *    that just finished, so the colours visibly "come again and spread" in a
+ *    genuinely different direction rather than retracing the previous path,
+ *  * legs are timed off their own length at a constant [WanderSpeedDpPerSecond],
+ *    so a long leg doesn't race and a short one doesn't crawl.
+ *
+ * The walk starts at the centre, so the first frame after the backdrop appears
+ * has zero offset and the drift grows out of nothing.
+ *
+ * ### Bounds
+ *
+ * [WanderRadiusDp] is the largest offset this can ever produce, and callers rely
+ * on that: the blurred artwork is drawn scaled up so that it still covers the
+ * screen at maximum offset, and the blur (64dp) has to be covered too. At scale
+ * 2.4 on a 360dp-wide screen the image overhangs 252dp per edge, against the
+ * 150 + 64 = 214dp asked for here.
+ *
+ * ### Threading / recomposition
+ *
+ * [xDp] and [yDp] are [FloatState]s meant to be read **only** from draw-phase
+ * lambdas (`Modifier.graphicsLayer { }`). Reading them during composition would
+ * invalidate the whole player subtree on every animation frame, which is what
+ * the lyrics views' frame budget cannot afford.
+ */
+internal class BlurWanderDrift(
+    private val random: Random = Random.Default,
+) {
+    private val xState = mutableFloatStateOf(0f)
+    private val yState = mutableFloatStateOf(0f)
+
+    /** Horizontal offset in dp, in `-WanderRadiusDp..WanderRadiusDp`. */
+    val xDp: FloatState get() = xState
+
+    /** Vertical offset in dp, in `-WanderRadiusDp..WanderRadiusDp`. */
+    val yDp: FloatState get() = yState
+
+    private var fromX = 0f
+    private var fromY = 0f
+    private var toX = 0f
+    private var toY = 0f
+    private var legAngle = random.nextFloat() * TwoPi
+    private var legDurationMs = 0f
+    private var legElapsedMs = 0f
+
+    init {
+        startNextLeg()
+    }
+
+    /**
+     * Advances the walk by [deltaMs] of wall time. Legs roll over inside the
+     * same call, so a dropped frame is caught up rather than skipped.
+     */
+    fun advance(deltaMs: Float) {
+        if (deltaMs <= 0f) return
+        legElapsedMs += deltaMs
+        while (legElapsedMs >= legDurationMs) {
+            legElapsedMs -= legDurationMs
+            startNextLeg()
+        }
+        // Raised cosine: zero velocity at both ends of the leg.
+        val t = legElapsedMs / legDurationMs
+        val eased = 0.5f - 0.5f * cos(PI.toFloat() * t)
+        xState.floatValue = fromX + (toX - fromX) * eased
+        yState.floatValue = fromY + (toY - fromY) * eased
+    }
+
+    private fun startNextLeg() {
+        fromX = toX
+        fromY = toY
+        // Turn by at least MinTurnRadians so the new leg is never a retread of
+        // the one that just ended.
+        val turn = MinTurnRadians + random.nextFloat() * (TwoPi - 2f * MinTurnRadians)
+        legAngle = (legAngle + turn) % TwoPi
+        // sqrt-free radius spread biased outwards: the backdrop reads as more
+        // alive when the colours actually reach the edges, so waypoints sit in
+        // the outer half of the disc.
+        val radius = WanderRadiusDp * (MinRadiusFraction + random.nextFloat() * (1f - MinRadiusFraction))
+        toX = cos(legAngle) * radius
+        toY = sin(legAngle) * radius * VerticalSquash
+        val distance = hypot(toX - fromX, toY - fromY)
+        legDurationMs =
+            (distance / WanderSpeedDpPerSecond * 1000f)
+                .coerceIn(MinLegDurationMs, MaxLegDurationMs)
+    }
+
+    internal companion object {
+        /** Largest offset the walk can reach, in dp. See the class docs. */
+        const val WanderRadiusDp = 150f
+
+        /**
+         * Vertical amplitude is squashed a little: phones are taller than they
+         * are wide, so the same absolute offset reads as less movement
+         * vertically, and the covering budget is tighter horizontally.
+         */
+        private const val VerticalSquash = 0.8f
+
+        /** Average travel speed. Deliberately slow — this sits behind lyrics. */
+        private const val WanderSpeedDpPerSecond = 26f
+
+        private const val MinLegDurationMs = 6_000f
+        private const val MaxLegDurationMs = 18_000f
+
+        /** Waypoints are never closer to the centre than this fraction of the radius. */
+        private const val MinRadiusFraction = 0.5f
+
+        /** ~72°: enough that a new leg is unmistakably a new direction. */
+        private const val MinTurnRadians = 1.25f
+
+        private const val TwoPi = (2.0 * PI).toFloat()
+    }
+}
+
+/**
+ * Remembers a [BlurWanderDrift] and advances it from the frame clock while
+ * [active].
+ *
+ * The loop is gated because it is the only thing keeping the frame clock busy:
+ * an `InfiniteTransition` (what this replaced) keeps asking for a frame every
+ * ~16ms for as long as it is composed, even when nothing reads its value — so
+ * the player kept the whole Compose frame pipeline awake while sitting on the
+ * cover with no drift on screen. When [active] goes false the walk freezes where
+ * it is and resumes from there, so closing and reopening lyrics doesn't restart
+ * the path.
+ */
+@Composable
+internal fun rememberBlurWanderDrift(active: Boolean): BlurWanderDrift {
+    val drift = remember { BlurWanderDrift() }
+    LaunchedEffect(active) {
+        if (!active) return@LaunchedEffect
+        var lastFrameNanos = 0L
+        while (isActive) {
+            withFrameNanos { frameTimeNanos ->
+                if (lastFrameNanos != 0L) {
+                    drift.advance((frameTimeNanos - lastFrameNanos) / 1_000_000f)
+                }
+                lastFrameNanos = frameTimeNanos
+            }
+        }
+    }
+    return drift
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
@@ -70,6 +70,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -184,6 +185,14 @@ val LocalVideoOnPreferredHeightChange = compositionLocalOf<(Int?) -> Unit> { {} 
 val LocalVideoAvailableHeights = compositionLocalOf<List<Int>> { emptyList() }
 
 /**
+ * CompositionLocal for the height actually being played, so the quality UI can report what the
+ * Auto / Data saver / High quality modes resolved to. Null until a stream resolves, or when
+ * YouTube did not label the chosen format.
+ * @see LocalVideoArtworkState
+ */
+val LocalVideoSelectedHeight = compositionLocalOf<Int?> { null }
+
+/**
  * CompositionLocal that tracks whether the host Activity is currently in
  * Picture-in-Picture mode. When true, the player UI hides non-essential
  * controls (overlays, gesture handlers, etc.) so the PiP window shows
@@ -258,6 +267,7 @@ fun InlineVideoPlayer(
     preferredHeight: Int? = LocalVideoPreferredHeight.current,
     onPreferredHeightChange: (Int?) -> Unit = LocalVideoOnPreferredHeightChange.current,
     availableHeights: List<Int> = LocalVideoAvailableHeights.current,
+    selectedHeight: Int? = LocalVideoSelectedHeight.current,
     modifier: Modifier = Modifier,
     onPlaybackFailed: () -> Unit = {},
     resizeMode: Int = AspectRatioFrameLayout.RESIZE_MODE_FIT,
@@ -334,42 +344,19 @@ fun InlineVideoPlayer(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 // Quality picker — only render if YouTube offered more than one height.
+                // Opens the same VideoQualitySheet the fullscreen overlay uses, so the two
+                // surfaces offer identical choices.
                 if (availableHeights.size > 1) {
-                    Box {
-                        IconButton(
-                            onClick = { qualityMenuOpen = true },
-                            modifier = Modifier.size(40.dp),
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.solar_settings_linear),
-                                contentDescription = stringResource(R.string.video_quality),
-                                tint = Color.White,
-                                modifier = Modifier.size(22.dp),
-                            )
-                        }
-                        DropdownMenu(
-                            expanded = qualityMenuOpen,
-                            onDismissRequest = { qualityMenuOpen = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.video_quality_auto)) },
-                                onClick = {
-                                    onPreferredHeightChange(null)
-                                    qualityMenuOpen = false
-                                },
-                            )
-                            availableHeights
-                                .sortedDescending()
-                                .forEach { h ->
-                                    DropdownMenuItem(
-                                        text = { Text(formatHeightLabel(h)) },
-                                        onClick = {
-                                            onPreferredHeightChange(h)
-                                            qualityMenuOpen = false
-                                        },
-                                    )
-                                }
-                        }
+                    IconButton(
+                        onClick = { qualityMenuOpen = true },
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.solar_settings_linear),
+                            contentDescription = stringResource(R.string.video_quality),
+                            tint = Color.White,
+                            modifier = Modifier.size(22.dp),
+                        )
                     }
                 }
 
@@ -388,6 +375,19 @@ fun InlineVideoPlayer(
                 }
             }
         }
+    }
+
+    // ── Quality bottom sheet ──
+    // Outside the `!isFullscreen` block on purpose: the sheet is a window of its own, so leaving it
+    // outside keeps it from being torn down mid-animation if fullscreen is entered while it is up.
+    if (qualityMenuOpen) {
+        VideoQualitySheet(
+            preferredHeight = preferredHeight,
+            availableHeights = availableHeights,
+            selectedHeight = selectedHeight,
+            onPreferredHeightChange = onPreferredHeightChange,
+            onDismissRequest = { qualityMenuOpen = false },
+        )
     }
 }
 
@@ -430,6 +430,7 @@ fun FullscreenVideoOverlay(
     preferredHeight: Int?,
     onPreferredHeightChange: (Int?) -> Unit,
     availableHeights: List<Int>,
+    selectedHeight: Int? = null,
     onDismiss: () -> Unit,
     resizeMode: Int = AspectRatioFrameLayout.RESIZE_MODE_FIT,
 ) {
@@ -905,124 +906,120 @@ fun FullscreenVideoOverlay(
                     horizontalArrangement = Arrangement.spacedBy(2.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    if (availableHeights.size > 1) {
-                        Box {
-                            IconButton(
-                                onClick = { qualityMenuOpen = true },
-                                modifier = Modifier.size(40.dp),
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.solar_settings_linear),
-                                    contentDescription = stringResource(R.string.video_quality),
-                                        tint = Color.White,
-                                        modifier = Modifier.size(22.dp),
-                                    )
-                                }
-                                DropdownMenu(
-                                    expanded = qualityMenuOpen,
-                                    onDismissRequest = { qualityMenuOpen = false },
-                                ) {
-                                    DropdownMenuItem(
-                                        text = { Text(stringResource(R.string.video_quality_auto)) },
-                                        onClick = {
-                                            onPreferredHeightChange(null)
-                                            qualityMenuOpen = false
-                                        },
-                                    )
-                                    availableHeights
-                                        .sortedDescending()
-                                        .forEach { h ->
-                                            DropdownMenuItem(
-                                                text = { Text(formatHeightLabel(h)) },
-                                                onClick = {
-                                                    onPreferredHeightChange(h)
-                                                    qualityMenuOpen = false
-                                                },
-                                            )
-                                        }
-                                }
-                            }
+                    // ── Quality pill ──
+                    // Icon + current-quality label, so the pill reports what is playing instead of
+                    // only being a way in. Tapping it raises VideoQualitySheet from the bottom of
+                    // the screen (the old DropdownMenu opened as a cramped popup pinned to this
+                    // corner, which is the far side of the screen from the user's thumb in
+                    // landscape).
+                    if (availableHeights.isNotEmpty()) {
+                        Row(
+                            modifier =
+                                Modifier
+                                    .clip(RoundedCornerShape(24.dp))
+                                    .clickable { qualityMenuOpen = true }
+                                    .padding(horizontal = 10.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.solar_settings_linear),
+                                contentDescription = stringResource(R.string.video_quality),
+                                tint = Color.White,
+                                modifier = Modifier.size(22.dp),
+                            )
+                            Text(
+                                text =
+                                    videoQualityPillLabel(
+                                        preferredHeight = preferredHeight,
+                                        selectedHeight = selectedHeight,
+                                    ),
+                                color = Color.White,
+                                style = MaterialTheme.typography.labelMedium,
+                                maxLines = 1,
+                            )
                         }
+                    }
 
-                        // ── Aspect ratio picker ──
-                        // Moved out of the overflow sheet so the user can quickly
-                        // cycle aspect ratios without opening the sheet. The
-                        // dropdown shows a checkmark next to the active option.
-                        Box {
-                            IconButton(
-                                onClick = { aspectRatioMenuOpen = true },
-                                modifier = Modifier.size(40.dp),
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.solar_aspect_ratio_linear),
-                                    contentDescription = stringResource(R.string.video_aspect_ratio),
-                                    tint = Color.White,
-                                    modifier = Modifier.size(22.dp),
+                    // ── Aspect ratio picker ──
+                    // Moved out of the overflow sheet so the user can quickly
+                    // cycle aspect ratios without opening the sheet. The
+                    // dropdown shows a checkmark next to the active option.
+                    Box {
+                        IconButton(
+                            onClick = { aspectRatioMenuOpen = true },
+                            modifier = Modifier.size(40.dp),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.solar_aspect_ratio_linear),
+                                contentDescription = stringResource(R.string.video_aspect_ratio),
+                                tint = Color.White,
+                                modifier = Modifier.size(22.dp),
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = aspectRatioMenuOpen,
+                            onDismissRequest = { aspectRatioMenuOpen = false },
+                        ) {
+                            val aspectOptions =
+                                listOf(
+                                    VideoAspectRatio.FIT to R.string.video_aspect_fit,
+                                    VideoAspectRatio.CROP to R.string.video_aspect_crop,
+                                    VideoAspectRatio.STRETCH to R.string.video_aspect_stretch,
+                                    VideoAspectRatio.FILL to R.string.video_aspect_fill,
+                                )
+                            aspectOptions.forEach { (ratio, labelRes) ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                            Text(
+                                                text = stringResource(labelRes),
+                                                modifier = Modifier.weight(1f),
+                                            )
+                                            if (ratio == aspectRatio) {
+                                                Icon(
+                                                    painter = painterResource(R.drawable.solar_check_circle_linear),
+                                                    contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.primary,
+                                                    modifier = Modifier.size(18.dp),
+                                                )
+                                            }
+                                        }
+                                    },
+                                    onClick = {
+                                        onAspectRatioChange(ratio)
+                                        aspectRatioMenuOpen = false
+                                    },
                                 )
                             }
-                            DropdownMenu(
-                                expanded = aspectRatioMenuOpen,
-                                onDismissRequest = { aspectRatioMenuOpen = false },
-                            ) {
-                                val aspectOptions =
-                                    listOf(
-                                        VideoAspectRatio.FIT to R.string.video_aspect_fit,
-                                        VideoAspectRatio.CROP to R.string.video_aspect_crop,
-                                        VideoAspectRatio.STRETCH to R.string.video_aspect_stretch,
-                                        VideoAspectRatio.FILL to R.string.video_aspect_fill,
-                                    )
-                                aspectOptions.forEach { (ratio, labelRes) ->
-                                    DropdownMenuItem(
-                                        text = {
-                                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                                Text(
-                                                    text = stringResource(labelRes),
-                                                    modifier = Modifier.weight(1f),
-                                                )
-                                                if (ratio == aspectRatio) {
-                                                    Icon(
-                                                        painter = painterResource(R.drawable.solar_check_circle_linear),
-                                                        contentDescription = null,
-                                                        tint = MaterialTheme.colorScheme.primary,
-                                                        modifier = Modifier.size(18.dp),
-                                                    )
-                                                }
-                                            }
-                                        },
-                                        onClick = {
-                                            onAspectRatioChange(ratio)
-                                            aspectRatioMenuOpen = false
-                                        },
-                                    )
-                                }
-                            }
                         }
+                    }
 
-                        // 3-dot overflow button — opens the ModalBottomSheet
-                        // with slider style / playback speed / ambient mode.
-                        IconButton(
-                            onClick = { showOverflowSheet = true },
-                            modifier = Modifier.size(40.dp),
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.solar_more_vert_linear),
-                                contentDescription = stringResource(R.string.video_overflow_menu),
-                                tint = Color.White,
-                                modifier = Modifier.size(22.dp),
-                            )
-                        }
+                    // 3-dot overflow button — opens the ModalBottomSheet
+                    // with slider style / playback speed / ambient mode.
+                    IconButton(
+                        onClick = { showOverflowSheet = true },
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.solar_more_vert_linear),
+                            contentDescription = stringResource(R.string.video_overflow_menu),
+                            tint = Color.White,
+                            modifier = Modifier.size(22.dp),
+                        )
+                    }
 
-                        IconButton(
-                            onClick = onDismiss,
-                            modifier = Modifier.size(40.dp),
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.solar_fullscreen_exit_linear),
-                                contentDescription = stringResource(R.string.video_exit_fullscreen),
-                                tint = Color.White,
-                                modifier = Modifier.size(22.dp),
-                            )
-                        }
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.solar_fullscreen_exit_linear),
+                            contentDescription = stringResource(R.string.video_exit_fullscreen),
+                            tint = Color.White,
+                            modifier = Modifier.size(22.dp),
+                        )
+                    }
                 }
 
                 // ── Center row: previous | play/pause | next ──
@@ -1190,6 +1187,19 @@ fun FullscreenVideoOverlay(
                 }
             }
         }
+    }
+
+    // ── Quality bottom sheet ──
+    // Slides up from the bottom over the fullscreen overlay. It carries its own SheetState, so it
+    // and the overflow sheet below can never fight over one animation.
+    if (qualityMenuOpen) {
+        VideoQualitySheet(
+            preferredHeight = preferredHeight,
+            availableHeights = availableHeights,
+            selectedHeight = selectedHeight,
+            onPreferredHeightChange = onPreferredHeightChange,
+            onDismissRequest = { qualityMenuOpen = false },
+        )
     }
 
     // ── 3-dot overflow bottom sheet ──
@@ -1432,29 +1442,6 @@ private fun isLoadingState(state: VideoArtworkState): Boolean =
                 state.isResyncing ||
                 (state.streamUrl != null && !state.isVideoReady)
         )
-
-/**
- * Format a video height (in px) as a human-readable label.
- * 1440 → "1440p (QHD)"
- * 2160 → "2160p (4K)"
- * 720  → "720p (HD)"
- * 480  → "480p (SD)"
- * 360  → "360p"
- * 240  → "240p"
- * 144  → "144p"
- */
-private fun formatHeightLabel(height: Int): String {
-    val qualityName =
-        when (height) {
-            2160 -> " (4K)"
-            1440 -> " (QHD)"
-            1080 -> " (FHD)"
-            720 -> " (HD)"
-            480 -> " (SD)"
-            else -> ""
-        }
-    return "${height}p$qualityName"
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fullscreen overlay gesture support

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
@@ -43,8 +43,6 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -943,56 +941,21 @@ fun FullscreenVideoOverlay(
 
                     // ── Aspect ratio picker ──
                     // Moved out of the overflow sheet so the user can quickly
-                    // cycle aspect ratios without opening the sheet. The
-                    // dropdown shows a checkmark next to the active option.
-                    Box {
-                        IconButton(
-                            onClick = { aspectRatioMenuOpen = true },
-                            modifier = Modifier.size(40.dp),
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.solar_aspect_ratio_linear),
-                                contentDescription = stringResource(R.string.video_aspect_ratio),
-                                tint = Color.White,
-                                modifier = Modifier.size(22.dp),
-                            )
-                        }
-                        DropdownMenu(
-                            expanded = aspectRatioMenuOpen,
-                            onDismissRequest = { aspectRatioMenuOpen = false },
-                        ) {
-                            val aspectOptions =
-                                listOf(
-                                    VideoAspectRatio.FIT to R.string.video_aspect_fit,
-                                    VideoAspectRatio.CROP to R.string.video_aspect_crop,
-                                    VideoAspectRatio.STRETCH to R.string.video_aspect_stretch,
-                                    VideoAspectRatio.FILL to R.string.video_aspect_fill,
-                                )
-                            aspectOptions.forEach { (ratio, labelRes) ->
-                                DropdownMenuItem(
-                                    text = {
-                                        Row(verticalAlignment = Alignment.CenterVertically) {
-                                            Text(
-                                                text = stringResource(labelRes),
-                                                modifier = Modifier.weight(1f),
-                                            )
-                                            if (ratio == aspectRatio) {
-                                                Icon(
-                                                    painter = painterResource(R.drawable.solar_check_circle_linear),
-                                                    contentDescription = null,
-                                                    tint = MaterialTheme.colorScheme.primary,
-                                                    modifier = Modifier.size(18.dp),
-                                                )
-                                            }
-                                        }
-                                    },
-                                    onClick = {
-                                        onAspectRatioChange(ratio)
-                                        aspectRatioMenuOpen = false
-                                    },
-                                )
-                            }
-                        }
+                    // cycle aspect ratios without opening the sheet. Raises the
+                    // same sliding sheet the quality pill uses (see
+                    // VideoAspectRatioSheet) rather than a corner-pinned
+                    // dropdown, which in landscape opened on the far side of the
+                    // screen from the user's thumb.
+                    IconButton(
+                        onClick = { aspectRatioMenuOpen = true },
+                        modifier = Modifier.size(40.dp),
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.solar_aspect_ratio_linear),
+                            contentDescription = stringResource(R.string.video_aspect_ratio),
+                            tint = Color.White,
+                            modifier = Modifier.size(22.dp),
+                        )
                     }
 
                     // 3-dot overflow button — opens the ModalBottomSheet
@@ -1199,6 +1162,16 @@ fun FullscreenVideoOverlay(
             selectedHeight = selectedHeight,
             onPreferredHeightChange = onPreferredHeightChange,
             onDismissRequest = { qualityMenuOpen = false },
+        )
+    }
+
+    // ── Aspect-ratio bottom sheet ──
+    // Same treatment as the quality sheet above, and likewise its own SheetState.
+    if (aspectRatioMenuOpen) {
+        VideoAspectRatioSheet(
+            aspectRatio = aspectRatio,
+            onAspectRatioChange = onAspectRatioChange,
+            onDismissRequest = { aspectRatioMenuOpen = false },
         )
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -16,11 +16,6 @@ import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -177,6 +172,13 @@ private val AppleMusicFallbackGradient =
     )
 
 private val LyricsSwipeStartRegion = 144.dp
+
+// Scale of the blurred backdrop. Must cover BlurWanderDrift.WanderRadiusDp of drift plus
+// the 64dp blur: at 2.4x the artwork overhangs 0.7*W per edge (252dp on a 360dp screen)
+// against the 150 + 64 = 214dp needed. Kept in sync with AmLyricsBlurDriftScale in
+// AppleMusicPlayer.kt. Was 1.9x, which was sized for an older, smaller drift and let the
+// blur sample transparent pixels at full offset — a dark band along the trailing edge.
+private const val MovingBlurDriftScale = 2.4f
 private val LyricsSwipeDismissThreshold = 96.dp
 
 /**
@@ -927,30 +929,21 @@ private fun MovingBlurBackground(
     //
     // Effective drift values: animated on S+, hard-zero on pre-S so the offset modifier is a
     // no-op and the bitmap stays pinned.
-    // Wandering backdrop, shared with the Apple-Music-style player — see [blurWanderXDp] in
-    // AppleMusicPlayer.kt for the amplitude and rate budget. One ever-advancing phase feeds two
-    // sines per axis, so the offset never reverses abruptly the way the previous pair of
-    // RepeatMode.Reverse tweens did (they hit ±160 / ±120 and snapped straight back, which read
-    // as the backdrop whipping around).
+    // Wandering backdrop, shared with the Apple-Music-style player — see [BlurWanderDrift] for
+    // the path. It walks between random waypoints with eased legs, so the artwork always finishes
+    // the leg it is on and comes to rest before setting off in a new, randomly chosen direction.
+    // Neither of the earlier versions did that: a pair of RepeatMode.Reverse tweens turned around
+    // at full speed at ±160 / ±120 (the backdrop "whipping around"), and the Lissajous path that
+    // replaced them still spent half of every cycle retracing its way back, which reads as the
+    // colours suddenly travelling the other way.
     //
-    // RepeatMode.Restart, not Reverse: the wander functions are periodic in the phase, so the
-    // 1→0 wrap is continuous. LinearEasing keeps the phase advancing at a constant rate; any
-    // eased curve would make the whole path stall once per cycle.
-    val transition = rememberInfiniteTransition(label = "moving-blur-drift")
+    // The offsets are deliberately left inside FloatState and read only from the graphicsLayer
+    // lambda below, which is a draw-phase read. Unwrapping them here would invalidate this whole
+    // composable (AnimatedContent, BoxWithConstraints, the AsyncImage subtree) on every animation
+    // frame, competing with the lyric scroll and the karaoke sweep for frame budget.
     //
-    // The State<Float> is deliberately NOT unwrapped with `by`: the phase is read only inside the
-    // graphicsLayer lambda below, which is a draw-phase read. Unwrapping it here would invalidate
-    // this whole composable (AnimatedContent, BoxWithConstraints, the AsyncImage subtree) on every
-    // animation frame, competing with the lyric scroll and the karaoke sweep for frame budget.
-    val blurPhaseState = transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = AmBlurWanderPeriodMs, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart,
-        ),
-        label = "moving-blur-phase",
-    )
+    // Pre-S doesn't drift at all (see below), so the frame loop is not started there.
+    val blurWander = rememberBlurWanderDrift(active = !isPreS)
     BoxWithConstraints(
         modifier =
             modifier
@@ -960,14 +953,13 @@ private fun MovingBlurBackground(
     ) {
         val preSDriftScale =
             if (isPreS) {
-                val driftMaxX = 160.dp
-                val driftMaxY = 120.dp
+                val driftMax = BlurWanderDrift.WanderRadiusDp.dp
                 val safetyMargin = 48.dp
-                val requiredScaleX = 1f + 2f * (driftMaxX.value + safetyMargin.value) / maxWidth.value
-                val requiredScaleY = 1f + 2f * (driftMaxY.value + safetyMargin.value) / maxHeight.value
+                val requiredScaleX = 1f + 2f * (driftMax.value + safetyMargin.value) / maxWidth.value
+                val requiredScaleY = 1f + 2f * (driftMax.value + safetyMargin.value) / maxHeight.value
                 maxOf(requiredScaleX, requiredScaleY, 1.4f)
             } else {
-                1.9f
+                MovingBlurDriftScale
             }
 
         AnimatedContent(
@@ -1029,25 +1021,13 @@ private fun MovingBlurBackground(
                             // translation is applied to the blurred result. This prevents
                             // the blur from sampling transparent areas at the translated
                             // image's trailing edge — the root cause of the corner flicker.
-                            //
-                            // Scale 2.4 extends the image 0.7*W beyond each edge
-                            // (252dp for W=360), which covers drift(±160) + blur(64)
-                            // = 224dp with a 28dp safety margin.
-                            //
-                            // Was 1.9 (0.45*W = 162dp), sized for the old ±60 drift.
-                            // When the drift was widened to ±160 for the faster
-                            // Apple-Music pan this was left behind, so at maximum
-                            // drift the blurred image no longer reached the parent's
-                            // trailing edge and the blur sampled transparent pixels —
-                            // a dark band along that edge. Kept in sync with
-                            // AmLyricsBlurDriftScale in AppleMusicPlayer.kt.
+                            // See [MovingBlurDriftScale] for the covering budget.
                             .graphicsLayer {
-                                scaleX = 2.4f
-                                scaleY = 2.4f
-                                // Deferred read — see blurPhaseState above.
-                                val phase = blurPhaseState.value
-                                translationX = blurWanderXDp(phase).dp.toPx()
-                                translationY = blurWanderYDp(phase).dp.toPx()
+                                scaleX = MovingBlurDriftScale
+                                scaleY = MovingBlurDriftScale
+                                // Deferred read — see blurWander above.
+                                translationX = blurWander.xDp.floatValue.dp.toPx()
+                                translationY = blurWander.yDp.floatValue.dp.toPx()
                                 compositingStrategy = CompositingStrategy.Offscreen
                             }
                             .blur(64.dp)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -94,6 +95,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -165,6 +167,7 @@ import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.viewmodels.LyricsMenuViewModel
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.abs
 
 private val AppleMusicFallbackGradient =
     listOf(
@@ -172,6 +175,9 @@ private val AppleMusicFallbackGradient =
         Color(0xFF141414),
         Color(0xFF050505),
     )
+
+private val LyricsSwipeStartRegion = 144.dp
+private val LyricsSwipeDismissThreshold = 96.dp
 
 /**
  * Plumbs the lyrics-scroll signal up from [LyricsEnhanced] / [LyricsV2] (which own the
@@ -228,6 +234,9 @@ fun LyricsScreen(
     val playerCustomContrast by rememberPreference(PlayerCustomContrastKey, 1f)
     val playerCustomBrightness by rememberPreference(PlayerCustomBrightnessKey, 1f)
     val foregroundColor = Color.White
+    val density = LocalDensity.current
+    val swipeStartRegionPx = with(density) { LyricsSwipeStartRegion.toPx() }
+    val swipeDismissThresholdPx = with(density) { LyricsSwipeDismissThreshold.toPx() }
     val showPlayerControlsState =
         rememberPreference(ShowLyricsPlayerControlsKey, true)
     val showPlayerControlsEnabled by showPlayerControlsState
@@ -582,11 +591,35 @@ fun LyricsScreen(
                 // content — hit-testing stops at the topmost hit sibling (the lyrics list),
                 // so the poke only ever fired in the padding gutters, which is why the
                 // tappable area felt so small.
-                .pointerInput(showPlayerControlsEnabled, autoHidePlayerControls) {
-                    if (!showPlayerControlsEnabled || !autoHidePlayerControls) return@pointerInput
+                .pointerInput(
+                    showPlayerControlsEnabled,
+                    autoHidePlayerControls,
+                    swipeStartRegionPx,
+                    swipeDismissThresholdPx,
+                    onBackClick,
+                ) {
                     awaitEachGesture {
-                        awaitFirstDown(requireUnconsumed = false)
-                        pokePlayerControlsVisibility()
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        if (showPlayerControlsEnabled && autoHidePlayerControls) {
+                            pokePlayerControlsVisibility()
+                        }
+
+                        if (down.position.y <= swipeStartRegionPx) {
+                            while (true) {
+                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                                if (!change.pressed) break
+
+                                val deltaX = change.position.x - down.position.x
+                                val deltaY = change.position.y - down.position.y
+                                if (deltaY < 0f || abs(deltaX) > abs(deltaY)) break
+                                if (deltaY >= swipeDismissThresholdPx) {
+                                    change.consume()
+                                    onBackClick()
+                                    break
+                                }
+                            }
+                        }
                     }
                 },
     ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -16,7 +16,7 @@ import android.view.HapticFeedbackConstants
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -884,16 +884,21 @@ private fun MovingBlurBackground(
     //
     // Effective drift values: animated on S+, hard-zero on pre-S so the offset modifier is a
     // no-op and the bitmap stays pinned.
-    // Apple-Music-style "breathing" drift. Previously 19 s / 27 s half-cycles made the motion
-    // nearly imperceptible (≈6 dp/s on X, ≈3 dp/s on Y against a 64-dp blur that masks motion
-    // under ~16 dp). Drop to 4 s / 6 s half-cycles and widen the range to ±160 / ±120 — that's
-    // ~5× faster perceived motion and a clearly visible pan.
+    // Apple-Music-style "breathing" drift. Previously 19 s / 27 s half-cycles over ±160 / ±120 —
+    // ~17 dp/s on X and ~9 dp/s on Y, which against a 64-dp blur (that masks any motion under
+    // ~16 dp) read as a still image. At 4 s / 6 s the same range gives 80 dp/s on X and 40 dp/s on
+    // Y: a clearly visible pan.
+    //
+    // LinearEasing, not FastOutSlowInEasing: the eased curve decelerates into each endpoint and
+    // accelerates back out, which at this speed reads as the backdrop stalling twice a cycle.
+    // Apple's own backdrop pans at a constant rate. Kept in sync with the drift in
+    // AppleMusicPlayer.kt, which drives the same effect for the Apple-Music-style player.
     val transition = rememberInfiniteTransition(label = "moving-blur-drift")
     val animatedDriftX by transition.animateFloat(
         initialValue = -160f,
         targetValue = 160f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 4_000, easing = FastOutSlowInEasing),
+            animation = tween(durationMillis = 4_000, easing = LinearEasing),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "moving-blur-x",
@@ -902,7 +907,7 @@ private fun MovingBlurBackground(
         initialValue = -120f,
         targetValue = 120f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 6_000, easing = FastOutSlowInEasing),
+            animation = tween(durationMillis = 6_000, easing = LinearEasing),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "moving-blur-y",
@@ -987,12 +992,20 @@ private fun MovingBlurBackground(
                             // the blur from sampling transparent areas at the translated
                             // image's trailing edge — the root cause of the corner flicker.
                             //
-                            // Scale 1.9 extends the image 0.45*W beyond each edge
-                            // (162dp for W=360), which covers drift(±60) + blur(64)
-                            // = 124dp with a 38dp safety margin.
+                            // Scale 2.4 extends the image 0.7*W beyond each edge
+                            // (252dp for W=360), which covers drift(±160) + blur(64)
+                            // = 224dp with a 28dp safety margin.
+                            //
+                            // Was 1.9 (0.45*W = 162dp), sized for the old ±60 drift.
+                            // When the drift was widened to ±160 for the faster
+                            // Apple-Music pan this was left behind, so at maximum
+                            // drift the blurred image no longer reached the parent's
+                            // trailing edge and the blur sampled transparent pixels —
+                            // a dark band along that edge. Kept in sync with
+                            // AmLyricsBlurDriftScale in AppleMusicPlayer.kt.
                             .graphicsLayer {
-                                scaleX = 1.9f
-                                scaleY = 1.9f
+                                scaleX = 2.4f
+                                scaleY = 2.4f
                                 translationX = driftX.dp.toPx()
                                 translationY = driftY.dp.toPx()
                                 compositingStrategy = CompositingStrategy.Offscreen

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -232,7 +232,7 @@ fun LyricsScreen(
         rememberPreference(ShowLyricsPlayerControlsKey, true)
     val showPlayerControlsEnabled by showPlayerControlsState
     val (autoHidePlayerControls, onAutoHidePlayerControlsChange) =
-        rememberPreference(AutoHideLyricsPlayerControlsKey, false)
+        rememberPreference(AutoHideLyricsPlayerControlsKey, true)
     var playerControlsExpanded by remember(mediaMetadata.id, showPlayerControlsEnabled) {
         mutableStateOf(showPlayerControlsEnabled)
     }
@@ -573,7 +573,22 @@ fun LyricsScreen(
     Box(
         modifier =
             modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                // Tap ANYWHERE to bring the auto-hidden controls back (Apple Music lyrics
+                // behaviour). This handler sits on the ROOT container so it is an ancestor of
+                // every hit path: Compose delivers pointer events to the hit node and its
+                // ancestors, so taps land here even when the lyrics LazyColumn consumes them
+                // for scrolling. The previous implementation was a sibling Box UNDER the
+                // content — hit-testing stops at the topmost hit sibling (the lyrics list),
+                // so the poke only ever fired in the padding gutters, which is why the
+                // tappable area felt so small.
+                .pointerInput(showPlayerControlsEnabled, autoHidePlayerControls) {
+                    if (!showPlayerControlsEnabled || !autoHidePlayerControls) return@pointerInput
+                    awaitEachGesture {
+                        awaitFirstDown(requireUnconsumed = false)
+                        pokePlayerControlsVisibility()
+                    }
+                },
     ) {
         LyricsScreenBackground(
             style = lyricsBackground,
@@ -587,18 +602,13 @@ fun LyricsScreen(
             playerCustomBrightness = playerCustomBrightness,
         )
 
+        // Keeps unconsumed taps from falling through to whatever is layered below the
+        // lyrics screen (e.g. the player behind it).
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .consumeUnhandledPointerInput()
-                    .pointerInput(showPlayerControlsEnabled, autoHidePlayerControls) {
-                        if (!showPlayerControlsEnabled || !autoHidePlayerControls) return@pointerInput
-                        awaitEachGesture {
-                            awaitFirstDown(requireUnconsumed = false)
-                            pokePlayerControlsVisibility()
-                        }
-                    },
+                    .consumeUnhandledPointerInput(),
         )
 
         CompositionLocalProvider(LocalLyricsScrollListener provides { scrolling ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -927,36 +927,30 @@ private fun MovingBlurBackground(
     //
     // Effective drift values: animated on S+, hard-zero on pre-S so the offset modifier is a
     // no-op and the bitmap stays pinned.
-    // Apple-Music-style "breathing" drift. Previously 19 s / 27 s half-cycles over ±160 / ±120 —
-    // ~17 dp/s on X and ~9 dp/s on Y, which against a 64-dp blur (that masks any motion under
-    // ~16 dp) read as a still image. At 4 s / 6 s the same range gives 80 dp/s on X and 40 dp/s on
-    // Y: a clearly visible pan.
+    // Wandering backdrop, shared with the Apple-Music-style player — see [blurWanderXDp] in
+    // AppleMusicPlayer.kt for the amplitude and rate budget. One ever-advancing phase feeds two
+    // sines per axis, so the offset never reverses abruptly the way the previous pair of
+    // RepeatMode.Reverse tweens did (they hit ±160 / ±120 and snapped straight back, which read
+    // as the backdrop whipping around).
     //
-    // LinearEasing, not FastOutSlowInEasing: the eased curve decelerates into each endpoint and
-    // accelerates back out, which at this speed reads as the backdrop stalling twice a cycle.
-    // Apple's own backdrop pans at a constant rate. Kept in sync with the drift in
-    // AppleMusicPlayer.kt, which drives the same effect for the Apple-Music-style player.
+    // RepeatMode.Restart, not Reverse: the wander functions are periodic in the phase, so the
+    // 1→0 wrap is continuous. LinearEasing keeps the phase advancing at a constant rate; any
+    // eased curve would make the whole path stall once per cycle.
     val transition = rememberInfiniteTransition(label = "moving-blur-drift")
-    val animatedDriftX by transition.animateFloat(
-        initialValue = -160f,
-        targetValue = 160f,
+    //
+    // The State<Float> is deliberately NOT unwrapped with `by`: the phase is read only inside the
+    // graphicsLayer lambda below, which is a draw-phase read. Unwrapping it here would invalidate
+    // this whole composable (AnimatedContent, BoxWithConstraints, the AsyncImage subtree) on every
+    // animation frame, competing with the lyric scroll and the karaoke sweep for frame budget.
+    val blurPhaseState = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 4_000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse,
+            animation = tween(durationMillis = AmBlurWanderPeriodMs, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
         ),
-        label = "moving-blur-x",
+        label = "moving-blur-phase",
     )
-    val animatedDriftY by transition.animateFloat(
-        initialValue = -120f,
-        targetValue = 120f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 6_000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = "moving-blur-y",
-    )
-    val driftX = if (isPreS) 0f else animatedDriftX
-    val driftY = if (isPreS) 0f else animatedDriftY
     BoxWithConstraints(
         modifier =
             modifier
@@ -1017,7 +1011,8 @@ private fun MovingBlurBackground(
                                     scaleX = preSDriftScale
                                     scaleY = preSDriftScale
                                 }
-                                .offset(x = driftX.dp, y = driftY.dp)
+                                // No offset: the pre-S fallback pins its single pre-blurred
+                                // bitmap (see above), so there is nothing to animate here.
                                 .alpha(0.95f),
                         )
                     }
@@ -1049,8 +1044,10 @@ private fun MovingBlurBackground(
                             .graphicsLayer {
                                 scaleX = 2.4f
                                 scaleY = 2.4f
-                                translationX = driftX.dp.toPx()
-                                translationY = driftY.dp.toPx()
+                                // Deferred read — see blurPhaseState above.
+                                val phase = blurPhaseState.value
+                                translationX = blurWanderXDp(phase).dp.toPx()
+                                translationY = blurWanderYDp(phase).dp.toPx()
                                 compositingStrategy = CompositingStrategy.Offscreen
                             }
                             .blur(64.dp)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -1068,6 +1068,9 @@ fun BottomSheetPlayer(
             ?.id
     var videoPreferredHeight by rememberSaveable { mutableStateOf<Int?>(null) }
     var videoAvailableHeights by remember { mutableStateOf<List<Int>>(emptyList()) }
+    // The resolution actually resolved for the current stream, so the quality UI can report what
+    // Auto / Data saver / High quality picked instead of only naming the mode.
+    var videoSelectedHeight by remember { mutableStateOf<Int?>(null) }
     var videoPlaybackFailed by remember { mutableStateOf(false) }
 
     // Reset the failure flag when the media changes — a new song gets a fresh
@@ -1083,7 +1086,10 @@ fun BottomSheetPlayer(
             positionProvider = { playerConnection.player.currentPosition },
             preferredHeight = videoPreferredHeight,
             holdAudioUntilVideoReady = true,
-            onStreamResolved = { info -> videoAvailableHeights = info?.availableHeights.orEmpty() },
+            onStreamResolved = { info ->
+                videoAvailableHeights = info?.availableHeights.orEmpty()
+                videoSelectedHeight = info?.selectedHeight
+            },
             onPlaybackFailed = { videoPlaybackFailed = true },
             onLoadingStateChange = { /* loading is computed from state directly in InlineVideoPlayer */ },
             onRequestPauseMain = {
@@ -1103,6 +1109,7 @@ fun BottomSheetPlayer(
         LocalVideoPreferredHeight provides videoPreferredHeight,
         LocalVideoOnPreferredHeightChange provides { videoPreferredHeight = it },
         LocalVideoAvailableHeights provides videoAvailableHeights,
+        LocalVideoSelectedHeight provides videoSelectedHeight,
     ) {
     Box(modifier = Modifier.fillMaxSize()) {
     BottomSheet(
@@ -1713,6 +1720,7 @@ fun BottomSheetPlayer(
                                 preferredHeight = videoPreferredHeight,
                                 onPreferredHeightChange = { videoPreferredHeight = it },
                                 availableHeights = videoAvailableHeights,
+                                selectedHeight = videoSelectedHeight,
                                 modifier =
                                     Modifier
                                         .align(Alignment.Center)
@@ -2075,6 +2083,7 @@ fun BottomSheetPlayer(
                                 preferredHeight = videoPreferredHeight,
                                 onPreferredHeightChange = { videoPreferredHeight = it },
                                 availableHeights = videoAvailableHeights,
+                                selectedHeight = videoSelectedHeight,
                                 modifier =
                                     Modifier
                                         .align(Alignment.Center)
@@ -2520,6 +2529,7 @@ fun BottomSheetPlayer(
                     preferredHeight = videoPreferredHeight,
                     onPreferredHeightChange = { videoPreferredHeight = it },
                     availableHeights = videoAvailableHeights,
+                    selectedHeight = videoSelectedHeight,
                     onDismiss = { videoFullscreenHolder.isFullscreen = false },
                 )
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -73,11 +73,16 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -208,13 +213,43 @@ internal fun PlayerTitleText(
 internal fun PlayerTextBackdrop(
     textColor: Color,
     modifier: Modifier = Modifier,
+    edgeFadeWidth: Dp = 16.dp,
     content: @Composable () -> Unit,
 ) {
-    // Removed the blurred gradient + rounded background pill that was creating
-    // a visible dark "pill" behind song names. The text now sits directly on
-    // the player background with no container — matching the user's request
-    // to "remove the black background pill behind the song's name."
-    Box(modifier = modifier) {
+    // No background pill — the text sits directly on the player background. What remains is a
+    // soft alpha fade at BOTH horizontal edges of the text block, so long marquee'd titles and
+    // artist names dissolve into the layout instead of clipping hard against the next control.
+    //
+    // The fade is drawn on this container, NOT chained onto the Text's own basicMarquee():
+    // basicMarquee measures its child unbounded, so a modifier chained after it would see the
+    // full scrolling width and place the gradient off-screen (the bug the one-sided mhsm
+    // implementation had). Masking here uses the container's real viewport width.
+    //
+    // DstIn over an Offscreen layer punches the content's alpha toward transparent at the
+    // edges, so the fade works over ANY backdrop (solid color, dynamic blur, artwork) without
+    // needing to know the background color.
+    Box(
+        modifier =
+            modifier
+                .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                .drawWithContent {
+                    drawContent()
+                    val edge = edgeFadeWidth.toPx().coerceIn(0f, size.width / 2f)
+                    if (edge <= 0f) return@drawWithContent
+                    drawRect(
+                        brush = Brush.horizontalGradient(listOf(Color.Transparent, Color.Black)),
+                        topLeft = Offset.Zero,
+                        size = Size(edge, size.height),
+                        blendMode = BlendMode.DstIn,
+                    )
+                    drawRect(
+                        brush = Brush.horizontalGradient(listOf(Color.Black, Color.Transparent)),
+                        topLeft = Offset(size.width - edge, 0f),
+                        size = Size(edge, size.height),
+                        blendMode = BlendMode.DstIn,
+                    )
+                },
+    ) {
         content()
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -73,16 +73,11 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.graphics.CompositingStrategy
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -138,6 +133,7 @@ import moe.rukamori.archivetune.ui.menu.PlayerMenu
 import moe.rukamori.archivetune.ui.theme.PlayerBackgroundColorUtils
 import moe.rukamori.archivetune.ui.theme.PlayerSliderColors
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
+import moe.rukamori.archivetune.ui.utils.fadingEdge
 import moe.rukamori.archivetune.ui.utils.highRes
 import moe.rukamori.archivetune.utils.isLocalMediaId
 import moe.rukamori.archivetune.utils.makeTimeString
@@ -213,42 +209,14 @@ internal fun PlayerTitleText(
 internal fun PlayerTextBackdrop(
     textColor: Color,
     modifier: Modifier = Modifier,
-    edgeFadeWidth: Dp = 16.dp,
+    edgeFadeWidth: Dp = 24.dp,
     content: @Composable () -> Unit,
 ) {
-    // No background pill — the text sits directly on the player background. What remains is a
-    // soft alpha fade at BOTH horizontal edges of the text block, so long marquee'd titles and
-    // artist names dissolve into the layout instead of clipping hard against the next control.
-    //
-    // The fade is drawn on this container, NOT chained onto the Text's own basicMarquee():
-    // basicMarquee measures its child unbounded, so a modifier chained after it would see the
-    // full scrolling width and place the gradient off-screen (the bug the one-sided mhsm
-    // implementation had). Masking here uses the container's real viewport width.
-    //
-    // DstIn over an Offscreen layer punches the content's alpha toward transparent at the
-    // edges, so the fade works over ANY backdrop (solid color, dynamic blur, artwork) without
-    // needing to know the background color.
+    // Keep the fade on the bounded wrapper, not after basicMarquee(). The shared helper uses
+    // explicit viewport coordinates for both edges, so scrolling text fades into any backdrop
+    // instead of placing the gradient at the marquee's unbounded intrinsic width.
     Box(
-        modifier =
-            modifier
-                .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
-                .drawWithContent {
-                    drawContent()
-                    val edge = edgeFadeWidth.toPx().coerceIn(0f, size.width / 2f)
-                    if (edge <= 0f) return@drawWithContent
-                    drawRect(
-                        brush = Brush.horizontalGradient(listOf(Color.Transparent, Color.Black)),
-                        topLeft = Offset.Zero,
-                        size = Size(edge, size.height),
-                        blendMode = BlendMode.DstIn,
-                    )
-                    drawRect(
-                        brush = Brush.horizontalGradient(listOf(Color.Black, Color.Transparent)),
-                        topLeft = Offset(size.width - edge, 0f),
-                        size = Size(edge, size.height),
-                        blendMode = BlendMode.DstIn,
-                    )
-                },
+        modifier = modifier.fadingEdge(left = edgeFadeWidth, right = edgeFadeWidth),
     ) {
         content()
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoArtworkPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoArtworkPlayer.kt
@@ -287,14 +287,20 @@ private const val VideoSyncPollIntervalMs = 250L
 private const val VideoStuckBufferingTimeoutMs = 20000L
 
 /**
- * Hard cap on the resolution we will ever attempt to play.
+ * Cap on the resolution we attempt to play, derived from the user's quality choice.
  *
- * Capped at 1080p — 4K (2160) VP9 decoding on mobile chipsets causes
- * persistent ~500ms decoder lag that makes the video fall behind audio,
- * triggering constant re-syncs. 1080p is more than sufficient for a phone
- * screen and decodes fast enough to keep drift under the tolerance.
+ * This used to be a hard-coded 1080 constant, which meant the original 4K (and higher) formats
+ * YouTube publishes were filtered out before they ever reached the picker — they were neither
+ * playable nor even listed. Now the ceiling comes from the choice itself:
+ *  - Auto keeps the old conservative 1080p limit (4K VP9/AV1 decoding on mid-range chipsets lags
+ *    far enough behind the separately-loaded audio to trip the resync watchdog),
+ *  - Data saver drops to 480p,
+ *  - High quality / an exact Advanced pick go as high as this device's decoders report.
+ *
+ * See [VideoQualityPreference] for the encoding and [VideoDecoderCapabilities] for the hardware
+ * ceiling that bounds every branch.
  */
-private const val MaxVideoHeightCap = 1080
+private fun maxVideoHeightFor(preferredHeight: Int?): Int = VideoQualityPreference.ceilingFor(preferredHeight)
 
 /**
  * Maximum time the main audio player stays paused while we wait for the
@@ -337,11 +343,19 @@ private const val VideoLoadResumeDelayMs = 1000L
  * Resolved information about a video stream — the playable URL plus the
  * menu of formats YouTube offered, so the user can pick a different
  * quality after playback has started.
+ *
+ * @property availableHeights every resolution this device could decode, ascending. Drives the
+ *   Advanced list in the quality sheet, so it is bounded only by
+ *   [VideoDecoderCapabilities.maxSupportedHeight] and not by the current quality mode.
+ * @property selectedHeight the height actually being played, so Auto / Data saver / High quality
+ *   can show what they resolved to (e.g. "Auto · 1080p"). Null when YouTube did not label the
+ *   chosen format.
  */
 data class VideoStreamInfo(
     val streamUrl: String,
     val availableHeights: List<Int>,
     val captionTracks: List<PlayerResponse.CaptionTrack>,
+    val selectedHeight: Int? = null,
 )
 
 /**
@@ -2144,20 +2158,23 @@ private fun VideoAmbientBackdrop(
  * silenced in an earlier attempt. Loading audio + video separately keeps
  * the audio path identical to non-music-video playback (no muting hooks,
  * no risk of dual audio) and lets the user pick any adaptive video
- * resolution up to [MaxVideoHeightCap] (1080p).
+ * resolution the device can decode — up to and including the original 4K
+ * (or higher) format, when the user asks for it via High quality or an
+ * exact Advanced pick.
  *
  * The picker scans BOTH `formats` and `adaptiveFormats` (YouTube
  * occasionally lists a video-only entry in `formats` on some clients),
- * filters to those at or below [MaxVideoHeightCap], and picks the highest
- * resolution at or below the user's [preferredHeight] (falling back to
- * the smallest available if the preferred height is below everything
- * YouTube offered).
+ * filters to those at or below the ceiling [preferredHeight] implies (see
+ * [maxVideoHeightFor]), and picks the highest remaining resolution
+ * (falling back to the smallest available when the ceiling is below
+ * everything YouTube offered).
  */
 private fun pickVideoFormat(
     playerResponse: PlayerResponse,
     preferredHeight: Int?,
 ): PlayerResponse.StreamingData.Format? {
     val streamingData = playerResponse.streamingData ?: return null
+    val heightCeiling = maxVideoHeightFor(preferredHeight)
 
     val allVideoFormats =
         (streamingData.formats.orEmpty() + streamingData.adaptiveFormats.orEmpty())
@@ -2170,27 +2187,34 @@ private fun pickVideoFormat(
                 val h = it.height
                 h != null && h > 0
             }
-            .filter { (it.height ?: 0) <= MaxVideoHeightCap }
+            .filter { (it.height ?: 0) <= heightCeiling }
             .filter { it.url != null || it.signatureCipher != null || it.cipher != null }
             .toList()
 
-    if (allVideoFormats.isEmpty()) return null
-
-    val heightFiltered =
-        if (preferredHeight != null) {
-            val atOrBelow = allVideoFormats.filter { (it.height ?: 0) <= preferredHeight }
-            if (atOrBelow.isNotEmpty()) atOrBelow else allVideoFormats.sortedBy { it.height ?: 0 }
-        } else {
-            allVideoFormats
-        }
+    if (allVideoFormats.isEmpty()) {
+        // The ceiling excluded everything — every format YouTube offered is taller than this
+        // device (or this mode) allows. Fall back to the smallest format rather than returning
+        // null, which the caller treats as "this client has no video at all" and would otherwise
+        // drop playback to album artwork.
+        return (streamingData.formats.withUsableHeight() + streamingData.adaptiveFormats.withUsableHeight())
+            .filter { it.url != null || it.signatureCipher != null || it.cipher != null }
+            .minByOrNull { it.height ?: Int.MAX_VALUE }
+    }
 
     val comparator =
         compareByDescending<PlayerResponse.StreamingData.Format> { it.height ?: 0 }
             .thenByDescending { it.url != null }
             .thenByDescending { it.audioQuality != null }
 
-    return heightFiltered.sortedWith(comparator).firstOrNull()
+    return allVideoFormats.sortedWith(comparator).firstOrNull()
 }
+
+/** Formats that declare a usable frame height. */
+private fun List<PlayerResponse.StreamingData.Format>?.withUsableHeight(): List<PlayerResponse.StreamingData.Format> =
+    orEmpty().filter {
+        val h = it.height
+        h != null && h > 0
+    }
 
 /**
  * Resolve a playable video stream URL for [videoId] by trying multiple YouTube
@@ -2254,8 +2278,15 @@ private suspend fun resolveVideoStreamUrl(
                     val availableHeights =
                         (playerResponse.streamingData?.formats.orEmpty() +
                             playerResponse.streamingData?.adaptiveFormats.orEmpty())
-                            .mapNotNull { it.height?.takeIf { height -> height in 1..MaxVideoHeightCap } }
-                            .distinct()
+                            .mapNotNull { format ->
+                                // Bounded by what this device can decode, NOT by the current
+                                // quality mode: the Advanced list has to offer every resolution
+                                // the user could switch to, including the 4K original that Auto
+                                // itself would never pick.
+                                format.height?.takeIf { height ->
+                                    height in 1..VideoDecoderCapabilities.maxSupportedHeight()
+                                }
+                            }.distinct()
                             .sorted()
                     val captionTracks =
                         playerResponse.captions
@@ -2270,6 +2301,7 @@ private suspend fun resolveVideoStreamUrl(
                         streamUrl = finalUrl,
                         availableHeights = availableHeights,
                         captionTracks = captionTracks,
+                        selectedHeight = format.height?.takeIf { it > 0 },
                     )
                 }.onFailure { error ->
                     if (error is CancellationException) throw error

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualityPreference.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualityPreference.kt
@@ -1,0 +1,165 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import android.media.MediaCodecList
+import timber.log.Timber
+import java.util.Locale
+
+/**
+ * How the user's video-quality choice is encoded.
+ *
+ * The choice travels as a nullable `Int` — through [LocalVideoPreferredHeight], the
+ * `preferredHeight` parameter of [rememberVideoArtworkStateOrNull], and Player.kt's
+ * `rememberSaveable` holder. Keeping it a primitive is deliberate: `rememberSaveable` can persist
+ * an `Int?` across configuration changes and process death with no custom `Saver`, which an enum
+ * or sealed type would need.
+ *
+ * The encoding is therefore:
+ *  - `null`            → **Auto**: best resolution the device decodes comfortably, capped at
+ *                        [AUTO_HEIGHT_CEILING].
+ *  - [DATA_SAVER]      → cap at [DATA_SAVER_HEIGHT_CEILING].
+ *  - [HIGH_QUALITY]    → highest resolution YouTube offers, up to whatever this device can
+ *                        actually decode ([VideoDecoderCapabilities.maxSupportedHeight]). This is
+ *                        the path to 4K/8K "original quality".
+ *  - any positive int  → an exact height picked from the Advanced list (e.g. `2160`).
+ *
+ * The two mode sentinels are negative so they can never collide with a real height.
+ */
+object VideoQualityPreference {
+    /** Sentinel for the "Data saver" mode. Negative so it cannot collide with a real height. */
+    const val DATA_SAVER = -1
+
+    /** Sentinel for the "High quality" mode — highest the device can decode. */
+    const val HIGH_QUALITY = -2
+
+    /**
+     * Ceiling applied in Auto mode.
+     *
+     * Auto stays at 1080p on purpose. 4K VP9/AV1 decoding on mid-range mobile chipsets costs
+     * enough per-frame time that the video falls behind the separately-loaded audio track and
+     * trips the resync watchdog in [VideoArtworkState] — the exact reason the old hard-coded
+     * 1080p cap existed. Auto is the default, so it keeps the conservative behaviour; a user who
+     * wants the original resolution asks for it explicitly via High quality or Advanced, and then
+     * the only remaining ceiling is what the decoder reports.
+     */
+    const val AUTO_HEIGHT_CEILING = 1080
+
+    /** Ceiling applied in Data saver mode. */
+    const val DATA_SAVER_HEIGHT_CEILING = 480
+
+    /** True when [preference] is an exact height picked from the Advanced list. */
+    fun isExactHeight(preference: Int?): Boolean = preference != null && preference > 0
+
+    /**
+     * The tallest resolution [preference] permits on this device.
+     *
+     * Every branch is clamped by [VideoDecoderCapabilities.maxSupportedHeight] so a stored
+     * preference can never ask for a stream the device cannot decode — which matters for exact
+     * heights especially, since a preference saved on one device can be restored from a backup on
+     * a weaker one.
+     */
+    fun ceilingFor(preference: Int?): Int {
+        val deviceMax = VideoDecoderCapabilities.maxSupportedHeight()
+        val requested =
+            when (preference) {
+                null -> AUTO_HEIGHT_CEILING
+                DATA_SAVER -> DATA_SAVER_HEIGHT_CEILING
+                HIGH_QUALITY -> deviceMax
+                else -> preference
+            }
+        return minOf(requested, deviceMax)
+    }
+}
+
+/**
+ * What resolution this device's video decoders can actually handle.
+ *
+ * Queried once from [MediaCodecList] and cached for the process. Used as the hard ceiling on every
+ * quality choice so "High quality" means "the best this phone can play" rather than "the best
+ * YouTube listed" — offering a 4K stream to a decoder that maxes out at 1080p produces a black
+ * surface or a hard decoder error, not a graceful downgrade.
+ */
+object VideoDecoderCapabilities {
+    /**
+     * Used when the codec query fails or reports nothing usable (an OEM with a broken
+     * `MediaCodecList`, for instance).
+     *
+     * 2160 rather than 1080: a failed probe should not silently take 4K away from a device that
+     * supports it. If the device really cannot decode 4K, [VideoArtworkState]'s existing
+     * playback-failure path falls back to album artwork, which is the same outcome as any other
+     * unplayable stream.
+     */
+    private const val FALLBACK_MAX_HEIGHT = 2160
+
+    /**
+     * Codecs YouTube serves adaptive video in. AV1 and VP9 carry the high-resolution formats;
+     * AVC/HEVC are here because a device whose only 4K decoder is AVC still counts as 4K-capable.
+     */
+    private val VIDEO_MIME_TYPES =
+        setOf(
+            "video/av01",
+            "video/x-vnd.on2.vp9",
+            "video/hevc",
+            "video/avc",
+        )
+
+    @Volatile
+    private var cachedMaxHeight: Int? = null
+
+    /** Tallest decodable frame height, e.g. 2160 on a 4K-capable device. Never returns 0. */
+    fun maxSupportedHeight(): Int =
+        cachedMaxHeight ?: probeMaxSupportedHeight().also { probed ->
+            cachedMaxHeight = probed
+            Timber.tag("VideoDecoder").d("Max decodable video height: %dp", probed)
+        }
+
+    private fun probeMaxSupportedHeight(): Int =
+        runCatching {
+            MediaCodecList(MediaCodecList.REGULAR_CODECS)
+                .codecInfos
+                .asSequence()
+                .filterNot { it.isEncoder }
+                .flatMap { info ->
+                    info.supportedTypes
+                        .asSequence()
+                        .map { type -> info to type.lowercase(Locale.US) }
+                }.filter { (_, mime) -> mime in VIDEO_MIME_TYPES }
+                .mapNotNull { (info, mime) ->
+                    // getCapabilitiesForType throws on some OEM codec entries that advertise a
+                    // type they cannot describe, so each lookup is guarded individually rather
+                    // than letting one bad codec discard the whole probe.
+                    runCatching {
+                        info.getCapabilitiesForType(mime).videoCapabilities?.supportedHeights?.upper
+                    }.getOrNull()
+                }.maxOrNull()
+        }.getOrElse { error ->
+            Timber.tag("VideoDecoder").w(error, "MediaCodecList probe failed")
+            null
+        }?.takeIf { it > 0 } ?: FALLBACK_MAX_HEIGHT
+}
+
+/**
+ * Format a video height (in px) as a human-readable label.
+ *
+ * `4320 → "4320p (8K)"`, `2160 → "2160p (4K)"`, `1440 → "1440p (QHD)"`, `1080 → "1080p (FHD)"`,
+ * `720 → "720p (HD)"`, `480 → "480p (SD)"`, anything else → bare `"<h>p"`.
+ */
+internal fun formatHeightLabel(height: Int): String {
+    val qualityName =
+        when (height) {
+            4320 -> " (8K)"
+            2160 -> " (4K)"
+            1440 -> " (QHD)"
+            1080 -> " (FHD)"
+            720 -> " (HD)"
+            480 -> " (SD)"
+            else -> ""
+        }
+    return "${height}p$qualityName"
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualitySheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualitySheet.kt
@@ -9,6 +9,7 @@
 
 package moe.rukamori.archivetune.ui.player
 
+import android.content.res.Configuration
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
@@ -44,11 +45,63 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import moe.rukamori.archivetune.constants.VideoAspectRatio
 import moe.rukamori.archivetune.R
+
+/**
+ * Row/title spacing for the sheets in this file.
+ *
+ * In landscape — which is the orientation the fullscreen video overlay locks to — the whole screen
+ * is only ~360dp tall, so a sheet laid out with the portrait metrics (24/12dp padding plus a
+ * description line under every row) is taller than the space it has and ends up scrolling the
+ * three quality modes. [compact] trades the descriptions and half the padding for fitting, which
+ * is the right call there: the row titles already name the modes.
+ */
+private data class SheetMetrics(
+    val horizontalPadding: Dp,
+    val rowVerticalPadding: Dp,
+    val titleBottomPadding: Dp,
+    val dividerVerticalPadding: Dp,
+    val listMaxHeight: Dp,
+    val showDescriptions: Boolean,
+)
+
+/**
+ * True when the sheet should use [SheetMetrics] compact spacing. Derived from the orientation
+ * rather than passed in, so both the inline player and the fullscreen overlay get it without
+ * either having to know about it.
+ */
+@Composable
+private fun rememberSheetMetrics(): SheetMetrics {
+    val landscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+    return remember(landscape) {
+        if (landscape) {
+            SheetMetrics(
+                horizontalPadding = 20.dp,
+                rowVerticalPadding = 6.dp,
+                titleBottomPadding = 4.dp,
+                dividerVerticalPadding = 2.dp,
+                listMaxHeight = 168.dp,
+                showDescriptions = false,
+            )
+        } else {
+            SheetMetrics(
+                horizontalPadding = 24.dp,
+                rowVerticalPadding = 12.dp,
+                titleBottomPadding = 12.dp,
+                dividerVerticalPadding = 8.dp,
+                listMaxHeight = 320.dp,
+                showDescriptions = true,
+            )
+        }
+    }
+}
 
 /**
  * Video-quality picker, presented as a bottom sheet that slides up from the bottom of the screen.
@@ -109,6 +162,7 @@ private fun VideoQualitySheetContent(
     onSelect: (Int?) -> Unit,
 ) {
     var advancedOpen by remember { mutableStateOf(VideoQualityPreference.isExactHeight(preferredHeight)) }
+    val metrics = rememberSheetMetrics()
 
     AnimatedContent(
         targetState = advancedOpen,
@@ -136,6 +190,7 @@ private fun VideoQualitySheetContent(
                 AdvancedQualityPage(
                     preferredHeight = preferredHeight,
                     availableHeights = availableHeights,
+                    metrics = metrics,
                     onBack = { advancedOpen = false },
                     onSelect = onSelect,
                 )
@@ -143,6 +198,7 @@ private fun VideoQualitySheetContent(
                 MainQualityPage(
                     preferredHeight = preferredHeight,
                     selectedHeight = selectedHeight,
+                    metrics = metrics,
                     onSelect = onSelect,
                     onOpenAdvanced = { advancedOpen = true },
                 )
@@ -156,61 +212,78 @@ private fun VideoQualitySheetContent(
 private fun MainQualityPage(
     preferredHeight: Int?,
     selectedHeight: Int?,
+    metrics: SheetMetrics,
     onSelect: (Int?) -> Unit,
     onOpenAdvanced: () -> Unit,
 ) {
     // The resolved resolution is only worth showing next to the mode that produced it — repeating
-    // "Playing at 1080p" under all three rows would read as if all three were active.
+    // "Playing at 1080p" under all three rows would read as if all three were active. It survives
+    // the compact layout even though the static descriptions do not: it is the one subtitle that
+    // says something the row title cannot.
     val playingLabel = selectedHeight?.let { stringResource(R.string.video_quality_current, formatHeightLabel(it)) }
 
-    SheetTitle(stringResource(R.string.video_quality))
+    fun subtitleFor(
+        active: Boolean,
+        description: String,
+    ) = when {
+        active && playingLabel != null -> playingLabel
+        metrics.showDescriptions -> description
+        else -> null
+    }
+
+    SheetTitle(stringResource(R.string.video_quality), metrics)
 
     QualityRow(
         title = stringResource(R.string.video_quality_mode_auto),
-        subtitle =
-            if (preferredHeight == null && playingLabel != null) {
-                playingLabel
-            } else {
-                stringResource(R.string.video_quality_mode_auto_desc)
-            },
+        subtitle = subtitleFor(preferredHeight == null, stringResource(R.string.video_quality_mode_auto_desc)),
         selected = preferredHeight == null,
+        metrics = metrics,
         onClick = { onSelect(null) },
     )
     QualityRow(
         title = stringResource(R.string.video_quality_mode_data_saver),
         subtitle =
-            if (preferredHeight == VideoQualityPreference.DATA_SAVER && playingLabel != null) {
-                playingLabel
-            } else {
-                stringResource(R.string.video_quality_mode_data_saver_desc)
-            },
+            subtitleFor(
+                preferredHeight == VideoQualityPreference.DATA_SAVER,
+                stringResource(R.string.video_quality_mode_data_saver_desc),
+            ),
         selected = preferredHeight == VideoQualityPreference.DATA_SAVER,
+        metrics = metrics,
         onClick = { onSelect(VideoQualityPreference.DATA_SAVER) },
     )
     QualityRow(
         title = stringResource(R.string.video_quality_mode_high),
         subtitle =
-            if (preferredHeight == VideoQualityPreference.HIGH_QUALITY && playingLabel != null) {
-                playingLabel
-            } else {
-                stringResource(R.string.video_quality_mode_high_desc)
-            },
+            subtitleFor(
+                preferredHeight == VideoQualityPreference.HIGH_QUALITY,
+                stringResource(R.string.video_quality_mode_high_desc),
+            ),
         selected = preferredHeight == VideoQualityPreference.HIGH_QUALITY,
+        metrics = metrics,
         onClick = { onSelect(VideoQualityPreference.HIGH_QUALITY) },
     )
 
-    HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
+    HorizontalDivider(
+        modifier =
+            Modifier.padding(
+                horizontal = metrics.horizontalPadding,
+                vertical = metrics.dividerVerticalPadding,
+            ),
+    )
 
     val exactHeight = preferredHeight?.takeIf { VideoQualityPreference.isExactHeight(it) }
     QualityRow(
         title = stringResource(R.string.video_quality_advanced),
+        // The exact-height subtitle is the current selection, so it stays in the compact layout
+        // for the same reason playingLabel does.
         subtitle =
-            if (exactHeight != null) {
-                formatHeightLabel(exactHeight)
-            } else {
-                stringResource(R.string.video_quality_advanced_desc)
+            when {
+                exactHeight != null -> formatHeightLabel(exactHeight)
+                metrics.showDescriptions -> stringResource(R.string.video_quality_advanced_desc)
+                else -> null
             },
         selected = exactHeight != null,
+        metrics = metrics,
         onClick = onOpenAdvanced,
         // A chevron rather than a checkmark: this row navigates, it does not itself apply a
         // quality. The `selected` tint still marks it when an exact height is in force.
@@ -223,11 +296,12 @@ private fun MainQualityPage(
 private fun AdvancedQualityPage(
     preferredHeight: Int?,
     availableHeights: List<Int>,
+    metrics: SheetMetrics,
     onBack: () -> Unit,
     onSelect: (Int?) -> Unit,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(start = 8.dp, end = 24.dp),
+        modifier = Modifier.fillMaxWidth().padding(start = 8.dp, end = metrics.horizontalPadding),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = onBack) {
@@ -251,7 +325,11 @@ private fun AdvancedQualityPage(
             text = stringResource(R.string.video_quality_unavailable_on_device),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+            modifier =
+                Modifier.padding(
+                    horizontal = metrics.horizontalPadding,
+                    vertical = metrics.rowVerticalPadding,
+                ),
         )
     } else {
         // Capped height + scroll: an 8K video offers ~11 resolutions, which is taller than a
@@ -259,7 +337,7 @@ private fun AdvancedQualityPage(
         Column(
             modifier =
                 Modifier
-                    .heightIn(max = 320.dp)
+                    .heightIn(max = metrics.listMaxHeight)
                     .verticalScroll(rememberScrollState()),
         ) {
             availableHeights.sortedDescending().forEach { height ->
@@ -267,6 +345,7 @@ private fun AdvancedQualityPage(
                     title = formatHeightLabel(height),
                     subtitle = null,
                     selected = preferredHeight == height,
+                    metrics = metrics,
                     onClick = { onSelect(height) },
                 )
             }
@@ -274,13 +353,77 @@ private fun AdvancedQualityPage(
     }
 }
 
+/**
+ * Aspect-ratio picker, presented as the same bottom sheet as [VideoQualitySheet].
+ *
+ * The fullscreen overlay used to anchor a [androidx.compose.material3.DropdownMenu] to the
+ * aspect-ratio button in the top-right pill, which had the same two problems the quality dropdown
+ * had: it opened in the corner furthest from the thumb in landscape, and it looked nothing like the
+ * quality picker sitting next to it. Sharing this sheet makes the two controls behave alike.
+ */
 @Composable
-private fun SheetTitle(text: String) {
+internal fun VideoAspectRatioSheet(
+    aspectRatio: VideoAspectRatio,
+    onAspectRatioChange: (VideoAspectRatio) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val metrics = rememberSheetMetrics()
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(bottom = 12.dp),
+        ) {
+            SheetTitle(stringResource(R.string.video_aspect_ratio), metrics)
+            VideoAspectRatio.entries.forEach { ratio ->
+                QualityRow(
+                    title = stringResource(ratio.labelRes),
+                    subtitle = null,
+                    selected = ratio == aspectRatio,
+                    metrics = metrics,
+                    onClick = {
+                        onAspectRatioChange(ratio)
+                        onDismissRequest()
+                    },
+                )
+            }
+        }
+    }
+}
+
+/** Label for each aspect-ratio mode. Kept next to the sheet that renders them. */
+private val VideoAspectRatio.labelRes: Int
+    get() =
+        when (this) {
+            VideoAspectRatio.FIT -> R.string.video_aspect_fit
+            VideoAspectRatio.CROP -> R.string.video_aspect_crop
+            VideoAspectRatio.STRETCH -> R.string.video_aspect_stretch
+            VideoAspectRatio.FILL -> R.string.video_aspect_fill
+        }
+
+@Composable
+private fun SheetTitle(
+    text: String,
+    metrics: SheetMetrics,
+) {
     Text(
         text = text,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.SemiBold,
-        modifier = Modifier.padding(start = 24.dp, end = 24.dp, top = 4.dp, bottom = 12.dp),
+        modifier =
+            Modifier.padding(
+                start = metrics.horizontalPadding,
+                end = metrics.horizontalPadding,
+                top = 4.dp,
+                bottom = metrics.titleBottomPadding,
+            ),
     )
 }
 
@@ -293,6 +436,7 @@ private fun QualityRow(
     title: String,
     subtitle: String?,
     selected: Boolean,
+    metrics: SheetMetrics,
     onClick: () -> Unit,
     @DrawableRes trailingIcon: Int? = null,
 ) {
@@ -301,7 +445,10 @@ private fun QualityRow(
             Modifier
                 .fillMaxWidth()
                 .clickable(onClick = onClick)
-                .padding(horizontal = 24.dp, vertical = 12.dp),
+                .padding(
+                    horizontal = metrics.horizontalPadding,
+                    vertical = metrics.rowVerticalPadding,
+                ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualitySheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualitySheet.kt
@@ -1,0 +1,373 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.player
+
+import androidx.annotation.DrawableRes
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import moe.rukamori.archivetune.R
+
+/**
+ * Video-quality picker, presented as a bottom sheet that slides up from the bottom of the screen.
+ *
+ * Replaces the [androidx.compose.material3.DropdownMenu] the quality button used to anchor. The
+ * dropdown had two problems in the fullscreen overlay: it opened as a small popup pinned under the
+ * button in the top-right corner (awkward to reach one-handed in landscape) and it listed every
+ * raw resolution with no notion of intent, so "just give me the best" and "don't eat my data" both
+ * required knowing which number to pick.
+ *
+ * The sheet has two pages:
+ *  - the **main page** offers the three intents — Auto, Data saver, High quality — plus a row that
+ *    opens Advanced,
+ *  - the **Advanced page** lists every resolution this device can decode, so an exact pick
+ *    (144p … 4320p) is still one tap away.
+ *
+ * @param preferredHeight current choice, encoded per [VideoQualityPreference].
+ * @param availableHeights resolutions YouTube offered for this video that the device can decode,
+ *   ascending. Drives the Advanced page.
+ * @param selectedHeight the resolution actually playing, shown as a subtitle so the modes report
+ *   what they resolved to.
+ */
+@Composable
+internal fun VideoQualitySheet(
+    preferredHeight: Int?,
+    availableHeights: List<Int>,
+    selectedHeight: Int?,
+    onPreferredHeightChange: (Int?) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        VideoQualitySheetContent(
+            preferredHeight = preferredHeight,
+            availableHeights = availableHeights,
+            selectedHeight = selectedHeight,
+            onSelect = { choice ->
+                onPreferredHeightChange(choice)
+                onDismissRequest()
+            },
+        )
+    }
+}
+
+/**
+ * Body of [VideoQualitySheet]. Split out so the two pages can swap in place without the sheet
+ * itself being torn down and re-animated.
+ */
+@Composable
+private fun VideoQualitySheetContent(
+    preferredHeight: Int?,
+    availableHeights: List<Int>,
+    selectedHeight: Int?,
+    onSelect: (Int?) -> Unit,
+) {
+    var advancedOpen by remember { mutableStateOf(VideoQualityPreference.isExactHeight(preferredHeight)) }
+
+    AnimatedContent(
+        targetState = advancedOpen,
+        transitionSpec = {
+            // Slide the way the navigation runs: forward into Advanced, backward out of it.
+            val direction = if (targetState) 1 else -1
+            (
+                slideInHorizontally(tween(220)) { width -> direction * width / 3 } +
+                    fadeIn(tween(220))
+            ) togetherWith (
+                slideOutHorizontally(tween(220)) { width -> -direction * width / 3 } +
+                    fadeOut(tween(160))
+            )
+        },
+        label = "video-quality-sheet-page",
+    ) { showAdvanced ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(bottom = 12.dp),
+        ) {
+            if (showAdvanced) {
+                AdvancedQualityPage(
+                    preferredHeight = preferredHeight,
+                    availableHeights = availableHeights,
+                    onBack = { advancedOpen = false },
+                    onSelect = onSelect,
+                )
+            } else {
+                MainQualityPage(
+                    preferredHeight = preferredHeight,
+                    selectedHeight = selectedHeight,
+                    onSelect = onSelect,
+                    onOpenAdvanced = { advancedOpen = true },
+                )
+            }
+        }
+    }
+}
+
+/** Auto / Data saver / High quality, plus the row that opens the Advanced page. */
+@Composable
+private fun MainQualityPage(
+    preferredHeight: Int?,
+    selectedHeight: Int?,
+    onSelect: (Int?) -> Unit,
+    onOpenAdvanced: () -> Unit,
+) {
+    // The resolved resolution is only worth showing next to the mode that produced it — repeating
+    // "Playing at 1080p" under all three rows would read as if all three were active.
+    val playingLabel = selectedHeight?.let { stringResource(R.string.video_quality_current, formatHeightLabel(it)) }
+
+    SheetTitle(stringResource(R.string.video_quality))
+
+    QualityRow(
+        title = stringResource(R.string.video_quality_mode_auto),
+        subtitle =
+            if (preferredHeight == null && playingLabel != null) {
+                playingLabel
+            } else {
+                stringResource(R.string.video_quality_mode_auto_desc)
+            },
+        selected = preferredHeight == null,
+        onClick = { onSelect(null) },
+    )
+    QualityRow(
+        title = stringResource(R.string.video_quality_mode_data_saver),
+        subtitle =
+            if (preferredHeight == VideoQualityPreference.DATA_SAVER && playingLabel != null) {
+                playingLabel
+            } else {
+                stringResource(R.string.video_quality_mode_data_saver_desc)
+            },
+        selected = preferredHeight == VideoQualityPreference.DATA_SAVER,
+        onClick = { onSelect(VideoQualityPreference.DATA_SAVER) },
+    )
+    QualityRow(
+        title = stringResource(R.string.video_quality_mode_high),
+        subtitle =
+            if (preferredHeight == VideoQualityPreference.HIGH_QUALITY && playingLabel != null) {
+                playingLabel
+            } else {
+                stringResource(R.string.video_quality_mode_high_desc)
+            },
+        selected = preferredHeight == VideoQualityPreference.HIGH_QUALITY,
+        onClick = { onSelect(VideoQualityPreference.HIGH_QUALITY) },
+    )
+
+    HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
+
+    val exactHeight = preferredHeight?.takeIf { VideoQualityPreference.isExactHeight(it) }
+    QualityRow(
+        title = stringResource(R.string.video_quality_advanced),
+        subtitle =
+            if (exactHeight != null) {
+                formatHeightLabel(exactHeight)
+            } else {
+                stringResource(R.string.video_quality_advanced_desc)
+            },
+        selected = exactHeight != null,
+        onClick = onOpenAdvanced,
+        // A chevron rather than a checkmark: this row navigates, it does not itself apply a
+        // quality. The `selected` tint still marks it when an exact height is in force.
+        trailingIcon = R.drawable.navigate_next,
+    )
+}
+
+/** Every resolution the device can decode for this video, tallest first. */
+@Composable
+private fun AdvancedQualityPage(
+    preferredHeight: Int?,
+    availableHeights: List<Int>,
+    onBack: () -> Unit,
+    onSelect: (Int?) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(start = 8.dp, end = 24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                painter = painterResource(R.drawable.arrow_back),
+                contentDescription = stringResource(R.string.video_quality_back),
+            )
+        }
+        Text(
+            text = stringResource(R.string.video_quality_advanced_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+
+    if (availableHeights.isEmpty()) {
+        // Reached only if the device's decoders reject every format YouTube listed. The mode rows
+        // on the main page still work (they clamp to whatever plays), so say why the list is empty
+        // rather than showing a blank sheet.
+        Text(
+            text = stringResource(R.string.video_quality_unavailable_on_device),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
+        )
+    } else {
+        // Capped height + scroll: an 8K video offers ~11 resolutions, which is taller than a
+        // landscape sheet can show.
+        Column(
+            modifier =
+                Modifier
+                    .heightIn(max = 320.dp)
+                    .verticalScroll(rememberScrollState()),
+        ) {
+            availableHeights.sortedDescending().forEach { height ->
+                QualityRow(
+                    title = formatHeightLabel(height),
+                    subtitle = null,
+                    selected = preferredHeight == height,
+                    onClick = { onSelect(height) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SheetTitle(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(start = 24.dp, end = 24.dp, top = 4.dp, bottom = 12.dp),
+    )
+}
+
+/**
+ * One selectable row: title, optional subtitle, and a trailing checkmark (or [trailingIcon]) when
+ * this row is the active choice.
+ */
+@Composable
+private fun QualityRow(
+    title: String,
+    subtitle: String?,
+    selected: Boolean,
+    onClick: () -> Unit,
+    @DrawableRes trailingIcon: Int? = null,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 24.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                color =
+                    if (selected) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+            )
+            if (subtitle != null) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        when {
+            trailingIcon != null ->
+                Icon(
+                    painter = painterResource(trailingIcon),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+
+            selected ->
+                Icon(
+                    painter = painterResource(R.drawable.check),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+        }
+    }
+}
+
+/**
+ * Short label for the quality button in the control pill, so the pill itself reports the current
+ * choice instead of only opening the sheet.
+ *
+ * Modes report the resolution they resolved to when it is known ("Auto" alone tells the user
+ * nothing about what they are actually watching); an exact pick reports its own height.
+ */
+@Composable
+internal fun videoQualityPillLabel(
+    preferredHeight: Int?,
+    selectedHeight: Int?,
+): String =
+    when {
+        VideoQualityPreference.isExactHeight(preferredHeight) -> "${preferredHeight}p"
+        selectedHeight != null -> "${selectedHeight}p"
+        preferredHeight == VideoQualityPreference.DATA_SAVER ->
+            stringResource(R.string.video_quality_mode_data_saver)
+
+        preferredHeight == VideoQualityPreference.HIGH_QUALITY ->
+            stringResource(R.string.video_quality_mode_high)
+
+        else -> stringResource(R.string.video_quality_mode_auto)
+    }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -78,6 +79,7 @@ private val HomeSectionSpacing = 28.dp
 fun HomeScreen(
     navController: NavController,
     headerScrollConnection: NestedScrollConnection? = null,
+    listState: LazyListState? = null,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -88,7 +90,7 @@ fun HomeScreen(
     val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
 
-    val lazyListState = rememberLazyListState()
+    val lazyListState = listState ?: rememberLazyListState()
     val forgottenFavoritesGridState = rememberLazyGridState()
     val scope = rememberCoroutineScope()
     val backStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -116,12 +117,18 @@ fun NavGraphBuilder.navigationBuilder(
     onClearUpdateBadge: () -> Unit = {},
     onSearchQuery: (String) -> Unit = {},
     onVoiceSearch: () -> Unit = {},
+    homeListState: LazyListState? = null,
+    searchListState: LazyListState? = null,
     homeScrollConnection: NestedScrollConnection? = null,
     searchScrollConnection: NestedScrollConnection? = null,
     onlineSearchSort: OnlineSearchSort = OnlineSearchSort.DEFAULT,
 ) {
     composable(Screens.Home.route) {
-        HomeScreen(navController, headerScrollConnection = homeScrollConnection)
+        HomeScreen(
+            navController,
+            headerScrollConnection = homeScrollConnection,
+            listState = homeListState,
+        )
     }
     composable(
         Screens.Library.route,
@@ -134,6 +141,7 @@ fun NavGraphBuilder.navigationBuilder(
             onSearchQuery = onSearchQuery,
             onVoiceSearch = onVoiceSearch,
             headerScrollConnection = searchScrollConnection,
+            listState = searchListState,
         )
     }
     composable("local_songs") {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
@@ -31,6 +31,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.spotify.SpotifyLibraryViewModel
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
+import moe.rukamori.archivetune.ui.component.SpotifyLikedSongsListItem
 import moe.rukamori.archivetune.ui.component.SpotifyLibraryPlaylistListItem
 
 @Composable
@@ -64,6 +65,10 @@ fun LibrarySpotifyPlaylistsScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             modifier = Modifier.fillMaxSize(),
         ) {
+            item(key = "spotify_liked_songs", contentType = "spotify_liked_songs") {
+                SpotifyLikedSongsListItem(navController = navController)
+            }
+
             if (playlists.isEmpty()) {
                 item(key = "spotify_empty", contentType = "spotify_empty") {
                     Text(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -84,6 +84,7 @@ import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.spotify.SpotifyMapper
 import moe.rukamori.archivetune.spotify.SpotifyDownloadItem
+import moe.rukamori.archivetune.spotify.SPOTIFY_LIKED_SONGS_ID
 import moe.rukamori.archivetune.spotify.SpotifyPlaybackResolver
 import moe.rukamori.archivetune.spotify.SpotifyPlaylistEvent
 import moe.rukamori.archivetune.spotify.SpotifyPlaylistQueue
@@ -435,7 +436,12 @@ fun SpotifyPlaylistScreen(
                         MediaDetailHero(
                             title = currentPlaylist.name,
                             thumbnailUrl = thumbnailUrl,
-                            fallbackIcon = R.drawable.queue_music,
+                            fallbackIcon =
+                                if (currentPlaylist.id == SPOTIFY_LIKED_SONGS_ID) {
+                                    R.drawable.favorite
+                                } else {
+                                    R.drawable.queue_music
+                                },
                             systemBarsTopPadding = systemBarsTopPadding,
                             subtitle =
                                 currentPlaylist.owner

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/OnlineSearchNavigation.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/OnlineSearchNavigation.kt
@@ -7,8 +7,8 @@
 
 package moe.rukamori.archivetune.ui.screens.search
 
-import android.util.Base64
 import moe.rukamori.archivetune.constants.SearchProvider
+import java.util.Base64
 
 internal const val OnlineSearchResultRoute = "search/{encodedQuery}?provider={provider}"
 internal const val OnlineSearchResultRoutePrefix = "search/"
@@ -16,8 +16,17 @@ internal const val OnlineSearchResultArgument = "encodedQuery"
 internal const val OnlineSearchProviderArgument = "provider"
 
 private const val EmptyOnlineSearchQuery = "~"
-private val OnlineSearchQueryEncodingFlags =
-    Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING
+
+// java.util.Base64 (API 26+, and minSdk is 26) rather than android.util.Base64.
+// Route building is pure string logic with no reason to touch the framework, and
+// android.util.Base64 is a stub in JVM unit tests — it threw "not mocked" and took
+// OnlineSearchNavigationTest with it.
+//
+// Byte-for-byte identical to the previous URL_SAFE or NO_WRAP or NO_PADDING flags:
+// getUrlEncoder() is the same RFC 4648 §5 alphabet ('-' and '_'), it does not wrap,
+// and withoutPadding() drops the '='. So routes encoded by older builds still decode.
+private val OnlineSearchQueryEncoder: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
+private val OnlineSearchQueryDecoder: Base64.Decoder = Base64.getUrlDecoder()
 
 internal fun onlineSearchResultRoute(
     query: String,
@@ -27,10 +36,7 @@ internal fun onlineSearchResultRoute(
         if (query.isEmpty()) {
             EmptyOnlineSearchQuery
         } else {
-            Base64.encodeToString(
-                query.toByteArray(Charsets.UTF_8),
-                OnlineSearchQueryEncodingFlags,
-            )
+            OnlineSearchQueryEncoder.encodeToString(query.toByteArray(Charsets.UTF_8))
         }
 
     return "$OnlineSearchResultRoutePrefix$encodedQuery?provider=${provider.name}"
@@ -42,7 +48,7 @@ internal fun decodeOnlineSearchQuery(encodedQuery: String): String =
     } else {
         runCatching {
             String(
-                Base64.decode(encodedQuery, OnlineSearchQueryEncodingFlags),
+                OnlineSearchQueryDecoder.decode(encodedQuery),
                 Charsets.UTF_8,
             )
         }.getOrElse {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/search/SearchScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -128,6 +129,7 @@ fun SearchScreen(
     onSearchQuery: (String) -> Unit,
     onVoiceSearch: () -> Unit = {},
     headerScrollConnection: NestedScrollConnection? = null,
+    listState: LazyListState? = null,
     viewModel: SearchDiscoveryViewModel = hiltViewModel(),
     historyViewModel: SearchHistoryViewModel = hiltViewModel(),
 ) {
@@ -139,7 +141,7 @@ fun SearchScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val selectedTab by viewModel.selectedTab.collectAsStateWithLifecycle()
     val recentSearches by historyViewModel.recentSearches.collectAsStateWithLifecycle()
-    val lazyListState = rememberLazyListState()
+    val lazyListState = listState ?: rememberLazyListState()
     val safeTopPadding = WindowInsets.safeDrawing.asPaddingValues().calculateTopPadding()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val scrollToTop =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
@@ -309,7 +309,11 @@ private fun DiscordDebugSection() {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                // weight(1f) keeps the trailing status chip at its intrinsic width. Without it a
+                // long localized subtitle consumes the whole row and the chip's Text is measured
+                // with near-zero width, wrapping "ACTIVE" one letter per line.
                 Row(
+                    modifier = Modifier.weight(1f),
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -342,6 +346,8 @@ private fun DiscordDebugSection() {
                             text = stringResource(R.string.discord_integration),
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                         Text(
                             text =
@@ -351,6 +357,8 @@ private fun DiscordDebugSection() {
                                     stringResource(R.string.presence_manager_stopped)
                                 },
                             style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                             color =
                                 if (isRunning) {
                                     MaterialTheme.colorScheme.primary

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
@@ -402,6 +402,7 @@ private fun DownloadSource.displayName(context: android.content.Context): String
     when (this) {
         DownloadSource.AUTO -> context.getString(R.string.download_source_auto)
         DownloadSource.QOBUZ -> context.getString(R.string.download_source_qobuz)
+        DownloadSource.QOBUZ_BACKUP -> context.getString(R.string.source_qobuz_backup)
         DownloadSource.TIDAL -> context.getString(R.string.download_source_tidal)
         DownloadSource.DEEZER -> context.getString(R.string.download_source_deezer)
         DownloadSource.JIOSAAVN -> context.getString(R.string.download_source_jiosaavn)
@@ -412,6 +413,7 @@ private fun DownloadSource.displayName(): String =
     when (this) {
         DownloadSource.AUTO -> "Auto"
         DownloadSource.QOBUZ -> "Qobuz"
+        DownloadSource.QOBUZ_BACKUP -> "Qobuz Backup"
         DownloadSource.TIDAL -> "Tidal"
         DownloadSource.DEEZER -> "Deezer"
         DownloadSource.JIOSAAVN -> "JioSaavn"
@@ -422,6 +424,7 @@ private fun DownloadSource.iconRes(): Int =
     when (this) {
         DownloadSource.AUTO -> R.drawable.download
         DownloadSource.QOBUZ -> R.drawable.provider_qobuz
+        DownloadSource.QOBUZ_BACKUP -> R.drawable.provider_qobuz
         DownloadSource.TIDAL -> R.drawable.provider_tidal
         DownloadSource.DEEZER -> R.drawable.provider_deezer
         DownloadSource.JIOSAAVN -> R.drawable.provider_jiosaavn

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -74,6 +75,7 @@ import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.ui.component.*
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.ProxyUtils
+import moe.rukamori.archivetune.utils.dataStore
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import okhttp3.OkHttpClient
@@ -305,6 +307,15 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
                             // the process. 400ms is enough for DataStore to flush and for
                             // the Toast to animate in.
                             scope.launch {
+                                // Drop the persisted visitorData too, not just the in-memory copy
+                                // above: App.kt restores YouTube.authState from DataStore on every
+                                // start, so an in-memory null was undone by the very restart this
+                                // handler schedules and the old region-pinned token came straight
+                                // back. Removing the key makes App.kt mint a fresh one against the
+                                // new region. The login cookie and dataSyncId are untouched.
+                                withContext(Dispatchers.IO) {
+                                    context.dataStore.edit { it.remove(VisitorDataKey) }
+                                }
                                 withContext(Dispatchers.Main) {
                                     Toast.makeText(
                                         context,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -549,6 +549,19 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
                                     loadingIpRotation = true
                                     try {
                                         YouTube.enableIpRotation()
+                                        // enableIpRotation() succeeds even when every candidate
+                                        // proxy failed validation, which used to leave the switch
+                                        // on and the description stuck at "0 active proxies" with
+                                        // no explanation. Revert and say what happened instead.
+                                        if (YouTube.ipRotationActiveCount.value == 0) {
+                                            YouTube.disableIpRotation()
+                                            onIpRotationEnabledChange(false)
+                                            Toast.makeText(
+                                                context,
+                                                context.getString(R.string.ip_rotation_no_proxies),
+                                                Toast.LENGTH_LONG,
+                                            ).show()
+                                        }
                                     } catch (_: Exception) {
                                         onIpRotationEnabledChange(false)
                                     } finally {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -198,7 +198,7 @@ fun LyricsSettings(
     val (showPlayerControls, onShowPlayerControlsChange) =
         rememberPreference(ShowLyricsPlayerControlsKey, defaultValue = true)
     val (autoHidePlayerControls, onAutoHidePlayerControlsChange) =
-        rememberPreference(AutoHideLyricsPlayerControlsKey, defaultValue = false)
+        rememberPreference(AutoHideLyricsPlayerControlsKey, defaultValue = true)
     val (lyricsRomanizeJapanese, onLyricsRomanizeJapaneseChange) = rememberPreference(LyricsRomanizeJapaneseKey, defaultValue = false)
     val (lyricsRomanizeKorean, onLyricsRomanizeKoreanChange) = rememberPreference(LyricsRomanizeKoreanKey, defaultValue = true)
     val (lyricsRomanizeChinese, onLyricsRomanizeChineseChange) = rememberPreference(LyricsRomanizeChineseKey, defaultValue = true)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlaybackSourceSections.kt
@@ -127,7 +127,7 @@ private fun AudioSourceType.iconRes(): Int =
  * scroll state the host owns.
  */
 @Composable
-fun PlaybackSourceSections(
+internal fun PlaybackSourceSections(
     navController: NavController,
     positions: PreferencePositions,
 ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -458,7 +458,7 @@ fun buildSettingsGroups(
                 SettingsChild("Lyrics click to seek", "lyrics_click", listOf("click lyrics", "tap lyrics", "seek lyrics")) { SearchResultSwitch(LyricsClickKey, false) },
                 SettingsChild("Lyrics auto-scroll", "lyrics_scroll", listOf("scroll", "auto scroll", "lyrics scroll")) { SearchResultSwitch(LyricsScrollKey, true) },
                 SettingsChild("Show lyrics player controls", "show_lyrics_player_controls", listOf("player controls", "lyrics controls")) { SearchResultSwitch(ShowLyricsPlayerControlsKey, true) },
-                SettingsChild("Auto-hide lyrics controls", "auto_hide_lyrics_player_controls", listOf("auto hide", "lyrics controls", "controls timeout", "5 seconds")) { SearchResultSwitch(AutoHideLyricsPlayerControlsKey, false) },
+                SettingsChild("Auto-hide lyrics controls", "auto_hide_lyrics_player_controls", listOf("auto hide", "lyrics controls", "controls timeout", "5 seconds")) { SearchResultSwitch(AutoHideLyricsPlayerControlsKey, true) },
                 SettingsChild("Preload queue lyrics", "preload_queue_lyrics", listOf("preload", "preload lyrics", "queue lyrics", "preload count", "queue lyrics count", "preload amount", "preload size")),
                 SettingsChild("Lyrics background style", "lyrics_background_style", listOf("lyrics background", "lyrics bg")),
                 SettingsChild("BetterLyrics", "betterlyrics", listOf("betterlyrics", "better lyrics", "better lyrics provider")),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceCheckService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceCheckService.kt
@@ -13,6 +13,7 @@ import moe.rukamori.archivetune.constants.AudioSourceType
 import moe.rukamori.archivetune.jiosaavn.SaavnService
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
+import moe.rukamori.archivetune.tidal.TidalAccountManager
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.utils.PoolAccountManager
 import okhttp3.OkHttpClient
@@ -33,8 +34,9 @@ data class SourceCheckResult(
  * Per-source health probe for the "Check source" row in Source Settings.
  *
  * Each source has different infrastructure, so each has its own probe:
- *  - Tidal: refresh the source pool, count Tidal accounts, then probe one
- *    Tidal instance health. Reports counts + the verdict.
+ *  - Tidal: refresh the source pool, count Tidal accounts, verify the first
+ *    premium pool token against the official Tidal API (this is the path that
+ *    actually streams), and report public instances as the optional fallback.
  *  - Qobuz: refresh the pool, count Qobuz accounts (premium first), then
  *    try a real user/get call on the first pool token to verify it works.
  *  - Qobuz backup: ping https://mlc.kouzu.in/api/stream?id=<test_id> with a
@@ -92,20 +94,60 @@ object SourceCheckService {
             )
         }
         val premium = accounts.count { it.premium }
-        // Probe Tidal instance health — the manager caches the verified list.
+
+        // Probe the path that actually streams. LosslessStreamResolver.resolveTidal tries the
+        // official Tidal API with the pool's subscriber tokens FIRST and only falls back to public
+        // HiFi/QQDL instances if every account fails — so a valid premium token means Tidal works
+        // with zero instances. Reporting the instance count as the headline verdict (as this check
+        // used to) told users Tidal was broken while it was streaming fine.
+        val probeAccount = accounts.firstOrNull { it.premium } ?: accounts.first()
+        val session = runCatching { TidalAccountManager.buildSessionFromBearer(probeAccount.token) }.getOrNull()
+        val subscription =
+            session?.userId?.let { userId ->
+                runCatching { TidalAccountManager.fetchSubscription(probeAccount.token, userId) }.getOrNull()
+            }
+        val accountLabel =
+            when {
+                session == null -> "token rejected by the Tidal API (expired — refresh the source pool)"
+                subscription == TidalAccountManager.Subscription.PREMIUM -> "valid (premium — lossless available)"
+                subscription == TidalAccountManager.Subscription.FREE -> "valid but FREE (previews only, no lossless)"
+                else -> "valid, subscription tier unknown"
+            }
+        val accountPathReady = session != null && subscription != TidalAccountManager.Subscription.FREE
+
+        // Instances are the optional no-account fallback. Report them as such.
         val healthyInstances = runCatching {
             moe.rukamori.archivetune.tidal.TidalInstanceHealthManager.healthyUrls(context).size
         }.getOrDefault(0)
+
         val summary = buildString {
             append("Pool accounts: ${accounts.size} ($premium premium)\n")
-            append("Healthy Tidal instances: $healthyInstances")
-            if (healthyInstances == 0 && accounts.isNotEmpty()) {
-                append("\n\nAccounts are loaded but no Tidal instance is reachable. " +
-                    "Tap 'Refresh source pool' to re-verify, or add a private Tidal instance via Integration.")
+            append("Account stream path: $accountLabel\n")
+            append("Public instances (optional fallback): $healthyInstances healthy")
+            if (accountPathReady) {
+                append("\n\nTidal source is READY via the account path.")
+                if (healthyInstances == 0) {
+                    append(
+                        " No public instance is reachable, but none is needed — " +
+                            "the pool's subscriber token streams directly from Tidal.",
+                    )
+                }
+            } else {
+                append("\n\nTidal source is NOT ready: ")
+                append(
+                    if (healthyInstances > 0) {
+                        "the account path failed, so playback will fall back to a public instance " +
+                            "(lower quality, may serve previews)."
+                    } else {
+                        "the account path failed and no public instance is reachable. " +
+                            "Tap 'Refresh source pool' to pull fresh tokens, or add a private " +
+                            "Tidal instance via Integration."
+                    },
+                )
             }
         }
         return SourceCheckResult(
-            healthy = accounts.isNotEmpty() && (healthyInstances > 0 || accounts.any { it.premium }),
+            healthy = accountPathReady || healthyInstances > 0,
             summary = summary,
         )
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/PlaybackAuthPreferences.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/PlaybackAuthPreferences.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.flow.first
 import moe.rukamori.archivetune.constants.AccountChannelHandleKey
 import moe.rukamori.archivetune.constants.AccountEmailKey
+import moe.rukamori.archivetune.constants.AccountImageUrlKey
 import moe.rukamori.archivetune.constants.AccountNameKey
 import moe.rukamori.archivetune.constants.DataSyncIdKey
 import moe.rukamori.archivetune.constants.InnerTubeCookieKey
@@ -47,6 +48,7 @@ fun MutablePreferences.clearPlaybackAuthSession(clearAccountIdentity: Boolean = 
     remove(PoTokenSourceUrlKey)
     if (clearAccountIdentity) {
         remove(AccountNameKey)
+        remove(AccountImageUrlKey)
         remove(AccountEmailKey)
         remove(AccountChannelHandleKey)
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/YTPlayerUtils.kt
@@ -14,6 +14,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import moe.rukamori.archivetune.constants.AllowAgeRestrictedKey
 import moe.rukamori.archivetune.constants.AudioQuality
 import moe.rukamori.archivetune.constants.PlayerStreamClient
 import moe.rukamori.archivetune.innertube.NewPipeUtils
@@ -25,9 +26,11 @@ import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.ANDROID
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.IOS
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.MWEB
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.TVHTML5
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMBEDDED_PLAYER
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.VISIONOS
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_CREATOR
+import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_EMBEDDED
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_PRIMARY
 import moe.rukamori.archivetune.innertube.models.YouTubeClient.Companion.WEB_REMIX
 import moe.rukamori.archivetune.innertube.models.response.PlayerResponse
@@ -136,6 +139,66 @@ object YTPlayerUtils {
             MWEB,
             WEB_CREATOR,
         )
+
+    /**
+     * Embedded-player clients used to play age-restricted tracks, appended to the client order only
+     * while Content Settings → "Allow age-restricted content" is on.
+     *
+     * YouTube serves age-gated videos to its embedded players without an adult-verified session,
+     * which is what makes them playable at all: every non-embedded client answers the player
+     * request with `LOGIN_REQUIRED` / "Sign in to confirm your age" instead of streaming data.
+     *
+     * Both profiles are copied with cookie auth and the login requirement stripped:
+     *  - `TVHTML5_SIMPLY_EMBEDDED_PLAYER` is catalogued as `loginRequired = true`, which would make
+     *    [buildStreamClientOrder]'s callers skip it outright (it has no cookie support, so the
+     *    `loginRequired && !usesCookieAuthentication` guard always fires). The embedded endpoint
+     *    does not actually need a session — it needs the signature timestamp, which the profile
+     *    already requests.
+     *  - `WEB_EMBEDDED` must go out anonymously: attaching the signed-in user's cookie reinstates
+     *    the account's age gate and defeats the point.
+     *
+     * They are appended LAST so nothing about normal playback changes — they are only reached once
+     * every regular client has failed, which for an age-gated track is exactly the gate.
+     */
+    private val AGE_GATE_BYPASS_CLIENTS: Array<YouTubeClient> =
+        arrayOf(
+            TVHTML5_SIMPLY_EMBEDDED_PLAYER.copy(
+                loginSupported = false,
+                loginRequired = false,
+                supportsCookieAuthentication = false,
+                friendlyName = "TV Embedded (age-gate bypass)",
+            ),
+            WEB_EMBEDDED.copy(
+                loginSupported = false,
+                loginRequired = false,
+                supportsCookieAuthentication = false,
+                friendlyName = "Web Embedded (age-gate bypass)",
+            ),
+        )
+
+    /**
+     * True while the user has opted in to age-restricted playback (Content Settings). Read fresh on
+     * every client-order build so toggling it takes effect on the next track without a restart.
+     */
+    private fun ageRestrictedPlaybackAllowed(): Boolean = PreferenceStore.get(AllowAgeRestrictedKey) == true
+
+    /**
+     * True when [failure] is an age-gate rejection *and* the user has opted in to age-restricted
+     * playback, meaning the native resolver's embedded-player clients (see [AGE_GATE_BYPASS_CLIENTS])
+     * are worth trying instead of surfacing a sign-in prompt.
+     *
+     * Deliberately narrower than [isLoginRecoveryError]: a genuine expired-session failure must
+     * still reach the user as "sign in again", because no embedded client can fix that.
+     */
+    fun isAgeRestrictedPlaybackFallbackAllowed(failure: LoginRequiredForPlaybackException): Boolean {
+        if (!ageRestrictedPlaybackAllowed()) return false
+        val lower = failure.message.orEmpty().lowercase(Locale.US)
+        return "confirm your age" in lower ||
+            "age-restricted" in lower ||
+            "age restricted" in lower ||
+            "inappropriate for some users" in lower ||
+            "mature audiences" in lower
+    }
 
     private data class CachedStreamUrl(
         val url: String,
@@ -599,6 +662,9 @@ object YTPlayerUtils {
                 ?.let { add(it) }
             addAll(orderedFallbackClients)
             if (preferredYouTubeClient != MAIN_CLIENT) add(MAIN_CLIENT)
+            // Last resort, opt-in only: the embedded players are the only clients YouTube will
+            // serve an age-gated track to. See [AGE_GATE_BYPASS_CLIENTS].
+            if (ageRestrictedPlaybackAllowed()) addAll(AGE_GATE_BYPASS_CLIENTS)
         }.distinct()
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
@@ -28,6 +28,7 @@ import moe.rukamori.archivetune.aicontentfilter.ObserveAiContentFilterUseCase
 import moe.rukamori.archivetune.auth.SwitchSavedYouTubeAccountUseCase
 import moe.rukamori.archivetune.constants.AccountChannelHandleKey
 import moe.rukamori.archivetune.constants.AccountEmailKey
+import moe.rukamori.archivetune.constants.AccountImageUrlKey
 import moe.rukamori.archivetune.constants.AccountNameKey
 import moe.rukamori.archivetune.constants.ContentCountryKey
 import moe.rukamori.archivetune.constants.ContentLanguageKey
@@ -825,8 +826,17 @@ class HomeViewModel
             }
 
         private suspend fun refreshAccountIdentity() {
-            _accountName.value = ""
-            _accountImageUrl.value = null
+            // Seed from the identity persisted at login before touching the network. accountInfo()
+            // is a live call, and this used to start by blanking the name and avatar and blank them
+            // again on failure — so any failed refresh made the app report that no account was
+            // connected even though the session was intact. That is what picking a YouTube Music
+            // region looked like: the picker restarts the process, the first identity fetch after
+            // the restart races the region/proxy restore in App.initializeDeferredAsync(), and a
+            // single failure left the top bar signed out until the next successful fetch.
+            context.dataStore.data.first().let { prefs ->
+                prefs[AccountNameKey]?.takeIf { it.isNotBlank() }?.let { _accountName.value = it }
+                prefs[AccountImageUrlKey]?.takeIf { it.isNotBlank() }?.let { _accountImageUrl.value = it }
+            }
             _accountChannelsState.value = AccountChannelsState.Loading
 
             try {
@@ -835,7 +845,12 @@ class HomeViewModel
                     .onSuccess { info ->
                         _accountName.value = info.name
                         _accountImageUrl.value = info.thumbnailUrl
+                        context.dataStore.edit { preferences ->
+                            preferences[AccountNameKey] = info.name
+                            info.thumbnailUrl?.let { preferences[AccountImageUrlKey] = it }
+                        }
                     }.onFailure { error ->
+                        // A failed refresh is not a logout: keep whatever was seeded above.
                         Timber.w(error, "Failed to fetch account info")
                     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
@@ -1131,6 +1131,22 @@ class HomeViewModel
                     }
             }
 
+            // Re-filter the feed as soon as the user hits "Don't recommend this song again"
+            // (or undoes it). The blocked set is applied while each section is built, so
+            // without this the song the user just dismissed stayed on screen until the next
+            // manual pull-to-refresh — which read as the action not working at all.
+            viewModelScope.launch(Dispatchers.IO) {
+                database
+                    .blockedSongIds()
+                    .map { it.toSet() }
+                    .distinctUntilChanged()
+                    .drop(1)
+                    .collectLatest {
+                        isLoading.filter { loading -> !loading }.first()
+                        load()
+                    }
+            }
+
             viewModelScope.launch(Dispatchers.IO) {
                 context.dataStore.data
                     .map { it[SpeedDialSongIdsKey].orEmpty() }

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -398,6 +398,19 @@
     <string name="video_captions_off">Captions off</string>
     <string name="video_quality">Video quality</string>
     <string name="video_quality_auto">Auto (highest available)</string>
+    <!-- Video quality bottom sheet -->
+    <string name="video_quality_mode_auto">Auto</string>
+    <string name="video_quality_mode_auto_desc">Adjusts to your connection, up to 1080p</string>
+    <string name="video_quality_mode_data_saver">Data saver</string>
+    <string name="video_quality_mode_data_saver_desc">Lower resolution to use less data</string>
+    <string name="video_quality_mode_high">High quality</string>
+    <string name="video_quality_mode_high_desc">Original resolution — uses more data and battery</string>
+    <string name="video_quality_advanced">Advanced</string>
+    <string name="video_quality_advanced_desc">Pick an exact resolution</string>
+    <string name="video_quality_advanced_title">Advanced quality</string>
+    <string name="video_quality_back">Back</string>
+    <string name="video_quality_current">Playing at %1$s</string>
+    <string name="video_quality_unavailable_on_device">Not supported by this device</string>
     <!-- Fullscreen video overlay transport controls -->
     <string name="video_fs_play_pause">Play/Pause</string>
     <string name="video_fs_next">Next</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -616,6 +616,7 @@
     <string name="ip_rotation_loading">Loading proxy list</string>
     <string name="ip_rotation_refreshing">Refreshing IP</string>
     <string name="ip_rotation_refresh">Refresh IP</string>
+    <string name="ip_rotation_no_proxies">No working proxies found. The public proxy list is unreachable or every candidate failed — try again later.</string>
     <string name="stream_bypass_proxy">Bypass proxy for streams</string>
     <string name="stream_bypass_proxy_desc">Use your direct IP for stream playback to avoid IP mismatch</string>
     <string name="enable_betterlyrics">Enable BetterLyrics</string>
@@ -793,7 +794,7 @@
     <string name="romanization">Romanization</string>
     <string name="hide_explicit">Hide explicit content</string>
     <string name="allow_age_restricted">Allow age-restricted content</string>
-    <string name="allow_age_restricted_summary">Enable playback of age-restricted songs that are normally filtered out</string>
+    <string name="allow_age_restricted_summary">Play age-restricted songs by routing them through YouTube\'s embedded player. Resolution can take a little longer, and may still fail if YouTube tightens the gate.</string>
     <string name="hide_video">Hide music videos</string>
     <string name="ai_content_filter">AI content filter</string>
     <string name="ai_content_filter_hide">Hide AI-generated content</string>
@@ -878,7 +879,7 @@
     <string name="tidal_disconnect">Disconnect Tidal account</string>
     <!-- Tidal HiFi instances -->
     <string name="tidal_instances">HiFi instances</string>
-    <string name="tidal_instances_description">Tidal streams are resolved through public HiFi/QQDL instances. None are bundled — add your own, then tap Test instances to check which ones work. If the list is empty, Tidal streaming is disabled.</string>
+    <string name="tidal_instances_description">Optional fallback for when no pool account can stream a track. ArchiveTune probes the well-known public HiFi/QQDL mirrors on startup and only uses the ones that pass; add your own here to have them tried first. Tap Test instances to see which are reachable.</string>
     <string name="tidal_add_instance">Add instance</string>
     <string name="tidal_instance_url_hint">https://instance.example.com</string>
     <string name="tidal_instance_invalid_url">Enter a valid http(s) URL</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,16 @@ junit = "4.13.2"
 turbine = "1.2.1"
 timber = "5.0.1"
 kuromojiIpadic = "0.9.0"
+# NewPipeExtractor's release tag. Kept because `newpipe-extractor` below still
+# points at it — :core has used either fork at different times.
+extractor = "0.26.5"
+
+# MetrolistExtractor needs its own version: it is a different artifact from
+# NewPipeExtractor and MetrolistGroup publishes no release numbered 0.26.5, so
+# sharing `extractor` is what broke CI with "Could not find
+# com.github.MetrolistGroup:MetrolistExtractor:0.26.5" the moment the :core
+# submodule switched back to `libs.metrolist.extractor`.
+#
 # Pinned to MetrolistGroup's commit `08a64867704c` (2026-05-29) — the last
 # commit before MetrolistExtractor bumped its java toolchain to JDK 25 in
 # `1cce4d0ce1bb` (2026-05-29). The :core submodule is a pure Kotlin/JVM module
@@ -53,7 +63,7 @@ kuromojiIpadic = "0.9.0"
 # JitPack (no Maven Central release) and has no git tags — JitPack resolves the
 # short commit hash. To move to a newer commit, the CI JDK and :core's
 # `jvmToolchain(...)` both need to be bumped to ≥ 25.
-extractor = "0.26.5"
+metrolistExtractor = "08a64867704c"
 quickjsKt = "1.0.10"
 bouncyCastle = "1.85"
 chaquopy = "17.0.0"
@@ -165,7 +175,7 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 # Same `org.schabi.newpipe.extractor` package namespace as upstream, so all
 # existing NewPipe imports keep working. Published on JitPack only.
 # Coordinates match the upstream Metrolist Android app (MetrolistGroup/Metrolist).
-metrolist-extractor = { module = "com.github.MetrolistGroup:MetrolistExtractor", version.ref = "extractor" }
+metrolist-extractor = { module = "com.github.MetrolistGroup:MetrolistExtractor", version.ref = "metrolistExtractor" }
 newpipe-extractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version.ref = "extractor" }
 quickjs-kt = { module = "io.github.dokar3:quickjs-kt", version.ref = "quickjsKt" }
 bcpg = { module = "org.bouncycastle:bcpg-jdk18on", version.ref = "bouncyCastle" }

--- a/spotifycore/src/moe/rukamori/archivetune/spotify/Spotify.kt
+++ b/spotifycore/src/moe/rukamori/archivetune/spotify/Spotify.kt
@@ -22,6 +22,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.TextContent
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -250,7 +251,7 @@ object Spotify {
         for (attempt in 0 until maxRetries) {
             log(
                 "D",
-                "GQL POST $operationName (token: ${token.take(8)}...)" +
+                "GQL POST $operationName" +
                     if (attempt > 0) " [retry $attempt]" else "",
             )
 
@@ -1132,92 +1133,173 @@ object Spotify {
         offset: Int = 0,
     ): Result<SpotifySearchResult> =
         runCatching {
-            val vars =
-                buildJsonObject {
-                    put("searchTerm", query)
-                    put("offset", offset)
-                    put("limit", limit)
-                    put("numberOfTopResults", 5)
-                    put("includeAudiobooks", false)
-                    put("includeArtistHasConcertsField", false)
-                    put("includePreReleases", false)
-                    put("includeLocalConcertsField", false)
-                    put("includeAuthors", false)
-                }
+            try {
+                hydrateSearchTracks(searchGraphQl(query, types, limit, offset))
+            } catch (cancel: CancellationException) {
+                throw cancel
+            } catch (error: Throwable) {
+                // The internal search endpoint is useful but its persisted hash and response shape
+                // can rotate independently of the public API. Keep catalog search usable when that
+                // happens; the same web-player token is accepted by Spotify's REST search endpoint.
+                log("W", "GQL search failed; falling back to REST search: ${error.message}")
+                searchRest(query, types, limit, offset)
+            }
+        }
 
-            val response =
-                graphqlPost(
-                    operationName = "searchDesktop",
-                    variables = vars,
-                )
+    private suspend fun hydrateSearchTracks(result: SpotifySearchResult): SpotifySearchResult {
+        val tracks = result.tracks?.items.orEmpty()
+        if (tracks.isEmpty()) return result
+        val ids = tracks.mapNotNull { it.id.takeIf(String::isNotBlank) }.distinct()
+        if (ids.isEmpty()) return result
 
-            val searchData =
-                response.obj("data")?.obj("searchV2")
-                    ?: throw SpotifyException(500, "Invalid searchDesktop response")
+        val hydrated =
+            try {
+                authenticatedGet<SpotifyTracksResponse>("tracks") {
+                    parameter("ids", ids.joinToString(","))
+                }.tracks
+            } catch (cancel: CancellationException) {
+                throw cancel
+            } catch (error: Throwable) {
+                // Search remains useful when Spotify's REST detail endpoint is unavailable; the GQL
+                // payload still contains the identity fields needed by the UI and mapper.
+                log("W", "Spotify track detail hydration failed: ${error.message}")
+                return result
+        }
+        if (hydrated.isEmpty()) return result
+        val byId = hydrated.associateBy { it.id }
+        val currentTracks = result.tracks ?: return result
+        return result.copy(
+            tracks = currentTracks.copy(items = tracks.map { byId[it.id] ?: it }),
+        )
+    }
 
-            val tracksSection = searchData.obj("tracksV2")
-            val trackItems =
+    private suspend fun searchGraphQl(
+        query: String,
+        types: List<String>,
+        limit: Int,
+        offset: Int,
+    ): SpotifySearchResult {
+        val requestedTypes = types.map { it.trim().lowercase() }.filter { it.isNotBlank() }.toSet()
+        val includeAllTypes = requestedTypes.isEmpty()
+        val vars =
+            buildJsonObject {
+                put("searchTerm", query)
+                put("offset", offset)
+                put("limit", limit)
+                put("numberOfTopResults", 5)
+                put("includeAudiobooks", false)
+                put("includeArtistHasConcertsField", false)
+                put("includePreReleases", false)
+                put("includeLocalConcertsField", false)
+                put("includeAuthors", false)
+            }
+
+        val response =
+            graphqlPost(
+                operationName = "searchDesktop",
+                variables = vars,
+            )
+
+        val searchData =
+            response.obj("data")?.obj("searchV2")
+                ?: throw SpotifyException(500, "Invalid searchDesktop response")
+
+        val tracksSection = searchData.obj("tracksV2")
+        val trackItems =
+            if (includeAllTypes || "track" in requestedTypes) {
                 tracksSection?.arr("items")?.mapNotNull { elem ->
-                    val itemWrapper = elem.jsonObject.obj("item") ?: return@mapNotNull null
-                    if (itemWrapper.str("__typename") != "TrackResponseWrapper") return@mapNotNull null
-                    val data = itemWrapper.obj("data") ?: return@mapNotNull null
-                    if (data.str("__typename") != "Track") return@mapNotNull null
-                    val wrapperUri = itemWrapper.str("_uri") ?: itemWrapper.str("uri")
+                    val raw = elem.jsonObject
+                    val itemWrapper = raw.obj("item") ?: raw
+                    val wrapperType = itemWrapper.str("__typename")
+                    val data = itemWrapper.obj("data") ?: itemWrapper
+                    val dataType = data.str("__typename")
+                    if (wrapperType != null && !wrapperType.contains("Track", ignoreCase = true)) return@mapNotNull null
+                    if (dataType != null && !dataType.equals("Track", ignoreCase = true)) return@mapNotNull null
+                    val wrapperUri = itemWrapper.str("_uri") ?: itemWrapper.str("uri") ?: data.str("uri")
                     parseGqlTrack(data, uriOverride = wrapperUri)
                 } ?: emptyList()
+            } else {
+                emptyList()
+            }
 
-            val albumsSection = searchData.obj("albumsV2")
-            val albumItems =
+        val albumsSection = searchData.obj("albumsV2")
+        val albumItems =
+            if (includeAllTypes || "album" in requestedTypes) {
                 albumsSection?.arr("items")?.mapNotNull { elem ->
-                    val wrapper = elem.jsonObject
-                    if (wrapper.str("__typename") != "AlbumResponseWrapper") return@mapNotNull null
-                    val data = wrapper.obj("data") ?: return@mapNotNull null
-                    if (data.str("__typename") != "Album") return@mapNotNull null
+                    val raw = elem.jsonObject
+                    val wrapper = raw.obj("item") ?: raw
+                    val data = wrapper.obj("data") ?: wrapper
+                    val wrapperType = wrapper.str("__typename")
+                    val dataType = data.str("__typename")
+                    if (wrapperType != null && !wrapperType.contains("Album", ignoreCase = true)) return@mapNotNull null
+                    if (dataType != null && !dataType.equals("Album", ignoreCase = true)) return@mapNotNull null
                     parseGqlSearchAlbum(data)
                 } ?: emptyList()
+            } else {
+                emptyList()
+            }
 
-            val artistsSection = searchData.obj("artists")
-            val artistItems =
+        val artistsSection = searchData.obj("artists")
+        val artistItems =
+            if (includeAllTypes || "artist" in requestedTypes) {
                 artistsSection?.arr("items")?.mapNotNull { elem ->
-                    val wrapper = elem.jsonObject
-                    if (wrapper.str("__typename") != "ArtistResponseWrapper") return@mapNotNull null
-                    val data = wrapper.obj("data") ?: return@mapNotNull null
-                    if (data.str("__typename") != "Artist") return@mapNotNull null
+                    val raw = elem.jsonObject
+                    val wrapper = raw.obj("item") ?: raw
+                    val data = wrapper.obj("data") ?: wrapper
+                    val wrapperType = wrapper.str("__typename")
+                    val dataType = data.str("__typename")
+                    if (wrapperType != null && !wrapperType.contains("Artist", ignoreCase = true)) return@mapNotNull null
+                    if (dataType != null && !dataType.equals("Artist", ignoreCase = true)) return@mapNotNull null
                     parseGqlSearchArtist(data)
                 } ?: emptyList()
+            } else {
+                emptyList()
+            }
 
-            val playlistsSection = searchData.obj("playlists")
-            val playlistItems =
+        val playlistsSection = searchData.obj("playlists")
+        val playlistItems =
+            if (includeAllTypes || "playlist" in requestedTypes) {
                 playlistsSection?.arr("items")?.mapNotNull { elem ->
-                    val wrapper = elem.jsonObject
-                    if (wrapper.str("__typename") != "PlaylistResponseWrapper") return@mapNotNull null
-                    val data = wrapper.obj("data") ?: return@mapNotNull null
-                    if (data.str("__typename") != "Playlist") return@mapNotNull null
+                    val raw = elem.jsonObject
+                    val wrapper = raw.obj("item") ?: raw
+                    val data = wrapper.obj("data") ?: wrapper
+                    val wrapperType = wrapper.str("__typename")
+                    val dataType = data.str("__typename")
+                    if (wrapperType != null && !wrapperType.contains("Playlist", ignoreCase = true)) return@mapNotNull null
+                    if (dataType != null && !dataType.equals("Playlist", ignoreCase = true)) return@mapNotNull null
                     parseGqlSearchPlaylist(data)
                 } ?: emptyList()
+            } else {
+                emptyList()
+            }
 
+        val result =
             SpotifySearchResult(
                 tracks =
-                    SpotifyPaging(
-                        items = trackItems,
-                        total = tracksSection?.int("totalCount") ?: 0,
-                        limit = limit,
-                        offset = offset,
-                    ),
+                    if (includeAllTypes || "track" in requestedTypes) {
+                        SpotifyPaging(
+                            items = trackItems,
+                            total = tracksSection?.int("totalCount") ?: 0,
+                            limit = limit,
+                            offset = offset,
+                        )
+                    } else {
+                        null
+                    },
                 albums =
-                    if (albumItems.isNotEmpty()) {
+                    if (includeAllTypes || "album" in requestedTypes) {
                         SpotifyPaging(items = albumItems, total = albumsSection?.int("totalCount") ?: 0, limit = limit, offset = offset)
                     } else {
                         null
                     },
                 artists =
-                    if (artistItems.isNotEmpty()) {
+                    if (includeAllTypes || "artist" in requestedTypes) {
                         SpotifyPaging(items = artistItems, total = artistsSection?.int("totalCount") ?: 0, limit = limit, offset = offset)
                     } else {
                         null
                     },
                 playlists =
-                    if (playlistItems.isNotEmpty()) {
+                    if (includeAllTypes || "playlist" in requestedTypes) {
                         SpotifyPaging(
                             items = playlistItems,
                             total = playlistsSection?.int("totalCount") ?: 0,
@@ -1228,7 +1310,33 @@ object Spotify {
                         null
                     },
             )
+
+        // A successful HTTP response with an unrecognised schema is indistinguishable from a real
+        // empty result to callers. Let REST repair that case instead of showing a false "no results".
+        if (query.isNotBlank() && !result.hasItems()) {
+            throw SpotifyException(502, "Spotify search returned no parseable results")
         }
+        return result
+    }
+
+    private suspend fun searchRest(
+        query: String,
+        types: List<String>,
+        limit: Int,
+        offset: Int,
+    ): SpotifySearchResult =
+        authenticatedGet("search") {
+            parameter("q", query)
+            parameter("type", types.joinToString(",").ifBlank { "track" })
+            parameter("limit", limit.coerceIn(1, 50))
+            parameter("offset", offset.coerceAtLeast(0))
+        }
+
+    private fun SpotifySearchResult.hasItems(): Boolean =
+        tracks?.items?.isNotEmpty() == true ||
+            albums?.items?.isNotEmpty() == true ||
+            artists?.items?.isNotEmpty() == true ||
+            playlists?.items?.isNotEmpty() == true
 
     private fun parseGqlSearchAlbum(data: JsonObject): SpotifyAlbum {
         val uri = data.str("uri") ?: ""
@@ -1715,4 +1823,9 @@ data class RelatedArtistsResponse(
 @kotlinx.serialization.Serializable
 data class NewReleasesResponse(
     val albums: SpotifyPaging<SpotifyAlbum>? = null,
+)
+
+@kotlinx.serialization.Serializable
+private data class SpotifyTracksResponse(
+    val tracks: List<SpotifyTrack> = emptyList(),
 )


### PR DESCRIPTION
Rolls up the second batch of fixes on top of the video-quality / age-restricted work already on this branch.

### core submodule
Bumped to `789b53e` — `origin/main` merged into `feat/ip-rotation-region-spoofer` plus the `YouTubeClient` constants the app imports (`ORIGIN_YOUTUBE_MOBILE`, `REFERER_YOUTUBE`, `REFERER_YOUTUBE_MOBILE`) restored after the merge. Opened as **4nx3b/core#2**.

### Apple Music player
- **Moving blur no longer rotates the artwork.** A single ever-advancing phase drives a Lissajous wander built from integer harmonics, so the phase's 1→0 wrap under `RepeatMode.Restart` is continuous. The old `RepeatMode.Reverse` pair of linear tweens snapped direction at the ±160/±120 endpoints, which is what read as "it rotates back really fast". Overall rate slowed down. — **Superseded later in this branch by `BlurWanderDrift`; see "Lyrics backdrop" below.** The Lissajous path fixed the hard turnaround but, being closed and periodic, still spent half of every cycle retracing itself.
- **BetterLyrics canvas** fades into a gradient behind the bottom controls (`BlendMode.DstIn` over the morph area, `CompositingStrategy.Offscreen`) instead of showing a blurred second copy of the canvas there.

### Video quality sheet
- Compact metrics in landscape (the orientation the fullscreen overlay locks to): halved padding, descriptions dropped, capped list height — the three modes no longer scroll.
- The **aspect-ratio toggle** in fullscreen now opens the same sliding sheet as the quality picker instead of a corner dropdown.

### Google account after a region change
- The visible account identity is seeded from the persisted name plus a new `AccountImageUrlKey` before any network call, and is no longer blanked when a live `accountInfo()` call fails. A failed refresh is not a logout — the region picker restarts the process, the first identity fetch races the region/proxy restore, and one failure used to leave the app reporting no account connected.
- The picker now removes `VisitorDataKey` from DataStore. Setting `YouTube.visitorData = null` in memory was undone by the very restart the handler schedules (App.kt restores `authState` from DataStore on every start), so the old region-pinned token came straight back instead of a fresh one being minted for the new region.

### Lyrics page switch lag
`LyricsEnhanced` and `LyricsV2` parsed TTML/LRC synchronously in composition and then walked the result again to build the synced model — for word-synced lyrics that is an XML parse plus one object per syllable, twice, landing on the exact frame the COVER→LYRICS morph starts. Both now parse on `Dispatchers.Default`; a `null` "not parsed yet" state keeps the shimmer up so "lyrics not found" cannot flash while the parse is in flight. Nothing was removed — the same formats, romanization pass and instrumental-break insertion still run.

### Qobuz backup search
The kouzu.in mirror's `/api/search` is a single `name LIKE %q% OR artists LIKE %q%` with no tokenizing and no cross-field match, so every "Title Artist" query returned `[]` — verified against the live mirror (`die with a smile` → 2 hits, `Die With A Smile Lady Gaga` → none). `searchCandidates` now retries with words dropped from the tail then the head (capped at 6 requests), over-fetches, and ranks locally by how much of the original query each row covers, so both "Title Artist" and "Artist Title" resolve to the right track first.

---

## Third batch

### Lyrics no longer reposition themselves on open
Opening lyrics showed the first verse for a frame and then visibly scrolled to wherever the song actually was: a fresh `LazyListState` starts at line 0 and the auto-scroll collector walked it to the active line with the list already on screen, so the trip got drawn. Worst in the Apple Music player, which composes the view from scratch on every open.

`LyricsEnhanced` and `LyricsV2` now hold the lines transparent until the active one is placed, snap that first placement instead of animating it (nothing is on screen to animate), then fade in over 200ms. Re-armed on line count so lyrics that arrive late — slow provider, translation — are placed the same way. The alpha is read only from a `graphicsLayer` lambda, so the fade never recomposes the karaoke view, and a 400ms timeout guarantees the lines are never left hidden if the placement never comes.

### Lyrics backdrop: a real wander, and a morphed hand-off
- **The colours no longer "suddenly travel the other way".** `BlurWanderDrift` (new, shared by the Apple Music player and `LyricsScreen`) walks between random waypoints on raised-cosine legs. Velocity is zero at both ends, so the artwork finishes its leg, settles, and only then sets off again at least ~72° away — no reversal ever happens while it is moving. Legs are timed off their own length, so a long one doesn't race and a short one doesn't crawl.
- **The backdrop no longer changes abruptly when lyrics opens.** It was two different nodes — 72dp blur at 1.2x, swapped for "64dp at 2.4x with drift" the instant `lyricsContentReady` flipped 350ms in. In one frame the effective blur more than doubled, the artwork jumped 1.2x → 2.4x, and the drift snapped to wherever the always-running wander had reached (up to 150dp of instant translation); on canvas songs the video surface had already been pulled 100ms earlier, flashing the undrifted fallback. Now **one** node interpolates between both looks over 650ms, and the canvas teardown waits until the still artwork underneath is fully opaque.
- The frame loop is gated on the backdrop actually being on screen — `rememberInfiniteTransition` kept the choreographer awake for a value nothing was reading while sitting on the cover. Every drift/progress read stays inside a `graphicsLayer` lambda, so none of it recomposes the player subtree.
- Fixes the pre-S path, which fell through to an **unblurred** `AsyncImage` on canvas songs.

### Two pre-existing unit-test failures
Unrelated to the above; both were failing on `dev` before this batch.
- **`TitleMatch` blamed the wrong signal.** The duration gate ran before the artist gate, so a same-title recording by a different artist — the case the matcher exists to catch — was rejected with "duration differs by more than 15s", since a different recording almost always has a different length too. The artist gate is now hoisted above it. Both gates reject, so **no stream changes from accepted to rejected or back**; only the reported reason changes. The artist-unavailable fallback deliberately stays *below* the duration gate, because with no artist to compare, duration is the only independent signal left.
- **Search routes used `android.util.Base64`**, a throwing stub under JVM unit tests, so `OnlineSearchNavigationTest` failed with "not mocked" instead of testing anything. Swapped for `java.util.Base64` (API 26+, minSdk is 26). `getUrlEncoder().withoutPadding()` is byte-for-byte identical to the previous `URL_SAFE or NO_WRAP or NO_PADDING` — same RFC 4648 §5 alphabet, no wrapping, no `=` — so routes encoded by older builds still decode.

### Verification
`:app:compileGmsMobileUniversalDebugKotlin` clean, and the fork contract suite is **112 tests, 0 failures** (was 109/112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
