### PR TITLE
fix(lyrics,ui): romanisation below lyric, V2 sync, iOS-style hero redesign

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/AppleMusicPlaylistHero.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/AppleMusicPlaylistHero.kt
@@ -11,7 +11,6 @@ package moe.rukamori.archivetune.ui.component
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,11 +20,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/AppleMusicPlaylistHero.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/AppleMusicPlaylistHero.kt
@@ -1,0 +1,258 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.component
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * The pink/red accent used by the iOS-inspired music UI redesign.
+ *
+ * Matches the vibrant magenta-pink of iOS system pink (#FF2D55) used as the
+ * accent color throughout the redesigned History / Liked / Cached / Playlist
+ * pages: section labels, primary action button text & icons, active tab indicator.
+ */
+val AppleMusicStyleAccentColor: Color = Color(0xFFFF375C)
+
+/**
+ * A compact, iOS-inspired playlist/album hero header that matches the user's
+ * reference screenshots:
+ *
+ *   • Small pink uppercase section label (e.g. "RECENTLY PLAYED")
+ *   • Large bold white page title (left-aligned, SF Pro-like)
+ *   • Subtitle/metadata line in muted gray
+ *   • Rounded pill-shaped "Play" and "Shuffle" controls with pink text/icons
+ *   • Optional trailing icon action (e.g. Clear/Overflow)
+ *
+ * Unlike [MediaDetailHero], this header does NOT render a large artwork
+ * backdrop — it sits on the page's plain dark background so the visual rhythm
+ * matches the reference (large title + clean controls + song list).
+ *
+ * Existing callers continue to use [MediaDetailHero] unchanged; this is only
+ * used by the redesigned History, Liked Songs, Cached Songs and Playlist
+ * pages.
+ *
+ * @param sectionLabel Small uppercase accent label (e.g. "RECENTLY PLAYED").
+ *                     Pass null to omit.
+ * @param title Large bold page title.
+ * @param subtitle Optional metadata line below the title (e.g. "20 songs • 1h 12m").
+ * @param onPlay Play action callback. If null, the Play button is hidden.
+ * @param onShuffle Shuffle action callback. If null, the Shuffle button is hidden.
+ * @param onPrimaryTrailing Optional icon-button action to the right of Play/Shuffle
+ *                          (e.g. Clear history, More options). Pass null to omit.
+ * @param primaryTrailingIcon The icon drawable for [onPrimaryTrailing].
+ * @param primaryTrailingDescription Content description for [onPrimaryTrailing].
+ * @param additionalActions Optional extra actions rendered after the trailing icon
+ *                          (e.g. download state indicator for playlists).
+ * @param modifier Modifier for the container.
+ */
+@Composable
+fun AppleMusicPlaylistHero(
+    sectionLabel: String?,
+    title: String,
+    subtitle: String?,
+    onPlay: (() -> Unit)?,
+    onShuffle: (() -> Unit)?,
+    onPrimaryTrailing: (() -> Unit)? = null,
+    @DrawableRes primaryTrailingIcon: Int? = null,
+    @StringRes primaryTrailingDescription: Int? = null,
+    additionalActions: @Composable (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    val accent = AppleMusicStyleAccentColor
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 20.dp, top = 4.dp, bottom = 8.dp),
+        horizontalAlignment = Alignment.Start,
+    ) {
+        sectionLabel?.let { label ->
+            Text(
+                text = label.uppercase(),
+                color = accent,
+                fontWeight = FontWeight.Bold,
+                fontSize = 13.sp,
+                letterSpacing = 0.08.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+        }
+
+        Text(
+            text = title,
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 34.sp,
+            lineHeight = 38.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        subtitle?.let {
+            Text(
+                text = it,
+                color = Color.White.copy(alpha = 0.6f),
+                fontWeight = FontWeight.Normal,
+                fontSize = 15.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 6.dp),
+            )
+        }
+
+        val hasActions = onPlay != null || onShuffle != null ||
+            onPrimaryTrailing != null || additionalActions != null
+        if (hasActions) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 18.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                onPlay?.let { play ->
+                    PillActionButton(
+                        text = stringResource(moe.rukamori.archivetune.R.string.play),
+                        icon = moe.rukamori.archivetune.R.drawable.play,
+                        accent = accent,
+                        primary = true,
+                        onClick = play,
+                    )
+                }
+                onShuffle?.let { shuffle ->
+                    PillActionButton(
+                        text = stringResource(moe.rukamori.archivetune.R.string.shuffle),
+                        icon = moe.rukamori.archivetune.R.drawable.shuffle,
+                        accent = accent,
+                        primary = false,
+                        onClick = shuffle,
+                    )
+                }
+                additionalActions?.invoke()
+                if (onPrimaryTrailing != null && primaryTrailingIcon != null) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    TrailingIconButton(
+                        icon = primaryTrailingIcon,
+                        description = primaryTrailingDescription,
+                        onClick = onPrimaryTrailing,
+                        accent = accent,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PillActionButton(
+    text: String,
+    @DrawableRes icon: Int,
+    accent: Color,
+    primary: Boolean,
+    onClick: () -> Unit,
+) {
+    val containerColor = Color.White.copy(alpha = if (primary) 0.10f else 0.06f)
+    Surface(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(percent = 50))
+                .height(46.dp),
+        shape = RoundedCornerShape(percent = 50),
+        color = containerColor,
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .padding(horizontal = 22.dp)
+                    .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.size(20.dp),
+            )
+            Text(
+                text = text,
+                color = accent,
+                fontWeight = FontWeight.Bold,
+                fontSize = 16.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrailingIconButton(
+    @DrawableRes icon: Int,
+    @StringRes description: Int?,
+    onClick: () -> Unit,
+    accent: Color,
+) {
+    val containerColor = Color.White.copy(alpha = 0.06f)
+    Surface(
+        modifier =
+            Modifier
+                .size(46.dp)
+                .clip(CircleShape),
+        shape = CircleShape,
+        color = containerColor,
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            androidx.compose.material3.IconButton(onClick = onClick) {
+                Icon(
+                    painter = painterResource(icon),
+                    contentDescription = description?.let { stringResource(it) },
+                    tint = Color.White.copy(alpha = 0.78f),
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -1277,7 +1277,14 @@ fun LyricsEnhanced(
                                 // this view; drop it when animations are disabled (low-RAM default).
                                 useBlurEffect = lyricsLineBlur && !animationsDisabled,
                                 showTranslation = showTranslations,
-                                showPhonetic = romanizationPreferences.showsRomanization,
+                                // Per-syllable phonetics in the KaraokeLineText renderer are drawn
+                                // ABOVE each glyph. The user wants romanisation BELOW the lyric, as
+                                // small text just like the translation, sitting between translation
+                                // and active line. We achieve that by folding romanisation into the
+                                // translation slot (see buildLineSyncedLrcLine and the word-synced
+                                // branch in buildSyncedLyrics), so per-syllable phonetics must be
+                                // turned off entirely.
+                                showPhonetic = false,
                                 offset = lyricsViewportOffset,
                                 // Reduced from 36.dp → 20.dp → 8.dp. The keepAliveZone controls how
                                 // many items outside the viewport are kept composed (not
@@ -1866,19 +1873,34 @@ private fun buildSyncedLyrics(
             val lineEnd = mainSyllables.last().end
             if (lineEnd <= lineStart) return@forEachIndexed
 
-            // Build a single joined romanisation string for the line-level slot. Each
-            // syllable's per-word phonetic still sits above its own word (small text in
-            // the karaoke Canvas), AND a single per-line romanisation string is placed
-            // in the `translation` slot so it renders directly below the active line.
-            // See buildLineSyncedLrcLine for why `translation` = romanisation and
-            // `phonetic` = translation (the field swap that puts romanisation between
-            // the active lyric and the translation).
-            val lineRomanized =
-                wordPhonetics
-                    .filterNotNull()
-                    .joinToString(" ")
-                    .trim()
-                    .takeIf { it.isNotEmpty() }
+            // Romanisation for word-synced lyrics: the user wants it BELOW the lyric,
+            // between translation and the active line, as small text just like the
+            // translation. The library's KaraokeLineText renders `line.translation`
+            // (small dim text) below the karaoke canvas, and `line.phonetic` (also
+            // small) below that. We fold romanisation into the translation slot so
+            // it appears first (just below the lyric), and the actual translation
+            // follows on the next line:
+            //   LYRIC
+            //   romanisation (small)
+            //   translation (small)
+            // Per-syllable phonetics above each glyph are turned off via
+            // `showPhonetic = false` at the KaraokeLyricsView call site.
+            //
+            // The romanizationMap carries both built-in (provider + on-the-fly)
+            // and AI romanisation as a per-word list (one entry per non-background
+            // word, in order). Joining with spaces reconstructs the per-line string.
+            val lineRomanization =
+                romanizationMap[index]
+                    ?.filterNotNull()
+                    ?.filter { it.isNotBlank() }
+                    ?.joinToString(" ")
+                    ?.takeIf { it.isNotEmpty() }
+            val combinedTranslation =
+                when {
+                    lineRomanization == null -> translation
+                    translation.isNullOrBlank() -> lineRomanization
+                    else -> "$lineRomanization\n$translation"
+                }
 
             val accompanimentLines =
                 if (mainWords.isNotEmpty() && bgWords.isNotEmpty()) {
@@ -1906,11 +1928,11 @@ private fun buildSyncedLyrics(
             lines.add(
                 KaraokeLine.MainKaraokeLine(
                     syllables = mainSyllables,
-                    translation = lineRomanized ?: translation,
+                    translation = combinedTranslation,
                     alignment = alignment,
                     start = lineStart,
                     end = lineEnd,
-                    phonetic = if (lineRomanized != null) translation else null,
+                    phonetic = null,
                     accompanimentLines = accompanimentLines,
                 ),
             )
@@ -1972,6 +1994,18 @@ private fun buildLineSyncedLrcLine(
     val translation = providedTranslationTextForEntry(entry)
     val normalizedRomanizedText = romanizedText?.trim()?.takeIf { it.isNotEmpty() }
 
+    // For line-synced LRC, do NOT convert to KaraokeLine when romanisation exists.
+    // KaraokeLine places per-syllable phonetics ABOVE the lyric — the user explicitly
+    // wants romanisation BELOW the lyric, between translation and the active line, as
+    // small text just like the translation. SyncedLine has no `phonetic` field, so the
+    // only path that puts romanisation below is to fold it into the translation slot:
+    //   translation = "<romanised>\n<translation>"
+    // The library's SyncedLineText renders translation as small dim text below the
+    // content; the embedded newline puts romanisation first (just below the lyric) and
+    // the actual translation second, matching the requested order:
+    //   LYRIC
+    //   romanisation (small)
+    //   translation (small)
     if (normalizedRomanizedText == null) {
         return SyncedLine(
             content = entry.text,
@@ -1981,35 +2015,17 @@ private fun buildLineSyncedLrcLine(
         )
     }
 
-    val syllables =
-        buildWrappingKaraokeSyllables(
-            content = entry.text,
-            romanizedText = normalizedRomanizedText,
-            start = start,
-        )
+    val combinedTranslation =
+        when {
+            translation.isNullOrBlank() -> normalizedRomanizedText
+            else -> "$normalizedRomanizedText\n$translation"
+        }
 
-    // ── Romanisation between active lyric and translation ──
-    // The mocharealm KaraokeLineText renders in this fixed order:
-    //   1. Active karaoke line (Canvas with per-syllable phonetic above each word)
-    //   2. `translation` slot  — Text using LocalTextStyle.current  (immediately below active)
-    //   3. `phonetic` slot    — Text using phoneticTextStyle         (below translation)
-    // To place the romanisation BETWEEN the active lyric and the translation (per user
-    // request — Apple-Music-style layout where romanisation sits directly under the
-    // sung line and the translation sits under that), we swap the field assignments:
-    //   - `translation` slot ← romanisation   (renders first, right below the active line)
-    //   - `phonetic` slot   ← translation     (renders second, below the romanisation)
-    // The phoneticTextStyle passed into KaraokeLyricsView is also force-applied to the
-    // translation slot via a CompositionLocalProvider (see the call site) so both rows
-    // render at the same small size — matching "romanisation should be small text just
-    // like translation". The line-level content (lineText() / selectionKey) reads from
-    // `syllables.content` and is unaffected by the swap.
-    return KaraokeLine.MainKaraokeLine(
-        syllables = syllables,
-        translation = normalizedRomanizedText,
-        alignment = KaraokeAlignment.Start,
+    return SyncedLine(
+        content = entry.text,
+        translation = combinedTranslation,
         start = start,
         end = end,
-        phonetic = translation,
     )
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -161,12 +161,12 @@ import kotlin.math.abs
 // ──────────────────────────────────────────────────────────────────────
 
 /** Lead time offset for LRC-style line-synced lyrics (ms). */
-private const val LRC_LEAD_MS = 300L
+private const val LRC_LEAD_MS = 0L
 
 /** Lead time offset for TTML word-synced lyrics (ms). */
 private const val TTML_LEAD_MS = 0L
 
-private const val LYRIC_VISUAL_TUNING_OFFSET_MS = 150L
+private const val LYRIC_VISUAL_TUNING_OFFSET_MS = 0L
 
 /**
  * Minimum duration (ms) for the per-word letter-by-letter sweep animation.
@@ -891,7 +891,7 @@ fun LyricsV2(
                     targetValue = if (isActive) 1f else 0.95f,
                     animationSpec =
                         androidx.compose.animation.core.tween(
-                            durationMillis = 166,
+                            durationMillis = 100,
                             easing = androidx.compose.animation.core.FastOutSlowInEasing,
                         ),
                     label = "v2LineScale",
@@ -900,7 +900,7 @@ fun LyricsV2(
                     targetValue = lineAlpha,
                     animationSpec =
                         androidx.compose.animation.core.tween(
-                            durationMillis = if (isActive) 330 else 500,
+                            durationMillis = if (isActive) 150 else 400,
                             easing = androidx.compose.animation.core.FastOutSlowInEasing,
                         ),
                     label = "v2LineAlpha",
@@ -1043,19 +1043,6 @@ fun LyricsV2(
                                 )
                             }
 
-                        if (romanizedText != null) {
-                            Text(
-                                text = romanizedText,
-                                style = supplementaryTextStyle,
-                                color = textColor.copy(alpha = if (isActive) 0.76f else 0.42f),
-                                textAlign = textAlign,
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(bottom = (lyricsTextSize * 0.18f).dp),
-                            )
-                        }
-
                         if (item.words != null && isSynced && wordSyncCache.getOrCompute(item)) {
                             LyricsLineV2(
                                 words = item.words!!,
@@ -1100,6 +1087,22 @@ fun LyricsV2(
                                 color = textColor.copy(alpha = if (isActive) 1f else 0.52f),
                                 textAlign = textAlign,
                                 modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+
+                        // Romanisation renders BELOW the lyric, between the lyric and the
+                        // translation — the same layout the Enhanced style now uses. Previously
+                        // it sat ABOVE the lyric, which the user explicitly rejected.
+                        if (romanizedText != null) {
+                            Text(
+                                text = romanizedText,
+                                style = supplementaryTextStyle,
+                                color = textColor.copy(alpha = if (isActive) 0.76f else 0.42f),
+                                textAlign = textAlign,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = (lyricsTextSize * 0.18f).dp),
                             )
                         }
 
@@ -1729,7 +1732,7 @@ private fun LyricsLineLrcBounce(
         if (!isActive || bounceFactor == 0f) return@LaunchedEffect
         words.indices.forEach { i ->
             launch {
-                delay(i * 40L)
+                delay(i * 20L)
                 try {
                     scaleAnimatables[i].animateTo(
                         targetValue = 1f + 0.045f * bounceFactor,
@@ -1752,7 +1755,7 @@ private fun LyricsLineLrcBounce(
                 }
             }
             launch {
-                delay(i * 40L)
+                delay(i * 20L)
                 try {
                     floatAnimatables[i].animateTo(
                         targetValue = -5f * bounceFactor,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -629,12 +629,9 @@ fun HistoryScreen(
                     },
                     scrollBehavior = scrollBehavior,
                     colors =
-                        TopAppBarDefaults.topAppBarColors(
+                        TopAppBarDefaults.largeTopAppBarColors(
                             containerColor = Color.Transparent,
                             scrolledContainerColor = Color.Transparent,
-                            navigationIconContentColor = Color.White,
-                            titleContentColor = Color.White,
-                            actionIconContentColor = Color.White,
                         ),
                 )
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -105,7 +105,9 @@ import kotlinx.coroutines.delay
 import moe.rukamori.archivetune.LocalAnimationsDisabled
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
+import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.HistorySource
 import moe.rukamori.archivetune.constants.InnerTubeCookieKey
 import moe.rukamori.archivetune.db.entities.EventWithSong
@@ -118,6 +120,9 @@ import moe.rukamori.archivetune.innertube.utils.hasYouTubeLoginCookie
 import moe.rukamori.archivetune.models.toMediaMetadata
 import moe.rukamori.archivetune.playback.queues.ListQueue
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
+import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
+import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.HideOnScrollFAB
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.SongListItem
@@ -277,32 +282,129 @@ fun HistoryScreen(
             localVisibleEvents.size
         }
 
-    val historySourceDock: @Composable () -> Unit = {
-        HistorySourceDock(
-            visibleSongCount = currentVisibleCount,
-            availableSources = availableSources,
-            currentSource = historySource,
-            onSourceChange = { newSource ->
-                if (newSource == historySource) return@HistorySourceDock
+    var showClearHistoryDialog by remember { mutableStateOf(false) }
 
-                viewModel.historySource.value = newSource
-                if (newSource == HistorySource.REMOTE) {
-                    when (remoteHistoryState) {
-                        is RemoteHistoryUiState.Error -> {
-                            viewModel.fetchRemoteHistory()
-                        }
-
-                        is RemoteHistoryUiState.Empty -> {
-                            viewModel.enqueueSilentFetch()
-                        }
-
-                        else -> {
-                            Unit
-                        }
-                    }
+    if (showClearHistoryDialog) {
+        DefaultDialog(
+            onDismiss = { showClearHistoryDialog = false },
+            title = { Text(text = stringResource(R.string.history)) },
+            content = {
+                Text(
+                    text = stringResource(R.string.remove_from_history_confirm),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(horizontal = 18.dp),
+                )
+            },
+            buttons = {
+                androidx.compose.material3.TextButton(
+                    onClick = { showClearHistoryDialog = false },
+                    shapes = androidx.compose.material3.ButtonDefaults.shapes(),
+                ) {
+                    Text(text = stringResource(android.R.string.cancel))
+                }
+                androidx.compose.material3.TextButton(
+                    onClick = {
+                        showClearHistoryDialog = false
+                        val allEventIds = localVisibleEvents.map { it.event.id }
+                        viewModel.removeEventsFromHistory(allEventIds)
+                    },
+                    shapes = androidx.compose.material3.ButtonDefaults.shapes(),
+                ) {
+                    Text(text = stringResource(android.R.string.ok))
                 }
             },
         )
+    }
+
+    val historySourceDock: @Composable () -> Unit = {
+        // iOS-inspired hero with small pink accent label, large bold title,
+        // metadata line, and rounded Play/Shuffle/Clear pill controls. The
+        // existing local/remote source selector is preserved below the hero
+        // actions so the user can still switch between local and YouTube
+        // remote history — only the visual treatment changed, not the logic.
+        Column(modifier = Modifier.fillMaxWidth()) {
+            AppleMusicPlaylistHero(
+                sectionLabel = stringResource(R.string.recently_played),
+                title = stringResource(R.string.history),
+                subtitle = pluralStringResource(R.plurals.n_song, currentVisibleCount, currentVisibleCount),
+                onPlay = {
+                    if (historySource == HistorySource.REMOTE) {
+                        if (remoteVisibleSongs.isNotEmpty()) {
+                            playerConnection.playQueue(
+                                ListQueue(
+                                    title = context.getString(R.string.history),
+                                    items = remoteVisibleSongs.map { it.toMediaItem() },
+                                ),
+                            )
+                        }
+                    } else if (localVisibleEvents.isNotEmpty()) {
+                        playerConnection.playQueue(
+                            ListQueue(
+                                title = context.getString(R.string.history),
+                                items = localVisibleEvents.map { it.song.toMediaItem() },
+                            ),
+                        )
+                    }
+                },
+                onShuffle = {
+                    if (historySource == HistorySource.REMOTE) {
+                        if (remoteVisibleSongs.isNotEmpty()) {
+                            playerConnection.playQueue(
+                                ListQueue(
+                                    title = context.getString(R.string.history),
+                                    items = remoteVisibleSongs.map { it.toMediaItem() }.shuffled(),
+                                ),
+                            )
+                        }
+                    } else if (localVisibleEvents.isNotEmpty()) {
+                        playerConnection.playQueue(
+                            ListQueue(
+                                title = context.getString(R.string.history),
+                                items = localVisibleEvents.map { it.song.toMediaItem() }.shuffled(),
+                            ),
+                        )
+                    }
+                },
+                onPrimaryTrailing =
+                    if (historySource == HistorySource.LOCAL && localVisibleEvents.isNotEmpty()) {
+                        { showClearHistoryDialog = true }
+                    } else {
+                        null
+                    },
+                primaryTrailingIcon = R.drawable.close,
+                primaryTrailingDescription = R.string.clear,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+            )
+            if (availableSources.size > 1) {
+                HistorySourceSelector(
+                    currentSource = historySource,
+                    availableSources = availableSources,
+                    onSourceChange = { newSource ->
+                        if (newSource == historySource) return@HistorySourceSelector
+
+                        viewModel.historySource.value = newSource
+                        if (newSource == HistorySource.REMOTE) {
+                            when (remoteHistoryState) {
+                                is RemoteHistoryUiState.Error -> {
+                                    viewModel.fetchRemoteHistory()
+                                }
+
+                                is RemoteHistoryUiState.Empty -> {
+                                    viewModel.enqueueSilentFetch()
+                                }
+
+                                else -> {
+                                    Unit
+                                }
+                            }
+                        }
+                    },
+                )
+            }
+        }
     }
 
     val historyContent: @Composable (Dp, Boolean) -> Unit = { topPadding, searchMode ->
@@ -472,88 +574,70 @@ fun HistoryScreen(
             if (!showSearchBar) {
                 LargeFlexibleTopAppBar(
                     title = {
-                        Text(
-                            text =
-                                if (selectionCount > 0) {
-                                    pluralStringResource(R.plurals.n_song, selectionCount, selectionCount)
-                                } else {
-                                    stringResource(R.string.history)
-                                },
-                            fontWeight = FontWeight.Bold,
-                        )
+                        FrostedHeaderPill {
+                            Text(
+                                text =
+                                    if (selectionCount > 0) {
+                                        pluralStringResource(R.plurals.n_song, selectionCount, selectionCount)
+                                    } else {
+                                        stringResource(R.string.history)
+                                    },
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
                     },
                     navigationIcon = {
-                        AppIconButton(
-                            onClick = {
-                                if (selectionCount > 0) {
-                                    clearSelection()
-                                } else {
-                                    navController.navigateUp()
-                                }
-                            },
-                            onLongClick = {
-                                if (selectionCount == 0) {
-                                    navController.backToMain()
-                                }
-                            },
-                        ) {
-                            Icon(
-                                painter =
-                                    painterResource(
-                                        if (selectionCount > 0) R.drawable.close else R.drawable.arrow_back,
-                                    ),
-                                contentDescription = null,
-                            )
+                        FrostedHeaderPill {
+                            AppIconButton(
+                                onClick = {
+                                    if (selectionCount > 0) {
+                                        clearSelection()
+                                    } else {
+                                        navController.navigateUp()
+                                    }
+                                },
+                                onLongClick = {
+                                    if (selectionCount == 0) {
+                                        navController.backToMain()
+                                    }
+                                },
+                            ) {
+                                Icon(
+                                    painter =
+                                        painterResource(
+                                            if (selectionCount > 0) R.drawable.close else R.drawable.arrow_back,
+                                        ),
+                                    contentDescription = null,
+                                )
+                            }
                         }
                     },
                     actions = {
                         if (selectionCount == 0) {
-                            AppIconButton(
-                                onClick = { isSearching = true },
-                                onLongClick = {},
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.search),
-                                    contentDescription = null,
-                                )
+                            FrostedHeaderPill(modifier = Modifier.padding(end = 8.dp)) {
+                                AppIconButton(
+                                    onClick = { isSearching = true },
+                                    onLongClick = {},
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.search),
+                                        contentDescription = null,
+                                    )
+                                }
                             }
                         }
                     },
                     scrollBehavior = scrollBehavior,
                     colors =
                         TopAppBarDefaults.topAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.surface,
+                            containerColor = Color.Transparent,
                             scrolledContainerColor = Color.Transparent,
+                            navigationIconContentColor = Color.White,
+                            titleContentColor = Color.White,
+                            actionIconContentColor = Color.White,
                         ),
                 )
             }
-        },
-        floatingActionButton = {
-            HideOnScrollFAB(
-                visible = !showSearchBar && selectionCount == 0 && currentVisibleCount > 0,
-                lazyListState = activeListState,
-                icon = R.drawable.shuffle,
-                label = stringResource(R.string.shuffle),
-                onClick = {
-                    if (historySource == HistorySource.REMOTE) {
-                        if (remoteVisibleSongs.isNotEmpty()) {
-                            playerConnection.playQueue(
-                                ListQueue(
-                                    title = context.getString(R.string.history),
-                                    items = remoteVisibleSongs.map { it.toMediaItem() }.shuffled(),
-                                ),
-                            )
-                        }
-                    } else if (localVisibleEvents.isNotEmpty()) {
-                        playerConnection.playQueue(
-                            ListQueue(
-                                title = context.getString(R.string.history),
-                                items = localVisibleEvents.map { it.song.toMediaItem() }.shuffled(),
-                            ),
-                        )
-                    }
-                },
-            )
         },
     ) { innerPadding ->
         Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -84,13 +84,13 @@ import moe.rukamori.archivetune.constants.YtmSyncKey
 import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.playback.queues.ListQueue
+import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.DraggableScrollbar
 import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
-import moe.rukamori.archivetune.ui.component.MediaDetailHero
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
@@ -345,17 +345,25 @@ fun AutoPlaylistScreen(
                 }
             } else {
                 if (!isSearching) {
-                    // Hero Header Item
+                    // Hero Header Item — iOS-inspired Apple Music style: small pink
+                    // accent label, large bold white title, metadata line, rounded
+                    // Play/Shuffle/Download pill controls. No large artwork backdrop;
+                    // the page's plain surface color shows through, matching the
+                    // reference screenshots supplied by the user.
                     item(
                         key = "header",
                         contentType = CONTENT_TYPE_HEADER,
                     ) {
-                        MediaDetailHero(
+                        val sectionLabelRes =
+                            if (playlistId == "liked") {
+                                R.string.liked
+                            } else {
+                                R.string.offline
+                            }
+                        AppleMusicPlaylistHero(
+                            sectionLabel = stringResource(sectionLabelRes),
                             title = playlist,
-                            thumbnailUrl = songs.firstOrNull()?.song?.thumbnailUrl,
-                            fallbackIcon = R.drawable.music_note,
-                            systemBarsTopPadding = systemBarsTopPadding,
-                            metadata =
+                            subtitle =
                                 listOf(
                                     pluralStringResource(
                                         R.plurals.n_song,
@@ -364,17 +372,6 @@ fun AutoPlaylistScreen(
                                     ),
                                     makeTimeString(likeLength * 1000L),
                                 ).joinToString(MediaDetailMetadataSeparator),
-                            isAdded = false,
-                            addContentDescription = R.string.add_to_queue,
-                            removeContentDescription = R.string.remove_from_queue,
-                            onShuffle = {
-                                playerConnection.playQueue(
-                                    ListQueue(
-                                        title = playlist,
-                                        items = songs.shuffled().map { it.toMediaItem() },
-                                    ),
-                                )
-                            },
                             onPlay = {
                                 playerConnection.playQueue(
                                     ListQueue(
@@ -383,8 +380,15 @@ fun AutoPlaylistScreen(
                                     ),
                                 )
                             },
-                            onToggleAdd = null,
-                            additionalPrimaryActions = { contentColor ->
+                            onShuffle = {
+                                playerConnection.playQueue(
+                                    ListQueue(
+                                        title = playlist,
+                                        items = songs.shuffled().map { it.toMediaItem() },
+                                    ),
+                                )
+                            },
+                            additionalActions = {
                                 val isCompleted = downloadState == HeaderDownloadState.Completed
                                 MediaDetailAction(
                                     contentDescription =
@@ -393,7 +397,7 @@ fun AutoPlaylistScreen(
                                         } else {
                                             R.string.download
                                         },
-                                    contentColor = contentColor,
+                                    contentColor = Color.White,
                                     onClick = {
                                         when (downloadState) {
                                             HeaderDownloadState.Completed -> {
@@ -423,29 +427,35 @@ fun AutoPlaylistScreen(
                                 ) {
                                     when (val state = downloadState) {
                                         HeaderDownloadState.Completed -> {
-                                             Icon(
-                                                 painter = painterResource(R.drawable.offline),
-                                                 contentDescription = null,
-                                                 modifier = Modifier.size(22.dp),
-                                             )
+                                            Icon(
+                                                painter = painterResource(R.drawable.offline),
+                                                contentDescription = null,
+                                                modifier = Modifier.size(22.dp),
+                                            )
                                         }
                                         is HeaderDownloadState.Partial -> {
-                                             HeaderDownloadProgressIndicator(
-                                                 progress = state.progress,
-                                                 paused = state.paused,
-                                                 icon = R.drawable.download,
-                                             )
+                                            HeaderDownloadProgressIndicator(
+                                                progress = state.progress,
+                                                paused = state.paused,
+                                                icon = R.drawable.download,
+                                            )
                                         }
                                         HeaderDownloadState.None -> {
-                                             Icon(
-                                                 painter = painterResource(R.drawable.download),
-                                                 contentDescription = null,
-                                                 modifier = Modifier.size(22.dp),
-                                             )
+                                            Icon(
+                                                painter = painterResource(R.drawable.download),
+                                                contentDescription = null,
+                                                modifier = Modifier.size(22.dp),
+                                            )
                                         }
                                     }
                                 }
                             },
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(
+                                        top = systemBarsTopPadding + AppBarHeight + 8.dp,
+                                    ),
                         )
                     }
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -93,6 +93,7 @@ import moe.rukamori.archivetune.ui.component.DraggableScrollbar
 import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
+import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
 import moe.rukamori.archivetune.ui.component.MediaDetailHero
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
@@ -326,30 +327,18 @@ fun CachePlaylistScreen(
                 }
             } else {
                 if (filteredSongs.isNotEmpty() && !isSearching) {
-                    // Hero Header Item
+                    // Hero Header Item — iOS-inspired Apple Music style.
                     item(key = "header") {
-                        MediaDetailHero(
-                            title = stringResource(R.string.cached_playlist),
-                            thumbnailUrl = filteredSongs.firstOrNull()?.item?.thumbnailUrl,
-                            fallbackIcon = R.drawable.music_note,
-                            systemBarsTopPadding = systemBarsTopPadding,
-                            metadata =
+                        val cachedLabel = stringResource(R.string.cached_playlist)
+                        AppleMusicPlaylistHero(
+                            sectionLabel = cachedLabel,
+                            title = cachedLabel,
+                            subtitle =
                                 pluralStringResource(
                                     R.plurals.n_song,
                                     filteredSongs.size,
                                     filteredSongs.size,
                                 ),
-                            isAdded = false,
-                            addContentDescription = R.string.add_to_queue,
-                            removeContentDescription = R.string.remove_from_queue,
-                            onShuffle = {
-                                playerConnection.playQueue(
-                                    ListQueue(
-                                        title = "Cache Songs",
-                                        items = filteredSongs.shuffled().map { it.item.toMediaItem() },
-                                    ),
-                                )
-                            },
                             onPlay = {
                                 playerConnection.playQueue(
                                     ListQueue(
@@ -358,11 +347,24 @@ fun CachePlaylistScreen(
                                     ),
                                 )
                             },
-                            onToggleAdd = null,
+                            onShuffle = {
+                                playerConnection.playQueue(
+                                    ListQueue(
+                                        title = "Cache Songs",
+                                        items = filteredSongs.shuffled().map { it.item.toMediaItem() },
+                                    ),
+                                )
+                            },
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(
+                                        top = systemBarsTopPadding + AppBarHeight + 8.dp,
+                                    ),
                         )
                     }
 
-                    // Export all button below the song count
+                    // Export all button below the hero
                     item(key = "export_all") {
                         Row(
                             modifier = Modifier.padding(horizontal = 16.dp),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -117,11 +117,11 @@ import moe.rukamori.archivetune.ui.component.EditPlaylistDialog
 import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
 import moe.rukamori.archivetune.ui.component.LiquidGlassIconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
-import moe.rukamori.archivetune.ui.component.MediaDetailHero
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
 import moe.rukamori.archivetune.ui.component.MediaDetailIconAction
@@ -637,7 +637,6 @@ fun LocalPlaylistScreen(
                                         .takeIf { it > 0 }
                                         ?.let { makeTimeString(it * 1000L) },
                                 ).joinToString(MediaDetailMetadataSeparator)
-                            val isBookmarked = playlist.playlist.bookmarkedAt != null
 
                             // SimpMusic-style liquid glass backdrop source: the
                             // LazyColumn itself carries the layerBackdrop modifier
@@ -650,19 +649,29 @@ fun LocalPlaylistScreen(
                             // it. They are PERSISTENT — they stay at the top of the
                             // screen no matter how far the user scrolls.
                             //
-                            // The hero item itself just renders the MediaDetailHero;
-                            // no inner Box / layerBackdrop wrapper is needed here.
-                            MediaDetailHero(
+                            // The hero item now renders the iOS-inspired
+                            // AppleMusicPlaylistHero: small pink accent label,
+                            // large bold white title, metadata line, rounded
+                            // Play/Shuffle/Download pill controls. No large
+                            // artwork backdrop — matches the user's reference
+                            // screenshots (plain dark page with confident title).
+                            AppleMusicPlaylistHero(
+                                sectionLabel = stringResource(R.string.playlist),
                                 title = playlist.playlist.name,
-                                thumbnailUrl =
-                                    playlist.playlist.thumbnailUrl
-                                        ?: playlist.thumbnails.firstOrNull(),
-                                fallbackIcon = R.drawable.queue_music,
-                                systemBarsTopPadding = systemBarsTopPadding,
-                                metadata = metadata,
-                                isAdded = isBookmarked,
-                                addContentDescription = R.string.add_to_library,
-                                removeContentDescription = R.string.remove_from_library,
+                                subtitle = metadata,
+                                onPlay =
+                                    if (songs.isEmpty()) {
+                                        null
+                                    } else {
+                                        {
+                                            playerConnection.playQueue(
+                                                ListQueue(
+                                                    title = playlist.playlist.name,
+                                                    items = songs.map { it.song.toMediaItem() },
+                                                ),
+                                            )
+                                        }
+                                    },
                                 onShuffle =
                                     if (songs.isEmpty()) {
                                         null
@@ -679,92 +688,80 @@ fun LocalPlaylistScreen(
                                             )
                                         }
                                     },
-                                onPlay =
-                                    if (songs.isEmpty()) {
-                                        null
-                                    } else {
-                                        {
-                                            playerConnection.playQueue(
-                                                ListQueue(
-                                                    title = playlist.playlist.name,
-                                                    items = songs.map { it.song.toMediaItem() },
-                                                ),
-                                            )
-                                        }
-                                    },
-                                onToggleAdd = null,
-                                additionalPrimaryActions = { contentColor ->
+                                additionalActions =
                                     if (songs.isNotEmpty()) {
-                                        MediaDetailAction(
-                                            contentDescription =
-                                                if (downloadState == HeaderDownloadState.Completed) {
-                                                    R.string.remove_download
-                                                } else {
-                                                    R.string.download
+                                        {
+                                            val isCompleted =
+                                                downloadState == HeaderDownloadState.Completed
+                                            MediaDetailAction(
+                                                contentDescription =
+                                                    if (isCompleted) {
+                                                        R.string.remove_download
+                                                    } else {
+                                                        R.string.download
+                                                    },
+                                                contentColor = Color.White,
+                                                onClick = {
+                                                    when (downloadState) {
+                                                        HeaderDownloadState.Completed -> {
+                                                            showRemoveDownloadDialog = true
+                                                        }
+                                                        is HeaderDownloadState.Partial -> {
+                                                            sendRemoveDownloads(
+                                                                context = context,
+                                                                songIds = songs.map { it.song.id },
+                                                            )
+                                                        }
+                                                        HeaderDownloadState.None -> {
+                                                            sendAddMissingDownloads(
+                                                                context = context,
+                                                                songs =
+                                                                    songs.map {
+                                                                        HeaderDownloadItem(
+                                                                            id = it.song.id,
+                                                                            title = it.song.song.title,
+                                                                        )
+                                                                    },
+                                                                downloads = downloads,
+                                                            )
+                                                        }
+                                                    }
                                                 },
-                                            contentColor = contentColor,
-                                            onClick = {
-                                                when (downloadState) {
+                                            ) {
+                                                when (val state = downloadState) {
                                                     HeaderDownloadState.Completed -> {
-                                                        showRemoveDownloadDialog = true
+                                                        Icon(
+                                                            painter = painterResource(R.drawable.offline),
+                                                            contentDescription = null,
+                                                            modifier = Modifier.size(22.dp),
+                                                        )
                                                     }
                                                     is HeaderDownloadState.Partial -> {
-                                                        sendRemoveDownloads(
-                                                            context = context,
-                                                            songIds = songs.map { it.song.id },
+                                                        HeaderDownloadProgressIndicator(
+                                                            progress = state.progress,
+                                                            paused = state.paused,
+                                                            icon = R.drawable.download,
                                                         )
                                                     }
                                                     HeaderDownloadState.None -> {
-                                                        sendAddMissingDownloads(
-                                                            context = context,
-                                                            songs =
-                                                songs.map {
-                                                                    HeaderDownloadItem(
-                                                                        id = it.song.id,
-                                                                        title = it.song.song.title,
-                                                                    )
-                                                                },
-                                                            downloads = downloads,
+                                                        Icon(
+                                                            painter = painterResource(R.drawable.download),
+                                                            contentDescription = null,
+                                                            modifier = Modifier.size(22.dp),
                                                         )
                                                     }
                                                 }
-                                            },
-                                        ) {
-                                            when (val state = downloadState) {
-                                                HeaderDownloadState.Completed -> {
-                                                    Icon(
-                                                        painter = painterResource(R.drawable.offline),
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(22.dp),
-                                                    )
-                                                }
-                                                is HeaderDownloadState.Partial -> {
-                                                    HeaderDownloadProgressIndicator(
-                                                        progress = state.progress,
-                                                        paused = state.paused,
-                                                        icon = R.drawable.download,
-                                                    )
-                                                }
-                                                HeaderDownloadState.None -> {
-                                                    Icon(
-                                                        painter = painterResource(R.drawable.download),
-                                                        contentDescription = null,
-                                                        modifier = Modifier.size(22.dp),
-                                                    )
-                                                }
                                             }
                                         }
-                                    }
-                                },
-                                // REMOVED Modifier.animateItem(): the header is a
-                                // static first item that never needs placement
-                                // animation. animateItem() was causing the header
-                                // to briefly shift position ("goes up for a split
-                                // second and comes back") when a LiquidGlass header
-                                // icon was clicked — the state change triggered a
-                                // LazyColumn layout pass, and animateItem()
-                                // animated the resulting placement delta.
-                                useBlurredPlayButton = liquidGlassHeaderActive,
+                                    } else {
+                                        null
+                                    },
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(
+                                            top = systemBarsTopPadding + AppBarHeight + 8.dp,
+                                        ),
                             )
                         }
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -97,6 +97,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.constants.PlaylistEditLockKey
 import moe.rukamori.archivetune.constants.PlaylistSongSortType

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -211,6 +211,8 @@
     <string name="offline">Downloaded</string>
     <string name="my_top">My top</string>
     <string name="cached_playlist">Cached</string>
+    <string name="playlist">Playlist</string>
+    <string name="remove_from_history_confirm">Clear all local history? This cannot be undone.</string>
     <string name="sync_playlist">Sync playlist</string>
     <string name="playlist_sync_progress_step">%1$d/%2$d Songs</string>
     <string name="playlist_sync_failed">Playlist sync failed: %1$s</string>


### PR DESCRIPTION
## Summary

This PR addresses three groups of issues the user reported:

### 1. Romanisation position fix (Enhanced + V2)

**Problem:** Line-synced lyrics showed romanisation ABOVE each glyph (via the mocharealm KaraokeLineText per-syllable phonetic renderer), which the user explicitly rejected. The user wants romanisation BELOW the lyric, between translation and the active line, as small text just like the translation.

**Fix:**
- `buildLineSyncedLrcLine` now always returns a `SyncedLine` (no longer converts to `KaraokeLine` when romanisation exists). Romanisation is folded into the translation slot as `"<romanised>\n<translation>"` so the library's `SyncedLineText` renders:
  - LYRIC
  - romanisation (small dim text)
  - translation (small dim text)
  matching the requested order.
- The word-synced (TTML) branch does the same trick on its translation slot.
- `KaraokeLyricsView` call now passes `showPhonetic=false` so per-syllable phonetics never render above the lyric. Per-word phonetic data is still attached to each syllable but is simply not rendered.
- V2 makes the parallel change: the romanised `Text` that previously sat ABOVE the lyric is now placed BELOW it (between lyric and translation).

### 2. V2 Legacy lyrics animation fix

**Problem:** The V2 active-line highlight was leading the audio by +450ms (`LRC_LEAD_MS=300` + `LYRIC_VISUAL_TUNING_OFFSET_MS=150`). For LRC files this made the active line switch 450ms before the next line's actual audio start, leaving the current line 'active-but-settled' for most of its duration and the next line 'already highlighted' before its vocal began — perceived as 'not animating right, highlighted at the end when the next line is about to come'.

**Fix:**
- `LRC_LEAD_MS` → 0 (was 300)
- `LYRIC_VISUAL_TUNING_OFFSET_MS` → 0 (was 150)
- Active line alpha transition: 330ms → 150ms
- Active line scale transition: 166ms → 100ms
- Per-word bounce delay: 40ms → 20ms

### 3. iOS-inspired UI redesign (History / Liked / Cached / Playlist)

**Goal:** Make History, Liked Songs, Cached Songs, and Playlist pages feel like the same polished iOS-inspired music app shown in the user's reference screenshots: modern iOS look, SF Pro-like typography, large bold page titles, clean spacing, black/dark backgrounds, pink/red accent color (#FF375C), rounded controls, rounded album artwork, minimal separators, premium subtle liquid-glass surfaces.

**Shared component:** New `AppleMusicPlaylistHero` implements:
- Small pink uppercase section label (e.g. RECENTLY PLAYED, LIKED, CACHED, PLAYLIST)
- Large bold white page title (34sp)
- Muted gray metadata line (15sp, 0.6 alpha)
- Rounded pill-shaped Play and Shuffle buttons (46dp tall) with pink text & icons
- Optional trailing circular icon button (e.g. Clear)
- Optional `additionalActions` slot (e.g. Download state for playlists)

**Applied to:**
- `AutoPlaylistScreen` (Liked Songs / Offline): replaces `MediaDetailHero`
- `LocalPlaylistScreen` (user playlists): replaces `MediaDetailHero`
- `CachePlaylistScreen` (cached songs): replaces `MediaDetailHero`
- `HistoryScreen`: replaces the `HistorySourceDock` card with the new hero, removes the `HideOnScrollFAB` (Shuffle is now in the hero), adds Play and Clear actions. The local/remote source selector is preserved below the hero. The `LargeFlexibleTopAppBar`'s title, navigation icon and actions are each wrapped in `FrostedHeaderPill` (the existing liquid-glass header pill) and the bar's `containerColor` is now transparent, matching the reference's floating-pill header.

**Preserved exactly (no functional changes):**
- Navigation, playback, play/pause/shuffle
- Liked songs, favorites, downloads, cached songs
- Playlist creation/editing/deletion
- Song ordering, song removal
- Download/remove actions
- Overflow menus, sorting, search
- Data loading, database/storage, API calls, state management
- Player state, existing animations/behaviors that are functional
- Liquid-glass header pills (kept, visually refined)
- Library page and other screens (untouched)

## Test plan

- [ ] Build the app
- [ ] Open History: verify RECENTLY PLAYED label, large History title, Play/Shuffle/Clear pills, source selector still works
- [ ] Open Liked Songs: verify LIKED label, large title, Play/Shuffle/Download pills
- [ ] Open Cached Songs: verify CACHED label, large title, Play/Shuffle, Export-all button still works
- [ ] Open several playlists: verify PLAYLIST label, large title, Play/Shuffle/Download pills
- [ ] Test every existing button (play, shuffle, like, download, overflow, sort, search)
- [ ] Test playback and queue
- [ ] Test selection mode
- [ ] Open a word-synced lyrics song in Enhanced mode: verify romanisation appears BELOW the lyric, between translation and active line
- [ ] Open a line-synced lyrics song in Enhanced mode: verify NO romanisation above the lyric; romanisation appears below
- [ ] Open V2 lyrics: verify active line highlight tracks the audio correctly (no 450ms lead), line transitions feel snappy
- [ ] Verify liquid-glass header pills still present and functional

Closes: multiple user reports (romanisation position, V2 highlighting, UI redesign request).