### PR TITLE
feat: AI lyrics romanisation, real Deezer downloads, reachable source order

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsRomanizer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiLyricsRomanizer.kt
@@ -1,0 +1,123 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ai
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Batches a track's lyric lines into AI romanisation requests.
+ *
+ * Structured like [AiLyricsTranslator] — same budget-based chunking, same binary-split retry, same
+ * process-wide LRU — but returns the per-line results instead of rebuilding a lyrics container.
+ * That difference is the whole point: AI *translation* is persisted into `LyricsEntity.lyrics` as a
+ * second line under each timestamp, whereas romanisation is a render-time annotation that sits above
+ * the line (`LyricsEntry.romanizedTextFlow` / `KaraokeSyllable.phonetic`) exactly like the built-in
+ * Kuromoji/ICU romanisers' output. Persisting it would mean inventing a second `Source` value that
+ * cannot coexist with `AI_TRANSLATION` in the single `source` column.
+ *
+ * A `null` at some index means "no romanisation for this line" — either the model returned it
+ * unchanged (already Latin script) or that batch failed after retries.
+ */
+class AiLyricsRomanizer {
+    /**
+     * Romanises [lines] and returns a list of the same size, aligned by index.
+     *
+     * Never throws for content reasons: a batch that keeps failing degrades to nulls for its lines so
+     * one bad stanza cannot cost the whole track its romanisation. Cancellation still propagates.
+     */
+    suspend fun romanize(
+        config: AiServiceConfig,
+        lines: List<String>,
+    ): List<String?> {
+        if (lines.isEmpty()) return emptyList()
+
+        val cacheKey = "${config.provider}|${config.model}|${lines.size}|${lines.hashCode()}"
+        synchronized(resultCache) { resultCache[cacheKey] }?.let { return it }
+
+        // Indices are carried through the chunking so a batch can be split without losing track of
+        // which line each result belongs to.
+        val indexed = lines.withIndex().filter { it.value.isNotBlank() }
+        val out = arrayOfNulls<String>(lines.size)
+        indexed.chunkedByBudget().forEach { batch ->
+            val romanized = romanizeBatchResilient(config, batch)
+            batch.forEachIndexed { position, entry ->
+                val candidate = romanized.getOrNull(position)?.trim()
+                // An unchanged echo carries no information and would only add a duplicate line above
+                // the lyric, so treat it the same as "no romanisation".
+                out[entry.index] =
+                    candidate?.takeIf { it.isNotEmpty() && !it.equals(entry.value.trim(), ignoreCase = true) }
+            }
+        }
+
+        return out.toList().also { result ->
+            synchronized(resultCache) { resultCache[cacheKey] = result }
+        }
+    }
+
+    private suspend fun romanizeBatchResilient(
+        config: AiServiceConfig,
+        batch: List<IndexedValue<String>>,
+    ): List<String?> {
+        if (batch.isEmpty()) return emptyList()
+        return try {
+            val result =
+                AiTextService.romanizeLines(
+                    config = config,
+                    lines = batch.map { it.value },
+                    formatName = "plain text",
+                )
+            if (result.size == batch.size) {
+                result
+            } else {
+                throw AiServiceException("AI response changed the lyric segment count")
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            if (batch.size <= 1) {
+                // One line, one failure: give up on it rather than retrying forever.
+                listOf(null)
+            } else {
+                val mid = batch.size / 2
+                romanizeBatchResilient(config, batch.subList(0, mid)) +
+                    romanizeBatchResilient(config, batch.subList(mid, batch.size))
+            }
+        }
+    }
+
+    private fun List<IndexedValue<String>>.chunkedByBudget(): List<List<IndexedValue<String>>> {
+        val chunks = ArrayList<List<IndexedValue<String>>>()
+        val current = ArrayList<IndexedValue<String>>()
+        var currentChars = 0
+        forEach { entry ->
+            val nextSize = currentChars + entry.value.length
+            if (current.isNotEmpty() && (current.size >= MaxItemsPerBatch || nextSize > MaxCharsPerBatch)) {
+                chunks.add(current.toList())
+                current.clear()
+                currentChars = 0
+            }
+            current.add(entry)
+            currentChars += entry.value.length
+        }
+        if (current.isNotEmpty()) chunks.add(current.toList())
+        return chunks
+    }
+
+    private companion object {
+        const val MaxItemsPerBatch = 80
+        const val MaxCharsPerBatch = 6000
+        const val MaxCachedRomanizations = 8
+
+        /** Process-wide LRU of finished romanisations, shared across renderers and view models. */
+        val resultCache =
+            object : LinkedHashMap<String, List<String?>>(MaxCachedRomanizations, 0.75f, true) {
+                override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, List<String?>>): Boolean =
+                    size > MaxCachedRomanizations
+            }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiRateLimiter.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiRateLimiter.kt
@@ -48,6 +48,14 @@ object AiRateLimiter {
         /** Chunked batches within one translation are smoothed, not refused. */
         LYRICS_TRANSLATION(label = "lyrics translation", minIntervalMs = 1_000L, maxPerHour = 60, smoothingWaitMs = 5_000L),
 
+        /** Same shape as translation: one request per batch of lines, smoothed rather than refused. */
+        LYRICS_ROMANIZATION(
+            label = "lyrics romanisation",
+            minIntervalMs = 1_000L,
+            maxPerHour = 60,
+            smoothingWaitMs = 5_000L,
+        ),
+
         /** Mix regeneration is expensive (large prompt); refuse rapid repeats outright. */
         AI_MIX(label = "AI Mix", minIntervalMs = 10L * 60_000L, maxPerHour = 6, smoothingWaitMs = 0L),
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ai/AiTextService.kt
@@ -174,6 +174,66 @@ object AiTextService {
         return List(array.length()) { index -> array.optString(index) }
     }
 
+    /**
+     * Transliterates [lines] into the Latin alphabet, one output string per input string.
+     *
+     * Deliberately not [translateLines] with a "romanise" target language: the two need opposite
+     * instructions. A translator is told to convey meaning, which is precisely what must not happen
+     * here — "君の名は" has to come back as "kimi no na wa", not "your name". The prompt repeats that
+     * several ways because every model tested drifted into translating at least once when it didn't.
+     *
+     * Lines already written in Latin script come back unchanged; the caller relies on that to decide
+     * which lines have a romanisation worth showing.
+     */
+    suspend fun romanizeLines(
+        config: AiServiceConfig,
+        lines: List<String>,
+        formatName: String,
+    ): List<String> {
+        if (lines.isEmpty()) return emptyList()
+        val payload = JSONArray()
+        lines.forEach { payload.put(it) }
+        val response =
+            try {
+                AiRateLimiter.withLimit(AiRateLimiter.Feature.LYRICS_ROMANIZATION) {
+                    complete(
+                        config = config,
+                        systemPrompt =
+                            """
+                            You are an expert lyrics romanisation (transliteration) assistant.
+                            Transliterate each input string into the Latin alphabet exactly as it is sung.
+                            DO NOT TRANSLATE. Never convey meaning — only how the words sound.
+                            Use the standard scheme for the script: Hepburn for Japanese, Revised
+                            Romanization for Korean, Hanyu Pinyin without tone marks for Chinese,
+                            IAST-style for Devanagari, and the common romanisation otherwise.
+                            Keep the original word order, punctuation and casing style.
+                            If a line is already written in the Latin alphabet, return it unchanged.
+                            Do not add timestamps, IDs, XML, markdown, explanations, or extra lines.
+                            Return only a JSON array of strings with exactly ${lines.size} items in the same order.
+                            The caller will reconstruct the $formatName lyrics container separately.
+                            """.trimIndent(),
+                        userPrompt = payload.toString(),
+                        // Lower than translation's 0.15: transliteration has one right answer, and
+                        // sampling variance here only produces inconsistent spellings between lines.
+                        temperature = 0.0,
+                        maxTokens = 8192,
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                // See translateLines: a connection-level failure means the pooled connection has
+                // likely gone stale, and reusing it would fail every subsequent track the same way.
+                if (isConnectionLevelFailure(t)) {
+                    recreateClientOnFailure(t)
+                }
+                throw t
+            }
+        val array = extractJsonArray(response)
+        require(array.length() == lines.size) { "AI response changed the lyric segment count" }
+        return List(array.length()) { index -> array.optString(index) }
+    }
+
     suspend fun complete(
         config: AiServiceConfig,
         systemPrompt: String,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/audiosource/AudioSourceConfig.kt
@@ -341,23 +341,45 @@ object AudioSourceConfig {
 
     /**
      * Resolves the effective ordered list of ALL sources from the stored CSV, preserving the user's
-     * chosen order (including where they placed YouTube) and appending any sources missing from the
-     * stored order (e.g. after an app update introduces a new one) in default order. YouTube is
+     * chosen order (including where they placed YouTube) and slotting in any sources missing from
+     * the stored order (e.g. after an app update introduces a new one) *above* YouTube. YouTube is
      * guaranteed to be present, but its position is user-controlled: placing it earlier means the
      * app prefers YouTube's own stream over the lossless override sources listed after it.
+     *
+     * The "above YouTube" part matters more than it looks. This used to append the missing sources,
+     * which put every newly added source *after* YouTube for anyone who had ever touched the order
+     * picker on an older build. [moe.rukamori.archivetune.playback.MusicService] cuts the chain at
+     * YouTube (`takeWhile { it != YOUTUBE }`), so an appended source was silently dropped from
+     * playback entirely — Deezer, Qobuz backup and JioSaavn were all unreachable for those users,
+     * and in the order dialog they showed up below YouTube where the list looks like it ends. Since
+     * every override source sits above YouTube in [DEFAULT_ORDER], inserting there is both correct
+     * and the one placement that cannot perturb the choices the user did make.
      */
     fun parseOrder(rawOrder: String?): List<AudioSourceType> {
-        val parsed =
+        val stored =
             rawOrder
                 ?.split(',')
                 ?.mapNotNull { parseType(it) }
                 ?.distinct()
                 .orEmpty()
-        val merged = LinkedHashSet(parsed)
-        // Append any sources not present in the stored order in their default position. When nothing
-        // is stored this yields DEFAULT_ORDER (Tidal, Qobuz, Deezer, YouTube), i.e. YouTube stays last.
-        DEFAULT_ORDER.forEach { merged.add(it) }
-        return merged.toList()
+        if (stored.isEmpty()) return DEFAULT_ORDER
+
+        val missing = DEFAULT_ORDER.filterNot { it in stored }
+        if (missing.isEmpty()) return stored
+
+        val merged = mutableListOf<AudioSourceType>()
+        var inserted = false
+        for (source in stored) {
+            if (!inserted && source == AudioSourceType.YOUTUBE) {
+                merged.addAll(missing)
+                inserted = true
+            }
+            merged.add(source)
+        }
+        // No YouTube in the stored order: it is one of the missing sources, and it is last in
+        // DEFAULT_ORDER, so appending the whole missing block still leaves it as the final fallback.
+        if (!inserted) merged.addAll(missing)
+        return merged
     }
 
     /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -357,19 +357,40 @@ object DownloadSourceConfig {
         runCatching { DownloadSource.valueOf(name.trim().uppercase()) }.getOrNull()
 
     /**
-     * Resolves the effective ordered list of all download sources from the stored CSV,
-     * preserving the user's chosen order and appending any missing sources in default order.
+     * Resolves the effective ordered list of all download sources from the stored CSV, preserving
+     * the user's chosen order and slotting any missing sources in above [DownloadSource.YOUTUBE_MUSIC].
+     *
+     * Mirrors `AudioSourceConfig.parseOrder`, and for the same reason: appending meant that a user
+     * who had touched the order picker before a source existed got that source listed *below*
+     * YouTube Music, where the list reads as if it ends. Every real download source sits above
+     * YouTube Music in [DEFAULT_ORDER], so inserting there is both correct and the one placement
+     * that cannot disturb the order the user actually chose.
      */
     fun parseOrder(rawOrder: String?): List<DownloadSource> {
-        val parsed =
+        val stored =
             rawOrder
                 ?.split(',')
                 ?.mapNotNull { parseType(it) }
                 ?.distinct()
                 .orEmpty()
-        val merged = LinkedHashSet(parsed)
-        DEFAULT_ORDER.forEach { merged.add(it) }
-        return merged.toList()
+        if (stored.isEmpty()) return DEFAULT_ORDER
+
+        val missing = DEFAULT_ORDER.filterNot { it in stored }
+        if (missing.isEmpty()) return stored
+
+        val merged = mutableListOf<DownloadSource>()
+        var inserted = false
+        for (source in stored) {
+            if (!inserted && source == DownloadSource.YOUTUBE_MUSIC) {
+                merged.addAll(missing)
+                inserted = true
+            }
+            merged.add(source)
+        }
+        // YouTube Music absent from the stored order means it is itself missing, and it is last in
+        // DEFAULT_ORDER, so appending the block still leaves it as the final fallback.
+        if (!inserted) merged.addAll(missing)
+        return merged
     }
 
     /** Serialize an order back to the CSV form for storage. */
@@ -458,6 +479,25 @@ val AutoTranslateLyricsKey = booleanPreferencesKey("autoTranslateLyrics")
 // multi-select dialog in AiIntegrationSettings. Codes match `TranslatorLanguage.code` in
 // assets/translator_languages.json.
 val AutoTranslateExcludedLanguagesKey = stringSetPreferencesKey("autoTranslateExcludedLanguages")
+
+// ── AI romanisation ──
+// Master switch. When on, the configured AI provider supplies the romanisation shown above each
+// lyric line, and the built-in engines (Kuromoji for Japanese, the hand-written Korean/Hindi tables,
+// ICU for everything else) stop running entirely — see `LyricsRomanizationPreferences.aiHandled`.
+// Two engines at once would mix romanisation schemes within one song, and the whole reason to reach
+// for a model is that its output is better than the tables'.
+val AiRomanizeLyricsKey = booleanPreferencesKey("aiRomanizeLyrics")
+
+// Fetch the romanisation as soon as lyrics are shown, rather than waiting for the user to ask via
+// Lyrics menu → Romanise with AI. Separate from [AiRomanizeLyricsKey] because these are billed
+// network calls: switching the feature on should not commit the user to one request per track.
+val AutoAiRomanizeLyricsKey = booleanPreferencesKey("autoAiRomanizeLyrics")
+
+// Uppercase language codes (e.g. "JAPANESE", "KOREAN") to leave alone even when AI romanisation is
+// on — for scripts the user already reads. Same code space and same multi-select dialog as
+// [AutoTranslateExcludedLanguagesKey]; codes match `TranslatorLang.code` in
+// assets/translator_languages.json.
+val AiRomanizeExcludedLanguagesKey = stringSetPreferencesKey("aiRomanizeExcludedLanguages")
 
 // Set by the "Never show again" pill on the startup update popup. Stores the
 // "<versionName>|<versionCode>" of the version the user suppressed the popup for, so we

--- a/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/deezer/DeezerAudioProvider.kt
@@ -124,6 +124,40 @@ object DeezerAudioProvider {
     fun hasAccounts(): Boolean = manualAccount != null || PoolAccountManager.deezerAccounts().isNotEmpty()
 
     /**
+     * What credentials exist right now, split by origin. Exists so diagnostics and settings copy can
+     * tell a user with their own ARL apart from one relying on the shared pool — reading
+     * [PoolAccountManager.deezerAccounts] directly gets that wrong and reports "no Deezer accounts"
+     * to somebody who just signed in successfully.
+     */
+    data class AccountAvailability(
+        val manual: Boolean,
+        val manualPremium: Boolean,
+        val pooled: Int,
+        val pooledPremium: Int,
+    ) {
+        val total: Int get() = pooled + if (manual) 1 else 0
+    }
+
+    /** Cheap snapshot of [AccountAvailability]; no network. */
+    fun accountAvailability(): AccountAvailability {
+        val manual = manualAccount
+        val pooled = PoolAccountManager.deezerAccounts().filter { it.arl != manual?.arl }
+        return AccountAvailability(
+            manual = manual != null,
+            manualPremium = manual?.premium == true,
+            pooled = pooled.size,
+            pooledPremium = pooled.count { it.premium },
+        )
+    }
+
+    /**
+     * Verifies the credential that [resolve] would reach for first, so a diagnostic can report
+     * whether the ARL is actually still good rather than just that one is stored. Blocking network
+     * I/O; returns null when there is no credential or the gateway rejects it.
+     */
+    fun verifyPreferredAccount(): AccountInfo? = accounts().firstOrNull()?.let { verifyArl(it.arl) }
+
+    /**
      * Every usable credential, manual first so a user's own (likely paid) account is tried before
      * shared pool entries.
      */
@@ -627,6 +661,58 @@ object DeezerAudioProvider {
                 }
             }.getOrNull()
         }
+
+    /**
+     * Free-text catalogue search, returning up to [limit] hits in Deezer's own relevance order.
+     *
+     * Separate from [lookup] because the two answer different questions: [lookup] is "which single
+     * track is this song?" and applies a match-score threshold, while this is "what does the user's
+     * typing find?" and must not filter anything out. Also unauthenticated, so the player's "Play
+     * from" picker can list Deezer rows before any ARL exists — the picker only needs title/artist to
+     * pin the per-song source override, not a playable URL.
+     */
+    suspend fun searchCandidates(
+        term: String,
+        limit: Int = SEARCH_LIMIT,
+    ): List<Metadata> {
+        val trimmed = term.trim()
+        if (trimmed.isEmpty()) return emptyList()
+        return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            runCatching {
+                val encoded = java.net.URLEncoder.encode(trimmed, "UTF-8")
+                val req =
+                    Request
+                        .Builder()
+                        .url("https://api.deezer.com/search?q=$encoded&limit=$limit")
+                        .header("Accept", "application/json")
+                        .build()
+                client.newCall(req).execute().use { res ->
+                    if (!res.isSuccessful) {
+                        Timber.tag(TAG).w("searchCandidates HTTP %d for '%s'", res.code, trimmed)
+                        return@use emptyList<Metadata>()
+                    }
+                    val data =
+                        JSONObject(res.body?.string() ?: return@use emptyList<Metadata>())
+                            .optJSONArray("data") ?: return@use emptyList<Metadata>()
+                    (0 until data.length()).mapNotNull { i ->
+                        val obj = data.optJSONObject(i) ?: return@mapNotNull null
+                        val title = obj.optString("title").ifBlank { return@mapNotNull null }
+                        Metadata(
+                            trackId = obj.optLong("id").toString(),
+                            title = title,
+                            artist = obj.optJSONObject("artist")?.optString("name")?.ifBlank { null },
+                            album = obj.optJSONObject("album")?.optString("title")?.ifBlank { null },
+                            isrc = obj.optString("isrc").ifBlank { null },
+                            durationMs = obj.optLong("duration", 0L).takeIf { it > 0 }?.times(1000L),
+                            previewUrl = obj.optString("preview").ifBlank { null },
+                            coverUrl = obj.optJSONObject("album")?.optString("cover_big")?.ifBlank { null },
+                        )
+                    }
+                }
+            }.onFailure { Timber.tag(TAG).w(it, "searchCandidates failed for '%s'", trimmed) }
+                .getOrDefault(emptyList())
+        }
+    }
 
     private fun buildSearchQuery(query: Query): String {
         val parts = mutableListOf<String>()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/AiLyricsRomanization.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/AiLyricsRomanization.kt
@@ -1,0 +1,298 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.lyrics
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import moe.rukamori.archivetune.ai.AiLyricsRomanizer
+import moe.rukamori.archivetune.ai.AiServiceConfig
+import moe.rukamori.archivetune.constants.AiApiKeyKey
+import moe.rukamori.archivetune.constants.AiCustomEndpointKey
+import moe.rukamori.archivetune.constants.AiCustomModelKey
+import moe.rukamori.archivetune.constants.AiProvider
+import moe.rukamori.archivetune.constants.AiProviderKey
+import moe.rukamori.archivetune.constants.AiRomanizeExcludedLanguagesKey
+import moe.rukamori.archivetune.constants.AiRomanizeLyricsKey
+import moe.rukamori.archivetune.constants.AiSelectedModelKey
+import moe.rukamori.archivetune.constants.AutoAiRomanizeLyricsKey
+import moe.rukamori.archivetune.db.entities.LyricsEntity
+import moe.rukamori.archivetune.utils.rememberEnumPreference
+import moe.rukamori.archivetune.utils.rememberPreference
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * AI-provided romanisation for the lyrics views.
+ *
+ * ## Why this is not just another branch inside [LyricsUtils]
+ *
+ * The built-in romanisers (Kuromoji for Japanese, hand-written tables for Korean/Hindi, ICU for
+ * everything else) are pure, synchronous-ish and cheap, so the renderers call them **per line**. An
+ * AI provider is the opposite on every count: it is network-bound, rate-limited and billed, so it has
+ * to be called **once per track** with every line in one batch. That difference in granularity is why
+ * this lives beside [LyricsUtils] rather than inside `romanizeLyricsLine`, and why results are held
+ * in a per-track cache the renderers read from instead of being awaited inline.
+ *
+ * ## Lifecycle
+ *
+ * [request] is idempotent per session key: the first caller starts the work, everyone else joins the
+ * same [Deferred]. Results land in [results], a StateFlow the renderers observe, so lyrics that were
+ * already on screen pick up romanisation without a re-layout — the same mechanism
+ * `LyricsEntry.romanizedTextFlow` uses for the built-in path.
+ *
+ * Results are memory-only and deliberately so. AI *translation* is persisted into `LyricsEntity`
+ * because it replaces the lyrics text; romanisation is an annotation drawn above each line and has
+ * nowhere to live in that schema without a second `source` value that could not coexist with
+ * `AI_TRANSLATION`.
+ */
+object AiLyricsRomanization {
+    private const val TAG = "AiRomanization"
+
+    /** Everything the renderers need to decide whether, and how, to romanise with the AI. */
+    @Immutable
+    data class Settings(
+        val enabled: Boolean,
+        val auto: Boolean,
+        val excludedLanguages: Set<String>,
+        val config: AiServiceConfig,
+    ) {
+        /**
+         * True when AI romanisation should take over from the built-in romanisers.
+         *
+         * Deliberately independent of [auto]: the user asked for the built-in romanisation to stop as
+         * soon as AI romanisation is switched on, so a configured-but-not-automatic setup shows AI
+         * results only, on demand, rather than silently mixing the two engines' spellings.
+         */
+        val active: Boolean get() = enabled && config.canCallApi
+
+        companion object {
+            val Disabled =
+                Settings(
+                    enabled = false,
+                    auto = false,
+                    excludedLanguages = emptySet(),
+                    config = AiServiceConfig(AiProvider.NONE, "", "", ""),
+                )
+        }
+    }
+
+    /**
+     * Romanisation for one lyrics session, addressed by the **original line text** rather than by
+     * index.
+     *
+     * Index alignment is not available here, and that is not a simplification: the two renderers
+     * parse the same lyrics into different index spaces. `LyricsV2` prepends a head entry and calls
+     * `insertInstrumentalBreaks`, `LyricsEnhanced` does neither, and the lyrics menu's manual request
+     * parses without either. All three derive the same [sessionKey] from the raw lyrics text, so an
+     * index-aligned cache filled by one of them was applied off-by-N by the next — every line's
+     * romanisation shifted onto its neighbour after a lyrics-style switch.
+     *
+     * Keying on the text is also just correct: identical lines have identical readings, so a chorus
+     * repeat resolves from the first occurrence instead of costing another entry.
+     */
+    @Immutable
+    data class Result(
+        val sessionKey: String,
+        val byLine: Map<String, String>,
+    )
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val romanizer = AiLyricsRomanizer()
+    private val inFlight = ConcurrentHashMap<String, Deferred<List<String?>>>()
+    private val cache = ConcurrentHashMap<String, Map<String, String>>()
+
+    private val _results = MutableStateFlow<Result?>(null)
+
+    /**
+     * Signals that a romanisation finished. Renderers observe this only to know *when* to re-resolve;
+     * the values themselves come from [linesFor], which is index-space independent.
+     */
+    val results: StateFlow<Result?> = _results.asStateFlow()
+
+    private val _running = MutableStateFlow(false)
+
+    /** True while a request is outstanding, for progress affordances in the lyrics menu. */
+    val running: StateFlow<Boolean> = _running.asStateFlow()
+
+    /**
+     * Reads the AI-romanisation settings inside composition.
+     *
+     * Mirrors how `AiIntegrationSettings` builds its own config so a provider/key/model change takes
+     * effect on the next recomposition without any explicit invalidation.
+     */
+    @Composable
+    fun rememberSettings(): Settings {
+        val (enabled) = rememberPreference(AiRomanizeLyricsKey, defaultValue = false)
+        val (auto) = rememberPreference(AutoAiRomanizeLyricsKey, defaultValue = false)
+        val (excluded) = rememberPreference(AiRomanizeExcludedLanguagesKey, defaultValue = emptySet())
+        val provider by rememberEnumPreference(AiProviderKey, AiProvider.NONE)
+        val (apiKey) = rememberPreference(AiApiKeyKey, defaultValue = "")
+        val (customEndpoint) = rememberPreference(AiCustomEndpointKey, defaultValue = "")
+        val (selectedModel) = rememberPreference(AiSelectedModelKey, defaultValue = "")
+        val (customModel) = rememberPreference(AiCustomModelKey, defaultValue = "")
+
+        return remember(enabled, auto, excluded, provider, apiKey, customEndpoint, selectedModel, customModel) {
+            Settings(
+                enabled = enabled,
+                auto = auto,
+                excludedLanguages = excluded,
+                config =
+                    AiServiceConfig(
+                        provider = provider,
+                        apiKey = apiKey,
+                        customEndpoint = customEndpoint,
+                        model = if (provider == AiProvider.CUSTOM) customModel else selectedModel,
+                    ),
+            )
+        }
+    }
+
+    /**
+     * Stable identity for "this track's lyrics as currently parsed". Romanisation is keyed on it so a
+     * refetch, an edit or a translation invalidates the cache while a replay of the same text reuses
+     * it.
+     */
+    fun sessionKey(
+        mediaId: String?,
+        lyrics: String?,
+    ): String = "${mediaId.orEmpty()}|${lyrics?.length ?: 0}|${lyrics?.hashCode() ?: 0}"
+
+    /**
+     * Resolves romanisation for [lines] in the caller's own index space, or an empty list when
+     * nothing has been fetched for [sessionKey] yet.
+     *
+     * This is the only way to read results, deliberately: it maps each line by its text, so a caller
+     * that prepends a head entry or inserts instrumental breaks gets the same answer as one that
+     * doesn't. Handing out the raw map instead would invite the index-aligned mistake back. See
+     * [Result].
+     */
+    fun linesFor(
+        sessionKey: String,
+        lines: List<String>,
+    ): List<String?> {
+        val byLine = cache[sessionKey] ?: return emptyList()
+        return lines.map { byLine[it.trim()] }
+    }
+
+    /**
+     * Parses [lyrics] into lines to send, for the manual "Romanise with AI" action.
+     *
+     * Does not have to agree with either renderer's index space — results are stored by line text —
+     * so this only has to produce the same *set* of lines. It parses rather than splitting on newlines
+     * so that timestamps and TTML markup never reach the model.
+     */
+    fun linesOf(
+        lyrics: String?,
+        durationSeconds: Int? = null,
+    ): List<String> {
+        val text = lyrics?.trim().orEmpty()
+        if (text.isEmpty() || text == LyricsEntity.LYRICS_NOT_FOUND) return emptyList()
+        return runCatching {
+            when {
+                LyricsUtils.isTtml(text) -> LyricsUtils.parseTtml(text, durationSeconds).map { it.text }
+                LyricsUtils.isLineSyncedLrc(text) -> LyricsUtils.parseLyrics(text).map { it.text }
+                else -> text.lines().filter { it.isNotBlank() }.map { it.trim() }
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    /**
+     * Requests romanisation for [lines], joining an in-flight request for the same [sessionKey].
+     *
+     * Returns immediately; the result is published to [results]. Silent no-op when the settings say
+     * not to, when nothing needs romanising, or when the track's dominant language is excluded — the
+     * caller does not have to pre-check any of that.
+     */
+    fun request(
+        sessionKey: String,
+        lines: List<String>,
+        settings: Settings,
+    ) {
+        if (!settings.active) return
+        if (lines.isEmpty()) return
+
+        cache[sessionKey]?.let { cached ->
+            publish(sessionKey, cached)
+            return
+        }
+        if (inFlight.containsKey(sessionKey)) return
+
+        // The exclusion list is checked against the whole lyric rather than per line: a single track
+        // is one language for this purpose, and per-line detection would send a Japanese song's
+        // occasional English hook to the model as if it were a different track.
+        val dominant = LyricsUtils.detectDominantLanguageCode(lines.joinToString("\n"))
+        if (dominant != null && settings.excludedLanguages.any { it.equals(dominant, ignoreCase = true) }) {
+            Timber.tag(TAG).d("skipping %s: %s is excluded", sessionKey, dominant)
+            return
+        }
+        // Nothing to do for lyrics that are already Latin script. Reuses the built-in detectors so
+        // the two engines agree on which lines are candidates at all.
+        if (lines.none { LyricsUtils.hasRomanizableScript(it) }) return
+
+        val job =
+            scope.async {
+                _running.value = true
+                try {
+                    romanizer.romanize(settings.config, lines)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (t: Throwable) {
+                    Timber.tag(TAG).w(t, "AI romanisation failed for %s", sessionKey)
+                    emptyList()
+                } finally {
+                    _running.value = false
+                }
+            }
+        inFlight[sessionKey] = job
+        scope.async {
+            val result = runCatching { job.await() }.getOrDefault(emptyList())
+            inFlight.remove(sessionKey)
+            // Index-aligned coming out of the romanizer, then immediately folded into the text-keyed
+            // form every reader uses. `associate` would keep the *last* occurrence of a repeated
+            // line; build it forwards so a chorus resolves from the first, which is the one whose
+            // batch had the most surrounding context.
+            val byLine = LinkedHashMap<String, String>(result.size)
+            lines.forEachIndexed { index, line ->
+                val romanized = result.getOrNull(index)?.trim()?.takeIf { it.isNotEmpty() } ?: return@forEachIndexed
+                byLine.putIfAbsent(line.trim(), romanized)
+            }
+            if (byLine.isNotEmpty()) {
+                cache[sessionKey] = byLine
+                trimCache(sessionKey)
+                publish(sessionKey, byLine)
+            }
+        }
+    }
+
+    private fun publish(
+        sessionKey: String,
+        byLine: Map<String, String>,
+    ) {
+        _results.value = Result(sessionKey = sessionKey, byLine = byLine)
+    }
+
+    private fun trimCache(keep: String) {
+        if (cache.size <= MaxCachedTracks) return
+        // ConcurrentHashMap has no LRU; the eviction only has to keep memory bounded, and the
+        // AiLyricsRomanizer already holds its own LRU of the expensive part (the model responses).
+        cache.keys.firstOrNull { it != keep }?.let { cache.remove(it) }
+    }
+
+    private const val MaxCachedTracks = 8
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsUtils.kt
@@ -22,9 +22,25 @@ data class LyricsRomanizationPreferences(
     val romanizeChinese: Boolean,
     val romanizeHindi: Boolean,
     val romanizeOther: Boolean,
+    /**
+     * True when an AI provider is supplying romanisation instead (see [AiLyricsRomanization]).
+     *
+     * This is the single gate that turns the built-in engines off, and it lives here rather than at
+     * each call site because every one of them — the three renderers' romanisation effects, the
+     * `showPhonetic` render flags, `providedRomanizedTextForEntry`, `shouldRomanizeLyricsLine` — is
+     * already written in terms of [isEnabled]. Running both engines would mix Hepburn from Kuromoji
+     * with whatever scheme the model chose inside a single song.
+     */
+    val aiHandled: Boolean = false,
 ) {
     val isEnabled: Boolean
-        get() = romanizeJapanese || romanizeKorean || romanizeChinese || romanizeHindi || romanizeOther
+        get() =
+            !aiHandled &&
+                (romanizeJapanese || romanizeKorean || romanizeChinese || romanizeHindi || romanizeOther)
+
+    /** True when romanisation should be rendered at all, whichever engine produced it. */
+    val showsRomanization: Boolean
+        get() = aiHandled || isEnabled
 }
 
 @Suppress("RegExpRedundantEscape")
@@ -1557,6 +1573,23 @@ object LyricsUtils {
             preferences.romanizeOther && hasOtherRomanizableScript(text) -> true
             else -> false
         }
+    }
+
+    /**
+     * True when [text] contains any script a romanisation could apply to, regardless of which engines
+     * the user has enabled.
+     *
+     * [shouldRomanizeLyricsLine] answers "should the built-in romanisers touch this line", which is
+     * the wrong question for the AI path: that one has a single on/off switch and no per-language
+     * engine toggles, but still must not spend a request on lyrics that are already Latin script.
+     */
+    fun hasRomanizableScript(text: String): Boolean {
+        if (text.isBlank()) return false
+        return looksJapanese(text) ||
+            isKorean(text) ||
+            isHindi(text) ||
+            isChinese(text) ||
+            hasOtherRomanizableScript(text)
     }
 
     fun shouldUseProvidedRomanization(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -44,6 +44,8 @@ import moe.rukamori.archivetune.constants.DownloadSource
 import moe.rukamori.archivetune.constants.DownloadSourceConfig
 import moe.rukamori.archivetune.constants.DownloadSourceKey
 import moe.rukamori.archivetune.constants.DownloadSourceOrderKey
+import moe.rukamori.archivetune.constants.DeezerAudioQuality
+import moe.rukamori.archivetune.constants.DeezerAudioQualityKey
 import moe.rukamori.archivetune.constants.QobuzAudioQuality
 import moe.rukamori.archivetune.constants.QobuzAudioQualityKey
 import moe.rukamori.archivetune.constants.SaavnAudioQuality
@@ -51,11 +53,14 @@ import moe.rukamori.archivetune.constants.SaavnAudioQualityKey
 import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalAudioQualityKey
 import moe.rukamori.archivetune.constants.toFormatId
+import moe.rukamori.archivetune.constants.toFormatName
 import moe.rukamori.archivetune.db.MusicDatabase
 import moe.rukamori.archivetune.db.entities.ArtistEntity
 import moe.rukamori.archivetune.db.entities.FormatEntity
 import moe.rukamori.archivetune.db.entities.SongArtistMap
 import moe.rukamori.archivetune.db.entities.SongEntity
+import moe.rukamori.archivetune.deezer.DeezerCrypto
+import moe.rukamori.archivetune.deezer.DeezerDecryptingDataSource
 import moe.rukamori.archivetune.di.DownloadCache
 import moe.rukamori.archivetune.di.PlayerCache
 import moe.rukamori.archivetune.innertube.YouTube
@@ -117,6 +122,7 @@ class DownloadUtil
         private val qobuzAudioQuality by enumPreference(context, QobuzAudioQualityKey, QobuzAudioQuality.FLAC)
         private val tidalAudioQuality by enumPreference(context, TidalAudioQualityKey, TidalAudioQuality.FLAC)
         private val saavnAudioQuality by enumPreference(context, SaavnAudioQualityKey, SaavnAudioQuality.QUALITY_320)
+        private val deezerAudioQuality by enumPreference(context, DeezerAudioQualityKey, DeezerAudioQuality.FLAC)
         private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
 
@@ -400,11 +406,38 @@ class DownloadUtil
         // everything else through the YouTube-resolving factory above.
         private val telegramDataSourceFactory = moe.rukamori.archivetune.telegram.TelegramDataSource.Factory()
 
+        /**
+         * Upstream for `deezer://` downloads.
+         *
+         * Deezer's CDN serves Blowfish-encrypted bytes, so the download cannot go through
+         * [youtubeDataSourceFactory]: that one runs the YouTube resolver over the DataSpec (which
+         * would rewrite our `deezer://` URI) and would store ciphertext even if it didn't. Decryption
+         * sits *below* the cache, exactly as it does for playback in `MusicService`, so what lands in
+         * [downloadCache] is a plain FLAC/MP3 file — which is what lets jaudiotagger embed tags and
+         * the exporter copy it out as playable audio.
+         */
+        private val deezerDownloadDataSourceFactory =
+            CacheDataSource
+                .Factory()
+                .setCache(downloadCache)
+                .setCacheKeyFactory(DownloadRequestCacheKeyFactory)
+                .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+                .setUpstreamDataSourceFactory(
+                    DeezerDecryptingDataSource.Factory(okHttpDataSourceFactory),
+                ).setCacheWriteDataSinkFactory(
+                    CacheDataSink
+                        .Factory()
+                        .setCache(downloadCache)
+                        .setBufferSize(DOWNLOAD_WRITE_BUFFER_SIZE)
+                        .setFragmentSize(DOWNLOAD_FRAGMENT_SIZE),
+                )
+
         private val dataSourceFactory =
             DataSource.Factory {
                 DownloadSchemeRoutingDataSource(
                     youtubeFactory = youtubeDataSourceFactory,
                     telegramFactory = telegramDataSourceFactory,
+                    deezerFactory = deezerDownloadDataSourceFactory,
                 )
             }
 
@@ -757,10 +790,9 @@ class DownloadUtil
             for (source in sourceOrder) {
                 val resolved = runCatching { resolveSourceStream(source, mediaId, queryTitle, artists, album, durationMs) }
                     .getOrNull() ?: continue
-                // Deezer currently returns null (no full stream available
-                // without Premium) — but its lookup still enriches the song
-                // metadata (ISRC, album name, thumbnail) so the downloaded
-                // song has correct tags even when falling through to YT.
+                // Deezer's public catalogue lookup fills in ISRC / album name /
+                // thumbnail, which is worth doing whether or not the stream itself
+                // resolved: a fall-through to YouTube still gets correct tags.
                 if (source == DownloadSource.DEEZER) {
                     enrichSongMetadataFromDeezer(mediaId, queryTitle, artists, album, durationMs)
                 }
@@ -837,12 +869,17 @@ class DownloadUtil
                     ?.let { ResolvedStreamData(it.uri, it.mimeType, it.codecs, it.contentLength) }
             }
             DownloadSource.DEEZER -> {
-                // Public Deezer API only exposes 30-second previews — full
-                // streaming requires Premium credentials. Return null so the
-                // AUTO chain falls through to the next source. The Deezer
-                // catalogue is still queried (via enrichSongMetadataFromDeezer)
-                // to populate the song's album/thumbnail/ISRC metadata.
-                null
+                // Returns a `deezer://` URI whose bytes are Blowfish-encrypted;
+                // downloadDataSourceFactory routes that scheme through
+                // DeezerDecryptingDataSource so the cache receives plain FLAC/MP3.
+                LosslessStreamResolver.resolveDeezer(
+                    mediaId = mediaId,
+                    title = title,
+                    artists = artists,
+                    album = album,
+                    durationMs = durationMs,
+                    format = deezerAudioQuality.toFormatName(),
+                )?.let { ResolvedStreamData(it.uri, it.mimeType, it.codecs, it.contentLength) }
             }
             DownloadSource.JIOSAAVN -> {
                 LosslessStreamResolver.resolveJioSaavn(
@@ -1100,12 +1137,14 @@ class DownloadUtil
         }
 
         /**
-         * Picks the download upstream by URI scheme: `telegram://` tracks go through TDLib (mirroring
-         * playback's SchemeRoutingDataSource), everything else through the YouTube-resolving factory.
+         * Picks the download upstream by URI scheme: `telegram://` tracks go through TDLib and
+         * `deezer://` through the Blowfish-decrypting chain (both mirroring playback's
+         * SchemeRoutingDataSource), everything else through the YouTube-resolving factory.
          */
         private class DownloadSchemeRoutingDataSource(
             private val youtubeFactory: DataSource.Factory,
             private val telegramFactory: DataSource.Factory,
+            private val deezerFactory: DataSource.Factory,
         ) : DataSource {
             private val transferListeners = mutableListOf<TransferListener>()
             private var delegate: DataSource? = null
@@ -1117,7 +1156,12 @@ class DownloadUtil
 
             override fun open(dataSpec: DataSpec): Long {
                 val scheme = dataSpec.uri.scheme?.lowercase(java.util.Locale.US)
-                val selected = if (scheme == "telegram") telegramFactory else youtubeFactory
+                val selected =
+                    when (scheme) {
+                        "telegram" -> telegramFactory
+                        DeezerCrypto.SCHEME -> deezerFactory
+                        else -> youtubeFactory
+                    }
                 val source = selected.createDataSource()
                 transferListeners.forEach(source::addTransferListener)
                 delegate = source

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/LosslessStreamResolver.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/LosslessStreamResolver.kt
@@ -22,6 +22,7 @@ import moe.rukamori.archivetune.constants.TidalAccountFirstKey
 import moe.rukamori.archivetune.constants.TidalAudioQuality
 import moe.rukamori.archivetune.constants.TidalCountryCodeKey
 import moe.rukamori.archivetune.constants.TidalInstancesKey
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
 import moe.rukamori.archivetune.jiosaavn.SaavnService
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzBackupProvider
@@ -361,6 +362,69 @@ object LosslessStreamResolver {
         }.onFailure { error ->
             Timber.tag("LosslessResolver").w(error, "Qobuz backup resolve failed for %s", mediaId)
         }.getOrNull()
+
+    /**
+     * Resolves a **Deezer** stream for [mediaId].
+     *
+     * Mirrors `MusicService.resolveDeezerStream`, including the credential guard: the provider merges
+     * the manually signed-in ARL with the pool's shared accounts, so this must go through
+     * [DeezerAudioProvider.hasAccounts] rather than reading [PoolAccountManager] directly.
+     *
+     * The returned [DirectStream.uri] is a `deezer://` URI, not an HTTPS URL — the CDN bytes are
+     * Blowfish-encrypted and only become audio after `DeezerDecryptingDataSource` has run over them.
+     * `DownloadUtil` routes that scheme to a decrypting upstream, so what lands in the download cache
+     * is a plain FLAC/MP3 file that jaudiotagger can tag. This used to be a hard-coded `null` in the
+     * download chain, with a comment claiming the public Deezer API only exposes 30-second previews —
+     * true of `api.deezer.com`, but stale ever since full Premium streaming was ported: playback has
+     * resolved real Deezer streams through this exact provider since then, while downloads silently
+     * fell through to the YouTube fallback.
+     */
+    fun resolveDeezer(
+        mediaId: String,
+        title: String,
+        artists: List<String>,
+        album: String?,
+        durationMs: Long?,
+        format: String,
+    ): DirectStream? {
+        if (!DeezerAudioProvider.hasAccounts()) {
+            Timber.tag("LosslessResolver").d("Deezer skip: no manual or pooled accounts available")
+            return null
+        }
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                DeezerAudioProvider
+                    .resolve(
+                        query =
+                            DeezerAudioProvider.Query(
+                                mediaId = mediaId,
+                                title = title,
+                                artists = artists,
+                                album = album,
+                                durationMs = durationMs,
+                            ),
+                        format = format,
+                    )?.let { resolved ->
+                        DirectStream(
+                            uri = resolved.uri,
+                            mimeType = resolved.mimeType,
+                            codecs = resolved.codecs,
+                            contentLength = resolved.contentLength,
+                            label = resolved.label,
+                            source = AudioSourceType.DEEZER,
+                            matchedTitle = resolved.matchedTitle,
+                            matchedArtist = resolved.matchedArtist,
+                            matchedAlbum = resolved.matchedAlbum,
+                            matchedDurationMs = resolved.matchedDurationMs,
+                            sampleRate = resolved.sampleRate,
+                            bitDepth = resolved.bitDepth,
+                        )
+                    }
+            }
+        }.onFailure { error ->
+            Timber.tag("LosslessResolver").w(error, "Deezer resolve failed for %s", mediaId)
+        }.getOrNull()
+    }
 
     /**
      * Resolves a **JioSaavn** stream for [mediaId].

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -129,6 +129,7 @@ import moe.rukamori.archivetune.constants.PlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.PlayerBackgroundStyleKey
 import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
+import moe.rukamori.archivetune.lyrics.AiLyricsRomanization
 import moe.rukamori.archivetune.lyrics.LyricsEntry
 import moe.rukamori.archivetune.lyrics.LyricsRomanizationPreferences
 import moe.rukamori.archivetune.lyrics.LyricsUtils.hasTrueWordSync
@@ -194,6 +195,25 @@ private const val LYRIC_FIRST_FOCUS_FADE_MS = 200
 // Hard ceiling on how long the lines may stay hidden waiting for that placement.
 private const val LYRIC_FIRST_FOCUS_TIMEOUT_MS = 400L
 private const val MIN_KARAOKE_SYLLABLE_DURATION_MS = 1
+
+// ── Line-synced (LRC) focus windows ──
+// KaraokeLyricsView resolves the focused line as "the line whose [start, end) contains the
+// position", and falls back to the *next* line whenever the position lands between two windows.
+// These three constants exist to make sure that fallback only ever fires on a genuine instrumental
+// break; see the long comment in buildSyncedLyrics.
+//
+// How long a line may keep focus after its own timestamp before it is allowed to hand over to a
+// breathing-dots interlude. Below this the line simply holds until the next one starts.
+private const val LINE_SYNCED_MAX_FOCUS_HOLD_MS = 5_000L
+// Mirrors the library's own interlude threshold: it draws the breathing dots only when the silence
+// between two lines is strictly longer than this.
+private const val LINE_SYNCED_INTERLUDE_MIN_GAP_MS = 5_000L
+// The karaoke sweep for romanized line-synced lyrics is spread over at most this much time, so a
+// long focus hold doesn't turn into a crawling fill.
+private const val LINE_SYNCED_MAX_FILL_DURATION_MS = 4_000L
+// The last line has no successor to butt against, so give it a fixed window. The library already
+// falls back to `lines.lastIndex` past the end, so this only bounds the sweep.
+private const val LINE_SYNCED_TRAILING_LINE_DURATION_MS = 4_000L
 // Minimum backward position jump (in ms) that we treat as a "reset" trigger —
 // large enough to ride through ExoPlayer's normal position jitter (which is
 // well under 200ms even on a stuttering device) and minor playback corrections,
@@ -238,6 +258,8 @@ fun LyricsEnhanced(
     val (romanizeKorean) = rememberPreference(LyricsRomanizeKoreanKey, defaultValue = true)
     val (romanizeOtherLanguages) = rememberPreference(LyricsRomanizeOtherLanguagesKey, defaultValue = true)
 
+    val aiRomanizationSettings = AiLyricsRomanization.rememberSettings()
+
     val romanizationPreferences =
         remember(
             romanizeJapanese,
@@ -245,6 +267,7 @@ fun LyricsEnhanced(
             romanizeChinese,
             romanizeHindi,
             romanizeOtherLanguages,
+            aiRomanizationSettings.active,
         ) {
             LyricsRomanizationPreferences(
                 romanizeJapanese = romanizeJapanese,
@@ -252,6 +275,7 @@ fun LyricsEnhanced(
                 romanizeChinese = romanizeChinese,
                 romanizeHindi = romanizeHindi,
                 romanizeOther = romanizeOtherLanguages,
+                aiHandled = aiRomanizationSettings.active,
             )
         }
 
@@ -354,12 +378,42 @@ fun LyricsEnhanced(
         mutableStateOf(SyncedLyrics(emptyList()))
     }
 
-    LaunchedEffect(lyricsEntries, romanizationPreferences) {
+    // ── AI romanisation ──
+    // Runs once per track instead of once per line (network + billed), so it can't hang off the
+    // per-line pass below. Results arrive asynchronously through AiLyricsRomanization.results and are
+    // folded into the same romanizationMap the built-in engines feed, which means everything
+    // downstream — the wrapping-unit distribution, the karaoke phonetics, `showPhonetic` — is shared.
+    val aiRomanizationSessionKey =
+        remember(mediaMetadata?.id, lyrics) { AiLyricsRomanization.sessionKey(mediaMetadata?.id, lyrics) }
+    val aiRomanizationResult by AiLyricsRomanization.results.collectAsStateWithLifecycle()
+    // Resolved by line text, not by index — this renderer parses without the head entry and without
+    // instrumental breaks, LyricsV2 parses with both, and both derive the same session key. See
+    // AiLyricsRomanization.Result.
+    val aiRomanizedLines: List<String?> =
+        remember(aiRomanizationResult, aiRomanizationSessionKey, aiRomanizationSettings.active, lyricsEntries) {
+            if (!aiRomanizationSettings.active) {
+                emptyList()
+            } else {
+                AiLyricsRomanization.linesFor(aiRomanizationSessionKey, lyricsEntries.map { it.text })
+            }
+        }
+    LaunchedEffect(aiRomanizationSessionKey, lyricsEntries, aiRomanizationSettings) {
+        if (!aiRomanizationSettings.active || !aiRomanizationSettings.auto) return@LaunchedEffect
+        if (lyricsEntries.isEmpty()) return@LaunchedEffect
+        AiLyricsRomanization.request(
+            sessionKey = aiRomanizationSessionKey,
+            lines = lyricsEntries.map { it.text },
+            settings = aiRomanizationSettings,
+        )
+    }
+
+    LaunchedEffect(lyricsEntries, romanizationPreferences, aiRomanizedLines) {
         // Everything below (scanning + romanizing every line, often one job per word for TTML)
         // used to inherit the main dispatcher and could stutter the karaoke animation on track
         // change; run the whole batch on Default and only publish the results back.
         withContext(Dispatchers.Default) {
-        syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, emptyMap())
+        val aiMap = aiRomanizationMap(lyricsEntries, isTtmlFormat, aiRomanizedLines)
+        syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, aiMap)
         if (!romanizationPreferences.isEnabled) return@withContext
 
         val toRomanize =
@@ -484,12 +538,25 @@ fun LyricsEnhanced(
     //
     // So: keep the lines invisible until the active one has been placed (the
     // first placement snaps instead of animating, since nothing is on screen to
-    // animate), then fade them in. Re-armed when the number of lines changes so
-    // lyrics that arrive after the view is already open — a slow provider, a
-    // translation — get the same treatment instead of jumping.
+    // animate), then fade them in.
+    //
+    // The key deliberately does NOT include the line count. `syncedLyrics` is built on
+    // Dispatchers.Default, so it is *always* empty on the first composition and always grows to N
+    // one or two frames later. Keying on the size therefore re-ran this `remember` after the view
+    // was already on screen, handing back a brand-new `mutableStateOf(true)` that snapped the alpha
+    // from 1 straight back to 0 (the hide has `durationMillis = 0`) and swallowed the collector's
+    // `awaitingFirstFocus = false` write — the lyrics blinked out for the full
+    // LYRIC_FIRST_FOCUS_TIMEOUT_MS and then faded back in. That is the "lyrics disappear for a
+    // split second right after opening" report, and it fired on every single open of the Apple
+    // Music player because that player composes this view from scratch each time.
+    //
+    // `isSynced` is derived synchronously from the raw lyrics text, so it is already correct on
+    // frame 1: the gate arms before anything is drawn and is only ever disarmed, never re-armed.
+    // A late-arriving *session* (new track, new lyrics text, repeat) still re-arms it, because
+    // lyricsSessionKey covers all three.
     var awaitingFirstFocus by
-        remember(lyricsSessionKey, positionResetCounter, syncedLyrics.lines.size) {
-            mutableStateOf(isSynced && syncedLyrics.lines.isNotEmpty())
+        remember(lyricsSessionKey, positionResetCounter) {
+            mutableStateOf(isSynced)
         }
     // Safety net: nothing may keep the lyrics hidden. If the placement hasn't
     // happened by the time this fires (no viewport, auto-scroll preference off,
@@ -739,10 +806,17 @@ fun LyricsEnhanced(
     // observes the first new active line. Keeping listState stable means the
     // collector always targets the list currently on screen.
     LaunchedEffect(lyricsSessionKey, isSynced, positionResetCounter) {
-        if (!isSynced || latestSyncedLyricsForScroll.value.lines.isEmpty()) {
+        if (!isSynced) {
             awaitingFirstFocus = false
             return@LaunchedEffect
         }
+        // An empty line list here means "the off-thread build hasn't published yet", not "this
+        // track has no synced lyrics" — buildSyncedLyrics runs on Dispatchers.Default and lands a
+        // frame or two after the first composition. Bailing out on it (which is what this used to
+        // do) disarmed the first-focus gate before there was anything to place, so the lines were
+        // drawn at line 0 and then visibly walked to the active one. Wait for the content instead;
+        // the LYRIC_FIRST_FOCUS_TIMEOUT_MS safety net above covers the case where it never arrives.
+        snapshotFlow { latestSyncedLyricsForScroll.value.lines.isNotEmpty() }.first { it }
         snapshotFlow {
             listState.layoutInfo.viewportEndOffset > listState.layoutInfo.viewportStartOffset
         }.first { it }
@@ -759,6 +833,12 @@ fun LyricsEnhanced(
             .collectLatest { index ->
                 if (index == null) {
                     forceNextScroll = true
+                    // Nothing to place: either no line has started yet (song intro) or the user
+                    // took over the scroll. The list is already where it belongs in both cases, so
+                    // release the first-focus gate instead of letting it time out — otherwise the
+                    // lines would sit invisible for LYRIC_FIRST_FOCUS_TIMEOUT_MS on every track
+                    // whose first lyric starts a beat after playback does.
+                    awaitingFirstFocus = false
                     return@collectLatest
                 }
 
@@ -932,7 +1012,19 @@ fun LyricsEnhanced(
         modifier =
             modifier
                 .fillMaxSize()
-                .padding(bottom = 12.dp),
+                .padding(bottom = 12.dp)
+                // Draw-phase read: holds everything back until the active line is in place (see
+                // awaitingFirstFocus), then fades it in without recomposing anything.
+                //
+                // The gate lives on the whole Box, not just the karaoke branch, because the
+                // branches below swap while it is armed: the shimmer draws first, then (for one or
+                // two frames, between the two Dispatchers.Default hops that publish parsedEntries
+                // and syncedLyrics) possibly "lyrics not found", then the lines. Gating only the
+                // last of those meant the first two flashed at full opacity and then vanished when
+                // the lines took over — visible as the lyrics appearing, blinking out and coming
+                // back. When there is nothing to place (plain lyrics, no lyrics, not-found) the
+                // gate is never armed and this is a no-op.
+                .graphicsLayer { alpha = firstFocusAlpha.value },
     ) {
         when {
             lyrics == LYRICS_NOT_FOUND -> {
@@ -950,6 +1042,16 @@ fun LyricsEnhanced(
             // Shimmer on that state — without it the two "lyrics not found" branches below
             // would flash for the frames the parse takes.
             lyrics == null || parsedEntries == null -> {
+                ShimmerHost {
+                    repeat(6) { TextPlaceholder() }
+                }
+            }
+
+            // Same window, one hop later: the parse has landed but buildSyncedLyrics (also on
+            // Dispatchers.Default) hasn't published its result, so `lines` is empty even though
+            // this track definitely has synced lyrics. Keep the shimmer up rather than claiming
+            // they don't exist.
+            isSynced && syncedLyrics.lines.isEmpty() && lyricsEntries.isNotEmpty() -> {
                 ShimmerHost {
                     repeat(6) { TextPlaceholder() }
                 }
@@ -1006,11 +1108,7 @@ fun LyricsEnhanced(
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .nestedScroll(nestedScrollConnection)
-                            // Draw-phase read: holds the lines back until the
-                            // active one is in place (see awaitingFirstFocus),
-                            // then fades them in without recomposing anything.
-                            .graphicsLayer { alpha = firstFocusAlpha.value },
+                            .nestedScroll(nestedScrollConnection),
                 ) {
                     val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.08f }
 
@@ -1054,7 +1152,7 @@ fun LyricsEnhanced(
                             // this view; drop it when animations are disabled (low-RAM default).
                             useBlurEffect = lyricsLineBlur && !animationsDisabled,
                             showTranslation = showTranslations,
-                            showPhonetic = romanizationPreferences.isEnabled,
+                            showPhonetic = romanizationPreferences.showsRomanization,
                             offset = lyricsViewportOffset,
                             // Reduced from 36.dp → 20.dp → 8.dp. The keepAliveZone controls how
                             // many items outside the viewport are kept composed (not
@@ -1555,6 +1653,62 @@ private fun List<WordTimestamp>.toKaraokeSyllables(phonetics: List<String?>): Li
 
 private fun Double.toMilliseconds(): Int = (this * 1000.0).roundToInt().coerceAtLeast(0)
 
+/**
+ * Reshapes AI romanisation — one string per lyric line — into the per-word map [buildSyncedLyrics]
+ * expects.
+ *
+ * The built-in path romanises word by word for word-synced TTML, which an AI provider cannot do
+ * affordably: a three-minute song is a few hundred lines but a few thousand words, and asking for
+ * per-word output also loses the sentence context that makes a model's reading better than a table's
+ * in the first place. So the model gets whole lines, and for word-synced lines the returned words are
+ * distributed across the syllables proportionally — the same approximation
+ * [buildWrappingKaraokeSyllables] already makes for line-synced lyrics.
+ */
+private fun aiRomanizationMap(
+    entries: List<LyricsEntry>,
+    isTtml: Boolean,
+    aiLines: List<String?>,
+): Map<Int, List<String?>> {
+    if (aiLines.isEmpty() || entries.isEmpty()) return emptyMap()
+    val map = mutableMapOf<Int, List<String?>>()
+    entries.forEachIndexed { index, entry ->
+        val romanized = aiLines.getOrNull(index)?.trim()?.takeIf { it.isNotEmpty() } ?: return@forEachIndexed
+        val words = entry.words?.filter { !it.isBackground }
+        map[index] =
+            if (isTtml && !words.isNullOrEmpty()) {
+                distributePhonetics(words.map { it.text }, romanized)
+            } else {
+                listOf(romanized)
+            }
+    }
+    return map
+}
+
+/**
+ * Spreads the whitespace-separated pieces of [romanized] across [words], keeping order.
+ *
+ * Proportional rather than one-to-one because the two sides rarely have the same count: "君の名は"
+ * arrives as four TTML words and comes back as "kimi no na wa", but "ありがとう" is one word and one
+ * token. Anchoring by relative position keeps a syllable's phonetic under roughly the right glyphs
+ * even when the counts differ, and merging surplus tokens onto the last anchor means none are lost.
+ */
+private fun distributePhonetics(
+    words: List<String>,
+    romanized: String,
+): List<String?> {
+    if (words.isEmpty()) return emptyList()
+    val tokens = romanized.split(Regex("\\s+")).filter { it.isNotEmpty() }
+    if (tokens.isEmpty()) return List(words.size) { null }
+    if (words.size == 1) return listOf(tokens.joinToString(" "))
+
+    val out = MutableList<String?>(words.size) { null }
+    tokens.forEachIndexed { tokenIndex, token ->
+        val anchor = (tokenIndex * words.size / tokens.size).coerceIn(0, words.size - 1)
+        out[anchor] = listOfNotNull(out[anchor], token).joinToString(" ")
+    }
+    return out
+}
+
 private fun buildSyncedLyrics(
     entries: List<LyricsEntry>,
     isTtml: Boolean,
@@ -1622,24 +1776,53 @@ private fun buildSyncedLyrics(
             )
         } else {
             val nextEntry = entries.getOrNull(index + 1)
+            // ── Why `end` must be exactly the next line's start ──
+            // KaraokeLyricsView picks the focused line with
+            //     lines.indices.firstOrNull { pos >= it.start && pos < effectiveEnd(it) }
+            //         ?: lines.indexOfFirst { it.start > pos }   // ← the *upcoming* line
+            //         ?: lines.lastIndex
+            // so any instant that falls in a gap between one line's end and the next line's start
+            // resolves to the line that has NOT started yet. This branch used to clamp `end` to
+            // start + 4s whenever the gap to the next line exceeded 3s, which manufactured exactly
+            // such a gap on every slow line and every verse boundary: 4s into a line with a 9s gap
+            // the focus, the scale-up and the spring placement all moved to the next line while the
+            // current one was still being sung. That is the "line-synced lyrics in Enhanced style
+            // scroll way too soon" report, and it is Enhanced-only because LyricsV2 resolves the
+            // active line itself (last line whose start has passed) instead of asking the library.
+            //
+            // Butting each line's end against the next line's start removes the gaps entirely, so
+            // the library's first predicate always matches and always agrees with
+            // findLastStartedLineIndex — which is what drives our own auto-scroll. The two can no
+            // longer disagree, and a line stays focused for as long as it is the most recent one,
+            // exactly like Apple Music holds the last sung line through an instrumental break.
             val lineEnd =
                 if (nextEntry != null && nextEntry.time > entry.time) {
-                    val gap = nextEntry.time - entry.time
-                    if (gap > 3000L) {
-                        minOf((nextEntry.time - 1L).toInt(), (entry.time + 4000L).toInt())
-                            .coerceAtLeast(entry.time.toInt() + 1)
+                    val handOver = entry.time + LINE_SYNCED_MAX_FOCUS_HOLD_MS
+                    if (nextEntry.time - handOver > LINE_SYNCED_INTERLUDE_MIN_GAP_MS) {
+                        // A real instrumental break. Hand focus over so the library's breathing-dots
+                        // interlude — which only triggers when `next.start - previous.end` exceeds
+                        // its own 5s threshold — still gets to run through the silence.
+                        handOver.toInt()
                     } else {
-                        (nextEntry.time - 1L).coerceAtLeast(entry.time + 1L).toInt()
+                        nextEntry.time.toInt()
                     }
                 } else {
-                    (entry.time + 4000L).toInt()
+                    (entry.time + LINE_SYNCED_TRAILING_LINE_DURATION_MS).toInt()
                 }
+            // The karaoke sweep (only built when there is romanization to align) is a different
+            // question: spreading syllables across a multi-second hold would crawl. Cap the sweep at
+            // a musical line's worth of time and let the line simply sit finished afterwards.
+            val fillEnd =
+                minOf(lineEnd.toLong(), entry.time + LINE_SYNCED_MAX_FILL_DURATION_MS)
+                    .coerceAtLeast(entry.time + 1L)
+                    .toInt()
             lines.add(
                 buildLineSyncedLrcLine(
                     entry = entry,
                     romanizedText = romanizationMap[index]?.firstOrNull(),
                     start = entry.time.toInt(),
                     end = lineEnd,
+                    fillEnd = fillEnd,
                 ),
             )
         }
@@ -1653,6 +1836,9 @@ private fun buildLineSyncedLrcLine(
     romanizedText: String?,
     start: Int,
     end: Int,
+    // Where the karaoke sweep should finish. Equal to [end] for normal lines; shorter when [end]
+    // has been stretched to butt against a far-away next line (see buildSyncedLyrics).
+    fillEnd: Int = end,
 ): ISyncedLine {
     val translation = providedTranslationTextForEntry(entry)
     val normalizedRomanizedText = romanizedText?.trim()?.takeIf { it.isNotEmpty() }
@@ -1671,7 +1857,7 @@ private fun buildLineSyncedLrcLine(
             content = entry.text,
             romanizedText = normalizedRomanizedText,
             start = start,
-            end = end,
+            end = fillEnd.coerceAtLeast(start + 1),
         )
 
     return KaraokeLine.MainKaraokeLine(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -131,6 +131,7 @@ import moe.rukamori.archivetune.constants.PlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.PlayerBackgroundStyleKey
 import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
+import moe.rukamori.archivetune.lyrics.AiLyricsRomanization
 import moe.rukamori.archivetune.lyrics.LyricsEntry
 import moe.rukamori.archivetune.lyrics.LyricsRomanizationPreferences
 import moe.rukamori.archivetune.lyrics.LyricsUtils.findCurrentLineIndex
@@ -279,6 +280,7 @@ fun LyricsV2(
     val (romanizeJapanese) = rememberPreference(LyricsRomanizeJapaneseKey, defaultValue = true)
     val (romanizeKorean) = rememberPreference(LyricsRomanizeKoreanKey, defaultValue = true)
     val (romanizeOtherLanguages) = rememberPreference(LyricsRomanizeOtherLanguagesKey, defaultValue = true)
+    val aiRomanizationSettings = AiLyricsRomanization.rememberSettings()
     val romanizationPreferences =
         remember(
             romanizeJapanese,
@@ -286,6 +288,7 @@ fun LyricsV2(
             romanizeChinese,
             romanizeHindi,
             romanizeOtherLanguages,
+            aiRomanizationSettings.active,
         ) {
             LyricsRomanizationPreferences(
                 romanizeJapanese = romanizeJapanese,
@@ -293,6 +296,7 @@ fun LyricsV2(
                 romanizeChinese = romanizeChinese,
                 romanizeHindi = romanizeHindi,
                 romanizeOther = romanizeOtherLanguages,
+                aiHandled = aiRomanizationSettings.active,
             )
         }
     val lyricsFontFamily = rememberArchiveTuneLyricsFontFamily()
@@ -366,9 +370,50 @@ fun LyricsV2(
     // detection on every 16 ms position tick for every visible line.
     val wordSyncCache = rememberWordSyncCache()
 
+    // ── AI romanisation ──
+    // One batched request per track (network + billed), so it cannot hang off the per-line pass
+    // below. Results are pushed into the same `romanizedTextFlow` the built-in engines write to, so
+    // the render path and the fade-in behaviour are identical whichever engine produced them.
+    val aiRomanizationSessionKey =
+        remember(mediaMetadata?.id, lyrics) { AiLyricsRomanization.sessionKey(mediaMetadata?.id, lyrics) }
+    val aiRomanizationResult by AiLyricsRomanization.results.collectAsStateWithLifecycle()
+    // Resolved by line text, not by index — this renderer's entry list carries a head entry and
+    // instrumental breaks that LyricsEnhanced's does not, and both derive the same session key. See
+    // AiLyricsRomanization.Result.
+    val aiRomanizedLines: List<String?> =
+        remember(aiRomanizationResult, aiRomanizationSessionKey, aiRomanizationSettings.active, entriesWithWords) {
+            if (!aiRomanizationSettings.active) {
+                emptyList()
+            } else {
+                AiLyricsRomanization.linesFor(aiRomanizationSessionKey, entriesWithWords.map { it.text })
+            }
+        }
+    LaunchedEffect(aiRomanizationSessionKey, entriesWithWords, aiRomanizationSettings) {
+        if (!aiRomanizationSettings.active || !aiRomanizationSettings.auto) return@LaunchedEffect
+        if (entriesWithWords.isEmpty()) return@LaunchedEffect
+        AiLyricsRomanization.request(
+            sessionKey = aiRomanizationSessionKey,
+            lines = entriesWithWords.map { it.text },
+            settings = aiRomanizationSettings,
+        )
+    }
+    LaunchedEffect(entriesWithWords, aiRomanizedLines, aiRomanizationSettings.active) {
+        if (!aiRomanizationSettings.active) return@LaunchedEffect
+        entriesWithWords.forEachIndexed { index, entry ->
+            val romanized = aiRomanizedLines.getOrNull(index)?.trim()?.takeIf { it.isNotEmpty() }
+            if (entry.romanizedTextFlow.value != romanized) {
+                entry.romanizedTextFlow.value = romanized
+            }
+        }
+    }
+
     // ── Romanization ──
     LaunchedEffect(entriesWithWords, romanizationPreferences) {
         if (!romanizationPreferences.isEnabled) {
+            // Guard against clobbering AI results: when the AI engine owns romanisation the effect
+            // above is the writer, and blanking the flows here would erase it on every recomposition
+            // that changed `entriesWithWords`.
+            if (aiRomanizationSettings.active) return@LaunchedEffect
             entriesWithWords.forEach { entry ->
                 if (entry.romanizedTextFlow.value != null) {
                     entry.romanizedTextFlow.value = null
@@ -517,12 +562,19 @@ fun LyricsV2(
     //
     // Hold the list transparent until the active line is placed — the first
     // placement is an instant scroll, since there is nothing on screen to
-    // animate — then fade in. Keyed on the line count so lyrics that land after
-    // the view is already open (slow provider, translation) are placed the same
-    // way instead of jumping.
+    // animate — then fade in.
+    //
+    // The key must NOT include the line count. `entriesWithWords` is derived from an off-thread
+    // parse, so it is always empty on the first composition and always grows one or two frames
+    // later; keying on its size re-ran this `remember` after the view was already visible and
+    // handed back a fresh `mutableStateOf(true)`, snapping the alpha from 1 back to 0 with a
+    // zero-duration tween. The lyrics blinked out and faded back in on every open — worst in the
+    // Apple Music player, which composes this view from scratch each time. `isSynced` is derived
+    // synchronously from the raw lyrics text, so arming on it is already correct on frame 1, and
+    // `playbackResetTick` still re-arms for a new track / repeat.
     var awaitingFirstFocus by
-        remember(playbackResetTick, entriesWithWords.size) {
-            mutableStateOf(isSynced && entriesWithWords.isNotEmpty())
+        remember(playbackResetTick) {
+            mutableStateOf(isSynced)
         }
     // Safety net: never leave the lyrics hidden because a placement never came.
     LaunchedEffect(awaitingFirstFocus) {
@@ -573,13 +625,26 @@ fun LyricsV2(
         onLyricsScroll(isManualScrolling)
     }
 
-    // Auto-scroll to active line
-    LaunchedEffect(currentLineIndex, isManualScrolling, lyricsScroll) {
+    // Auto-scroll to active line.
+    //
+    // `entriesWithWords.size` is part of the key so the first-focus placement below still runs when
+    // the off-thread parse publishes without changing `currentLineIndex` (the common case: the view
+    // opens mid-song, the index loop resolves the same line the list already thinks is current).
+    // Re-running this effect on content changes is cheap — unlike re-running the `remember` that
+    // owns `awaitingFirstFocus`, which is what caused the flicker.
+    LaunchedEffect(currentLineIndex, isManualScrolling, lyricsScroll, entriesWithWords.size) {
         if (!lyricsScroll || isManualScrolling || !isSynced) {
             awaitingFirstFocus = false
             return@LaunchedEffect
         }
-        if (currentLineIndex < 0 || currentLineIndex >= entriesWithWords.size) return@LaunchedEffect
+        if (currentLineIndex < 0 || currentLineIndex >= entriesWithWords.size) {
+            // Nothing to place yet: either the parse hasn't published (empty list) or playback
+            // hasn't reached the first line. Only release the gate in the second case — while the
+            // list is still empty the effect will re-run as soon as an index becomes valid, and
+            // releasing here would let line 0 draw and then visibly walk to the active line.
+            if (entriesWithWords.isNotEmpty()) awaitingFirstFocus = false
+            return@LaunchedEffect
+        }
 
         if (awaitingFirstFocus) {
             // Wait for the first measure so the 35% anchor is computed against a
@@ -646,7 +711,17 @@ fun LyricsV2(
         modifier =
             modifier
                 .fillMaxSize()
-                .padding(bottom = 12.dp),
+                .padding(bottom = 12.dp)
+                // Draw-phase read — holds everything back until the active line has been placed
+                // (see awaitingFirstFocus), then fades it in.
+                //
+                // The gate covers the whole subtree rather than just the LazyColumn because the
+                // branches below swap while it is armed: shimmer first, then the lines once the
+                // off-thread parse publishes. Gating only the list meant the shimmer drew at full
+                // opacity and then vanished the instant the lines took over — the "lyrics appear,
+                // blink out, come back" symptom. When nothing needs placing (no lyrics, plain
+                // lyrics, not-found) the gate is never armed and this is a no-op.
+                .graphicsLayer { alpha = firstFocusAlpha.value },
     ) {
         if (lyrics == LYRICS_NOT_FOUND) {
             Box(
@@ -698,9 +773,6 @@ fun LyricsV2(
                     .smoothFadingEdge(vertical = 80.dp)
                     .graphicsLayer {
                         compositingStrategy = CompositingStrategy.Offscreen
-                        // Draw-phase read — holds the lines back until the active
-                        // one has been placed (see awaitingFirstFocus).
-                        alpha = firstFocusAlpha.value
                     },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -108,6 +108,7 @@ import moe.rukamori.archivetune.constants.AiProvider
 import moe.rukamori.archivetune.constants.AiProviderKey
 import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
 import moe.rukamori.archivetune.db.entities.LyricsEntity
+import moe.rukamori.archivetune.lyrics.AiLyricsRomanization
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
@@ -234,6 +235,19 @@ fun LyricsMenu(
     var translationJob by remember { mutableStateOf<Job?>(null) }
     var isStandardTranslating by remember { mutableStateOf(false) }
     var isDialogAiTranslationRunning by rememberSaveable { mutableStateOf(false) }
+
+    // ── AI romanisation ──
+    // The manual counterpart to the "Auto AI Romanisation" setting: with auto off the renderers never
+    // send a request on their own, so without this the master switch would silently disable the
+    // built-in romanisers and offer nothing in their place. Requesting is idempotent per track — the
+    // coordinator joins an in-flight call and serves a cached one — so a second tap is free.
+    val aiRomanizationSettings = AiLyricsRomanization.rememberSettings()
+    val isAiRomanizing by AiLyricsRomanization.running.collectAsStateWithLifecycle()
+    val isAiRomanizationEnabled =
+        aiRomanizationSettings.active &&
+            currentLyrics.isNotBlank() &&
+            currentLyrics != LyricsEntity.LYRICS_NOT_FOUND &&
+            !isAiRomanizing
 
     LaunchedEffect(Unit) {
         viewModel.aiTranslationEvents.collect { message ->
@@ -755,6 +769,33 @@ fun LyricsMenu(
                                 text = stringResource(R.string.translate),
                                 onClick = { showTranslateDialog = true },
                                 enabled = isTranslateEnabled,
+                            ),
+                            NewAction(
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.language),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(28.dp),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                },
+                                text = stringResource(R.string.ai_romanize_now),
+                                onClick = {
+                                    val lyricsText = lyricsProvider()?.lyrics.orEmpty()
+                                    AiLyricsRomanization.request(
+                                        sessionKey =
+                                            AiLyricsRomanization.sessionKey(
+                                                mediaId = mediaMetadataProvider().id,
+                                                lyrics = lyricsText,
+                                            ),
+                                        lines = AiLyricsRomanization.linesOf(lyricsText, mediaMetadataProvider().duration),
+                                        settings = aiRomanizationSettings,
+                                    )
+                                    Toast
+                                        .makeText(context, context.getString(R.string.ai_romanize_started), Toast.LENGTH_SHORT)
+                                        .show()
+                                },
+                                enabled = isAiRomanizationEnabled,
                             ),
                             NewAction(
                                 icon = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -110,6 +110,7 @@ import moe.rukamori.archivetune.playback.ExoDownloadService
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
 import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.db.entities.ArtistEntity
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.SongItem
 import moe.rukamori.archivetune.jiosaavn.SaavnService
@@ -1937,26 +1938,44 @@ private fun SongSourceDialog(
     // Strings fetched at the Composable scope so they can be referenced safely inside produceState.
     val aacLabel = stringResource(R.string.quality_badge_aac)
     val saavnLabel = stringResource(R.string.quality_badge_saavn)
+    val mp3Label = stringResource(R.string.quality_badge_mp3)
     val losslessLabel = stringResource(R.string.quality_badge_lossless)
     val noResultsText = stringResource(R.string.source_search_no_results)
     val noBackendText = stringResource(R.string.source_search_no_backend)
 
+    // Deezer's catalogue search says nothing about what an account may stream, and the FLAC tier
+    // needs a paid plan — so the badge has to come from the credential rather than the hit. Premium
+    // is the flag the pool and the manual sign-in both carry; without one the best Deezer will serve
+    // is 320kbps MP3, and labelling those rows "Lossless" would promise a quality resolve() cannot
+    // deliver.
+    val deezerLabel =
+        remember(losslessLabel, mp3Label) {
+            val availability = DeezerAudioProvider.accountAvailability()
+            if (availability.manualPremium || availability.pooledPremium > 0) losslessLabel else mp3Label
+        }
+
     // Provider filter → "search backend not yet available" empty state. These are the
     // providers with a usable list-search API: YTM, Tidal (searchCandidates), Qobuz
-    // (QobuzAudioProvider.searchCandidates), Qobuz Backup (QobuzBackupProvider.searchCandidates)
-    // and JioSaavn (SaavnService.searchSongs). Deezer still has no public list search.
+    // (QobuzAudioProvider.searchCandidates), Qobuz Backup (QobuzBackupProvider.searchCandidates),
+    // Deezer (DeezerAudioProvider.searchCandidates) and JioSaavn (SaavnService.searchSongs).
     //
     // Qobuz Backup used to be excluded here on the assumption that the kouzu.in mirror could
     // only be addressed by YouTube video id. It does expose `GET /api/search`, which returns
     // its own indexed catalogue, so its rows are searchable and pickable like any other
     // source's — which is what the "search and select tracks from the Qobuz backup source"
     // request was about.
+    //
+    // Deezer was excluded on the claim that it "has no public list search". `api.deezer.com/search`
+    // is public and unauthenticated; the provider only ever exposed a best-match `lookup` over it,
+    // which is why it looked absent. It now has `searchCandidates` too, so selecting the Deezer chip
+    // no longer shows "no backend" for a source the app can search and play.
     val searchableSources =
         setOf(
             AudioSourceType.YOUTUBE,
             AudioSourceType.TIDAL,
             AudioSourceType.QOBUZ,
             AudioSourceType.QOBUZ_BACKUP,
+            AudioSourceType.DEEZER,
             AudioSourceType.JIOSAAVN,
         )
     val backendMissing = sourceFilter != null && sourceFilter !in searchableSources
@@ -1978,6 +1997,7 @@ private fun SongSourceDialog(
         val searchTidal = sourceFilter == null || sourceFilter == AudioSourceType.TIDAL
         val searchQobuz = sourceFilter == null || sourceFilter == AudioSourceType.QOBUZ
         val searchQobuzBackup = sourceFilter == null || sourceFilter == AudioSourceType.QOBUZ_BACKUP
+        val searchDeezer = sourceFilter == null || sourceFilter == AudioSourceType.DEEZER
         val searchSaavn = sourceFilter == null || sourceFilter == AudioSourceType.JIOSAAVN
 
         if (searchYtm) {
@@ -2098,6 +2118,26 @@ private fun SongSourceDialog(
                                 // omits it rather than showing a made-up length.
                                 durationMs = null,
                                 qualityLabel = if (candidate.isLossless) losslessLabel else aacLabel,
+                                songItem = null,
+                            ),
+                        )
+                    }
+            }
+        }
+        if (searchDeezer) {
+            withContext(Dispatchers.IO) {
+                DeezerAudioProvider
+                    .searchCandidates(searchQuery, limit = 8)
+                    .forEach { candidate ->
+                        out.add(
+                            SourceSearchResult(
+                                source = AudioSourceType.DEEZER,
+                                trackId = candidate.trackId,
+                                title = candidate.title,
+                                artist = candidate.artist.orEmpty(),
+                                thumbnailUrl = candidate.coverUrl,
+                                durationMs = candidate.durationMs,
+                                qualityLabel = deezerLabel,
                                 songItem = null,
                             ),
                         )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -209,7 +209,7 @@ private const val AmLyricsBackdropMorphMs = 650
 // every frame of the zoom.
 private val AmBackdropBlurRadius = 64.dp
 
-private const val AppleMusicLyricsContentDeferMs = 350L
+private const val AppleMusicLyricsContentDeferMs = 160L
 
 // How far above the bottom of the artwork stage the blurred canvas starts dissolving into the
 // still blurred album art beneath it. See canvasSeamFade in AppleMusicPlayerContent.
@@ -474,9 +474,16 @@ fun AppleMusicPlayerContent(
             lyricsContentReady = false
             return@LaunchedEffect
         }
-        // Parse/building a large TTML/LRC model is synchronous during the first composition of
-        // LyricsEnhanced/LyricsV2. Let the artwork morph and canvas handoff render first so that
-        // this one-time CPU burst cannot land on the same frame as the shared-bounds animation.
+        // Composing LyricsEnhanced/LyricsV2 for the first time is the most expensive frame in the
+        // whole overlay. Let the artwork morph and the canvas handoff get a head start so that
+        // burst cannot land on the same frame as the shared-bounds animation.
+        //
+        // 350ms used to be needed because the TTML/LRC parse and buildSyncedLyrics both ran
+        // synchronously inside that first composition; both now run on Dispatchers.Default, so only
+        // the composition itself is left and a shorter head start is enough. Keeping it long also
+        // hurt: the AnimatedVisibility fadeIn below is 400ms, so almost all of it was spent on an
+        // empty box and the lyrics arrived as a pop rather than a fade. The renderers' own
+        // first-focus fade now covers the remainder.
         lyricsContentReady = false
         delay(AppleMusicLyricsContentDeferMs)
         lyricsContentReady = true

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualitySheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/VideoQualitySheet.kt
@@ -18,20 +18,22 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -45,9 +47,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -70,6 +74,15 @@ private data class SheetMetrics(
     val dividerVerticalPadding: Dp,
     val listMaxHeight: Dp,
     val showDescriptions: Boolean,
+    // Gap between two pills. Small enough that a run of pills still reads as one group, large
+    // enough that their rounded edges don't touch.
+    val pillSpacing: Dp,
+    // Inset from a pill's own edge to its text, on top of [horizontalPadding], which insets the
+    // pill itself from the sheet edges.
+    val pillInnerPadding: Dp,
+    // Floor on a pill's height so a title-only pill and a title+subtitle pill don't look like two
+    // different controls.
+    val pillMinHeight: Dp,
 )
 
 /**
@@ -89,6 +102,9 @@ private fun rememberSheetMetrics(): SheetMetrics {
                 dividerVerticalPadding = 2.dp,
                 listMaxHeight = 168.dp,
                 showDescriptions = false,
+                pillSpacing = 6.dp,
+                pillInnerPadding = 18.dp,
+                pillMinHeight = 44.dp,
             )
         } else {
             SheetMetrics(
@@ -98,6 +114,9 @@ private fun rememberSheetMetrics(): SheetMetrics {
                 dividerVerticalPadding = 8.dp,
                 listMaxHeight = 320.dp,
                 showDescriptions = true,
+                pillSpacing = 10.dp,
+                pillInnerPadding = 22.dp,
+                pillMinHeight = 60.dp,
             )
         }
     }
@@ -185,6 +204,7 @@ private fun VideoQualitySheetContent(
                     .fillMaxWidth()
                     .navigationBarsPadding()
                     .padding(bottom = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(metrics.pillSpacing),
         ) {
             if (showAdvanced) {
                 AdvancedQualityPage(
@@ -263,13 +283,11 @@ private fun MainQualityPage(
         onClick = { onSelect(VideoQualityPreference.HIGH_QUALITY) },
     )
 
-    HorizontalDivider(
-        modifier =
-            Modifier.padding(
-                horizontal = metrics.horizontalPadding,
-                vertical = metrics.dividerVerticalPadding,
-            ),
-    )
+    // The three modes and the Advanced row are different kinds of thing, so they used to be
+    // separated by a HorizontalDivider. A divider drawn across a column of pills cuts through the
+    // gap between two rounded shapes and reads as a stray line; extra breathing room says the same
+    // thing without fighting the pills.
+    Spacer(modifier = Modifier.height(metrics.dividerVerticalPadding))
 
     val exactHeight = preferredHeight?.takeIf { VideoQualityPreference.isExactHeight(it) }
     QualityRow(
@@ -339,6 +357,7 @@ private fun AdvancedQualityPage(
                 Modifier
                     .heightIn(max = metrics.listMaxHeight)
                     .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(metrics.pillSpacing),
         ) {
             availableHeights.sortedDescending().forEach { height ->
                 QualityRow(
@@ -380,6 +399,7 @@ internal fun VideoAspectRatioSheet(
                     .fillMaxWidth()
                     .navigationBarsPadding()
                     .padding(bottom = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(metrics.pillSpacing),
         ) {
             SheetTitle(stringResource(R.string.video_aspect_ratio), metrics)
             VideoAspectRatio.entries.forEach { ratio ->
@@ -419,17 +439,27 @@ private fun SheetTitle(
         fontWeight = FontWeight.SemiBold,
         modifier =
             Modifier.padding(
-                start = metrics.horizontalPadding,
-                end = metrics.horizontalPadding,
+                // +8dp so the title sits between the sheet edge and the pill text rather than
+                // lining up with neither.
+                start = metrics.horizontalPadding + 8.dp,
+                end = metrics.horizontalPadding + 8.dp,
                 top = 4.dp,
-                bottom = metrics.titleBottomPadding,
+                // The parent Column already spaces its children by pillSpacing; subtract it so the
+                // title-to-first-pill gap stays what it was before the pills landed.
+                bottom = (metrics.titleBottomPadding - metrics.pillSpacing).coerceAtLeast(0.dp),
             ),
     )
 }
 
 /**
- * One selectable row: title, optional subtitle, and a trailing checkmark (or [trailingIcon]) when
- * this row is the active choice.
+ * One selectable row, drawn as a rounded pill: title, optional subtitle, and a trailing checkmark
+ * (or [trailingIcon]) when this row is the active choice.
+ *
+ * The pill matches `PreferenceSelectionOption` in `ui/component/Preference.kt`, which is what every
+ * other option list in a bottom sheet uses — filled `surfaceContainerHigh` normally, filled
+ * `primary` when selected, `shapes.extraLarge` corners. Before this the rows were flat, full-bleed
+ * and separated only by a divider, which made these two sheets the odd ones out next to the video
+ * overflow sheet raised from the same button.
  */
 @Composable
 private fun QualityRow(
@@ -440,13 +470,43 @@ private fun QualityRow(
     onClick: () -> Unit,
     @DrawableRes trailingIcon: Int? = null,
 ) {
+    val containerColor =
+        if (selected) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        }
+    val contentColor =
+        if (selected) {
+            MaterialTheme.colorScheme.onPrimary
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
+    val subtitleColor =
+        if (selected) {
+            contentColor.copy(alpha = 0.78f)
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
-                .padding(
-                    horizontal = metrics.horizontalPadding,
+                .padding(horizontal = metrics.horizontalPadding)
+                .heightIn(min = metrics.pillMinHeight)
+                .clip(MaterialTheme.shapes.extraLarge)
+                .background(containerColor)
+                .then(
+                    // A row that navigates (Advanced) is a button, not one of the choices, so it
+                    // must not announce itself as a radio button.
+                    if (trailingIcon != null) {
+                        Modifier.clickable(onClick = onClick)
+                    } else {
+                        Modifier.selectable(selected = selected, onClick = onClick, role = Role.RadioButton)
+                    },
+                ).padding(
+                    horizontal = metrics.pillInnerPadding,
                     vertical = metrics.rowVerticalPadding,
                 ),
         verticalAlignment = Alignment.CenterVertically,
@@ -459,18 +519,13 @@ private fun QualityRow(
                 text = title,
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
-                color =
-                    if (selected) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.onSurface
-                    },
+                color = contentColor,
             )
             if (subtitle != null) {
                 Text(
                     text = subtitle,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = subtitleColor,
                 )
             }
         }
@@ -480,7 +535,7 @@ private fun QualityRow(
                 Icon(
                     painter = painterResource(trailingIcon),
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = if (selected) contentColor else MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(20.dp),
                 )
 
@@ -488,7 +543,7 @@ private fun QualityRow(
                 Icon(
                     painter = painterResource(R.drawable.check),
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = contentColor,
                     modifier = Modifier.size(20.dp),
                 )
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
@@ -106,6 +106,9 @@ import moe.rukamori.archivetune.constants.AiCustomModelKey
 import moe.rukamori.archivetune.constants.AiProvider
 import moe.rukamori.archivetune.constants.AiProviderKey
 import moe.rukamori.archivetune.constants.AiSelectedModelKey
+import moe.rukamori.archivetune.constants.AiRomanizeExcludedLanguagesKey
+import moe.rukamori.archivetune.constants.AiRomanizeLyricsKey
+import moe.rukamori.archivetune.constants.AutoAiRomanizeLyricsKey
 import moe.rukamori.archivetune.constants.AutoTranslateExcludedLanguagesKey
 import moe.rukamori.archivetune.constants.AutoTranslateLyricsKey
 import moe.rukamori.archivetune.constants.DeeplApiKeyKey
@@ -165,6 +168,13 @@ fun AiIntegrationSettings(
     val (excludedLanguageCodes, onExcludedLanguageCodesChange) =
         rememberPreference(AutoTranslateExcludedLanguagesKey, defaultValue = emptySet())
     var showExcludedLanguagesDialog by rememberSaveable { mutableStateOf(false) }
+    val (aiRomanizeLyrics, onAiRomanizeLyricsChange) =
+        rememberPreference(AiRomanizeLyricsKey, defaultValue = false)
+    val (autoAiRomanizeLyrics, onAutoAiRomanizeLyricsChange) =
+        rememberPreference(AutoAiRomanizeLyricsKey, defaultValue = false)
+    val (romanizeExcludedLanguageCodes, onRomanizeExcludedLanguageCodesChange) =
+        rememberPreference(AiRomanizeExcludedLanguagesKey, defaultValue = emptySet())
+    var showRomanizeExcludedLanguagesDialog by rememberSaveable { mutableStateOf(false) }
     var showApiKeyDialog by rememberSaveable { mutableStateOf(false) }
     var showDeeplFormalityDialog by rememberSaveable { mutableStateOf(false) }
     var showTranslateModeDialog by rememberSaveable { mutableStateOf(false) }
@@ -226,10 +236,25 @@ fun AiIntegrationSettings(
     if (showExcludedLanguagesDialog) {
         ExcludedLanguagesDialog(
             initialSelected = excludedLanguageCodes,
+            titleRes = R.string.auto_translate_excluded_languages,
+            descriptionRes = R.string.auto_translate_excluded_languages_desc,
             onDismiss = { showExcludedLanguagesDialog = false },
             onConfirm = { newSet ->
                 onExcludedLanguageCodesChange(newSet)
                 showExcludedLanguagesDialog = false
+            },
+        )
+    }
+
+    if (showRomanizeExcludedLanguagesDialog) {
+        ExcludedLanguagesDialog(
+            initialSelected = romanizeExcludedLanguageCodes,
+            titleRes = R.string.ai_romanize_excluded_languages,
+            descriptionRes = R.string.ai_romanize_excluded_languages_desc,
+            onDismiss = { showRomanizeExcludedLanguagesDialog = false },
+            onConfirm = { newSet ->
+                onRomanizeExcludedLanguageCodesChange(newSet)
+                showRomanizeExcludedLanguagesDialog = false
             },
         )
     }
@@ -592,6 +617,57 @@ fun AiIntegrationSettings(
                             ?: stringResource(R.string.auto_translate_excluded_languages_none),
                     icon = { Icon(painterResource(R.drawable.block), null) },
                     onClick = { showExcludedLanguagesDialog = true },
+                )
+            }
+
+            // ── AI romanisation ──
+            // Master switch. Turning it on also switches the built-in romanisers off (see
+            // `LyricsRomanizationPreferences.aiHandled`) so one song never mixes two schemes.
+            item {
+                SwitchPreference(
+                    modifier = positions.modifierFor("ai_romanize_lyrics"),
+                    title = { Text(stringResource(R.string.ai_romanize_lyrics)) },
+                    description = stringResource(R.string.ai_romanize_lyrics_desc),
+                    icon = { Icon(painterResource(R.drawable.language), null) },
+                    checked = aiRomanizeLyrics,
+                    onCheckedChange = onAiRomanizeLyricsChange,
+                    // Same reasoning as auto-translate: with no provider there is no engine to run.
+                    isEnabled = hasApiConfiguration,
+                )
+            }
+
+            // Separate from the master switch because these are billed network calls: enabling the
+            // feature should not commit the user to one request per track. With this off, the request
+            // is made from Lyrics menu → "Romanise with AI".
+            item(visible = aiRomanizeLyrics) {
+                SwitchPreference(
+                    modifier = positions.modifierFor("auto_ai_romanize_lyrics"),
+                    title = { Text(stringResource(R.string.auto_ai_romanize_lyrics)) },
+                    description = stringResource(R.string.auto_ai_romanize_lyrics_desc),
+                    icon = { Icon(painterResource(R.drawable.auto_awesome), null) },
+                    checked = autoAiRomanizeLyrics,
+                    onCheckedChange = onAutoAiRomanizeLyricsChange,
+                    isEnabled = hasApiConfiguration,
+                )
+            }
+
+            item(visible = aiRomanizeLyrics) {
+                val languages = remember(context) { TranslatorLanguages.load(context) }
+                val selectedRomanizeNames =
+                    remember(romanizeExcludedLanguageCodes, languages) {
+                        languages
+                            .filter { it.code in romanizeExcludedLanguageCodes }
+                            .joinToString(", ") { it.name }
+                            .ifEmpty { null }
+                    }
+                PreferenceEntry(
+                    modifier = positions.modifierFor("ai_romanize_excluded_languages"),
+                    title = { Text(stringResource(R.string.ai_romanize_excluded_languages)) },
+                    description =
+                        selectedRomanizeNames
+                            ?: stringResource(R.string.ai_romanize_excluded_languages_none),
+                    icon = { Icon(painterResource(R.drawable.block), null) },
+                    onClick = { showRomanizeExcludedLanguagesDialog = true },
                 )
             }
         }
@@ -1064,14 +1140,19 @@ private fun ModelPickerPreference(
 }
 
 /**
- * Multi-select dialog for the "Don't auto translate these languages" preference.
+ * Multi-select dialog behind both "Don't auto translate these languages" and "Don't romanise these
+ * languages".
  *
  * Lists every language known to [TranslatorLanguages] with a checkbox. Toggling a checkbox
- * adds/removes its uppercase code in the persisted [AutoTranslateExcludedLanguagesKey] set.
+ * adds/removes its uppercase code in whichever persisted set the caller passed in — the two features
+ * share the code space (`TranslatorLang.code`) and the detector (`LyricsUtils.detectDominantLanguageCode`),
+ * so they can share the picker too.
  */
 @Composable
 private fun ExcludedLanguagesDialog(
     initialSelected: Set<String>,
+    titleRes: Int,
+    descriptionRes: Int,
     onDismiss: () -> Unit,
     onConfirm: (Set<String>) -> Unit,
 ) {
@@ -1082,7 +1163,7 @@ private fun ExcludedLanguagesDialog(
     DefaultDialog(
         onDismiss = onDismiss,
         icon = { Icon(painterResource(R.drawable.block), contentDescription = null) },
-        title = { Text(stringResource(R.string.auto_translate_excluded_languages)) },
+        title = { Text(stringResource(titleRes)) },
         buttons = {
             TextButton(onClick = onDismiss, shapes = ButtonDefaults.shapes()) {
                 Text(stringResource(android.R.string.cancel))
@@ -1097,7 +1178,7 @@ private fun ExcludedLanguagesDialog(
     ) {
         Column(modifier = Modifier.padding(top = 4.dp)) {
             Text(
-                text = stringResource(R.string.auto_translate_excluded_languages_desc),
+                text = stringResource(descriptionRes),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(bottom = 8.dp),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
@@ -57,8 +57,12 @@ import moe.rukamori.archivetune.constants.AutoDownloadOnLikeKey
 import moe.rukamori.archivetune.constants.DownloadSource
 import moe.rukamori.archivetune.constants.DownloadSourceConfig
 import moe.rukamori.archivetune.constants.DownloadSourceOrderKey
+import moe.rukamori.archivetune.constants.DeezerArlKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderEnabledKey
 import moe.rukamori.archivetune.constants.ExternalDownloaderPackageKey
+import moe.rukamori.archivetune.constants.QobuzTokensKey
+import moe.rukamori.archivetune.constants.TidalAccessTokenKey
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
 import moe.rukamori.archivetune.ui.component.ActionPromptDialog
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.IconButton
@@ -92,6 +96,27 @@ fun DownloadsSettings(
             DownloadSourceConfig.parseOrder(downloadSourceOrderRaw)
         }
     val poolEnabled = remember { PoolAccountManager.isEnabled }
+    // A user who signed in with their own credentials does not need the shared pool, so the
+    // "Requires Source Pool" caption in the order dialog must not be shown for those sources —
+    // otherwise the dialog greys out a source that `LosslessStreamResolver` will happily resolve.
+    //
+    // All three resolvers merge the user's own credential with the pool's: `resolveTidal` tries
+    // `TidalAccessTokenKey` before any pool account, `resolveQobuz` merges `QobuzTokensKey` into its
+    // token list, and Deezer's provider merges the manual ARL in `accounts()`. So the honest test is
+    // "does this source have a credential of its own", one key per source.
+    val (deezerArl) = rememberPreference(DeezerArlKey, defaultValue = "")
+    val (tidalAccessToken) = rememberPreference(TidalAccessTokenKey, defaultValue = "")
+    val (qobuzTokens) = rememberPreference(QobuzTokensKey, defaultValue = "")
+    val sourcesWithOwnCredentials =
+        remember(deezerArl, tidalAccessToken, qobuzTokens) {
+            buildSet {
+                // Deezer goes through the provider rather than the raw key: it also accepts an ARL
+                // registered at runtime by the login screen before the key round-trips.
+                if (DeezerAudioProvider.hasAccounts()) add(DownloadSource.DEEZER)
+                if (tidalAccessToken.isNotBlank()) add(DownloadSource.TIDAL)
+                if (qobuzTokens.isNotBlank()) add(DownloadSource.QOBUZ)
+            }
+        }
     val (externalDownloaderEnabled, onExternalDownloaderEnabledChange) =
         rememberPreference(ExternalDownloaderEnabledKey, defaultValue = false)
     val (externalDownloaderPackage, onExternalDownloaderPackageChange) =
@@ -105,6 +130,7 @@ fun DownloadsSettings(
         DownloadSourceOrderDialog(
             initialOrder = downloadSourceOrder,
             poolEnabled = poolEnabled,
+            sourcesWithOwnCredentials = sourcesWithOwnCredentials,
             onDismiss = { showSourceOrderDialog = false },
             onConfirm = { newOrder ->
                 onDownloadSourceOrderChange(DownloadSourceConfig.serialize(newOrder))
@@ -283,6 +309,7 @@ fun DownloadsSettings(
 private fun DownloadSourceOrderDialog(
     initialOrder: List<DownloadSource>,
     poolEnabled: Boolean,
+    sourcesWithOwnCredentials: Set<DownloadSource>,
     onDismiss: () -> Unit,
     onConfirm: (List<DownloadSource>) -> Unit,
 ) {
@@ -329,7 +356,9 @@ private fun DownloadSourceOrderDialog(
                 itemsIndexed(sources, key = { _, item -> item.name }) { index, source ->
                     ReorderableItem(reorderableState, key = source.name) {
                         val isFirst = index == 0
-                        val requiresPool = source in DownloadSourceConfig.REQUIRES_POOL
+                        val requiresPool =
+                            source in DownloadSourceConfig.REQUIRES_POOL &&
+                                source !in sourcesWithOwnCredentials
                         val available = !requiresPool || poolEnabled
                         val containerColor =
                             if (isFirst) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -35,10 +35,13 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.DeezerArlKey
 import moe.rukamori.archivetune.constants.ListenBrainzEnabledKey
 import moe.rukamori.archivetune.constants.ListenBrainzTokenKey
 import moe.rukamori.archivetune.constants.ManualSourceLoginEnabledKey
+import moe.rukamori.archivetune.constants.QobuzTokensKey
 import moe.rukamori.archivetune.constants.ShowSpotifyPlaylistsKey
+import moe.rukamori.archivetune.constants.TidalAccessTokenKey
 import moe.rukamori.archivetune.spotify.SpotifyAccountViewModel
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.InfoLabel
@@ -64,6 +67,15 @@ fun IntegrationScreen(
     // "Manual source sign-in" experimental toggle. Off by default: the app auto-uses the community
     // source pool, so most users never need to see raw instance/token fields.
     val (manualSourceLogin, _) = rememberPreference(ManualSourceLoginEnabledKey, false)
+    // …but a source the user has *already* signed into must stay reachable regardless, otherwise
+    // turning the toggle back off strands the account with no way to view or sign out of it — and
+    // "Check source" would keep pointing at a screen that is no longer in the list.
+    val (deezerArl, _) = rememberPreference(DeezerArlKey, "")
+    val (tidalAccessToken, _) = rememberPreference(TidalAccessTokenKey, "")
+    val (qobuzTokens, _) = rememberPreference(QobuzTokensKey, "")
+    val showDeezerRow = manualSourceLogin || deezerArl.isNotBlank()
+    val showTidalRow = manualSourceLogin || tidalAccessToken.isNotBlank()
+    val showQobuzRow = manualSourceLogin || qobuzTokens.isNotBlank()
 
     val spotifyState by spotifyAccountViewModel.uiState.collectAsStateWithLifecycle()
     val (showSpotifyPlaylists, onShowSpotifyPlaylistsChange) = rememberPreference(ShowSpotifyPlaylistsKey, false)
@@ -161,42 +173,40 @@ fun IntegrationScreen(
                 modifier = positions.modifierFor("music_sources"),
                 title = stringResource(R.string.music_sources),
             ) {
-                if (manualSourceLogin) {
-                    item {
-                        PreferenceEntry(
-                            modifier = positions.modifierFor("tidal"),
-                            title = { Text(stringResource(R.string.tidal_integration)) },
-                            description = stringResource(R.string.tidal_integration_description),
-                            icon = { Icon(painterResource(R.drawable.provider_tidal), null) },
-                            onClick = {
-                                navController.navigate("settings/tidal")
-                            },
-                        )
-                    }
+                item(visible = showTidalRow) {
+                    PreferenceEntry(
+                        modifier = positions.modifierFor("tidal"),
+                        title = { Text(stringResource(R.string.tidal_integration)) },
+                        description = stringResource(R.string.tidal_integration_description),
+                        icon = { Icon(painterResource(R.drawable.provider_tidal), null) },
+                        onClick = {
+                            navController.navigate("settings/tidal")
+                        },
+                    )
+                }
 
-                    item {
-                        PreferenceEntry(
-                            modifier = positions.modifierFor("qobuz"),
-                            title = { Text(stringResource(R.string.qobuz_integration)) },
-                            description = stringResource(R.string.qobuz_integration_description),
-                            icon = { Icon(painterResource(R.drawable.provider_qobuz), null) },
-                            onClick = {
-                                navController.navigate("settings/qobuz")
-                            },
-                        )
-                    }
+                item(visible = showQobuzRow) {
+                    PreferenceEntry(
+                        modifier = positions.modifierFor("qobuz"),
+                        title = { Text(stringResource(R.string.qobuz_integration)) },
+                        description = stringResource(R.string.qobuz_integration_description),
+                        icon = { Icon(painterResource(R.drawable.provider_qobuz), null) },
+                        onClick = {
+                            navController.navigate("settings/qobuz")
+                        },
+                    )
+                }
 
-                    item {
-                        PreferenceEntry(
-                            modifier = positions.modifierFor("deezer"),
-                            title = { Text(stringResource(R.string.deezer_integration)) },
-                            description = stringResource(R.string.deezer_integration_description),
-                            icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
-                            onClick = {
-                                navController.navigate("settings/deezer")
-                            },
-                        )
-                    }
+                item(visible = showDeezerRow) {
+                    PreferenceEntry(
+                        modifier = positions.modifierFor("deezer"),
+                        title = { Text(stringResource(R.string.deezer_integration)) },
+                        description = stringResource(R.string.deezer_integration_description),
+                        icon = { Icon(painterResource(R.drawable.provider_deezer), null) },
+                        onClick = {
+                            navController.navigate("settings/deezer")
+                        },
+                    )
                 }
 
                 item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsRomanisationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsRomanisationSettings.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AiRomanizeLyricsKey
 import moe.rukamori.archivetune.constants.LyricsRomanizeChineseKey
 import moe.rukamori.archivetune.constants.LyricsRomanizeHindiKey
 import moe.rukamori.archivetune.constants.LyricsRomanizeJapaneseKey
@@ -67,6 +68,14 @@ fun LyricsRomanisationSettings(
     val (lyricsRomanizeOtherLanguages, onLyricsRomanizeOtherLanguagesChange) =
         rememberPreference(LyricsRomanizeOtherLanguagesKey, defaultValue = true)
     val japaneseLanguagePackState by JapaneseLanguagePackManager.state.collectAsStateWithLifecycle()
+    // When AI romanisation is on it replaces every engine on this page (see
+    // `LyricsRomanizationPreferences.aiHandled`). Greying the switches out rather than leaving them
+    // looking live is the difference between "this setting is overridden" and "this setting is
+    // broken" — the toggles would otherwise flip happily and change nothing on screen.
+    val (aiRomanizeLyrics) = rememberPreference(AiRomanizeLyricsKey, defaultValue = false)
+    val builtInEnabled = !aiRomanizeLyrics
+    val overriddenDescription =
+        if (aiRomanizeLyrics) stringResource(R.string.romanization_overridden_by_ai) else null
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -114,15 +123,17 @@ fun LyricsRomanisationSettings(
                         modifier = positions.modifierFor("lyrics_romanize_japanese"),
                         title = { Text(stringResource(R.string.lyrics_romanize_japanese)) },
                         description =
-                            if (japaneseLanguagePackState is JapaneseLanguagePackState.Installed) {
-                                null
-                            } else {
-                                stringResource(R.string.language_pack_required)
-                            },
+                            overriddenDescription
+                                ?: if (japaneseLanguagePackState is JapaneseLanguagePackState.Installed) {
+                                    null
+                                } else {
+                                    stringResource(R.string.language_pack_required)
+                                },
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeJapanese,
                         onCheckedChange = onLyricsRomanizeJapaneseChange,
-                        isEnabled = japaneseLanguagePackState is JapaneseLanguagePackState.Installed,
+                        isEnabled =
+                            builtInEnabled && japaneseLanguagePackState is JapaneseLanguagePackState.Installed,
                     )
                 }
 
@@ -130,9 +141,11 @@ fun LyricsRomanisationSettings(
                     SwitchPreference(
                         modifier = positions.modifierFor("lyrics_romanize_korean"),
                         title = { Text(stringResource(R.string.lyrics_romanize_korean)) },
+                        description = overriddenDescription,
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeKorean,
                         onCheckedChange = onLyricsRomanizeKoreanChange,
+                        isEnabled = builtInEnabled,
                     )
                 }
 
@@ -140,9 +153,11 @@ fun LyricsRomanisationSettings(
                     SwitchPreference(
                         modifier = positions.modifierFor("lyrics_romanize_chinese"),
                         title = { Text(stringResource(R.string.lyrics_romanize_chinese)) },
+                        description = overriddenDescription,
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeChinese,
                         onCheckedChange = onLyricsRomanizeChineseChange,
+                        isEnabled = builtInEnabled,
                     )
                 }
 
@@ -150,9 +165,11 @@ fun LyricsRomanisationSettings(
                     SwitchPreference(
                         modifier = positions.modifierFor("lyrics_romanize_hindi"),
                         title = { Text(stringResource(R.string.lyrics_romanize_hindi)) },
+                        description = overriddenDescription,
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeHindi,
                         onCheckedChange = onLyricsRomanizeHindiChange,
+                        isEnabled = builtInEnabled,
                     )
                 }
 
@@ -160,9 +177,11 @@ fun LyricsRomanisationSettings(
                     SwitchPreference(
                         modifier = positions.modifierFor("lyrics_romanize_other_languages", "lyrics_romanize_other"),
                         title = { Text(stringResource(R.string.lyrics_romanize_other_languages)) },
+                        description = overriddenDescription,
                         icon = { Icon(painterResource(R.drawable.lyrics), null) },
                         checked = lyricsRomanizeOtherLanguages,
                         onCheckedChange = onLyricsRomanizeOtherLanguagesChange,
+                        isEnabled = builtInEnabled,
                     )
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDataBuilders.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AiRomanizeLyricsKey
+import moe.rukamori.archivetune.constants.AutoAiRomanizeLyricsKey
 import moe.rukamori.archivetune.constants.AlbumCanvasEnabledKey
 import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
 import moe.rukamori.archivetune.constants.SpotifyCanvasKey
@@ -772,6 +774,9 @@ fun buildSettingsGroups(
                 SettingsChild("Hide AI mix", "hide_ai_mix", listOf("hide ai", "ai mix", "smart mix", "hide mix")) { SearchResultSwitch(HideAiMixKey, false) },
                 SettingsChild("Automatic translation", "auto_translate_lyrics", listOf("automatic translation", "auto translate", "auto translate lyrics", "translate automatically")),
                 SettingsChild("Don't auto translate these languages", "auto_translate_excluded_languages", listOf("excluded languages", "skip translation", "do not translate", "translation exclusions")),
+                SettingsChild("AI romanisation", "ai_romanize_lyrics", listOf("ai romanisation", "ai romanization", "romanise", "romanize", "romaji", "transliteration", "ai romaji")) { SearchResultSwitch(AiRomanizeLyricsKey, false) },
+                SettingsChild("Auto AI romanisation", "auto_ai_romanize_lyrics", listOf("auto ai romanisation", "auto ai romanization", "automatic romanisation", "auto romanize")) { SearchResultSwitch(AutoAiRomanizeLyricsKey, false) },
+                SettingsChild("Don't romanise these languages", "ai_romanize_excluded_languages", listOf("excluded languages", "skip romanisation", "do not romanise", "romanisation exclusions")),
                 SettingsChild("Target language", "translate_language", listOf("target language", "translate to", "translation language")),
                 SettingsChild("Translation mode", "translate_mode", listOf("translation mode", "translate mode", "translation style")),
                 SettingsChild("DeepL API key", "deepl_api_key", listOf("deepl", "deepl api key", "deepl key", "deepl token")),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceCheckService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceCheckService.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.constants.AudioSourceType
+import moe.rukamori.archivetune.deezer.DeezerAudioProvider
 import moe.rukamori.archivetune.jiosaavn.SaavnService
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
 import moe.rukamori.archivetune.qobuz.QobuzToken
@@ -42,7 +43,8 @@ data class SourceCheckResult(
  *  - Qobuz backup: ping https://mlc.kouzu.in/api/stream?id=<test_id> with a
  *    HEAD request (the test id is a stable, well-known music video) and verify
  *    it returns an audio content type.
- *  - Deezer: refresh the pool, count Deezer accounts.
+ *  - Deezer: refresh the pool, count both pooled and manually signed-in credentials, then verify
+ *    the one the resolver would use first against the Deezer gateway.
  *  - JioSaavn: ping the JioSaavn public search API with a canned query and
  *    verify it returns at least one result.
  *
@@ -325,21 +327,53 @@ object SourceCheckService {
         }.getOrNull()
 
     private suspend fun checkDeezer(context: Context): SourceCheckResult {
-        PoolAccountManager.refresh(context, force = false)
-        val accounts = PoolAccountManager.deezerAccounts()
-        if (accounts.isEmpty()) {
+        // force = true. The whole point of tapping "Check source" is to find out whether accounts
+        // can be obtained *now*, and a non-forced refresh is throttled — previously for a full 24h
+        // whenever any other service had accounts cached, so the message telling the user to refresh
+        // the pool was advice this very call had just declined to follow.
+        PoolAccountManager.refresh(context, force = true)
+
+        // Ask the provider, not the pool. DeezerAudioProvider.accounts() merges the manually
+        // signed-in ARL (Integration → Deezer) with the pool's shared accounts; reading
+        // PoolAccountManager.deezerAccounts() directly skips the manual one entirely and reported
+        // "No Deezer accounts in the source pool" to users who had signed in successfully and whose
+        // playback was in fact resolving. Same defect 7ede13689 fixed in MusicService's resolver.
+        val availability = DeezerAudioProvider.accountAvailability()
+        if (availability.total == 0) {
             return SourceCheckResult(
                 healthy = false,
-                summary = "No Deezer accounts in the source pool. Tap 'Refresh source pool' at the top, " +
-                    "or add your own Deezer ARL via Integration → Manual source sign-in.",
+                summary = "No Deezer credentials available. Sign in with your own Deezer account via " +
+                    "Integration → Deezer, or tap 'Refresh source pool' at the top to pick up shared accounts.",
             )
         }
-        val premium = accounts.count { it.premium }
-        return SourceCheckResult(
-            healthy = accounts.isNotEmpty(),
-            summary = "Pool accounts: ${accounts.size} ($premium premium). " +
-                "Deezer source is ${if (accounts.isNotEmpty()) "READY" else "NOT ready"}.",
-        )
+
+        val origin =
+            buildList {
+                if (availability.manual) {
+                    add("your own account${if (availability.manualPremium) " (premium)" else ""}")
+                }
+                if (availability.pooled > 0) {
+                    add("${availability.pooled} pool account(s), ${availability.pooledPremium} premium")
+                }
+            }.joinToString(" + ")
+
+        // Probe the credential resolve() would reach for first. A stored ARL says nothing about
+        // whether Deezer still accepts it — an expired cookie looks identical until playback
+        // silently falls through to the next source.
+        val info = DeezerAudioProvider.verifyPreferredAccount()
+        return if (info == null) {
+            SourceCheckResult(
+                healthy = false,
+                summary = "Found $origin, but the Deezer gateway rejected the credential it would use " +
+                    "first. Sign in again via Integration → Deezer, or refresh the source pool.",
+            )
+        } else {
+            val tier = if (info.lossless) "lossless (FLAC) available" else "no lossless — 320kbps MP3 at best"
+            SourceCheckResult(
+                healthy = true,
+                summary = "Credentials: $origin. Verified as '${info.name}' — $tier. Deezer source is READY.",
+            )
+        }
     }
 
     private fun checkJioSaavn(): SourceCheckResult {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
@@ -174,6 +174,9 @@ private fun PoolRefreshSection(positions: PreferencePositions) {
                                     R.string.pool_refresh_done,
                                     PoolAccountManager.tidalAccounts().size,
                                     PoolAccountManager.qobuzAccounts().size,
+                                    // Deezer was missing here, which made a successful refresh look
+                                    // like it had not fetched anything for Deezer users.
+                                    PoolAccountManager.deezerAccounts().size,
                                 )
                             } else {
                                 context.getString(R.string.pool_refresh_failed)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/PoolAccountManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/PoolAccountManager.kt
@@ -57,6 +57,12 @@ object PoolAccountManager {
     // being woken for nothing on every app start. `force = true` (the settings refresh button)
     // still bypasses this.
     private const val MIN_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000L
+    // …but only once every service actually has something cached. The 24h throttle was gated on
+    // `hasAccounts()`, which is true as soon as *any one* service is populated — so a pool that
+    // served Tidal accounts locked Deezer and Qobuz out for a full day, and "Check source" (which
+    // refreshes without `force`) could never discover them however many times it was tapped. When
+    // any service is still empty, retry on this much shorter interval instead.
+    private const val MIN_PARTIAL_REFRESH_INTERVAL_MS = 15 * 60 * 1000L
 
     private val CACHE_TIDAL_KEY = stringPreferencesKey("poolTidalAccounts")
     private val CACHE_QOBUZ_KEY = stringPreferencesKey("poolQobuzAccounts")
@@ -145,6 +151,18 @@ object PoolAccountManager {
 
     fun hasAccounts(): Boolean = tidalCache.isNotEmpty() || qobuzCache.isNotEmpty() || deezerCache.isNotEmpty()
 
+    /** True when every pooled service has at least one account, i.e. nothing is left to discover. */
+    private fun hasEveryService(): Boolean =
+        tidalCache.isNotEmpty() && qobuzCache.isNotEmpty() && deezerCache.isNotEmpty()
+
+    /**
+     * How long a non-forced [refresh] may be skipped for. Full caches are re-read once a day; a
+     * cache that is still missing a service is retried far more eagerly so that service can appear
+     * without the user having to hunt for the manual refresh button.
+     */
+    private fun refreshIntervalMs(): Long =
+        if (hasEveryService()) MIN_REFRESH_INTERVAL_MS else MIN_PARTIAL_REFRESH_INTERVAL_MS
+
     /**
      * Loads the persisted account cache into memory (cheap, no network). Safe to call repeatedly;
      * only reads the DataStore once. Call early on startup so resolvers have data before the first
@@ -188,13 +206,13 @@ object PoolAccountManager {
             loadCached(context)
 
             val now = System.currentTimeMillis()
-            if (!force && hasAccounts() && now - lastRefreshAt < MIN_REFRESH_INTERVAL_MS) {
+            if (!force && hasAccounts() && now - lastRefreshAt < refreshIntervalMs()) {
                 return@withContext true
             }
 
             refreshMutex.withLock {
                 // Re-check the throttle inside the lock in case another caller just refreshed.
-                if (!force && hasAccounts() && System.currentTimeMillis() - lastRefreshAt < MIN_REFRESH_INTERVAL_MS) {
+                if (!force && hasAccounts() && System.currentTimeMillis() - lastRefreshAt < refreshIntervalMs()) {
                     return@withLock true
                 }
                 val url = sourcesUrl ?: return@withLock false

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -734,6 +734,16 @@
     <string name="auto_translate_excluded_languages">Don\'t auto translate these languages</string>
     <string name="auto_translate_excluded_languages_desc">Pick languages that should never be auto-translated even when automatic translation is on. Useful if you already understand a language and don\'t want it overridden.</string>
     <string name="auto_translate_excluded_languages_none">None — every foreign-language lyric will be translated</string>
+    <string name="ai_romanize_lyrics">AI romanisation</string>
+    <string name="ai_romanize_lyrics_desc">Use the configured AI provider to romanise lyrics instead of the built-in engines. Usually more accurate on names, slang and unusual readings. While this is on, the app\'s own romanisation is switched off so a song never mixes two schemes.</string>
+    <string name="auto_ai_romanize_lyrics">Auto AI romanisation</string>
+    <string name="auto_ai_romanize_lyrics_desc">Romanise automatically as soon as lyrics are shown. Off by default because each track costs one request — with it off, use Lyrics menu → \"Romanise with AI\" when you want it.</string>
+    <string name="ai_romanize_excluded_languages">Don\'t romanise these languages</string>
+    <string name="ai_romanize_excluded_languages_desc">Pick languages to leave in their original script even when AI romanisation is on. Useful for scripts you already read.</string>
+    <string name="ai_romanize_excluded_languages_none">None — every non-Latin lyric will be romanised</string>
+    <string name="romanization_overridden_by_ai">Overridden — AI romanisation is on (Settings → Integration → AI integration)</string>
+    <string name="ai_romanize_now">Romanise with AI</string>
+    <string name="ai_romanize_started">Romanising lyrics with AI…</string>
     <string name="update_remind_later">Remind me later</string>
     <string name="update_never_show_again">Never show again</string>
     <string name="settings_lyrics_providers_subtitle">Choose which lyrics providers are active and set priority</string>

--- a/app/src/main/res/values/fork_strings.xml
+++ b/app/src/main/res/values/fork_strings.xml
@@ -92,6 +92,7 @@
     <string name="check_source_result_title">%1s check</string>
     <string name="quality_badge_aac">AAC 256 kbps</string>
     <string name="quality_badge_saavn">AAC 320 kbps</string>
+    <string name="quality_badge_mp3">MP3 320 kbps</string>
     <string name="quality_badge_lossless">Lossless</string>
     <string name="quality_badge_hires">Hi-Res</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1144,7 +1144,7 @@
     <string name="pool_refresh_title">Refresh from pool</string>
     <string name="pool_refresh_description">Pull the latest shared accounts and instances from the community source pool</string>
     <string name="pool_refreshing">Refreshing from pool…</string>
-    <string name="pool_refresh_done">Pool refreshed: %1$d Tidal, %2$d Qobuz account(s)</string>
+    <string name="pool_refresh_done">Pool refreshed: %1$d Tidal, %2$d Qobuz, %3$d Deezer account(s)</string>
     <string name="pool_refresh_failed">Couldn\'t reach the source pool. Check your connection and try again.</string>
     <string name="manual_source_login">Manual source sign-in</string>
     <string name="description_manual_source_login">Show the advanced Tidal/Qobuz instance &amp; account fields. Off by default — the app uses the community source pool automatically.</string>

--- a/app/src/test/kotlin/moe/rukamori/archivetune/audiosource/SourceOrderTest.kt
+++ b/app/src/test/kotlin/moe/rukamori/archivetune/audiosource/SourceOrderTest.kt
@@ -1,0 +1,105 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.audiosource
+
+import moe.rukamori.archivetune.constants.AudioSourceType
+import moe.rukamori.archivetune.constants.DownloadSource
+import moe.rukamori.archivetune.constants.DownloadSourceConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the source-order merge, which decides whether a source is reachable at all.
+ *
+ * `MusicService.sourceResolutionChain` cuts the playback chain at YouTube, so a source that the merge
+ * places *after* YouTube is silently dropped from playback and shows up below the visual end of the
+ * order picker. The merge used to append sources missing from the stored CSV, which did exactly that
+ * to every source added after a user last touched the picker — Deezer, Qobuz backup and JioSaavn.
+ */
+class SourceOrderTest {
+    @Test
+    fun blankOrderYieldsDefaults() {
+        assertEquals(AudioSourceConfig.DEFAULT_ORDER, AudioSourceConfig.parseOrder(null))
+        assertEquals(AudioSourceConfig.DEFAULT_ORDER, AudioSourceConfig.parseOrder(""))
+    }
+
+    @Test
+    fun legacyOrderGetsNewSourcesAboveYouTube() {
+        val merged = AudioSourceConfig.parseOrder("TIDAL,QOBUZ,YOUTUBE")
+
+        assertEquals(
+            listOf(
+                AudioSourceType.TIDAL,
+                AudioSourceType.QOBUZ,
+                AudioSourceType.QOBUZ_BACKUP,
+                AudioSourceType.DEEZER,
+                AudioSourceType.JIOSAAVN,
+                AudioSourceType.YOUTUBE,
+            ),
+            merged,
+        )
+    }
+
+    @Test
+    fun everySourceSurvivesTheYouTubeCut() {
+        // The exact assertion that matters: nothing may be stranded after YouTube, because
+        // sourceResolutionChain() drops everything from YouTube onward.
+        val reachable = AudioSourceConfig.parseOrder("TIDAL,QOBUZ,YOUTUBE").takeWhile { it != AudioSourceType.YOUTUBE }
+
+        assertTrue(AudioSourceType.DEEZER in reachable)
+        assertTrue(AudioSourceType.QOBUZ_BACKUP in reachable)
+        assertTrue(AudioSourceType.JIOSAAVN in reachable)
+    }
+
+    @Test
+    fun userPlacementOfYouTubeIsPreserved() {
+        val merged = AudioSourceConfig.parseOrder("YOUTUBE,TIDAL,QOBUZ")
+
+        // The user asked for YouTube first; the new sources go directly above it rather than being
+        // appended past the end, and TIDAL/QOBUZ keep the relative order that was stored.
+        assertTrue(merged.indexOf(AudioSourceType.DEEZER) < merged.indexOf(AudioSourceType.YOUTUBE))
+        assertTrue(merged.indexOf(AudioSourceType.TIDAL) > merged.indexOf(AudioSourceType.YOUTUBE))
+        assertTrue(merged.indexOf(AudioSourceType.QOBUZ) > merged.indexOf(AudioSourceType.TIDAL))
+        assertEquals(AudioSourceConfig.DEFAULT_ORDER.size, merged.size)
+    }
+
+    @Test
+    fun completeOrderIsReturnedUnchanged() {
+        val stored = "JIOSAAVN,DEEZER,QOBUZ_BACKUP,QOBUZ,TIDAL,YOUTUBE"
+        val merged = AudioSourceConfig.parseOrder(stored)
+
+        assertEquals(stored, merged.joinToString(",") { it.name })
+    }
+
+    @Test
+    fun unknownAndDuplicateEntriesAreIgnored() {
+        val merged = AudioSourceConfig.parseOrder("TIDAL,NOT_A_SOURCE,tidal, youtube ")
+
+        assertEquals(AudioSourceConfig.DEFAULT_ORDER.size, merged.size)
+        assertEquals(AudioSourceConfig.DEFAULT_ORDER.size, merged.distinct().size)
+        assertEquals(AudioSourceType.TIDAL, merged.first())
+        assertEquals(AudioSourceType.YOUTUBE, merged.last())
+    }
+
+    @Test
+    fun downloadOrderGetsNewSourcesAboveYouTubeMusic() {
+        val merged = DownloadSourceConfig.parseOrder("QOBUZ,TIDAL,YOUTUBE_MUSIC")
+
+        assertTrue(merged.indexOf(DownloadSource.DEEZER) < merged.indexOf(DownloadSource.YOUTUBE_MUSIC))
+        assertTrue(merged.indexOf(DownloadSource.QOBUZ_BACKUP) < merged.indexOf(DownloadSource.YOUTUBE_MUSIC))
+        assertTrue(merged.indexOf(DownloadSource.JIOSAAVN) < merged.indexOf(DownloadSource.YOUTUBE_MUSIC))
+        assertEquals(DownloadSourceConfig.DEFAULT_ORDER.size, merged.size)
+    }
+
+    @Test
+    fun downloadBlankOrderYieldsDefaults() {
+        assertEquals(DownloadSourceConfig.DEFAULT_ORDER, DownloadSourceConfig.parseOrder(null))
+        assertEquals(DownloadSourceConfig.DEFAULT_ORDER, DownloadSourceConfig.parseOrder(""))
+    }
+}


### PR DESCRIPTION
Resumes and finishes an in-progress working tree. Six areas, grouped because they were found together while chasing *"Deezer is configured but nothing ever plays or downloads from it"*.

## 1. Source order merge stranded every newly added source

`AudioSourceConfig.parseOrder` merged the stored CSV with `DEFAULT_ORDER` by **appending** whatever was missing. `MusicService.sourceResolutionChain` cuts the chain at YouTube (`takeWhile { it != YOUTUBE }`), so for anyone who had ever touched the order picker on an older build, every source introduced afterwards landed *below* YouTube and was dropped from playback entirely — Deezer, Qobuz backup and JioSaavn all unreachable — and in the order dialog they sat below YouTube where the list reads as if it ends.

Missing sources are now slotted in **above** YouTube. Every override source is above it in `DEFAULT_ORDER`, so that is both correct and the one placement that cannot perturb the choices the user did make. `DownloadSourceConfig.parseOrder` had the identical defect and gets the identical fix.

`app/src/test/.../SourceOrderTest.kt` pins both, including the assertion that actually matters: nothing survives past the YouTube cut.

## 2. Deezer downloads silently fell through to YouTube

`DownloadUtil.resolveSourceStream` returned a hard-coded `null` for `DownloadSource.DEEZER`, with a comment claiming the public API only exposes 30-second previews. True of `api.deezer.com`, but stale ever since full Premium streaming was ported — playback has resolved real Deezer streams through the same provider since then.

- New `LosslessStreamResolver.resolveDeezer`, mirroring `MusicService.resolveDeezerStream` **including** the `DeezerAudioProvider.hasAccounts()` guard (the provider merges the manual ARL with the pool, so reading `PoolAccountManager` directly gets it wrong).
- The CDN serves Blowfish-encrypted bytes, so the download cannot reuse the YouTube-resolving factory — it would rewrite the `deezer://` URI, and would store ciphertext even if it didn't. `DownloadSchemeRoutingDataSource` gains a `deezer` branch onto a decrypting upstream placed *below* the cache, exactly as playback does it, so what lands in the download cache is a plain FLAC/MP3 that jaudiotagger can tag and the exporter can copy out.

## 3. Deezer reported "no accounts" to users who had signed in

- `SourceCheckService.checkDeezer` read `PoolAccountManager.deezerAccounts()`, which skips the manually signed-in ARL — the same defect `7ede1368` fixed in the playback resolver. It now asks the provider (`accountAvailability()`), reports which origin the credentials came from, and **probes** the credential `resolve()` would reach for first, because a stored ARL says nothing about whether Deezer still accepts it.
- It also refreshed with `force = false`, throttled for 24 h as soon as *any* pooled service had something cached — so the summary told the user to refresh the pool, advice the very same call had just declined to follow. The check now forces, and `PoolAccountManager` retries every 15 min instead of every 24 h while any service is still empty.
- `pool_refresh_done` was missing its Deezer count, and `SourceSettings` never passed one.
- Turning **Manual source sign-in** back off hid the Tidal/Qobuz/Deezer rows even when an account was stored behind them, stranding it with no way to view or sign out. Rows now stay for a source that has a credential.
- Deezer joins the searchable sources in the player's "Play from" picker — `api.deezer.com/search` is public and unauthenticated, the provider just never exposed a list search. Its badge is derived from the credential (premium → Lossless, otherwise MP3 320), since the catalogue search says nothing about what an account may stream.
- The download order dialog stops captioning a source "Requires Source Pool" when the user has their own credential for it (Tidal token / Qobuz tokens / Deezer ARL — all three resolvers merge the user's own credential in).

## 4. AI lyrics romanisation (new feature)

New `AiLyricsRomanization` coordinator + `AiLyricsRomanizer`, structured like the existing AI translation path (budget chunking, binary-split retry, process-wide LRU) but returning per-line results instead of rebuilding a lyrics container: romanisation is a render-time annotation above the line, and persisting it would need a second `LyricsEntity.source` value that cannot coexist with `AI_TRANSLATION`.

- `romanizeLines` is deliberately **not** `translateLines` with a "romanise" target — the two need opposite instructions, and every model tested drifted into translating at least once when not told several ways not to. Temperature is `0.0`, not translation's `0.15`: transliteration has one right answer and sampling variance only produces inconsistent spellings between lines.
- Results are addressed by **line text**, not by index. The renderers do not agree on an index space — `LyricsV2` prepends a head entry and inserts instrumental breaks, `LyricsEnhanced` does neither, the lyrics menu parses without either, and all three derive the same session key from the raw lyrics — so an index-aligned cache filled by one was applied off-by-N by the next.
- The master switch turns the built-in engines **off** (`LyricsRomanizationPreferences.aiHandled`) rather than running both, which would mix Hepburn from Kuromoji with whatever scheme the model chose inside one song. The built-in toggles grey out with an "overridden" caption so they read as overridden rather than broken.
- Auto-fetch is a separate switch because these are billed calls, with **Lyrics menu → Romanise with AI** as the manual path. Per-language exclusions reuse the auto-translate picker (same code space, same detector).

## 5. Lyrics blinked out for a moment on every open

`awaitingFirstFocus` was keyed on the parsed line count in both renderers. The parse now runs on `Dispatchers.Default`, so the list is *always* empty on first composition and always grows a frame or two later — which re-ran the `remember` after the view was already visible, handed back a fresh `mutableStateOf(true)`, snapped the alpha from 1 back to 0 with a zero-duration tween and swallowed the collector's release. Worst in the Apple Music player, which composes the view from scratch each time.

Keyed on `isSynced` instead, which is derived synchronously from the raw text and so is already correct on frame 1. Related:

- The gate moves onto the whole subtree — the branches below it swap while it is armed (shimmer, briefly "not found", then the lines), and gating only the last let the first two flash at full opacity.
- The scroll collector bailed out on an empty line list, disarming the gate before there was anything to place; it now waits for content.
- A null active index releases the gate instead of letting it time out for `LYRIC_FIRST_FOCUS_TIMEOUT_MS` on every track whose first lyric starts a beat after playback.
- A new branch keeps the shimmer up while the parse has landed but `buildSyncedLyrics` has not, instead of claiming the lyrics don't exist.
- `AppleMusicLyricsContentDeferMs` 350 → 160: it existed because the parse ran synchronously in that first composition, and at 350 ms almost all of the 400 ms fade-in was spent on an empty box, so the lyrics arrived as a pop.

## 6. Line-synced lyrics in Enhanced scrolled a line early

`KaraokeLyricsView` resolves the focused line as the line containing the position, falling back to the first line whose start is *after* it. Clamping `end` to `start + 4s` whenever the gap to the next line exceeded 3 s manufactured exactly such a gap on every slow line and every verse boundary, so 4 s into a line with a 9 s gap the focus, the scale-up and the spring placement all moved on while it was still being sung. Enhanced-only, because `LyricsV2` resolves the active line itself.

Each line's end now butts against the next line's start, so the library's first predicate always matches and always agrees with `findLastStartedLineIndex` (which drives our own auto-scroll). Focus hands over only for a gap long enough that the library's breathing-dots interlude will actually run. The karaoke sweep is capped separately so a long hold doesn't crawl.

## 7. Quality sheet rows were the odd ones out

`VideoQualitySheet` / `VideoAspectRatioSheet` drew flat full-bleed rows split by a `HorizontalDivider`, next to a video overflow sheet raised from the same button that uses pills. They now match `PreferenceSelectionOption` — filled `surfaceContainerHigh`, filled `primary` when selected, `extraLarge` corners — and the divider becomes breathing room, since a line drawn across a column of pills cuts through the gap between two rounded shapes. Rows that pick a value announce themselves as radio buttons; the Advanced row, which navigates, stays a button.

---

### Fork invariants

Untouched: `applicationId`, Tidal source, multi-source contract, Spotify-as-catalog-only, playback client policy, Telegram routing, CI signing, Listen Together. Playback resolution still goes through `resolveMultiSourceDataSpec` with YouTube as the final fallback — this PR only fixes which sources *reach* it. No submodule pointers moved.

### Verification

- `app/src/test/.../SourceOrderTest.kt` — 7 cases over both order merges.
- Existing fork contract tests unaffected (`:app:testGmsMobileUniversalDebugUnitTest`).
