### PR TITLE
fix(lyrics): repair broken KaraokeLyricsView call site + restore CompositionLocalProvider (MAIN IS BROKEN)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -1228,23 +1228,33 @@ fun LyricsEnhanced(
                     // dispose the cache along with them, or those lines never show it. See
                     // [KaraokeBuild].
                     key(lyricsSessionKey, positionResetCounter, karaokeGeneration) {
-                        KaraokeLyricsView(
-                            listState = listState,
-                            lyrics = syncedLyrics,
-                            currentPosition = playbackSyncPosition,
-                            onLineClicked = { line ->
-                                if (isSelectionModeActive) {
-                                    toggleSelectedLine(line.selectionKey())
-                                } else if (lyricsClick && isSynced && line.start > 0) {
-                                    player.seekTo(line.start.toLong())
-                                }
-                            },
-                            onLinePressed = { line ->
-                                val lineKey = line.selectionKey()
-                                if (!isSelectionModeActive) {
-                                    isSelectionModeActive = true
-                                    if (!selectedLineKeys.contains(lineKey)) {
-                                        selectedLineKeys.add(lineKey)
+                        // ── Force the translation slot to use the small phonetic style ──
+                        // The mocharealm KaraokeLineText renders the `translation` slot with
+                        // `LocalTextStyle.current` (no explicit style), while the `phonetic`
+                        // slot uses `phoneticTextStyle`. With the romanisation swap in
+                        // buildSyncedLyrics / buildLineSyncedLrcLine (translation field carries
+                        // romanisation, phonetic field carries actual translation), the
+                        // translation slot would render at the ambient bodyLarge size — much
+                        // larger than the translation below it. Pinning LocalTextStyle to the
+                        // same small phoneticTextStyle makes both rows visually consistent —
+                        // "romanisation should be small text just like translation" — and is
+                        // local to this lyrics subtree so the rest of the app is unaffected.
+                        // KaraokeLyricsView's explicit `normalLineTextStyle` /
+                        // `accompanimentLineTextStyle` / `phoneticTextStyle` parameters all
+                        // bypass LocalTextStyle, so the active karaoke line itself is not
+                        // affected.
+                        androidx.compose.runtime.CompositionLocalProvider(
+                            androidx.compose.material3.LocalTextStyle provides phoneticTextStyle,
+                        ) {
+                            KaraokeLyricsView(
+                                listState = listState,
+                                lyrics = syncedLyrics,
+                                currentPosition = playbackSyncPosition,
+                                onLineClicked = { line ->
+                                    if (isSelectionModeActive) {
+                                        toggleSelectedLine(line.selectionKey())
+                                    } else if (lyricsClick && isSynced && line.start > 0) {
+                                        player.seekTo(line.start.toLong())
                                     }
                                 },
                                 onLinePressed = { line ->


### PR DESCRIPTION
## 🚨 Main is currently broken — this is a critical fix

PR #168 was auto-merged via a merge commit (`0c4ba1f1d`) that left a duplicate `onLinePressed` lambda and a missing closing brace in `LyricsEnhanced.kt` — a syntax error that **breaks compilation of main**. The auto-merge also dropped the `CompositionLocalProvider` wrapper that pins the translation slot to the small `phoneticTextStyle`, which was the second half of the Issue 3 fix ("romanisation should be small text just like translation").

## What this PR does

Restores the correct call site at `LyricsEnhanced.kt:1230`:
- A single `KaraokeLyricsView(...)` invocation (no duplicate `onLinePressed`).
- Wrapped in `CompositionLocalProvider(LocalTextStyle provides phoneticTextStyle)` so the translation slot (which now carries the romanisation after the field swap) renders at the same small size as the phonetic slot below it (which now carries the actual translation).

## Why this happened

My original PR #168 was based on `b2930cfe0` (before dev was merged to main). While CI was running, dev was merged to main via PR #167, introducing two commits (`193c942a4`, `b0da4f969`) that overlapped with my changes. GitHub's auto-merge created a merge commit on my branch that resolved the conflict by keeping my version, but my version had a conflict-resolution artifact (duplicate `onLinePressed`) that I had introduced earlier when resolving the rebase conflict with a regex that didn't handle the partial overlap correctly. The result was a syntax error in main.

## Verification
- [ ] CI build of this PR succeeds (`assembleGmsMobileUniversalDebug` + `lintGmsMobileUniversalDebug`).
- [ ] No `onLinePressed` duplicate in the file.
- [ ] `CompositionLocalProvider` is present around the `KaraokeLyricsView` call.

Merge ASAP — main does not compile without this.
