### PR TITLE
fix(player): resolve unresolved references to removed player-control symbols (MAIN STILL BROKEN)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -794,14 +794,14 @@ fun AppleMusicPlayerContent(
                     mediaMetadataProvider = { mediaMetadata },
                     lyricsSyncOffset = lyricsSyncOffset,
                     onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                    showPlayerControlsState = showLyricsPlayerControlsState,
-                    onShowPlayerControlsChange = { showLyricsPlayerControlsState.value = it },
-                    onAutoHidePlayerControlsChange = {
-                        // LyricsMenu already persists the preference; the countdown effect
-                        // keys off it, so all this has to do is reveal the controls again so
-                        // the change is immediately visible.
-                        pokePlayerControlsVisibility()
-                    },
+                    // showPlayerControlsState / onShowPlayerControlsChange / onAutoHidePlayerControlsChange
+                    // are no-ops / null because the toggles were removed from the UI. The backing
+                    // preferences are still hardcoded to true in this composable (see
+                    // showLyricsPlayerControls / autoHideLyricsPlayerControls above), so the
+                    // controls always show and always auto-hide after 5 s.
+                    showPlayerControlsState = null,
+                    onShowPlayerControlsChange = null,
+                    onAutoHidePlayerControlsChange = {},
                     onDismiss = menuState::dismiss,
                     showControlsToggles = false,
                 )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -243,11 +243,21 @@ fun LyricsScreen(
     val density = LocalDensity.current
     val swipeStartRegionPx = with(density) { LyricsSwipeStartRegion.toPx() }
     val swipeDismissThresholdPx = with(density) { LyricsSwipeDismissThreshold.toPx() }
-    val showPlayerControlsState =
-        rememberPreference(ShowLyricsPlayerControlsKey, true)
-    val showPlayerControlsEnabled by showPlayerControlsState
-    val (autoHidePlayerControls, onAutoHidePlayerControlsChange) =
-        rememberPreference(AutoHideLyricsPlayerControlsKey, true)
+    // The "Show player controls" and "Auto-hide controls" toggles were removed from the
+    // Lyrics settings UI by user request. The standalone lyrics page now ALWAYS shows
+    // the bottom transport controls and ALWAYS auto-hides them after 5 s. The original
+    // preferences are not read at all — they're left in PreferenceKeys.kt purely so
+    // existing DataStore entries don't cause migration errors on upgrade.
+    //
+    // The state hoisting follows the pattern from the b0da4f969 fix on dev: `remember`
+    // with NO keys so the closure survives track changes, and a single countdown
+    // LaunchedEffect with every reveal trigger as a key (instead of a pair where one
+    // bumped the tick that the other used as its timer key, which relaunched across two
+    // frames). Setting `playerControlsExpanded = true` unconditionally at the top means
+    // any key change reveals the controls FIRST and only then decides whether to start
+    // hiding them — that is what guarantees the full five second window.
+    val showPlayerControlsEnabled = true
+    val autoHidePlayerControls = true
     var playerControlsExpanded by remember { mutableStateOf(true) }
     var controlsRevealToken by remember { mutableIntStateOf(0) }
     val autoHideDelayMs = 5_000L
@@ -255,16 +265,11 @@ fun LyricsScreen(
     // LyricsEnhanced / LyricsV2 via [LocalLyricsScrollListener] so the bottom Apple Music
     // controls can slide in on scroll.
     var isUserScrollingLyrics by remember { mutableStateOf(false) }
-    val onShowPlayerControlsChange =
-        remember(showPlayerControlsState) {
-            { showControls: Boolean ->
-                showPlayerControlsState.value = showControls
-                playerControlsExpanded = showControls
-            }
-        }
-    val onAutoHidePlayerControlsToggle: (Boolean) -> Unit = { enabled ->
-        onAutoHidePlayerControlsChange(enabled)
-        controlsRevealToken++
+    val onShowPlayerControlsChange: (Boolean) -> Unit = { _ ->
+        // No-op: setting was removed from the UI; behavior is hardcoded on.
+    }
+    val onAutoHidePlayerControlsToggle: (Boolean) -> Unit = { _ ->
+        // No-op: setting was removed from the UI; behavior is hardcoded on.
     }
 
     // Bumping the token reveals the controls and restarts the countdown below.


### PR DESCRIPTION
## 🚨 Main is STILL broken — build fails with unresolved references

PR #168's auto-merge left two broken spots in main that PR #169 didn't catch because it only touched `LyricsEnhanced.kt`. This PR fixes the remaining two compile errors.

## The errors

```
e: AppleMusicPlayer.kt:797:47 Unresolved reference 'showLyricsPlayerControlsState'.
e: AppleMusicPlayer.kt:798:52 Unresolved reference 'showLyricsPlayerControlsState'.
e: LyricsScreen.kt:247:28 Unresolved reference 'ShowLyricsPlayerControlsKey'.
e: LyricsScreen.kt:250:28 Unresolved reference 'AutoHideLyricsPlayerControlsKey'.
> Task :app:compileGmsMobileUniversalDebugKotlin FAILED
BUILD FAILED in 4m 58s
```

## Root cause

PR #168 was based on `b2930cfe0` (before dev was merged to main). While CI was running, dev was merged to main via PR #167, introducing two commits (`193c942a4`, `b0da4f969`) that overlapped with my changes. GitHub's auto-merge created a merge commit that resolved the conflicts by mixing my hardcoded `showLyricsPlayerControls = true` with the dev b0da4f969 fix's preference-reading LyricsMenu call site — so the call site references `showLyricsPlayerControlsState` which no longer exists, and LyricsScreen.kt's state hoisting reads `ShowLyricsPlayerControlsKey` whose import I had removed.

## The fix

* `AppleMusicPlayer.kt` — LyricsMenu call site now passes `showPlayerControlsState = null`, `onShowPlayerControlsChange = null`, `onAutoHidePlayerControlsChange = {}` (matching the hardcoded `showLyricsPlayerControls = true` / `autoHideLyricsPlayerControls = true` above).
* `LyricsScreen.kt` — the state-hoisting block now hardcodes `showPlayerControlsEnabled = true` and `autoHidePlayerControls = true` instead of calling `rememberPreference(ShowLyricsPlayerControlsKey, ...)` / `rememberPreference(AutoHideLyricsPlayerControlsKey, ...)`. The no-op callbacks are kept for the LyricsMenu call site.

Both match the original Issue 1/2 intent: the toggles were removed from the UI and the behavior is hardcoded on.

## Verification
- [ ] CI build of this PR succeeds (`assembleGmsMobileUniversalDebug` + `lintGmsMobileUniversalDebug`).
- [ ] No `Unresolved reference` errors in the build log.

Merge ASAP — main does not compile without this.
