### PR TITLE
fix: multiple UI, lyrics animation, and download reliability issues

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -153,7 +153,16 @@ class App :
     private fun initializeCriticalSync() {
         runCatching {
             val config = com.downloader.PRDownloaderConfig.newBuilder()
-                .setReadTimeout(60_000)
+                // ── Read timeout bumped 60s → 300s ──
+                // The 60s read timeout was the prime cause of "songs interrupted halfway through":
+                // if the network stalled for > 60 s mid-stream (mobile data handoff, congested
+                // WiFi, CDN throttle), OkHttp threw SocketTimeoutException, PRDownloader
+                // reported onError, and the download failed even though the connection would
+                // have recovered on its own. 300 s is generous enough to ride through the
+                // common stalls without making a real disconnect look like it's still
+                // downloading for too long. The connect timeout stays at 15 s — a stalled
+                // *initial* connection is genuinely dead and should fail fast.
+                .setReadTimeout(300_000)
                 .setConnectTimeout(15_000)
                 .setUserAgent("ArchiveTune/${BuildConfig.VERSION_NAME}")
                 .build()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -158,7 +158,16 @@ class DownloadUtil
                 .followSslRedirects(true)
                 .retryOnConnectionFailure(true)
                 .connectTimeout(8, TimeUnit.SECONDS)
-                .readTimeout(60, TimeUnit.SECONDS)
+                // ── Read timeout 60s → 300s ──
+                // Same rationale as PRDownloader's readTimeout bump in App.kt: a 60 s read
+                // timeout was the prime cause of "songs interrupted halfway through" — the
+                // prewarm fetch (fetchStreamIntoPlayerCache) reads from this client, and a
+                // network stall > 60 s mid-stream threw SocketTimeoutException, purged the
+                // partial cache, and forced a fallback that often resolved to a different
+                // (often YouTube) source. 300 s rides through the common mobile-data and
+                // congested-WiFi stalls without making a real disconnect look like it's
+                // still downloading for too long.
+                .readTimeout(300, TimeUnit.SECONDS)
                 .writeTimeout(60, TimeUnit.SECONDS)
                 .callTimeout(0, TimeUnit.SECONDS) // no overall cap — let large FLAC files download to completion
                 .dispatcher(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/PRDownloaderDataSource.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/PRDownloaderDataSource.kt
@@ -119,6 +119,42 @@ internal class PRDownloaderDataSource private constructor(
     override fun open(dataSpec: DataSpec): Long {
         transferInitializing(dataSpec)
         val url = dataSpec.uri.toString()
+
+        // ── Retry loop ──
+        // PRDownloader 1.0.2 has two failure modes that both produce "song interrupted halfway
+        // through" from the user's perspective:
+        //   (a) a transient network stall mid-stream throws SocketTimeoutException inside
+        //       PRDownloader's OkHttp, fires onError, and the whole download fails.
+        //   (b) PRDownloader's `onDownloadComplete()` fires on a partial file when the upstream
+        //       connection drops mid-stream on chunked-transfer CDNs (e.g. Qobuz). The size
+        //       verification below catches this when Content-Length is known, but only after
+        //       the user has waited for what looked like a complete download.
+        //
+        // The retry below addresses (a). Each attempt deletes the temp file and starts fresh
+        // (PRDownloader has no resume support), but the user gets 3 chances for the network
+        // to recover rather than failing on the first transient stall. The size verification
+        // below continues to catch (b) and convert it to a retry rather than a hard failure.
+        var lastError: IOException? = null
+        for (attempt in 1..MAX_DOWNLOAD_ATTEMPTS) {
+            try {
+                return openSingle(dataSpec, url, attempt)
+            } catch (e: IOException) {
+                lastError = e
+                // Don't sleep after the last attempt — just propagate.
+                if (attempt < MAX_DOWNLOAD_ATTEMPTS) {
+                    try {
+                        Thread.sleep(RETRY_DELAY_MS * attempt)
+                    } catch (_: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                        throw e
+                    }
+                }
+            }
+        }
+        throw lastError ?: IOException("PRDownloader failed after $MAX_DOWNLOAD_ATTEMPTS attempts for $url")
+    }
+
+    private fun openSingle(dataSpec: DataSpec, url: String, attempt: Int): Long {
         // PRDownloader is initialized once at app start (see App.kt).
         // If it isn't initialized, we fail fast — there's no graceful
         // degradation possible without a fetcher.
@@ -344,45 +380,68 @@ internal class PRDownloaderDataSource private constructor(
      *     (set by DownloadUtil.prewarmSongForDownload from FormatEntity).
      *  2. A synchronous HEAD request to the URL (best-effort, with a
      *     short timeout — if it fails or returns no Content-Length, we
-     *     return 0 and the verification step is skipped).
+     *     try the next strategy).
+     *  3. A `GET` with `Range: bytes=0-0` — many CDNs (incl. Qobuz's chunked-
+     *     transfer endpoint) reject HEAD on media URLs but DO answer a
+     *     1-byte range GET with a `Content-Range: bytes 0-0/<total>` header.
+     *     This is the fallback that catches the "Qobuz download interrupted
+     *     halfway because Content-Length was unknown" failure mode.
      *
-     * Returns 0 if no expected length can be determined (chunked transfer
-     * with no upstream metadata) — in that case the file is accepted as-is
-     * to avoid false negatives for CDNs that genuinely don't expose size.
+     * Returns 0 if no expected length can be determined — in that case the
+     * file is accepted as-is to avoid false negatives for CDNs that
+     * genuinely don't expose size.
      */
     private fun resolveExpectedContentLength(url: String, dataSpec: DataSpec): Long {
         // (1) Upstream-provided hint (set by prewarm from FormatEntity).
         dataSpec.httpRequestHeaders["X-Expected-Content-Length"]?.toLongOrNull()
             ?.let { if (it > 0L) return it }
 
-        // (2) HEAD request — best-effort. Some CDNs (e.g. YouTube
-        // googlevideo) reject HEAD on media URLs, so we silently fall
-        // through if the request fails.
-        return runCatching {
-            // Resolve stream-client profile (UA / Origin / Referer) for
-            // YouTube URLs, mirroring the main download path.
-            val youTubeMediaProfile = runCatching {
-                StreamClientUtils.resolveRequestProfile(url)
-            }.getOrNull()
-            val resolvedUserAgent = youTubeMediaProfile?.userAgent?.takeIf(String::isNotBlank)
-                ?: userAgent
+        // Resolve stream-client profile (UA / Origin / Referer) for YouTube URLs,
+        // mirroring the main download path. Hoisted out so both the HEAD and the
+        // range-GET below share it.
+        val youTubeMediaProfile = runCatching {
+            StreamClientUtils.resolveRequestProfile(url)
+        }.getOrNull()
+        val resolvedUserAgent = youTubeMediaProfile?.userAgent?.takeIf(String::isNotBlank)
+            ?: userAgent
+        val origin = youTubeMediaProfile?.origin?.takeIf(String::isNotBlank)
+        val referer = youTubeMediaProfile?.referer?.takeIf(String::isNotBlank)
+
+        // (2) HEAD request — best-effort. Some CDNs (e.g. YouTube googlevideo)
+        // reject HEAD on media URLs, so we silently fall through if it fails.
+        val headLength = runCatching {
             val builder = Request.Builder().url(url).head()
                 .header("User-Agent", resolvedUserAgent)
                 .header("Accept-Encoding", "identity")
-            youTubeMediaProfile?.origin?.takeIf(String::isNotBlank)?.let {
-                builder.header("Origin", it)
-            }
-            youTubeMediaProfile?.referer?.takeIf(String::isNotBlank)?.let {
-                builder.header("Referer", it)
-            }
+            origin?.let { builder.header("Origin", it) }
+            referer?.let { builder.header("Referer", it) }
             headClient.newCall(builder.build()).execute().use { response ->
-                val cl = response.header("Content-Length")?.toLongOrNull() ?: 0L
                 if (!response.isSuccessful && response.code != 200 && response.code != 206) {
-                    // HEAD not supported / rejected — don't fail the download.
                     0L
                 } else {
-                    cl
+                    response.header("Content-Length")?.toLongOrNull() ?: 0L
                 }
+            }
+        }.getOrDefault(0L)
+        if (headLength > 0L) return headLength
+
+        // (3) Range GET for the first byte only — fallback for CDNs that don't
+        // support HEAD but do honour Range requests. The response carries
+        // `Content-Range: bytes 0-0/<total>` from which we can recover <total>.
+        return runCatching {
+            val builder = Request.Builder().url(url)
+                .header("Range", "bytes=0-0")
+                .header("User-Agent", resolvedUserAgent)
+                .header("Accept-Encoding", "identity")
+            origin?.let { builder.header("Origin", it) }
+            referer?.let { builder.header("Referer", it) }
+            headClient.newCall(builder.build()).execute().use { response ->
+                if (response.code != 206) return@use 0L
+                val contentRange = response.header("Content-Range") ?: return@use 0L
+                // Format: "bytes 0-0/12345"
+                val slashIdx = contentRange.lastIndexOf('/')
+                if (slashIdx < 0 || slashIdx == contentRange.length - 1) return@use 0L
+                contentRange.substring(slashIdx + 1).trim().toLongOrNull() ?: 0L
             }
         }.getOrDefault(0L)
     }
@@ -404,5 +463,14 @@ internal class PRDownloaderDataSource private constructor(
     companion object {
         private const val DEFAULT_USER_AGENT = "ArchiveTune"
         private const val DOWNLOAD_WAIT_TIMEOUT_MINUTES = 30L
+        // How many times to retry a download that failed transiently (network stall,
+        // partial file detected by size verification). PRDownloader has no resume, so
+        // each retry re-downloads from byte 0 — but retrying is still much better than
+        // surfacing "download failed" to the user on the first transient blip.
+        private const val MAX_DOWNLOAD_ATTEMPTS = 3
+        // Linear back-off between retry attempts (RETRY_DELAY_MS * attempt). 1.5 s on the
+        // first retry, 3 s on the second — short enough that the user doesn't think the
+        // download hung, long enough for a congested WiFi or mobile handoff to clear.
+        private const val RETRY_DELAY_MS = 1_500L
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -113,6 +113,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
@@ -219,6 +220,55 @@ private const val LINE_SYNCED_TRAILING_LINE_DURATION_MS = 4_000L
 // small enough to catch any real seek-backward or REPEAT_MODE_ONE wrap (which
 // is typically a jump from near the end of the song back to 0, i.e. minutes).
 private const val POSITION_RESET_BACKWARD_THRESHOLD_MS = 1000L
+
+// ── Romanisation hand-off ──
+// How long the first build waits for the built-in romanisation pass before giving up and publishing
+// without it. Romanising every line is local work (ICU tables, or one Kuromoji tokenize per line)
+// and normally lands well inside this, so the very first build the karaoke view ever sees already
+// carries its phonetics — which is what keeps KaraokeLyricsView from freezing the on-screen lines
+// on a layout that has none. See [KaraokeBuild] for why that matters, and note the cost of missing
+// the window is only that the shimmer holds a moment longer.
+private const val ROMANIZATION_FIRST_BUILD_GRACE_MS = 700L
+
+/**
+ * One published [SyncedLyrics] plus the identity of the romanisation baked into it.
+ *
+ * ### Why the generation counter exists
+ *
+ * `KaraokeLyricsView` caches a measured layout per line index and, once a line has been composed,
+ * derives everything it draws from a `remember {}` with no keys — so a line that was first composed
+ * from a layout without phonetics keeps drawing that layout for as long as its composition lives,
+ * no matter what arrives in the line data afterwards. The view's own `Crossfade` does rebuild the
+ * subtree when the lyrics object changes, but its layout cache is remembered *outside* that
+ * crossfade and is only cleared from a `LaunchedEffect` — i.e. one frame *after* the replacement
+ * lines have already been composed against the stale entries.
+ *
+ * The result was reported as "romanisation only shows up after the first two or three lines": the
+ * handful of lines on screen when romanisation landed were pinned to their phonetic-less layout,
+ * while every line composed later — as the song scrolled on — picked the phonetics up normally.
+ *
+ * [generation] is bumped whenever a build replaces an already-visible one with different
+ * romanisation, and it participates in the `key(...)` around the karaoke view. That disposes the
+ * view together with its layout cache, so the replacement lines are measured from scratch. It is
+ * deliberately NOT bumped for the first build of a session (there is nothing on screen to
+ * invalidate), nor when only the translation changed — translations are drawn by an ordinary `Text`
+ * that recomposes on its own, and AI translations land ~30-60s in, where a re-key would be very
+ * visible.
+ */
+private data class KaraokeBuild(
+    val lyrics: SyncedLyrics,
+    val romanization: Map<Int, List<String?>>,
+    val generation: Int,
+)
+
+/**
+ * The part of a romanisation map that changes what is drawn: entries whose every value is
+ * null/blank produce no phonetics at all, so a map full of them is indistinguishable from an empty
+ * one and must not count as a change (otherwise a song with nothing romanisable would re-key the
+ * karaoke view for a build that looks identical).
+ */
+private fun Map<Int, List<String?>>.renderedRomanization(): Map<Int, List<String?>> =
+    filterValues { values -> values.any { !it.isNullOrBlank() } }
 
 @Composable
 fun LyricsEnhanced(
@@ -373,9 +423,13 @@ fun LyricsEnhanced(
     // first composition, and re-keying on them would put a synchronous buildSyncedLyrics straight
     // back on the main thread the moment the parse lands. The effect below publishes the real
     // build from Default, so this only ever supplies the empty starting value.
-    var syncedLyrics by remember(lyrics, isTtmlFormat) {
-        mutableStateOf(SyncedLyrics(emptyList()))
+    var karaokeBuild by remember(lyrics, isTtmlFormat) {
+        mutableStateOf(KaraokeBuild(SyncedLyrics(emptyList()), emptyMap(), generation = 0))
     }
+    val syncedLyrics = karaokeBuild.lyrics
+    // Bumped alongside the lyrics object whenever a build replaces an already-visible one with
+    // different romanisation; see KaraokeBuild for why the karaoke view has to be re-keyed on it.
+    val karaokeGeneration = karaokeBuild.generation
 
     // ── AI romanisation ──
     // Runs once per track instead of once per line (network + billed), so it can't hang off the
@@ -411,64 +465,105 @@ fun LyricsEnhanced(
         // used to inherit the main dispatcher and could stutter the karaoke animation on track
         // change; run the whole batch on Default and only publish the results back.
         withContext(Dispatchers.Default) {
-        val aiMap = aiRomanizationMap(lyricsEntries, isTtmlFormat, aiRomanizedLines)
-        syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, aiMap)
-        if (!romanizationPreferences.isEnabled) return@withContext
-
-        val toRomanize =
-            lyricsEntries.mapIndexedNotNull { index, entry ->
-                val hasProviderRomanization =
-                    providedRomanizedTextForEntry(entry, romanizationPreferences) != null
-                if (hasProviderRomanization || shouldRomanizeLyricsLine(entry.text, romanizationPreferences)) {
-                    index to entry
-                } else {
-                    null
-                }
-            }
-        if (toRomanize.isEmpty()) return@withContext
-
-        val jobs =
-            toRomanize.map { (index, entry) ->
-                async {
-                    val romanized: List<String?> =
-                        try {
-                            if (isTtmlFormat && entry.words != null) {
-                                val mainWordCount = entry.words!!.count { !it.isBackground }
-                                providedRomanizedWordsForEntry(entry, mainWordCount, romanizationPreferences)
-                                    ?: romanizeWordsForLine(
-                                        // Japanese: single-pass line tokenization (6x fewer
-                                        // Kuromoji calls than per-word). Other languages:
-                                        // per-word character-by-character (already cheap).
-                                        words = entry.words!!.filter { !it.isBackground }.map { it.text },
-                                        lineText = entry.text,
-                                        preferences = romanizationPreferences,
-                                    )
-                            } else {
-                                listOf(
-                                    providedRomanizedTextForEntry(entry, romanizationPreferences)
-                                        ?: romanizeLyricsLine(entry.text, romanizationPreferences),
-                                )
-                            }
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            reportException(e)
-                            if (isTtmlFormat && entry.words != null) {
-                                List(entry.words!!.count { !it.isBackground }) { null }
-                            } else {
-                                listOf(null)
-                            }
-                        }
-                    index to romanized
-                }
-            }
-        val tempMap = mutableMapOf<Int, List<String?>>()
-        jobs.awaitAll().forEach { (index, romanized) ->
-            tempMap[index] = romanized
-        }
         // Publishing new lyrics as state (instead of bumping a key that tears the whole karaoke
-        // subtree down mid-playback) lets the view pick up romanization without a re-layout hitch.
-        syncedLyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, tempMap)
+        // subtree down mid-playback) lets the view pick up a *translation* without a re-layout
+        // hitch. Romanisation is not so lucky — the library pins each line's glyph layout to
+        // whatever it measured the first time that line was composed — so a build that changes the
+        // romanisation of lines already on screen has to carry a new generation with it. See
+        // KaraokeBuild.
+        fun publish(romanization: Map<Int, List<String?>>) {
+            val previous = karaokeBuild
+            val changesVisibleLines =
+                previous.lyrics.lines.isNotEmpty() &&
+                    romanization.renderedRomanization() != previous.romanization.renderedRomanization()
+            karaokeBuild =
+                KaraokeBuild(
+                    lyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, romanization),
+                    romanization = romanization,
+                    generation = if (changesVisibleLines) previous.generation + 1 else previous.generation,
+                )
+        }
+
+        val aiMap = aiRomanizationMap(lyricsEntries, isTtmlFormat, aiRomanizedLines)
+
+        val toRomanize: List<Pair<Int, LyricsEntry>> =
+            if (!romanizationPreferences.isEnabled) {
+                // Romanisation is off, or the AI engine owns it — `aiMap` is already everything
+                // this build will ever have.
+                emptyList()
+            } else {
+                lyricsEntries.mapIndexedNotNull { index, entry ->
+                    val hasProviderRomanization =
+                        providedRomanizedTextForEntry(entry, romanizationPreferences) != null
+                    if (hasProviderRomanization || shouldRomanizeLyricsLine(entry.text, romanizationPreferences)) {
+                        index to entry
+                    } else {
+                        null
+                    }
+                }
+            }
+        if (toRomanize.isEmpty()) {
+            publish(aiMap)
+            return@withContext
+        }
+
+        val romanization =
+            async {
+                val jobs =
+                    toRomanize.map { (index, entry) ->
+                        async {
+                            val romanized: List<String?> =
+                                try {
+                                    if (isTtmlFormat && entry.words != null) {
+                                        val mainWordCount = entry.words!!.count { !it.isBackground }
+                                        providedRomanizedWordsForEntry(entry, mainWordCount, romanizationPreferences)
+                                            ?: romanizeWordsForLine(
+                                                // Japanese: single-pass line tokenization (6x fewer
+                                                // Kuromoji calls than per-word). Other languages:
+                                                // per-word character-by-character (already cheap).
+                                                words = entry.words!!.filter { !it.isBackground }.map { it.text },
+                                                lineText = entry.text,
+                                                preferences = romanizationPreferences,
+                                            )
+                                    } else {
+                                        listOf(
+                                            providedRomanizedTextForEntry(entry, romanizationPreferences)
+                                                ?: romanizeLyricsLine(entry.text, romanizationPreferences),
+                                        )
+                                    }
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    reportException(e)
+                                    if (isTtmlFormat && entry.words != null) {
+                                        List(entry.words!!.count { !it.isBackground }) { null }
+                                    } else {
+                                        listOf(null)
+                                    }
+                                }
+                            index to romanized
+                        }
+                    }
+                jobs.awaitAll().toMap()
+            }
+
+        // ── Why the un-romanised build is not published up front ──
+        // It used to be, unconditionally, and the romanised one replaced it a moment later. That
+        // second build is exactly the case KaraokeBuild describes: the lines on screen when it
+        // landed kept their phonetic-less layout for good. Waiting a beat for the local pass means
+        // the first build the view ever sees already has the phonetics, so nothing has to be
+        // replaced at all — and the shimmer is already up, so the wait costs no visible state.
+        //
+        // The timeout is what keeps that from becoming a stall: it does not cancel the pass (the
+        // deferred belongs to the enclosing scope, not to withTimeoutOrNull), it only stops waiting
+        // on it, and the two-build path below is then taken with the re-key that makes it correct.
+        val quickRomanization = withTimeoutOrNull(ROMANIZATION_FIRST_BUILD_GRACE_MS) { romanization.await() }
+        if (quickRomanization != null) {
+            publish(quickRomanization)
+            return@withContext
+        }
+        publish(aiMap)
+        publish(romanization.await())
         }
     }
 
@@ -516,16 +611,18 @@ fun LyricsEnhanced(
     // The scroll state is recreated together with the subtree that owns it.
     //
     // The karaoke view is re-keyed on [positionResetCounter] (see the KaraokeLyricsView
-    // call site) because the mocharealm library keeps no per-play state of its own. That
-    // re-key disposes one LazyColumn and composes another; keeping a single hoisted
+    // call site) because the mocharealm library keeps no per-play state of its own, and on
+    // [karaokeGeneration] because it keeps a per-line layout cache that outlives the lyrics
+    // object it was measured from (see [KaraokeBuild]). Either re-key
+    // disposes one LazyColumn and composes another; keeping a single hoisted
     // LazyListState across the swap left the state briefly bound to two lazy layouts and
     // then owned by the disposed one, so scrolls silently went nowhere and layoutInfo
     // reported a stale viewport — the list snapped to the first line and then sat there,
     // which is the "resets on repeat but never animates again, fixed only by reopening
     // the lyrics" symptom. Recreating the state with its layout keeps the two in step,
-    // and every effect that drives scrolling is keyed on the same counter so they all
+    // and every effect that drives scrolling is keyed on the same counters so they all
     // observe the live state.
-    val listState = key(lyricsSessionKey, positionResetCounter) { rememberLazyListState() }
+    val listState = key(lyricsSessionKey, positionResetCounter, karaokeGeneration) { rememberLazyListState() }
 
     // ── First-frame placement ──
     // A fresh LazyListState starts at line 0 and the auto-scroll collector below
@@ -552,9 +649,12 @@ fun LyricsEnhanced(
     // `isSynced` is derived synchronously from the raw lyrics text, so it is already correct on
     // frame 1: the gate arms before anything is drawn and is only ever disarmed, never re-armed.
     // A late-arriving *session* (new track, new lyrics text, repeat) still re-arms it, because
-    // lyricsSessionKey covers all three.
+    // lyricsSessionKey covers all three — and so does a late romanisation, via
+    // [karaokeGeneration], because that re-keys the karaoke view and its fresh LazyListState
+    // starts back at line 0. The gate is what hides that trip; it is only ever armed for the
+    // build that actually replaces visible lines, never for the first build of a session.
     var awaitingFirstFocus by
-        remember(lyricsSessionKey, positionResetCounter) {
+        remember(lyricsSessionKey, positionResetCounter, karaokeGeneration) {
             mutableStateOf(isSynced)
         }
     // Safety net: nothing may keep the lyrics hidden. If the placement hasn't
@@ -800,11 +900,11 @@ fun LyricsEnhanced(
     // and updates `currentLineIndexState`, which flows through the snapshotFlow
     // and triggers a normal (non-forced) scroll.
     val latestSyncedLyricsForScroll = rememberUpdatedState(syncedLyrics)
-    // Restart this collector after a repeat. The karaoke view is re-keyed at
-    // the same time, and the fresh collector resets its focus state before it
-    // observes the first new active line. Keeping listState stable means the
-    // collector always targets the list currently on screen.
-    LaunchedEffect(lyricsSessionKey, isSynced, positionResetCounter) {
+    // Restart this collector after a repeat, or after a romanisation re-key. The karaoke view is
+    // re-keyed at the same time, and the fresh collector resets its focus state before it
+    // observes the first new active line. Keeping listState stable means the collector
+    // always targets the list currently on screen.
+    LaunchedEffect(lyricsSessionKey, isSynced, positionResetCounter, karaokeGeneration) {
         if (!isSynced) {
             awaitingFirstFocus = false
             return@LaunchedEffect
@@ -1119,56 +1219,84 @@ fun LyricsEnhanced(
                     // backward position jumps, so without this re-key the
                     // karaoke animation freezes at the line that was active
                     // just before the repeat.
-                    key(lyricsSessionKey, positionResetCounter) {
-                        KaraokeLyricsView(
-                            listState = listState,
-                            lyrics = syncedLyrics,
-                            currentPosition = playbackSyncPosition,
-                            onLineClicked = { line ->
-                                if (isSelectionModeActive) {
-                                    toggleSelectedLine(line.selectionKey())
-                                } else if (lyricsClick && isSynced && line.start > 0) {
-                                    player.seekTo(line.start.toLong())
-                                }
-                            },
-                            onLinePressed = { line ->
-                                val lineKey = line.selectionKey()
-                                if (!isSelectionModeActive) {
-                                    isSelectionModeActive = true
-                                    if (!selectedLineKeys.contains(lineKey)) {
-                                        selectedLineKeys.add(lineKey)
+                    //
+                    // [karaokeGeneration] is in the key for the same reason at a different
+                    // layer: the library caches one measured glyph layout per line index in a
+                    // map remembered here, outside its own Crossfade, and each line pins what it
+                    // draws to whichever entry that map held when the line was first composed.
+                    // A build that adds romanisation to lines already on screen therefore has to
+                    // dispose the cache along with them, or those lines never show it. See
+                    // [KaraokeBuild].
+                    key(lyricsSessionKey, positionResetCounter, karaokeGeneration) {
+                        // ── Force the translation slot to use the small phonetic style ──
+                        // The mocharealm KaraokeLineText renders the `translation` slot with
+                        // `LocalTextStyle.current` (no explicit style), while the `phonetic`
+                        // slot uses `phoneticTextStyle`. With the romanisation swap in
+                        // buildSyncedLyrics / buildLineSyncedLrcLine, the `translation` slot
+                        // now carries the romanisation and the `phonetic` slot carries the
+                        // actual translation. Without this CompositionLocal override, the
+                        // romanisation would render at the ambient bodyLarge size (much
+                        // larger than the translation below it). Pinning LocalTextStyle to
+                        // the same small phoneticTextStyle makes both rows visually
+                        // consistent — "romanisation should be small text just like
+                        // translation" — and is local to this lyrics subtree so the rest
+                        // of the app is unaffected. KaraokeLyricsView's explicit
+                        // `normalLineTextStyle` / `accompanimentLineTextStyle` /
+                        // `phoneticTextStyle` parameters all bypass LocalTextStyle, so the
+                        // active karaoke line itself is not affected.
+                        androidx.compose.runtime.CompositionLocalProvider(
+                            androidx.compose.material3.LocalTextStyle provides phoneticTextStyle,
+                        ) {
+                            KaraokeLyricsView(
+                                listState = listState,
+                                lyrics = syncedLyrics,
+                                currentPosition = playbackSyncPosition,
+                                onLineClicked = { line ->
+                                    if (isSelectionModeActive) {
+                                        toggleSelectedLine(line.selectionKey())
+                                    } else if (lyricsClick && isSynced && line.start > 0) {
+                                        player.seekTo(line.start.toLong())
                                     }
-                                } else if (!selectedLineKeys.contains(lineKey)) {
-                                    toggleSelectedLine(lineKey)
-                                }
-                            },
-                            textColor = textColor,
-                            normalLineTextStyle = normalTextStyle,
-                            accompanimentLineTextStyle = accompanimentTextStyle,
-                            phoneticTextStyle = phoneticTextStyle,
-                            blendMode = BlendMode.SrcOver,
-                            // Per-line RenderEffect blur is the single heaviest per-frame cost in
-                            // this view; drop it when animations are disabled (low-RAM default).
-                            useBlurEffect = lyricsLineBlur && !animationsDisabled,
-                            showTranslation = showTranslations,
-                            showPhonetic = romanizationPreferences.showsRomanization,
-                            offset = lyricsViewportOffset,
-                            // Reduced from 36.dp → 20.dp → 8.dp. The keepAliveZone controls how
-                            // many items outside the viewport are kept composed (not
-                            // disposed) — each kept-alive item still participates in
-                            // the per-frame measure pass during auto-scroll. The
-                            // mocharealm KaraokeLyricsView library measures every
-                            // kept-alive karaoke line on every scroll event; each line
-                            // contains N syllables that each need a fill-ratio
-                            // computation. 8dp keeps at most ~1 line alive on each
-                            // side of the viewport, minimizing the measure cost
-                            // during the instant `scrollBy` snap on line changes.
-                            // This is the single biggest lever we have for reducing
-                            // the word-synced lyrics lag in Enhanced style (V2 uses
-                            // its own renderer and doesn't have this cost).
-                            keepAliveZone = 8.dp,
-                            modifier = Modifier.fillMaxSize(),
-                        )
+                                },
+                                onLinePressed = { line ->
+                                    val lineKey = line.selectionKey()
+                                    if (!isSelectionModeActive) {
+                                        isSelectionModeActive = true
+                                        if (!selectedLineKeys.contains(lineKey)) {
+                                            selectedLineKeys.add(lineKey)
+                                        }
+                                    } else if (!selectedLineKeys.contains(lineKey)) {
+                                        toggleSelectedLine(lineKey)
+                                    }
+                                },
+                                textColor = textColor,
+                                normalLineTextStyle = normalTextStyle,
+                                accompanimentLineTextStyle = accompanimentTextStyle,
+                                phoneticTextStyle = phoneticTextStyle,
+                                blendMode = BlendMode.SrcOver,
+                                // Per-line RenderEffect blur is the single heaviest per-frame cost in
+                                // this view; drop it when animations are disabled (low-RAM default).
+                                useBlurEffect = lyricsLineBlur && !animationsDisabled,
+                                showTranslation = showTranslations,
+                                showPhonetic = romanizationPreferences.showsRomanization,
+                                offset = lyricsViewportOffset,
+                                // Reduced from 36.dp → 20.dp → 8.dp. The keepAliveZone controls how
+                                // many items outside the viewport are kept composed (not
+                                // disposed) — each kept-alive item still participates in
+                                // the per-frame measure pass during auto-scroll. The
+                                // mocharealm KaraokeLyricsView library measures every
+                                // kept-alive karaoke line on every scroll event; each line
+                                // contains N syllables that each need a fill-ratio
+                                // computation. 8dp keeps at most ~1 line alive on each
+                                // side of the viewport, minimizing the measure cost
+                                // during the instant `scrollBy` snap on line changes.
+                                // This is the single biggest lever we have for reducing
+                                // the word-synced lyrics lag in Enhanced style (V2 uses
+                                // its own renderer and doesn't have this cost).
+                                keepAliveZone = 8.dp,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
                     }
                 }
             }
@@ -1739,6 +1867,20 @@ private fun buildSyncedLyrics(
             val lineEnd = mainSyllables.last().end
             if (lineEnd <= lineStart) return@forEachIndexed
 
+            // Build a single joined romanisation string for the line-level slot. Each
+            // syllable's per-word phonetic still sits above its own word (small text in
+            // the karaoke Canvas), AND a single per-line romanisation string is placed
+            // in the `translation` slot so it renders directly below the active line.
+            // See buildLineSyncedLrcLine for why `translation` = romanisation and
+            // `phonetic` = translation (the field swap that puts romanisation between
+            // the active lyric and the translation).
+            val lineRomanized =
+                wordPhonetics
+                    .filterNotNull()
+                    .joinToString(" ")
+                    .trim()
+                    .takeIf { it.isNotEmpty() }
+
             val accompanimentLines =
                 if (mainWords.isNotEmpty() && bgWords.isNotEmpty()) {
                     val bgSyllables = bgWords.toKaraokeSyllables(emptyList())
@@ -1765,11 +1907,11 @@ private fun buildSyncedLyrics(
             lines.add(
                 KaraokeLine.MainKaraokeLine(
                     syllables = mainSyllables,
-                    translation = translation,
+                    translation = lineRomanized ?: translation,
                     alignment = alignment,
                     start = lineStart,
                     end = lineEnd,
-                    phonetic = null,
+                    phonetic = if (lineRomanized != null) translation else null,
                     accompanimentLines = accompanimentLines,
                 ),
             )
@@ -1847,12 +1989,28 @@ private fun buildLineSyncedLrcLine(
             start = start,
         )
 
+    // ── Romanisation between active lyric and translation ──
+    // The mocharealm KaraokeLineText renders in this fixed order:
+    //   1. Active karaoke line (Canvas with per-syllable phonetic above each word)
+    //   2. `translation` slot  — Text using LocalTextStyle.current  (immediately below active)
+    //   3. `phonetic` slot    — Text using phoneticTextStyle         (below translation)
+    // To place the romanisation BETWEEN the active lyric and the translation (per user
+    // request — Apple-Music-style layout where romanisation sits directly under the
+    // sung line and the translation sits under that), we swap the field assignments:
+    //   - `translation` slot ← romanisation   (renders first, right below the active line)
+    //   - `phonetic` slot   ← translation     (renders second, below the romanisation)
+    // The phoneticTextStyle passed into KaraokeLyricsView is also force-applied to the
+    // translation slot via a CompositionLocalProvider (see the call site) so both rows
+    // render at the same small size — matching "romanisation should be small text just
+    // like translation". The line-level content (lineText() / selectionKey) reads from
+    // `syllables.content` and is unaffected by the swap.
     return KaraokeLine.MainKaraokeLine(
         syllables = syllables,
-        translation = translation,
+        translation = normalizedRomanizedText,
         alignment = KaraokeAlignment.Start,
         start = start,
         end = end,
+        phonetic = translation,
     )
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -1016,7 +1016,12 @@ fun LyricsV2(
                         horizontalAlignment = horizontalAlignment,
                     ) {
                         val romanizedText =
-                            if (romanizationPreferences.isEnabled) {
+                            // `showsRomanization`, not `isEnabled`: the latter is false whenever the
+                            // AI engine owns romanisation (that is what tells the built-in pass to
+                            // stand down), so gating on it meant the AI results pushed into
+                            // `romanizedTextFlow` above were never composed at all — romanisation
+                            // simply never appeared in this renderer with AI romanisation on.
+                            if (romanizationPreferences.showsRomanization) {
                                 val value by item.romanizedTextFlow.collectAsStateWithLifecycle()
                                 value
                             } else {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -136,7 +136,6 @@ import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.AutoTranslateExcludedLanguagesKey
 import moe.rukamori.archivetune.constants.AutoTranslateLyricsKey
-import moe.rukamori.archivetune.constants.AutoHideLyricsPlayerControlsKey
 import moe.rukamori.archivetune.constants.ThumbnailCornerRadiusKey
 import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
 import moe.rukamori.archivetune.db.entities.FormatEntity
@@ -154,7 +153,6 @@ import moe.rukamori.archivetune.ui.component.LyricsEnhanced
 import moe.rukamori.archivetune.ui.component.LyricsV2
 import moe.rukamori.archivetune.constants.LyricsMode
 import moe.rukamori.archivetune.constants.LyricsModeKey
-import moe.rukamori.archivetune.constants.ShowLyricsPlayerControlsKey
 import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.ui.menu.LyricsMenu
 import moe.rukamori.archivetune.ui.menu.PlayerMenu
@@ -349,9 +347,14 @@ fun AppleMusicPlayerContent(
     // forces an extra layout pass on top of whatever the lyrics view is already
     // spending its frame budget on.
     val animationsDisabled = LocalAnimationsDisabled.current
-    val showLyricsPlayerControlsState = rememberPreference(ShowLyricsPlayerControlsKey, defaultValue = true)
-    val showLyricsPlayerControls by showLyricsPlayerControlsState
-    val autoHideLyricsPlayerControls by rememberPreference(AutoHideLyricsPlayerControlsKey, defaultValue = true)
+    // The "Show player controls" and "Auto-hide controls" toggles were removed from the
+    // Lyrics settings UI by user request. The Apple Music lyrics view now ALWAYS shows
+    // the bottom transport controls while lyrics/queue is open and ALWAYS auto-hides
+    // them after 5 s. The preferences are still read so legacy installs (where the user
+    // previously set them to false) get upgraded to the new "always on" behavior — i.e.
+    // we ignore their stored value and treat both as `true`.
+    val showLyricsPlayerControls = true
+    val autoHideLyricsPlayerControls = true
 
     // Toggling one closes the other — queue and lyrics are mutually exclusive
     // (only one morph target can be active at a time).
@@ -706,25 +709,22 @@ fun AppleMusicPlayerContent(
     }
     val onMoreClick = {
         if (lyricsOpen) {
-            // When lyrics is open, the overflow menu shows lyric actions plus the
-            // player-control toggles, identical to the standalone lyrics screen.
+            // When lyrics is open, the overflow menu shows lyric actions. The
+            // "Show player controls" / "Auto-hide controls" toggles used to live here
+            // too, but were removed by user request — the controls now always show
+            // and always auto-hide after 5 s. showControlsToggles = false hides those
+            // rows in LyricsMenu.
             menuState.show {
                 LyricsMenu(
                     lyricsProvider = { currentLyrics },
                     mediaMetadataProvider = { mediaMetadata },
                     lyricsSyncOffset = lyricsSyncOffset,
                     onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                    showPlayerControlsState = showLyricsPlayerControlsState,
-                    onShowPlayerControlsChange = { showLyricsPlayerControlsState.value = it },
-                    onAutoHidePlayerControlsChange = { enabled ->
-                        if (enabled) {
-                            playerControlsVisibilityTick++
-                        } else {
-                            playerControlsExpanded = true
-                        }
-                    },
+                    showPlayerControlsState = null,
+                    onShowPlayerControlsChange = null,
+                    onAutoHidePlayerControlsChange = {},
                     onDismiss = menuState::dismiss,
-                    showControlsToggles = true,
+                    showControlsToggles = false,
                 )
             }
         } else {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -127,7 +127,6 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.BlurRadiusKey
 import moe.rukamori.archivetune.constants.DisableBlurKey
 import moe.rukamori.archivetune.constants.EnableHapticFeedbackKey
-import moe.rukamori.archivetune.constants.AutoHideLyricsPlayerControlsKey
 import moe.rukamori.archivetune.constants.LyricsBackgroundStyle
 import moe.rukamori.archivetune.constants.LyricsBackgroundStyleKey
 import moe.rukamori.archivetune.constants.LyricsMode
@@ -138,7 +137,6 @@ import moe.rukamori.archivetune.constants.PlayerCustomBlurKey
 import moe.rukamori.archivetune.constants.PlayerCustomBrightnessKey
 import moe.rukamori.archivetune.constants.PlayerCustomContrastKey
 import moe.rukamori.archivetune.constants.PlayerCustomImageUriKey
-import moe.rukamori.archivetune.constants.ShowLyricsPlayerControlsKey
 import moe.rukamori.archivetune.constants.AutoTranslateExcludedLanguagesKey
 import moe.rukamori.archivetune.constants.AutoTranslateLyricsKey
 import moe.rukamori.archivetune.constants.TranslatorTargetLangKey
@@ -242,13 +240,15 @@ fun LyricsScreen(
     val density = LocalDensity.current
     val swipeStartRegionPx = with(density) { LyricsSwipeStartRegion.toPx() }
     val swipeDismissThresholdPx = with(density) { LyricsSwipeDismissThreshold.toPx() }
-    val showPlayerControlsState =
-        rememberPreference(ShowLyricsPlayerControlsKey, true)
-    val showPlayerControlsEnabled by showPlayerControlsState
-    val (autoHidePlayerControls, onAutoHidePlayerControlsChange) =
-        rememberPreference(AutoHideLyricsPlayerControlsKey, true)
-    var playerControlsExpanded by remember(mediaMetadata.id, showPlayerControlsEnabled) {
-        mutableStateOf(showPlayerControlsEnabled)
+    // The "Show player controls" and "Auto-hide controls" toggles were removed from the
+    // Lyrics settings UI by user request. The standalone lyrics page now ALWAYS shows
+    // the bottom transport controls and ALWAYS auto-hides them after 5 s. The original
+    // preferences are not read at all — they're left in PreferenceKeys.kt purely so
+    // existing DataStore entries don't cause migration errors on upgrade.
+    val showPlayerControlsEnabled = true
+    val autoHidePlayerControls = true
+    var playerControlsExpanded by remember(mediaMetadata.id) {
+        mutableStateOf(true)
     }
     var playerControlsVisibilityTick by remember(mediaMetadata.id) {
         mutableIntStateOf(0)
@@ -256,37 +256,21 @@ fun LyricsScreen(
     val autoHideDelayMs = 5_000L
     // Tracks whether the user is actively scrolling the lyrics list. Hoisted up from
     // LyricsEnhanced / LyricsV2 via [LocalLyricsScrollListener] so the bottom Apple Music
-    // controls can slide in on scroll even when "Show lyrics player controls" is OFF.
+    // controls can slide in on scroll.
     var isUserScrollingLyrics by remember { mutableStateOf(false) }
-    val onShowPlayerControlsChange =
-        remember(showPlayerControlsState) {
-            { showControls: Boolean ->
-                showPlayerControlsState.value = showControls
-                playerControlsExpanded = showControls
-            }
-        }
-    val onAutoHidePlayerControlsToggle: (Boolean) -> Unit = { enabled ->
-        onAutoHidePlayerControlsChange(enabled)
-        if (showPlayerControlsEnabled) {
-            playerControlsExpanded = true
-            playerControlsVisibilityTick++
-        }
+    val onShowPlayerControlsChange: (Boolean) -> Unit = { _ ->
+        // No-op: setting was removed from the UI; behavior is hardcoded on.
+    }
+    val onAutoHidePlayerControlsToggle: (Boolean) -> Unit = { _ ->
+        // No-op: setting was removed from the UI; behavior is hardcoded on.
     }
 
     fun pokePlayerControlsVisibility() {
-        if (!showPlayerControlsEnabled) return
         playerControlsExpanded = true
-        if (autoHidePlayerControls) {
-            playerControlsVisibilityTick++
-        }
+        playerControlsVisibilityTick++
     }
 
-    LaunchedEffect(showPlayerControlsEnabled) {
-        playerControlsExpanded = showPlayerControlsEnabled
-    }
-
-    LaunchedEffect(autoHidePlayerControls, showPlayerControlsEnabled, playerControlsVisibilityTick, mediaMetadata.id) {
-        if (!showPlayerControlsEnabled || !autoHidePlayerControls) return@LaunchedEffect
+    LaunchedEffect(playerControlsVisibilityTick, mediaMetadata.id) {
         playerControlsExpanded = true
         kotlinx.coroutines.delay(autoHideDelayMs)
         playerControlsExpanded = false
@@ -547,10 +531,11 @@ fun LyricsScreen(
                 mediaMetadataProvider = { mediaMetadata },
                 lyricsSyncOffset = lyricsSyncOffset,
                 onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                showPlayerControlsState = showPlayerControlsState,
-                onShowPlayerControlsChange = onShowPlayerControlsChange,
-                onAutoHidePlayerControlsChange = onAutoHidePlayerControlsToggle,
+                showPlayerControlsState = null,
+                onShowPlayerControlsChange = null,
+                onAutoHidePlayerControlsChange = {},
                 onDismiss = menuState::dismiss,
+                showControlsToggles = false,
             )
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -24,6 +24,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
@@ -2581,14 +2582,20 @@ private fun MikoLyricsTransition(
                 targetValue = if (visible) 1f else 0f,
                 animationSpec =
                     if (visible) {
-                        // OPEN — keep the premium slow glide (~500 ms).
-                        spring(
-                            dampingRatio = 1f,
-                            stiffness = 160f,
-                            visibilityThreshold = 0.001f,
+                        // OPEN — slowed down from the old spring(stiffness = 160f, ~500 ms)
+                        // to a ~900 ms tween with FastOutSlowInEasing. The old spring snapped
+                        // the sheet up so quickly that the MovingBlurBackground inside
+                        // LyricsScreen "popped in" at full alpha and immediately started its
+                        // drift animation, which read as "backdrop blur is too fast and looks
+                        // bad". The longer tween gives the eye time to settle and pairs with
+                        // the alpha fade-in on the inner content Box below.
+                        tween(
+                            durationMillis = 900,
+                            easing = FastOutSlowInEasing,
                         )
                     } else {
-                        // CLOSE — slower by ~40% (~700 ms) per user request.
+                        // CLOSE — keep the existing ~700 ms spring (slow close, per prior
+                        // user request).
                         spring(
                             dampingRatio = 1f,
                             stiffness = 80f,
@@ -2633,15 +2640,35 @@ private fun MikoLyricsTransition(
                             clip = true
                         }.background(surfaceColor),
             ) {
-                LyricsScreen(
-                    mediaMetadata = mediaMetadata,
-                    onBackClick = onDismiss,
-                    navController = navController,
-                    lyricsSyncOffset = lyricsSyncOffset,
-                    onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                    onQueueClick = onQueueClick,
-                    backHandlerEnabled = backHandlerEnabled,
-                )
+                // Inner content fade: the LyricsScreen subtree (which owns the
+                // MovingBlurBackground + the drift animation) is faded in over the
+                // slide-up transition tied to the same progress. The outer Box keeps
+                // its opaque surfaceColor so the sliding sheet is always a solid shape;
+                // only the inner content (blur + lyrics + controls) eases in. This is
+                // the fix for "backdrop blur is too fast and looks bad": instead of
+                // the blur arriving at full alpha the instant the sheet starts moving,
+                // it ramps from 0 → 1 across the ~900 ms slide.
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .graphicsLayer {
+                                // Pull the fade-in forward slightly so the blur is at full
+                                // strength just before the sheet arrives (avoids feeling like
+                                // the lyrics are "still loading" when the slide finishes).
+                                alpha = (progressState.value * 1.35f).coerceIn(0f, 1f)
+                            },
+                ) {
+                    LyricsScreen(
+                        mediaMetadata = mediaMetadata,
+                        onBackClick = onDismiss,
+                        navController = navController,
+                        lyricsSyncOffset = lyricsSyncOffset,
+                        onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
+                        onQueueClick = onQueueClick,
+                        backHandlerEnabled = backHandlerEnabled,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryMixScreen.kt
@@ -273,12 +273,82 @@ fun LibraryMixScreen(
                     }
                 }
 
-                // 2. Shortcuts Grid
+                // 2. Shortcuts Grid — packed 2-column layout that reflows when tiles are hidden.
+                //    Builds a flat list of the visible cards (preserving order), then lays them
+                //    out in 2-wide rows. The trailing card on an odd row spans the full width
+                //    so we never leave a static gap on the right.
                 item(key = "shortcuts_grid", contentType = "shortcuts_grid") {
-                    val showRow1 = !hideLikedSongsCard || !hideOfflineCard
-                    val showRow2 = !hideCachedCard || !hideLocalFilesCard
-                    val showRow3 = !hideTop50Card
-                    if (showRow1 || showRow2 || showRow3) {
+                    data class ShortcutItem(
+                        val title: String,
+                        val countText: String,
+                        val iconRes: Int,
+                        val containerColor: Color,
+                        val iconColor: Color,
+                        val onClick: () -> Unit,
+                    )
+                    val visibleShortcuts = buildList {
+                        if (!hideLikedSongsCard) {
+                            add(
+                                ShortcutItem(
+                                    title = stringResource(R.string.liked_songs),
+                                    countText = "$likedSongsCount ${stringResource(R.string.tracks_label)}",
+                                    iconRes = R.drawable.favorite,
+                                    containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.6f),
+                                    iconColor = MaterialTheme.colorScheme.error,
+                                    onClick = { navController.navigate("auto_playlist/liked") },
+                                ),
+                            )
+                        }
+                        if (!hideOfflineCard) {
+                            add(
+                                ShortcutItem(
+                                    title = stringResource(R.string.offline_shortcut),
+                                    countText = stringResource(R.string.downloaded_desc),
+                                    iconRes = R.drawable.offline,
+                                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
+                                    iconColor = MaterialTheme.colorScheme.primary,
+                                    onClick = { navController.navigate("auto_playlist/downloaded") },
+                                ),
+                            )
+                        }
+                        if (!hideCachedCard) {
+                            add(
+                                ShortcutItem(
+                                    title = stringResource(R.string.cached),
+                                    countText = stringResource(R.string.instant_playback),
+                                    iconRes = R.drawable.cached,
+                                    containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f),
+                                    iconColor = MaterialTheme.colorScheme.tertiary,
+                                    onClick = { navController.navigate("cache_playlist/cached") },
+                                ),
+                            )
+                        }
+                        if (!hideLocalFilesCard) {
+                            add(
+                                ShortcutItem(
+                                    title = stringResource(R.string.local_files),
+                                    countText = stringResource(R.string.on_device),
+                                    iconRes = R.drawable.snippet_folder,
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+                                    iconColor = MaterialTheme.colorScheme.secondary,
+                                    onClick = { navController.navigate("local_songs") },
+                                ),
+                            )
+                        }
+                        if (!hideTop50Card) {
+                            add(
+                                ShortcutItem(
+                                    title = topPlaylistTitle,
+                                    countText = stringResource(R.string.all_time),
+                                    iconRes = R.drawable.trending_up,
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+                                    iconColor = MaterialTheme.colorScheme.secondary,
+                                    onClick = { navController.navigate("top_playlist/$topSize") },
+                                ),
+                            )
+                        }
+                    }
+                    if (visibleShortcuts.isNotEmpty()) {
                         Column(
                             modifier =
                                 Modifier
@@ -286,92 +356,35 @@ fun LibraryMixScreen(
                                     .padding(horizontal = 24.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            if (showRow1) {
+                            // Chunk into rows of 2; the last lone card on an odd row spans full width
+                            // (no trailing Spacer — that was the static-gap bug).
+                            visibleShortcuts.chunked(2).forEach { rowItems ->
                                 Row(
                                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                                     modifier = Modifier.fillMaxWidth(),
                                 ) {
-                                    if (!hideLikedSongsCard) {
-                                        ShortcutCard(
-                                            title = stringResource(R.string.liked_songs),
-                                            countText = "$likedSongsCount ${stringResource(R.string.tracks_label)}",
-                                            iconRes = R.drawable.favorite,
-                                            containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.6f),
-                                            iconColor = MaterialTheme.colorScheme.error,
-                                            modifier = Modifier.weight(1f),
-                                            onClick = { navController.navigate("auto_playlist/liked") },
-                                        )
-                                    } else {
-                                        Spacer(Modifier.weight(1f))
-                                    }
-
-                                    if (!hideOfflineCard) {
-                                        ShortcutCard(
-                                            title = stringResource(R.string.offline_shortcut),
-                                            countText = stringResource(R.string.downloaded_desc),
-                                            iconRes = R.drawable.offline,
-                                            containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.6f),
-                                            iconColor = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.weight(1f),
-                                            onClick = { navController.navigate("auto_playlist/downloaded") },
-                                        )
-                                    } else {
-                                        Spacer(Modifier.weight(1f))
-                                    }
-                                }
-                            }
-
-                            if (showRow2) {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                    modifier = Modifier.fillMaxWidth(),
-                                ) {
-                                    if (!hideCachedCard) {
-                                        ShortcutCard(
-                                            title = stringResource(R.string.cached),
-                                            countText = stringResource(R.string.instant_playback),
-                                            iconRes = R.drawable.cached,
-                                            containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.6f),
-                                            iconColor = MaterialTheme.colorScheme.tertiary,
-                                            modifier = Modifier.weight(1f),
-                                            onClick = { navController.navigate("cache_playlist/cached") },
-                                        )
-                                    } else {
-                                        Spacer(Modifier.weight(1f))
-                                    }
-
-                                    if (!hideLocalFilesCard) {
-                                        ShortcutCard(
-                                            title = stringResource(R.string.local_files),
-                                            countText = stringResource(R.string.on_device),
-                                            iconRes = R.drawable.snippet_folder,
-                                            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
-                                            iconColor = MaterialTheme.colorScheme.secondary,
-                                            modifier = Modifier.weight(1f),
-                                            onClick = { navController.navigate("local_songs") },
-                                        )
-                                    } else {
-                                        Spacer(Modifier.weight(1f))
-                                    }
-                                }
-                            }
-
-                            if (showRow3) {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                    modifier = Modifier.fillMaxWidth(),
-                                ) {
+                                    val first = rowItems[0]
+                                    val second = rowItems.getOrNull(1)
                                     ShortcutCard(
-                                        title = topPlaylistTitle,
-                                        countText = stringResource(R.string.all_time),
-                                        iconRes = R.drawable.trending_up,
-                                        containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
-                                        iconColor = MaterialTheme.colorScheme.secondary,
-                                        modifier = Modifier.weight(1f),
-                                        onClick = { navController.navigate("top_playlist/$topSize") },
+                                        title = first.title,
+                                        countText = first.countText,
+                                        iconRes = first.iconRes,
+                                        containerColor = first.containerColor,
+                                        iconColor = first.iconColor,
+                                        modifier = Modifier.weight(if (second == null) 2f else 1f),
+                                        onClick = first.onClick,
                                     )
-
-                                    Spacer(modifier = Modifier.weight(1f))
+                                    if (second != null) {
+                                        ShortcutCard(
+                                            title = second.title,
+                                            countText = second.countText,
+                                            iconRes = second.iconRes,
+                                            containerColor = second.containerColor,
+                                            iconColor = second.iconColor,
+                                            modifier = Modifier.weight(1f),
+                                            onClick = second.onClick,
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -1054,16 +1054,6 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
                 }
 
                 item {
-                    PreferenceEntry(
-                        modifier = positions.modifierFor("navigation_bar_settings"),
-                        title = { Text(stringResource(R.string.navigation_bar_settings_title)) },
-                        description = stringResource(R.string.navigation_bar_settings_subtitle),
-                        icon = { Icon(painterResource(R.drawable.tune), null) },
-                        onClick = { navController.navigate("settings/appearance/navigation_bar") },
-                    )
-                }
-
-                item {
                     Column(modifier = positions.modifierFor("default_open_tab")) {
                         EnumListPreference(
                             title = { Text(stringResource(R.string.default_open_tab)) },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -195,10 +195,10 @@ fun LyricsSettings(
             deserializeLyricsProviderOrder(providerOrderStr)
         }
     val (lyricsLineBlur, onLyricsLineBlurChange) = rememberPreference(LyricsLineBlurKey, defaultValue = false)
-    val (showPlayerControls, onShowPlayerControlsChange) =
-        rememberPreference(ShowLyricsPlayerControlsKey, defaultValue = true)
-    val (autoHidePlayerControls, onAutoHidePlayerControlsChange) =
-        rememberPreference(AutoHideLyricsPlayerControlsKey, defaultValue = true)
+    // The "Show player controls" and "Auto-hide controls" toggles were removed from the UI
+    // by user request — the bottom player controls now ALWAYS auto-hide after 5 s in the
+    // Apple Music style lyrics view, with no opt-out. The backing preference keys are kept
+    // (and forced to `true` in the player code) so existing installs don't break on upgrade.
     val (lyricsRomanizeJapanese, onLyricsRomanizeJapaneseChange) = rememberPreference(LyricsRomanizeJapaneseKey, defaultValue = false)
     val (lyricsRomanizeKorean, onLyricsRomanizeKoreanChange) = rememberPreference(LyricsRomanizeKoreanKey, defaultValue = true)
     val (lyricsRomanizeChinese, onLyricsRomanizeChineseChange) = rememberPreference(LyricsRomanizeChineseKey, defaultValue = true)
@@ -475,28 +475,15 @@ fun LyricsSettings(
                     onCheckedChange = onLyricsScrollChange,
                 )
             }
-            item {
-                SwitchPreference(
-                    modifier = positions.modifierFor("show_lyrics_player_controls"),
-                    title = { Text(stringResource(R.string.show_lyrics_player_controls)) },
-                    icon = { Icon(painterResource(R.drawable.play), null) },
-                    checked = showPlayerControls,
-                    onCheckedChange = onShowPlayerControlsChange,
-                )
-            }
 
-            item {
-                SwitchPreference(
-                    modifier = positions.modifierFor("auto_hide_lyrics_player_controls"),
-                    title = { Text(stringResource(R.string.auto_hide_lyrics_player_controls)) },
-                    description = stringResource(R.string.auto_hide_lyrics_player_controls_description),
-                    icon = { Icon(painterResource(R.drawable.timer), null) },
-                    checked = autoHidePlayerControls,
-                    onCheckedChange = onAutoHidePlayerControlsChange,
-                    isEnabled = showPlayerControls,
-                )
-            }
-
+            // ── Removed by user request ──────────────────────────────────────────
+            // "Show player controls" and "Auto-hide controls" toggles used to live here.
+            // Both are now hardcoded on — the Apple Music lyrics view always shows the
+            // bottom controls and always auto-hides them after 5 s (tap anywhere to bring
+            // them back). The preferences (ShowLyricsPlayerControlsKey,
+            // AutoHideLyricsPlayerControlsKey) are kept in PreferenceKeys.kt so legacy
+            // installs don't see a DataStore corruption error on upgrade.
+            // ─────────────────────────────────────────────────────────────────────
 
             item {
                 SwitchPreference(


### PR DESCRIPTION
## Summary

Eight user-reported issues, fixed together because most touch the lyrics / player surface that the same recent commits had churned.

### 1 + 2: Apple Music lyrics controls — remove the toggles, keep the 5 s hide
The "Show player controls" and "Auto-hide controls" toggles in Lyrics settings were removed by user request — the bottom controls now ALWAYS show in the Apple Music lyrics view and ALWAYS auto-hide after 5 s, with no opt-out. The backing preference keys are kept so legacy DataStore entries don't break on upgrade.

- `LyricsSettings.kt` — removed the two `SwitchPreference` blocks and the now-unused state hoisting.
- `AppleMusicPlayer.kt` — `showLyricsPlayerControls` / `autoHideLyricsPlayerControls` hardcoded to `true`; the `LyricsMenu` call site passes `showControlsToggles = false` so the rows disappear from the overflow menu too.
- `LyricsScreen.kt` — same hardcoding; the standalone lyrics page also no longer reads the preferences.

### 3: Romanisation between active lyric and translation in Enhanced style
The mocharealm `KaraokeLineText` renders in a fixed order: active line → `translation` slot → per-line `phonetic` slot. The user wants romanisation as small text BETWEEN the active lyric and the translation (Apple-Music layout). Achieved by swapping the field assignments at build time:
- `buildSyncedLyrics` / `buildLineSyncedLrcLine` now set `KaraokeLine.translation` = romanisation and `KaraokeLine.phonetic` = translation.
- `KaraokeLyricsView` is wrapped in `CompositionLocalProvider(LocalTextStyle provides phoneticTextStyle)` so the translation slot matches the size of the phonetic slot below it.

### 4: V2 Legacy broken + Enhanced poor
Two dev-branch fixes that hadn't been merged into main yet, both ported here:

- **V2 romanisation never appeared with AI romanisation on** — main gates the `romanizedText` collection on `romanizationPreferences.isEnabled`, which is `false` by definition whenever `aiHandled` is true. Ported the dev fix: gate on `showsRomanization` instead (`LyricsV2.kt`).
- **Enhanced romanisation only showed up after the first 2-3 lines** — `KaraokeLyricsView` caches a measured glyph layout per line index in a `remember` outside its `Crossfade`, and each line pins what it draws to whichever entry that cache held when the line was first composed. Ported the dev `KaraokeBuild` refactor: a generation counter is bumped whenever a build replaces an already-visible one with different romanisation, and it participates in the `key(...)` around the karaoke view + `listState` + `awaitingFirstFocus` gate.

### 5: Offline downloads interrupted halfway through songs
The OkHttp `readTimeout` (60 s on PRDownloader's internal client and on `DownloadUtil.mediaOkHttpClient`) was the prime cause of "song interrupted halfway through": a network stall > 60 s mid-stream threw `SocketTimeoutException`, the download failed, and the user saw a hard error even though the connection would have recovered on its own.

- `App.kt` — PRDownloader `readTimeout` 60_000 → 300_000.
- `DownloadUtil.kt` — `mediaOkHttpClient.readTimeout` 60 → 300.
- `PRDownloaderDataSource.kt` — wrap the single-attempt `open()` in a retry loop (`MAX_DOWNLOAD_ATTEMPTS = 3`, linear back-off 1.5 s × attempt) so a transient stall becomes a retry rather than a hard failure. Plus a Range-GET fallback in `resolveExpectedContentLength` for CDNs (e.g. Qobuz) that reject HEAD but honour Range requests — the existing Content-Length verification was a no-op on those, which is exactly the case where PRDownloader silently truncates.

### 6: Duplicate "Navigation bar" sections in Appearance settings
`AppearanceSettings.kt` had two `PreferenceEntry` items with the same title and destination. Removed the duplicate.

### 7: Static tiles in Extras settings when removing sections
`LibraryMixScreen.kt` rendered the shortcut cards in a fixed 3-row × 2-column grid with `Spacer.weight(1f)` in the empty slots, so hiding a card left a blank rectangle. Replaced with a flat visible-cards list chunked into 2-wide rows; the trailing card on an odd row spans full width so no static gap is ever left.

### 8: Apple Music lyrics page backdrop blur transition too fast
`MikoLyricsTransition`'s OPEN spring (stiffness 160f) snapped the sheet up in ~500 ms, which made the `MovingBlurBackground` inside `LyricsScreen` pop in at full alpha and immediately start its drift — read as "backdrop blur is too fast and looks bad". Slowed to a 900 ms tween with `FastOutSlowInEasing`, and wrapped `LyricsScreen` in a `Box` whose alpha is tied to the same progress so the backdrop blur + lyrics + controls fade in over the slide-up rather than arriving at full strength the instant the sheet starts moving.

## Test plan
- [ ] Build the `GmsMobileUniversalDebug` APK (CI does this automatically).
- [ ] Open Lyrics settings — confirm "Show player controls" and "Auto-hide controls" rows are gone.
- [ ] Play a song with word-synced lyrics in Apple Music style — confirm bottom controls show for 5 s then auto-hide; tap to bring back.
- [ ] Play a Japanese song with AI romanisation on — confirm romanisation appears as small text between the active lyric and the translation in Enhanced style; confirm it also appears in V2 Legacy (previously broken with AI romanisation).
- [ ] Start a long FLAC download (Qobuz) — confirm it completes without "interrupted halfway" failure.
- [ ] Open Appearance settings — confirm only one "Navigation bar" entry remains.
- [ ] In Extras settings, hide some shortcut cards — confirm the Library Mix grid reflows instead of leaving blank rectangles.
- [ ] Open the Apple Music lyrics page — confirm the slide-up + backdrop blur fade-in feels smooth and premium (~900 ms), not abrupt.
