### PR TITLE
Apple Music controls' five second window + Show toggle, lyrics romanisation on first lines, backdrop wedges

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -113,6 +113,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
@@ -219,6 +220,55 @@ private const val LINE_SYNCED_TRAILING_LINE_DURATION_MS = 4_000L
 // small enough to catch any real seek-backward or REPEAT_MODE_ONE wrap (which
 // is typically a jump from near the end of the song back to 0, i.e. minutes).
 private const val POSITION_RESET_BACKWARD_THRESHOLD_MS = 1000L
+
+// ── Romanisation hand-off ──
+// How long the first build waits for the built-in romanisation pass before giving up and publishing
+// without it. Romanising every line is local work (ICU tables, or one Kuromoji tokenize per line)
+// and normally lands well inside this, so the very first build the karaoke view ever sees already
+// carries its phonetics — which is what keeps KaraokeLyricsView from freezing the on-screen lines
+// on a layout that has none. See [KaraokeBuild] for why that matters, and note the cost of missing
+// the window is only that the shimmer holds a moment longer.
+private const val ROMANIZATION_FIRST_BUILD_GRACE_MS = 700L
+
+/**
+ * One published [SyncedLyrics] plus the identity of the romanisation baked into it.
+ *
+ * ### Why the generation counter exists
+ *
+ * `KaraokeLyricsView` caches a measured layout per line index and, once a line has been composed,
+ * derives everything it draws from a `remember {}` with no keys — so a line that was first composed
+ * from a layout without phonetics keeps drawing that layout for as long as its composition lives,
+ * no matter what arrives in the line data afterwards. The view's own `Crossfade` does rebuild the
+ * subtree when the lyrics object changes, but its layout cache is remembered *outside* that
+ * crossfade and is only cleared from a `LaunchedEffect` — i.e. one frame *after* the replacement
+ * lines have already been composed against the stale entries.
+ *
+ * The result was reported as "romanisation only shows up after the first two or three lines": the
+ * handful of lines on screen when romanisation landed were pinned to their phonetic-less layout,
+ * while every line composed later — as the song scrolled on — picked the phonetics up normally.
+ *
+ * [generation] is bumped whenever a build replaces an already-visible one with different
+ * romanisation, and it participates in the `key(...)` around the karaoke view. That disposes the
+ * view together with its layout cache, so the replacement lines are measured from scratch. It is
+ * deliberately NOT bumped for the first build of a session (there is nothing on screen to
+ * invalidate), nor when only the translation changed — translations are drawn by an ordinary `Text`
+ * that recomposes on its own, and AI translations land ~30-60s in, where a re-key would be very
+ * visible.
+ */
+private data class KaraokeBuild(
+    val lyrics: SyncedLyrics,
+    val romanization: Map<Int, List<String?>>,
+    val generation: Int,
+)
+
+/**
+ * The part of a romanisation map that changes what is drawn: entries whose every value is
+ * null/blank produce no phonetics at all, so a map full of them is indistinguishable from an empty
+ * one and must not count as a change (otherwise a song with nothing romanisable would re-key the
+ * karaoke view for a build that looks identical).
+ */
+private fun Map<Int, List<String?>>.renderedRomanization(): Map<Int, List<String?>> =
+    filterValues { values -> values.any { !it.isNullOrBlank() } }
 
 @Composable
 fun LyricsEnhanced(
@@ -373,9 +423,13 @@ fun LyricsEnhanced(
     // first composition, and re-keying on them would put a synchronous buildSyncedLyrics straight
     // back on the main thread the moment the parse lands. The effect below publishes the real
     // build from Default, so this only ever supplies the empty starting value.
-    var syncedLyrics by remember(lyrics, isTtmlFormat) {
-        mutableStateOf(SyncedLyrics(emptyList()))
+    var karaokeBuild by remember(lyrics, isTtmlFormat) {
+        mutableStateOf(KaraokeBuild(SyncedLyrics(emptyList()), emptyMap(), generation = 0))
     }
+    val syncedLyrics = karaokeBuild.lyrics
+    // Bumped alongside the lyrics object whenever a build replaces an already-visible one with
+    // different romanisation; see KaraokeBuild for why the karaoke view has to be re-keyed on it.
+    val karaokeGeneration = karaokeBuild.generation
 
     // ── AI romanisation ──
     // Runs once per track instead of once per line (network + billed), so it can't hang off the
@@ -411,64 +465,105 @@ fun LyricsEnhanced(
         // used to inherit the main dispatcher and could stutter the karaoke animation on track
         // change; run the whole batch on Default and only publish the results back.
         withContext(Dispatchers.Default) {
-        val aiMap = aiRomanizationMap(lyricsEntries, isTtmlFormat, aiRomanizedLines)
-        syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, aiMap)
-        if (!romanizationPreferences.isEnabled) return@withContext
-
-        val toRomanize =
-            lyricsEntries.mapIndexedNotNull { index, entry ->
-                val hasProviderRomanization =
-                    providedRomanizedTextForEntry(entry, romanizationPreferences) != null
-                if (hasProviderRomanization || shouldRomanizeLyricsLine(entry.text, romanizationPreferences)) {
-                    index to entry
-                } else {
-                    null
-                }
-            }
-        if (toRomanize.isEmpty()) return@withContext
-
-        val jobs =
-            toRomanize.map { (index, entry) ->
-                async {
-                    val romanized: List<String?> =
-                        try {
-                            if (isTtmlFormat && entry.words != null) {
-                                val mainWordCount = entry.words!!.count { !it.isBackground }
-                                providedRomanizedWordsForEntry(entry, mainWordCount, romanizationPreferences)
-                                    ?: romanizeWordsForLine(
-                                        // Japanese: single-pass line tokenization (6x fewer
-                                        // Kuromoji calls than per-word). Other languages:
-                                        // per-word character-by-character (already cheap).
-                                        words = entry.words!!.filter { !it.isBackground }.map { it.text },
-                                        lineText = entry.text,
-                                        preferences = romanizationPreferences,
-                                    )
-                            } else {
-                                listOf(
-                                    providedRomanizedTextForEntry(entry, romanizationPreferences)
-                                        ?: romanizeLyricsLine(entry.text, romanizationPreferences),
-                                )
-                            }
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            reportException(e)
-                            if (isTtmlFormat && entry.words != null) {
-                                List(entry.words!!.count { !it.isBackground }) { null }
-                            } else {
-                                listOf(null)
-                            }
-                        }
-                    index to romanized
-                }
-            }
-        val tempMap = mutableMapOf<Int, List<String?>>()
-        jobs.awaitAll().forEach { (index, romanized) ->
-            tempMap[index] = romanized
-        }
         // Publishing new lyrics as state (instead of bumping a key that tears the whole karaoke
-        // subtree down mid-playback) lets the view pick up romanization without a re-layout hitch.
-        syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, tempMap)
+        // subtree down mid-playback) lets the view pick up a *translation* without a re-layout
+        // hitch. Romanisation is not so lucky — the library pins each line's glyph layout to
+        // whatever it measured the first time that line was composed — so a build that changes the
+        // romanisation of lines already on screen has to carry a new generation with it. See
+        // KaraokeBuild.
+        fun publish(romanization: Map<Int, List<String?>>) {
+            val previous = karaokeBuild
+            val changesVisibleLines =
+                previous.lyrics.lines.isNotEmpty() &&
+                    romanization.renderedRomanization() != previous.romanization.renderedRomanization()
+            karaokeBuild =
+                KaraokeBuild(
+                    lyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, romanization),
+                    romanization = romanization,
+                    generation = if (changesVisibleLines) previous.generation + 1 else previous.generation,
+                )
+        }
+
+        val aiMap = aiRomanizationMap(lyricsEntries, isTtmlFormat, aiRomanizedLines)
+
+        val toRomanize: List<Pair<Int, LyricsEntry>> =
+            if (!romanizationPreferences.isEnabled) {
+                // Romanisation is off, or the AI engine owns it — `aiMap` is already everything
+                // this build will ever have.
+                emptyList()
+            } else {
+                lyricsEntries.mapIndexedNotNull { index, entry ->
+                    val hasProviderRomanization =
+                        providedRomanizedTextForEntry(entry, romanizationPreferences) != null
+                    if (hasProviderRomanization || shouldRomanizeLyricsLine(entry.text, romanizationPreferences)) {
+                        index to entry
+                    } else {
+                        null
+                    }
+                }
+            }
+        if (toRomanize.isEmpty()) {
+            publish(aiMap)
+            return@withContext
+        }
+
+        val romanization =
+            async {
+                val jobs =
+                    toRomanize.map { (index, entry) ->
+                        async {
+                            val romanized: List<String?> =
+                                try {
+                                    if (isTtmlFormat && entry.words != null) {
+                                        val mainWordCount = entry.words!!.count { !it.isBackground }
+                                        providedRomanizedWordsForEntry(entry, mainWordCount, romanizationPreferences)
+                                            ?: romanizeWordsForLine(
+                                                // Japanese: single-pass line tokenization (6x fewer
+                                                // Kuromoji calls than per-word). Other languages:
+                                                // per-word character-by-character (already cheap).
+                                                words = entry.words!!.filter { !it.isBackground }.map { it.text },
+                                                lineText = entry.text,
+                                                preferences = romanizationPreferences,
+                                            )
+                                    } else {
+                                        listOf(
+                                            providedRomanizedTextForEntry(entry, romanizationPreferences)
+                                                ?: romanizeLyricsLine(entry.text, romanizationPreferences),
+                                        )
+                                    }
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    reportException(e)
+                                    if (isTtmlFormat && entry.words != null) {
+                                        List(entry.words!!.count { !it.isBackground }) { null }
+                                    } else {
+                                        listOf(null)
+                                    }
+                                }
+                            index to romanized
+                        }
+                    }
+                jobs.awaitAll().toMap()
+            }
+
+        // ── Why the un-romanised build is not published up front ──
+        // It used to be, unconditionally, and the romanised one replaced it a moment later. That
+        // second build is exactly the case KaraokeBuild describes: the lines on screen when it
+        // landed kept their phonetic-less layout for good. Waiting a beat for the local pass means
+        // the first build the view ever sees already has the phonetics, so nothing has to be
+        // replaced at all — and the shimmer is already up, so the wait costs no visible state.
+        //
+        // The timeout is what keeps that from becoming a stall: it does not cancel the pass (the
+        // deferred belongs to the enclosing scope, not to withTimeoutOrNull), it only stops waiting
+        // on it, and the two-build path below is then taken with the re-key that makes it correct.
+        val quickRomanization = withTimeoutOrNull(ROMANIZATION_FIRST_BUILD_GRACE_MS) { romanization.await() }
+        if (quickRomanization != null) {
+            publish(quickRomanization)
+            return@withContext
+        }
+        publish(aiMap)
+        publish(romanization.await())
         }
     }
 
@@ -516,16 +611,18 @@ fun LyricsEnhanced(
     // The scroll state is recreated together with the subtree that owns it.
     //
     // The karaoke view is re-keyed on [positionResetCounter] (see the KaraokeLyricsView
-    // call site) because the mocharealm library keeps no per-play state of its own. That
-    // re-key disposes one LazyColumn and composes another; keeping a single hoisted
+    // call site) because the mocharealm library keeps no per-play state of its own, and on
+    // [karaokeGeneration] because it keeps a per-line layout cache that outlives the lyrics
+    // object it was measured from (see [KaraokeBuild]). Either re-key
+    // disposes one LazyColumn and composes another; keeping a single hoisted
     // LazyListState across the swap left the state briefly bound to two lazy layouts and
     // then owned by the disposed one, so scrolls silently went nowhere and layoutInfo
     // reported a stale viewport — the list snapped to the first line and then sat there,
     // which is the "resets on repeat but never animates again, fixed only by reopening
     // the lyrics" symptom. Recreating the state with its layout keeps the two in step,
-    // and every effect that drives scrolling is keyed on the same counter so they all
+    // and every effect that drives scrolling is keyed on the same counters so they all
     // observe the live state.
-    val listState = key(lyricsSessionKey, positionResetCounter) { rememberLazyListState() }
+    val listState = key(lyricsSessionKey, positionResetCounter, karaokeGeneration) { rememberLazyListState() }
 
     // ── First-frame placement ──
     // A fresh LazyListState starts at line 0 and the auto-scroll collector below
@@ -552,9 +649,12 @@ fun LyricsEnhanced(
     // `isSynced` is derived synchronously from the raw lyrics text, so it is already correct on
     // frame 1: the gate arms before anything is drawn and is only ever disarmed, never re-armed.
     // A late-arriving *session* (new track, new lyrics text, repeat) still re-arms it, because
-    // lyricsSessionKey covers all three.
+    // lyricsSessionKey covers all three — and so does a late romanisation, via
+    // [karaokeGeneration], because that re-keys the karaoke view and its fresh LazyListState
+    // starts back at line 0. The gate is what hides that trip; it is only ever armed for the
+    // build that actually replaces visible lines, never for the first build of a session.
     var awaitingFirstFocus by
-        remember(lyricsSessionKey, positionResetCounter) {
+        remember(lyricsSessionKey, positionResetCounter, karaokeGeneration) {
             mutableStateOf(isSynced)
         }
     // Safety net: nothing may keep the lyrics hidden. If the placement hasn't
@@ -800,11 +900,11 @@ fun LyricsEnhanced(
     // and updates `currentLineIndexState`, which flows through the snapshotFlow
     // and triggers a normal (non-forced) scroll.
     val latestSyncedLyricsForScroll = rememberUpdatedState(syncedLyrics)
-    // Restart this collector after a repeat. The karaoke view is re-keyed at
-    // the same time, and the fresh collector resets its focus state before it
-    // observes the first new active line. Keeping listState stable means the
-    // collector always targets the list currently on screen.
-    LaunchedEffect(lyricsSessionKey, isSynced, positionResetCounter) {
+    // Restart this collector after a repeat, or after a romanisation re-key. The karaoke view is
+    // re-keyed at the same time, and the fresh collector resets its focus state before it
+    // observes the first new active line. Keeping listState stable means the collector
+    // always targets the list currently on screen.
+    LaunchedEffect(lyricsSessionKey, isSynced, positionResetCounter, karaokeGeneration) {
         if (!isSynced) {
             awaitingFirstFocus = false
             return@LaunchedEffect
@@ -1119,7 +1219,15 @@ fun LyricsEnhanced(
                     // backward position jumps, so without this re-key the
                     // karaoke animation freezes at the line that was active
                     // just before the repeat.
-                    key(lyricsSessionKey, positionResetCounter) {
+                    //
+                    // [karaokeGeneration] is in the key for the same reason at a different
+                    // layer: the library caches one measured glyph layout per line index in a
+                    // map remembered here, outside its own Crossfade, and each line pins what it
+                    // draws to whichever entry that map held when the line was first composed.
+                    // A build that adds romanisation to lines already on screen therefore has to
+                    // dispose the cache along with them, or those lines never show it. See
+                    // [KaraokeBuild].
+                    key(lyricsSessionKey, positionResetCounter, karaokeGeneration) {
                         KaraokeLyricsView(
                             listState = listState,
                             lyrics = syncedLyrics,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -1016,7 +1016,12 @@ fun LyricsV2(
                         horizontalAlignment = horizontalAlignment,
                     ) {
                         val romanizedText =
-                            if (romanizationPreferences.isEnabled) {
+                            // `showsRomanization`, not `isEnabled`: the latter is false whenever the
+                            // AI engine owns romanisation (that is what tells the built-in pass to
+                            // stand down), so gating on it meant the AI results pushed into
+                            // `romanizedTextFlow` above were never composed at all — romanisation
+                            // simply never appeared in this renderer with AI romanisation on.
+                            if (romanizationPreferences.showsRomanization) {
                                 val value by item.romanizedTextFlow.collectAsStateWithLifecycle()
                                 value
                             } else {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -57,6 +57,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -85,6 +86,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.geometry.CornerRadius
@@ -186,14 +188,13 @@ private val AppleMusicMiniArtworkSize = 56.dp
 // the walk also rotates, which is what lets a colour reach the far side of the
 // screen at all.
 //
-// [AmLyricsBlurDriftScale] has to cover the drift plus the blur radius, measured
-// to the container's furthest *corner* because the layer rotates:
-//     1.2 * max(W, H) - blurRadius * scale  >=  hypot(W, H) / 2 + maxDrift
-// ContentScale.Crop renders the square artwork at side max(W, H), so at 2.4x its
-// inscribed circle has radius 1.2 * max(W, H) and the outer 64 * 2.4 = 154dp of
-// that is softened by the blur. For a 360x800 phone:
-//     1.2 * 800 - 154 = 806dp  >=  439 + 120 = 559dp.  ✔
-// (320x480, the smallest screen this could ever run on, still clears it: 422 vs 408.)
+// The rotation is why the backdrop node is NOT sized to the player: Modifier.blur
+// clips the layer it creates to that node's bounds, and a rotated rectangle only
+// reliably covers its own inscribed circle — the radius of its *short* side. A
+// screen-shaped node therefore leaves the screen's corners exposed however far it
+// is scaled up. [blurBackdropFootprint] sizes the node so it cannot; see its docs
+// for the derivation, and note that it takes BOTH ends of the zoom below, because
+// the resting scale is the tighter of the two.
 private const val AmLyricsBlurDriftScale = 2.4f
 
 // Scale of the blurred backdrop in the COVER/QUEUE states. The LYRICS state
@@ -856,25 +857,22 @@ fun AppleMusicPlayerContent(
                 // rather than the `if (lyricsOpen && lyricsContentReady)` step
                 // it replaced.
                 val progress = lyricsBackdropProgress.value
-                // Scale [AmLyricsBlurDriftScale] (lyrics fully open) leaves the
-                // solid part of the rotated image covering a circle of radius
-                // 806dp on a 360x800 screen, against the 559dp the corner plus
-                // drift(±120) asks for — see the constant's own comment for the
-                // full budget. A smaller scale would let a corner expose
-                // transparent areas, which the blur then sampled as a flickering
-                // dark band.
+                // Scale [AmLyricsBlurDriftScale] (lyrics fully open) together with
+                // the [backdropFootprint] the node is sized to leaves the rotated
+                // layer covering every screen corner plus the ±120dp drift — see
+                // blurBackdropFootprint for the budget. Scale on its own cannot do
+                // it: the blur clips the layer to the node's bounds, so a rotated
+                // screen-shaped rectangle exposes the corners at any scale, which
+                // is what used to read as dark wedges sweeping round the corners.
                 //
                 // Drift and rotation both scale with the same progress, so
                 // neither can outrun the zoom that has to cover them: at p = 0
                 // there is no translation and no rotation at all, and both reach
-                // full amplitude only once the zoom does.
-                //
-                // At low p the overhang is short of the *blur radius* alone (36dp
-                // vs 64dp at p = 0) — but that is the COVER state, which has zero
-                // drift and zero rotation and looked exactly this way before the
-                // ramp existed (a 72dp blur at a fixed 1.2x, i.e. a slightly
-                // larger shortfall). What the ramp has to avoid is motion
-                // outrunning the zoom, and it does.
+                // full amplitude only once the zoom does. The footprint is sized
+                // for both ends of that ramp, because the resting scale
+                // ([AmCoverBlurScale]) is the tighter of the two — rotation can be
+                // at any angle for any p > 0, since BlurWanderDrift.rotationDeg
+                // accumulates.
                 val scale = AmCoverBlurScale + (AmLyricsBlurDriftScale - AmCoverBlurScale) * progress
                 scaleX = scale
                 scaleY = scale
@@ -946,40 +944,66 @@ fun AppleMusicPlayerContent(
             // The artwork backdrop. Composed in every state so there is no node
             // swap (and so no re-decode, no new RenderEffect, no one-frame
             // discontinuity) when lyrics opens or closes.
-            if (isPreS && preBlurredBitmap != null) {
-                // Pre-Android-12 has no RenderEffect, so the blur was baked
-                // into the bitmap on a background thread instead.
-                Image(
-                    bitmap = preBlurredBitmap!!.asImageBitmap(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .matchParentSize()
-                            .graphicsLayer(driftGraphicsLayer),
-                )
-            } else {
-                AsyncImage(
-                    model = artworkRequest ?: artworkUrl,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .matchParentSize()
-                            // graphicsLayer OUTSIDE blur: the blur is applied to
-                            // the centered image (inside the layer), then the
-                            // scale + translation is applied to the blurred
-                            // result. Blurring after the transform would sample
-                            // the translated image's edges instead.
-                            .graphicsLayer(driftGraphicsLayer)
-                            .then(
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                    Modifier.blur(AmBackdropBlurRadius)
-                                } else {
-                                    Modifier
-                                },
-                            ),
-                )
+            //
+            // Deliberately larger than the player and centred inside it: the drift
+            // rotates this node, and Modifier.blur clips its result to the node's
+            // own bounds, so a node the size of the player would swing its corners
+            // into view. requiredSize is what lets it ignore the incoming
+            // constraints; the wrapper clips the overhang back to the player so it
+            // cannot bleed over anything else. See blurBackdropFootprint.
+            val backdropFootprint =
+                remember(maxWidth, maxHeight) {
+                    blurBackdropFootprint(
+                        width = maxWidth,
+                        height = maxHeight,
+                        restScale = AmCoverBlurScale,
+                        driftScale = AmLyricsBlurDriftScale,
+                    )
+                }
+            Box(
+                modifier =
+                    Modifier
+                        .matchParentSize()
+                        .clipToBounds(),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (isPreS && preBlurredBitmap != null) {
+                    // Pre-Android-12 has no RenderEffect, so the blur was baked
+                    // into the bitmap on a background thread instead. It still goes
+                    // through driftGraphicsLayer, rotation included, so it needs the
+                    // same footprint.
+                    Image(
+                        bitmap = preBlurredBitmap!!.asImageBitmap(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier =
+                            Modifier
+                                .requiredSize(backdropFootprint)
+                                .graphicsLayer(driftGraphicsLayer),
+                    )
+                } else {
+                    AsyncImage(
+                        model = artworkRequest ?: artworkUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier =
+                            Modifier
+                                .requiredSize(backdropFootprint)
+                                // graphicsLayer OUTSIDE blur: the blur is applied to
+                                // the centered image (inside the layer), then the
+                                // scale + translation is applied to the blurred
+                                // result. Blurring after the transform would sample
+                                // the translated image's edges instead.
+                                .graphicsLayer(driftGraphicsLayer)
+                                .then(
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                        Modifier.blur(AmBackdropBlurRadius)
+                                    } else {
+                                        Modifier
+                                    },
+                                ),
+                    )
+                }
             }
 
             if (useCanvasBackdrop) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -16,6 +16,7 @@ package moe.rukamori.archivetune.ui.player
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Build
+import android.os.SystemClock
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
@@ -217,6 +218,12 @@ private val AmBackdropBlurRadius = 64.dp
 
 private const val AppleMusicLyricsContentDeferMs = 160L
 
+// Minimum spacing between auto-hide-timer pokes coming from a CONTINUOUS gesture (seekbar
+// scrub, volume drag). See pokePlayerControlsVisibilityThrottled in AppleMusicPlayerContent:
+// each poke recomposes the player, so an unthrottled per-delta poke would spend the lyrics
+// view's frame budget on composition. Well under the five second window it keeps alive.
+private const val ControlsGesturePokeThrottleMs = 1_000L
+
 // How far above the bottom of the artwork stage the blurred canvas starts dissolving into the
 // still blurred album art beneath it. See canvasSeamFade in AppleMusicPlayerContent.
 private val AmCanvasSeamFadeDp = 88.dp
@@ -393,26 +400,69 @@ fun AppleMusicPlayerContent(
     // "Initially, you'll see other controls on the screen. But after five seconds,
     // the lyrics will automatically start showing on the full screen." Tapping
     // anywhere brings them back (see the pointerInput on the content Column/Row).
-    var playerControlsExpanded by remember(mediaMetadata.id) { mutableStateOf(true) }
-    var playerControlsVisibilityTick by remember(mediaMetadata.id) { mutableIntStateOf(0) }
+    //
+    // The player sheet is composed with keepContentAlive = true (see [BottomSheet]), so
+    // collapsing to the mini player only sets alpha = 0 — this composable is never
+    // unmounted, and `lyricsOpen` / `playerControlsExpanded` survive the collapse. The
+    // reveal therefore has to key off "the lyrics view is actually on screen", not off the
+    // `lyricsOpen` transition alone. See the countdown below.
+    var playerControlsExpanded by remember { mutableStateOf(true) }
+    var controlsRevealToken by remember { mutableIntStateOf(0) }
     val autoHideDelayMs = 5_000L
+    val playerExpanded = state.isExpanded
 
-    LaunchedEffect(lyricsOpen) {
-        if (lyricsOpen) {
-            playerControlsExpanded = true
-            if (autoHideLyricsPlayerControls) playerControlsVisibilityTick++
-        } else {
-            playerControlsExpanded = true
+    // Bumping the token reveals the controls and restarts the countdown. Deliberately
+    // remembered with NO keys: the lambda closes over the token state and nothing else, so
+    // it stays valid for the life of the composable. The previous version was
+    // remember(lyricsOpen, queueOpen) while the state it wrote was
+    // remember(mediaMetadata.id) — after a track change it kept writing to the discarded
+    // MutableState, so tap-to-reveal silently stopped working.
+    val pokePlayerControlsVisibility: () -> Unit = remember { { controlsRevealToken++ } }
+
+    // Same poke, throttled, for CONTINUOUS gestures (seekbar scrub, volume drag).
+    //
+    // The tap-anywhere handler below only fires on the initial down, so a scrub or volume
+    // drag that outlasted the five second window had the controls — and therefore the very
+    // slider under the user's finger — animate away mid-gesture, cancelling the drag. These
+    // callbacks re-poke while the gesture runs.
+    //
+    // Throttled because bumping the token invalidates this composable (the countdown reads
+    // it as a LaunchedEffect key), and recomposing the whole Apple Music player on every
+    // drag delta is exactly the kind of frame-budget theft the lyrics view cannot afford.
+    // The timestamp lives in a plain array, NOT in a snapshot state, so reading and writing
+    // it costs no invalidation of its own. One poke per second is enough: the window is five.
+    val lastGesturePokeMs = remember { longArrayOf(0L) }
+    val pokePlayerControlsVisibilityThrottled: () -> Unit =
+        remember {
+            {
+                val now = SystemClock.uptimeMillis()
+                if (now - lastGesturePokeMs[0] >= ControlsGesturePokeThrottleMs) {
+                    lastGesturePokeMs[0] = now
+                    controlsRevealToken++
+                }
+            }
         }
-    }
-    LaunchedEffect(queueOpen) {
-        if (queueOpen) {
-            playerControlsExpanded = true
-            if (autoHideLyricsPlayerControls) playerControlsVisibilityTick++
-        } else {
-            playerControlsExpanded = true
+    val onControlsSliderValueChange: (Long) -> Unit =
+        remember(onSliderValueChange) {
+            { position ->
+                pokePlayerControlsVisibilityThrottled()
+                onSliderValueChange(position)
+            }
         }
-    }
+    val onControlsSliderValueChangeFinished: () -> Unit =
+        remember(onSliderValueChangeFinished) {
+            {
+                pokePlayerControlsVisibility()
+                onSliderValueChangeFinished()
+            }
+        }
+    val onControlsVolumeChange: (Float) -> Unit =
+        remember(onVolumeChange) {
+            { newVolume ->
+                pokePlayerControlsVisibilityThrottled()
+                onVolumeChange(newVolume)
+            }
+        }
 
     // ISSUE 1 FIX: propagate inline-lyrics visibility to the parent so back-stack
     // screens suspend their GPU work during the morph.
@@ -422,16 +472,48 @@ fun AppleMusicPlayerContent(
     DisposableEffect(Unit) {
         onDispose { onLyricsVisibilityChange(false) }
     }
-    // Auto-hide timer: show controls for 5s, then hide. Fires for both lyrics and queue,
-    // but ONLY when the Auto-hide controls preference is on. Turning the preference off
-    // mid-session immediately restores the controls and keeps them.
-    LaunchedEffect(lyricsOpen, queueOpen, playerControlsVisibilityTick, autoHideLyricsPlayerControls) {
-        if (!autoHideLyricsPlayerControls) {
-            playerControlsExpanded = true
-            return@LaunchedEffect
-        }
-        if (!lyricsOpen && !queueOpen) return@LaunchedEffect
+    // Auto-hide timer: show the controls, then hide them after 5s. Fires for both lyrics
+    // and queue, but ONLY when the Auto-hide controls preference is on. Turning the
+    // preference off restores the controls and keeps them.
+    //
+    // ONE countdown, with every reveal trigger as a key. This used to be three effects:
+    // two that bumped a tick which the third used as its timer key, so the countdown was
+    // launched, cancelled and relaunched across two frames and the ordering was
+    // load-bearing. Setting `playerControlsExpanded = true` unconditionally at the top
+    // means any key change reveals the controls FIRST and only then decides whether to
+    // start hiding them — that is what guarantees the full five second window.
+    //
+    // `playerExpanded` is a key because of the keepContentAlive note above: re-expanding
+    // the player from the mini player used to restore the lyrics view with the controls
+    // already hidden by the PREVIOUS visit's expired timer — no five second window at all,
+    // just an instant hide, with a tap as the only way to get them back.
+    // `mediaMetadata.id` is a key so a track change re-reveals them too.
+    //
+    // `showLyricsPlayerControls` is a key, and the countdown bails out while it is off,
+    // because the visibility condition below ANDs it with `playerControlsExpanded`: with the
+    // timer running behind a hidden view, the five second window was silently burned in the
+    // background, so switching "Show player controls" back on in the Apple Music player
+    // revealed nothing at all — the setting looked dead and only a tap brought the controls
+    // back. Holding the flag expanded while the controls are suppressed means the toggle
+    // both shows them immediately and grants the full five seconds. Queue mode is not
+    // gated: the preference is lyrics-only, and its controls stay on the auto-hide cycle.
+    LaunchedEffect(
+        lyricsOpen,
+        queueOpen,
+        playerExpanded,
+        mediaMetadata.id,
+        controlsRevealToken,
+        autoHideLyricsPlayerControls,
+        showLyricsPlayerControls,
+    ) {
         playerControlsExpanded = true
+        if (!lyricsOpen && !queueOpen) return@LaunchedEffect
+        // Collapsed: there is nothing on screen to auto-hide, and burning the window here
+        // is exactly what caused the instant hide on re-expand.
+        if (!playerExpanded) return@LaunchedEffect
+        if (!autoHideLyricsPlayerControls) return@LaunchedEffect
+        // Lyrics with the controls suppressed: nothing on screen to hide, same reasoning.
+        if (lyricsOpen && !queueOpen && !showLyricsPlayerControls) return@LaunchedEffect
         delay(autoHideDelayMs)
         playerControlsExpanded = false
     }
@@ -494,15 +576,6 @@ fun AppleMusicPlayerContent(
         delay(AppleMusicLyricsContentDeferMs)
         lyricsContentReady = true
     }
-    val pokePlayerControlsVisibility = remember(lyricsOpen, queueOpen) {
-        {
-            if (lyricsOpen || queueOpen) {
-                playerControlsExpanded = true
-                playerControlsVisibilityTick++
-            }
-        }
-    }
-
     // === Deferred position reads for the lyrics overlay ===
     // `sliderPosition` is non-null ONLY while the user is actively scrubbing
     // the seekbar. When null, LyricsEnhanced/LyricsV2 fall back to reading
@@ -717,12 +790,11 @@ fun AppleMusicPlayerContent(
                     onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
                     showPlayerControlsState = showLyricsPlayerControlsState,
                     onShowPlayerControlsChange = { showLyricsPlayerControlsState.value = it },
-                    onAutoHidePlayerControlsChange = { enabled ->
-                        if (enabled) {
-                            playerControlsVisibilityTick++
-                        } else {
-                            playerControlsExpanded = true
-                        }
+                    onAutoHidePlayerControlsChange = {
+                        // LyricsMenu already persists the preference; the countdown effect
+                        // keys off it, so all this has to do is reveal the controls again so
+                        // the change is immediately visible.
+                        pokePlayerControlsVisibility()
                     },
                     onDismiss = menuState::dismiss,
                     showControlsToggles = true,
@@ -1118,15 +1190,15 @@ fun AppleMusicPlayerContent(
                         playerConnection = playerConnection,
                         currentSongLiked = currentSongLiked,
                         volume = volume,
-                        onVolumeChange = onVolumeChange,
+                        onVolumeChange = onControlsVolumeChange,
                         titleActions = titleActions,
                         onPlayPauseClick = onPlayPauseClick,
                         onMoreClick = onMoreClick,
                         onOutputClick = onOutputClick,
                         onQueueClick = onQueueClick,
                         onLyricsClick = onLyricsClick,
-                        onSliderValueChange = onSliderValueChange,
-                        onSliderValueChangeFinished = onSliderValueChangeFinished,
+                        onSliderValueChange = onControlsSliderValueChange,
+                        onSliderValueChangeFinished = onControlsSliderValueChangeFinished,
                         currentFormat = currentFormat,
                         onQualityChipClick = {
                             bottomSheetPageState.show { ShowMediaInfo(mediaMetadata.id) }
@@ -1606,15 +1678,15 @@ fun AppleMusicPlayerContent(
                         playerConnection = playerConnection,
                         currentSongLiked = currentSongLiked,
                         volume = volume,
-                        onVolumeChange = onVolumeChange,
+                        onVolumeChange = onControlsVolumeChange,
                         titleActions = titleActions,
                         onPlayPauseClick = onPlayPauseClick,
                         onMoreClick = onMoreClick,
                         onOutputClick = onOutputClick,
                         onQueueClick = toggleQueue,
                         onLyricsClick = toggleLyrics,
-                        onSliderValueChange = onSliderValueChange,
-                        onSliderValueChangeFinished = onSliderValueChangeFinished,
+                        onSliderValueChange = onControlsSliderValueChange,
+                        onSliderValueChangeFinished = onControlsSliderValueChangeFinished,
                         currentFormat = currentFormat,
                         onQualityChipClick = {
                             bottomSheetPageState.show { ShowMediaInfo(mediaMetadata.id) }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/BlurWanderDrift.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/BlurWanderDrift.kt
@@ -13,10 +13,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.isActive
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.hypot
+import kotlin.math.max
 import kotlin.math.sin
 import kotlin.random.Random
 
@@ -74,16 +78,16 @@ import kotlin.random.Random
  *
  * [WanderRadiusDp] is the largest offset this can ever produce, and callers rely
  * on that: the blurred artwork is drawn scaled up so that it still covers the
- * screen at maximum offset, and the blur (64dp) has to be covered too.
+ * screen at maximum offset.
  *
- * Rotation changes that sum, because a rotated square only reliably covers its
+ * Rotation changes that sum, because a rotated rectangle only reliably covers its
  * own inscribed circle — so the budget must be measured to the container's
- * furthest *corner* rather than its nearest edge. `ContentScale.Crop` of a square
- * artwork renders a square of side `S = max(W, H)`, which callers then scale by
- * 2.4, giving an inscribed circle of radius `1.2 S` whose outer `64 * 2.4 =
- * 154dp` is softened by the blur. What has to fit inside the solid remainder is
- * `hypot(W, H) / 2 + WanderRadiusDp`. On a 360x800 phone that is 806dp available
- * against 559dp needed; even a 320x480 screen clears it, 422 against 408.
+ * furthest *corner* rather than its nearest edge. Scaling up is not enough on its
+ * own: `Modifier.blur`'s default `BlurredEdgeTreatment.Rectangle` clips the layer
+ * it creates to the composable's bounds, so what actually rotates is a rectangle
+ * of exactly those bounds — its inscribed circle has the radius of the *short*
+ * side, which on a phone is far too small however much the layer is scaled. See
+ * [blurBackdropFootprint], which is what callers use to size the layer.
  *
  * ### Threading / recomposition
  *
@@ -215,6 +219,85 @@ internal class BlurWanderDrift(
         private const val TwoPi = (2.0 * PI).toFloat()
     }
 }
+
+/**
+ * Footprint the heavily blurred backdrop layer has to occupy so that [BlurWanderDrift]'s rotation
+ * can never swing one of the layer's own corners into view.
+ *
+ * ### Why the layer cannot simply be the container
+ *
+ * The backdrop is built as `Modifier.graphicsLayer { scale / translate / rotate }.blur(radius)`:
+ * the blur is applied to the still, centred artwork and the drift transform is applied to the
+ * blurred result. `Modifier.blur`'s default `BlurredEdgeTreatment.Rectangle` sets `clip = true` on
+ * the layer it creates, so the blurred result is an opaque rectangle of **exactly the composable's
+ * bounds** — not the `max(W, H)` square that `ContentScale.Crop` painted into it, which is clipped
+ * away before the transform ever runs.
+ *
+ * A rectangle rotated by an arbitrary angle only reliably covers its own inscribed circle, whose
+ * radius comes from the rectangle's *short* side. With the layer sized to the container, that is
+ * `scale * min(W, H) / 2` — 432dp on a 360x800 phone at 2.4x — while the point that has to stay
+ * covered is the container's furthest corner plus the drift, `hypot(W, H) / 2 + WanderRadiusDp` =
+ * 559dp. The 127dp shortfall is not theoretical: it is a near-black wedge sweeping through a corner
+ * of the lyrics backdrop in time with the rotation, and it is there even at zero drift (432 against
+ * 439 for the bare corner).
+ *
+ * ### What this returns
+ *
+ * A footprint whose *shorter* side is long enough that the inscribed circle reaches that corner.
+ * Only the short side grows: `max(width, height)` comes out unchanged in every real window shape,
+ * and because `ContentScale.Crop` of a square artwork renders it at side `max(w, h)`, that means
+ * the artwork is still rasterised at exactly the same scale and the backdrop looks identical. The
+ * extra area exists purely for the rotation to swing into.
+ *
+ * ### Cost
+ *
+ * A bigger layer is a bigger offscreen buffer — 1.3x the container's area for the lyrics screen,
+ * up to ~2x for the Apple-Music player, whose resting scale is the tighter constraint. Sized
+ * against correctness that is the right way round: the exposed corner is on screen for a large
+ * share of all rotation angles, on every device, whereas this is one background layer that only
+ * exists while the player is.
+ *
+ * If it ever needs to come down, the lever is resolution rather than footprint: halving the
+ * footprint while doubling the caller's scales and halving its blur radius is pixel-identical (the
+ * on-screen blur is `radius * scale`, the visible window is `containerSide / scale` of an artwork
+ * drawn at `max(footprint)`, and the coverage product `scale * footprint` is unchanged) at a
+ * quarter of the pixels.
+ *
+ * @param restScale the scale the layer sits at while it carries no drift and no rotation (equal to
+ *   [driftScale] for surfaces that never ramp).
+ * @param driftScale the scale the layer reaches once it carries the full drift and rotation.
+ * @param maxDriftDp the largest translation the walk can produce, i.e. [BlurWanderDrift.WanderRadiusDp].
+ */
+internal fun blurBackdropFootprint(
+    width: Dp,
+    height: Dp,
+    restScale: Float,
+    driftScale: Float,
+    maxDriftDp: Float = BlurWanderDrift.WanderRadiusDp,
+): DpSize {
+    val w = width.value
+    val h = height.value
+    if (w <= 0f || h <= 0f || restScale <= 0f || driftScale <= 0f) return DpSize(width, height)
+
+    val corner = hypot(w, h) / 2f
+    // Callers ramp scale, translation and rotation off one progress value, so the requirement along
+    // the ramp is `2 * (corner + drift * p) / (restScale + (driftScale - restScale) * p)`. That is
+    // a Mobius function of p, so it has no interior extremum and the worst case is an endpoint:
+    // either resting (no drift, but the smallest scale) or fully drifting (largest scale, but the
+    // corner has moved out by the whole wander radius).
+    val requiredAtRest = 2f * corner / restScale
+    val requiredAtFullDrift = 2f * (corner + maxDriftDp) / driftScale
+    val required = max(requiredAtRest, requiredAtFullDrift) * BlurBackdropCoverSafety
+
+    return DpSize(max(w, required).dp, max(h, required).dp)
+}
+
+/**
+ * A little headroom on [blurBackdropFootprint]'s result. The derivation is exact, so this only
+ * absorbs rounding between the dp maths here and the pixel maths the layer is actually rasterised
+ * with — 2% is a couple of dp on a phone.
+ */
+private const val BlurBackdropCoverSafety = 1.02f
 
 /**
  * Remembers a [BlurWanderDrift] and advances it from the frame clock while

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
@@ -176,11 +177,13 @@ private val LyricsSwipeStartRegion = 144.dp
 
 // Scale of the blurred backdrop. Must cover BlurWanderDrift.WanderRadiusDp of drift plus the
 // 64dp blur — and, because the walk rotates, must do so out to the container's furthest corner
-// rather than its nearest edge. Crop renders the square artwork at side max(W, H), so at 2.4x the
-// solid (un-softened) coverage is a circle of radius 1.2*max(W,H) - 154dp: 806dp on a 360x800
-// screen, against hypot(360,800)/2 + 120 = 559dp needed. Kept in sync with AmLyricsBlurDriftScale
-// in AppleMusicPlayer.kt. Was 1.9x, which was sized for an older, smaller drift and let the blur
-// sample transparent pixels at full offset — a dark band along the trailing edge.
+// rather than its nearest edge. Kept in sync with AmLyricsBlurDriftScale in AppleMusicPlayer.kt.
+// Was 1.9x, which was sized for an older, smaller drift and let the blur sample transparent pixels
+// at full offset — a dark band along the trailing edge.
+//
+// Scaling alone does NOT make the rotation safe: the layer Modifier.blur produces is clipped to the
+// composable's bounds, so a rotated *screen-shaped* rectangle only covers a circle of
+// 2.4 * min(W, H) / 2. blurBackdropFootprint is what closes that gap; see its docs.
 private const val MovingBlurDriftScale = 2.4f
 private val LyricsSwipeDismissThreshold = 96.dp
 
@@ -979,6 +982,25 @@ private fun MovingBlurBackground(
                 MovingBlurDriftScale
             }
 
+        // Footprint of the drifting layer. NOT the screen: the layer Modifier.blur creates is
+        // clipped to its own bounds, so a screen-shaped rectangle rotated by the walk only covers a
+        // circle of MovingBlurDriftScale * min(W, H) / 2 = 432dp on a 360x800 phone, against the
+        // 559dp the furthest corner plus the drift needs — the missing wedge is what read as black
+        // artefacts rotating through the corners. Widening the short side fixes it without changing
+        // the look, because max(W, H) — and so ContentScale.Crop's scale factor — is untouched.
+        // See blurBackdropFootprint.
+        val driftFootprint =
+            remember(maxWidth, maxHeight) {
+                blurBackdropFootprint(
+                    width = maxWidth,
+                    height = maxHeight,
+                    // No ramp here: this backdrop is only ever composed with lyrics open, so it
+                    // sits at the drifting scale the whole time.
+                    restScale = MovingBlurDriftScale,
+                    driftScale = MovingBlurDriftScale,
+                )
+            }
+
         AnimatedContent(
             targetState = mediaMetadata.thumbnailUrl,
             transitionSpec = { fadeIn(tween(700)) togetherWith fadeOut(tween(700)) },
@@ -1026,36 +1048,47 @@ private fun MovingBlurBackground(
                         )
                     }
                 } else {
-                    AsyncImage(
-                        model = thumbnailUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        colorFilter = vibrancyColorFilter,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            // graphicsLayer OUTSIDE blur: the blur is applied to the
-                            // centered image (inside graphicsLayer), then the scale +
-                            // translation is applied to the blurred result. This prevents
-                            // the blur from sampling transparent areas at the translated
-                            // image's trailing edge — the root cause of the corner flicker.
-                            // See [MovingBlurDriftScale] for the covering budget.
-                            .graphicsLayer {
-                                scaleX = MovingBlurDriftScale
-                                scaleY = MovingBlurDriftScale
-                                // Deferred read — see blurWander above.
-                                translationX = blurWander.xDp.floatValue.dp.toPx()
-                                translationY = blurWander.yDp.floatValue.dp.toPx()
-                                // Rotation is the only part of the walk that can
-                                // carry a colour across the whole surface;
-                                // translation moves every colour by the same
-                                // vector, so on its own it leaves the top the top.
-                                // See BlurWanderDrift.
-                                rotationZ = blurWander.rotationDeg.floatValue
-                                compositingStrategy = CompositingStrategy.Offscreen
-                            }
-                            .blur(64.dp)
-                            .alpha(0.95f),
-                    )
+                    // Centred inside a full-size box rather than filling it: the image is
+                    // deliberately larger than the screen (see driftFootprint) and requiredSize is
+                    // what lets it ignore the incoming constraints. The overflow is clipped by the
+                    // clipToBounds on the BoxWithConstraints above.
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        AsyncImage(
+                            model = thumbnailUrl,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            colorFilter = vibrancyColorFilter,
+                            modifier = Modifier
+                                .requiredSize(driftFootprint)
+                                // graphicsLayer OUTSIDE blur: the blur is applied to the
+                                // centered image (inside graphicsLayer), then the scale +
+                                // translation is applied to the blurred result. This prevents
+                                // the blur from sampling transparent areas at the translated
+                                // image's trailing edge — the root cause of the corner flicker.
+                                // The flip side is that the blur clips its result to this
+                                // element's bounds, which is why those bounds are the
+                                // driftFootprint and not the screen.
+                                .graphicsLayer {
+                                    scaleX = MovingBlurDriftScale
+                                    scaleY = MovingBlurDriftScale
+                                    // Deferred read — see blurWander above.
+                                    translationX = blurWander.xDp.floatValue.dp.toPx()
+                                    translationY = blurWander.yDp.floatValue.dp.toPx()
+                                    // Rotation is the only part of the walk that can
+                                    // carry a colour across the whole surface;
+                                    // translation moves every colour by the same
+                                    // vector, so on its own it leaves the top the top.
+                                    // See BlurWanderDrift.
+                                    rotationZ = blurWander.rotationDeg.floatValue
+                                    compositingStrategy = CompositingStrategy.Offscreen
+                                }
+                                .blur(64.dp)
+                                .alpha(0.95f),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -250,12 +250,8 @@ fun LyricsScreen(
     val showPlayerControlsEnabled by showPlayerControlsState
     val (autoHidePlayerControls, onAutoHidePlayerControlsChange) =
         rememberPreference(AutoHideLyricsPlayerControlsKey, true)
-    var playerControlsExpanded by remember(mediaMetadata.id, showPlayerControlsEnabled) {
-        mutableStateOf(showPlayerControlsEnabled)
-    }
-    var playerControlsVisibilityTick by remember(mediaMetadata.id) {
-        mutableIntStateOf(0)
-    }
+    var playerControlsExpanded by remember { mutableStateOf(true) }
+    var controlsRevealToken by remember { mutableIntStateOf(0) }
     val autoHideDelayMs = 5_000L
     // Tracks whether the user is actively scrolling the lyrics list. Hoisted up from
     // LyricsEnhanced / LyricsV2 via [LocalLyricsScrollListener] so the bottom Apple Music
@@ -270,27 +266,35 @@ fun LyricsScreen(
         }
     val onAutoHidePlayerControlsToggle: (Boolean) -> Unit = { enabled ->
         onAutoHidePlayerControlsChange(enabled)
-        if (showPlayerControlsEnabled) {
-            playerControlsExpanded = true
-            playerControlsVisibilityTick++
-        }
+        controlsRevealToken++
     }
 
-    fun pokePlayerControlsVisibility() {
-        if (!showPlayerControlsEnabled) return
+    // Bumping the token reveals the controls and restarts the countdown below.
+    //
+    // Deliberately remembered with NO keys, and the state it writes is likewise unkeyed:
+    // the root `pointerInput` that calls this only restarts on its own keys, so it holds
+    // this closure across track changes. When the state above was
+    // remember(mediaMetadata.id, showPlayerControlsEnabled) and this was a plain local fun,
+    // that captured closure kept writing to the MutableState discarded by the track change
+    // and tap-to-reveal silently stopped working. The countdown effect takes
+    // mediaMetadata.id and the preferences as keys instead, so those events still re-reveal
+    // the controls without swapping the state objects underneath.
+    val pokePlayerControlsVisibility: () -> Unit = remember { { controlsRevealToken++ } }
+
+    // Single countdown, with every reveal trigger as a key. Setting
+    // `playerControlsExpanded = true` unconditionally at the top means any key change
+    // reveals the controls FIRST and only then decides whether to start hiding them, which
+    // is what guarantees the full five second window. This replaced a pair of effects where
+    // one bumped the tick that the other used as its timer key, so the countdown was
+    // launched, cancelled and relaunched across two frames.
+    LaunchedEffect(
+        autoHidePlayerControls,
+        showPlayerControlsEnabled,
+        controlsRevealToken,
+        mediaMetadata.id,
+    ) {
         playerControlsExpanded = true
-        if (autoHidePlayerControls) {
-            playerControlsVisibilityTick++
-        }
-    }
-
-    LaunchedEffect(showPlayerControlsEnabled) {
-        playerControlsExpanded = showPlayerControlsEnabled
-    }
-
-    LaunchedEffect(autoHidePlayerControls, showPlayerControlsEnabled, playerControlsVisibilityTick, mediaMetadata.id) {
         if (!showPlayerControlsEnabled || !autoHidePlayerControls) return@LaunchedEffect
-        playerControlsExpanded = true
         kotlinx.coroutines.delay(autoHideDelayMs)
         playerControlsExpanded = false
     }


### PR DESCRIPTION
Release `dev` → `main`. Two commits.

## Apple Music player controls: the five second window, and a toggle that wasn't dead (`b0da4f9`)

Reported: in the Apple Music player *only*, the bottom controls hid themselves
on their own instead of after five seconds, and neither **Show player controls**
nor **Hide controls automatically** appeared to affect them. Four causes:

- **The window was burned off screen.** The player sheet is composed with
  `keepContentAlive = true`, so collapsing to the mini player only drops the
  sheet's alpha — `AppleMusicPlayerContent` is never unmounted, and `lyricsOpen`
  plus the *already expired* timer survive the collapse. Re-expanding restored
  the lyrics view with the controls gone: no window at all, and a tap as the only
  way back. The standalone lyrics screen is immune because
  `MikoLyricsTransition` gates it behind `if (showContent)` and remounts on every
  open — hence "Apple Music only". `state.isExpanded` is now a countdown key and
  the countdown bails out while collapsed.
- **"Show player controls" could not bring the controls back.** The visibility
  condition ANDs the preference with the countdown's flag, but the countdown
  never looked at the preference: with the toggle off the timer ran behind a
  hidden view and expired, so switching it back on revealed nothing. The
  preference is now a key and suppresses the countdown, so the toggle shows the
  controls immediately *and* grants the full five seconds. Queue mode stays on
  the cycle — the preference is lyrics-only.
- **Three effects, load-bearing ordering, and a discarded state.**
  `playerControlsExpanded` and the reveal tick were `remember(mediaMetadata.id)`
  while the poke lambda was `remember(lyricsOpen, queueOpen)`, so after a track
  change the lambda wrote to a discarded `MutableState` and tap-to-reveal
  silently died; separately, two effects bumped a tick that a third used as its
  timer key, so the countdown was launched, cancelled and relaunched across two
  frames. Now one countdown, keyless states, reveal-then-decide. `LyricsScreen`
  had the same key mismatch and gets the same treatment.
- **The controls slid out from under the finger mid-scrub.** Tap-to-reveal pokes
  only on the initial down, so a scrub or volume drag longer than the window had
  the slider being dragged animate away, cancelling the drag. The slider and
  volume callbacks now re-poke during the gesture, throttled to once a second
  because each poke invalidates the player composable.

## Lyrics romanisation and backdrop (`193c942`)

- Romanisation only appeared after the first two or three lines: the karaoke
  glyph layout cache pinned lines composed against a phonetic-less build. The
  romanised build is now the first one published, with a `generation` re-key as
  the fallback for the case that misses the grace window.
- `LyricsV2` showed no romanisation at all with AI romanisation selected — it
  gated collection on `isEnabled`, which is false by design when `aiHandled` is
  true. It now uses the render-time `showsRomanization`.
- Backdrop corner wedges during the lyrics drift, and translate exclusions that
  were ignored.

## Verification

Not built locally (phone, per request) — relying on the PR checks: assemble
across the flavour matrix plus the fork contract unit tests.
