### PR TITLE
fix(hero): wire play onClick, light-mode contrast, Library back pill + Home dock + bottom fade

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/AppleMusicPlaylistHero.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/AppleMusicPlaylistHero.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,6 +45,12 @@ import androidx.compose.ui.unit.sp
  * Matches the vibrant magenta-pink of iOS system pink (#FF2D55) used as the
  * accent color throughout the redesigned History / Liked / Cached / Playlist
  * pages: section labels, primary action button text & icons, active tab indicator.
+ *
+ * Chosen because it remains highly legible against both the dark-mode surface
+ * (deep black/charcoal) AND a light-mode surface (off-white): the saturated
+ * pink has enough chroma and luminance contrast to pass WCAG AA against both
+ * backgrounds, so the hero's accent text (section label, Play/Shuffle labels,
+ * and pill icons) reads cleanly in either theme.
  */
 val AppleMusicStyleAccentColor: Color = Color(0xFFFF375C)
 
@@ -52,7 +59,7 @@ val AppleMusicStyleAccentColor: Color = Color(0xFFFF375C)
  * reference screenshots:
  *
  *   • Small pink uppercase section label (e.g. "RECENTLY PLAYED")
- *   • Large bold white page title (left-aligned, SF Pro-like)
+ *   • Large bold page title (left-aligned, SF Pro-like)
  *   • Subtitle/metadata line in muted gray
  *   • Rounded pill-shaped "Play" and "Shuffle" controls with pink text/icons
  *   • Optional trailing icon action (e.g. Clear/Overflow)
@@ -64,6 +71,14 @@ val AppleMusicStyleAccentColor: Color = Color(0xFFFF375C)
  * Existing callers continue to use [MediaDetailHero] unchanged; this is only
  * used by the redesigned History, Liked Songs, Cached Songs and Playlist
  * pages.
+ *
+ * ## Light-mode contrast
+ * The title, subtitle, and pill container colors are derived from
+ * [MaterialTheme.colorScheme] so the hero remains legible against the light
+ * theme surface as well as the dark theme surface. The pink accent
+ * ([AppleMusicStyleAccentColor]) is intentionally NOT theme-derived — it is
+ * a saturated brand pink that has acceptable contrast on both light and dark
+ * surfaces and matches the iOS Music reference.
  *
  * @param sectionLabel Small uppercase accent label (e.g. "RECENTLY PLAYED").
  *                     Pass null to omit.
@@ -93,6 +108,13 @@ fun AppleMusicPlaylistHero(
     modifier: Modifier = Modifier,
 ) {
     val accent = AppleMusicStyleAccentColor
+    // Theme-aware foreground colors so the hero remains legible against both
+    // the dark theme (Color.Black-ish surface) and the light theme
+    // (off-white surface). Using `onBackground` keeps the title at full
+    // contrast against the page surface, while `onSurfaceVariant` gives the
+    // metadata line the muted-gray look the reference screenshots have.
+    val onBackgroundColor = MaterialTheme.colorScheme.onBackground
+    val subtitleColor = MaterialTheme.colorScheme.onSurfaceVariant
 
     Column(
         modifier =
@@ -116,7 +138,7 @@ fun AppleMusicPlaylistHero(
 
         Text(
             text = title,
-            color = Color.White,
+            color = onBackgroundColor,
             fontWeight = FontWeight.Bold,
             fontSize = 34.sp,
             lineHeight = 38.sp,
@@ -127,7 +149,7 @@ fun AppleMusicPlaylistHero(
         subtitle?.let {
             Text(
                 text = it,
-                color = Color.White.copy(alpha = 0.6f),
+                color = subtitleColor,
                 fontWeight = FontWeight.Normal,
                 fontSize = 15.sp,
                 maxLines = 1,
@@ -147,6 +169,19 @@ fun AppleMusicPlaylistHero(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
+                // Play and Shuffle pills share the available horizontal space
+                // evenly (each gets weight 1f), matching the reference layout
+                // where Play and Shuffle sit side-by-side as roughly
+                // equal-width pills, and any trailing circular action
+                // (download / clear / overflow) sits as a fixed-size circle on
+                // the right end.
+                //
+                // The previous implementation wrapped each pill's inner Row
+                // in `Modifier.fillMaxWidth()`, which forced the first pill
+                // (Play) to consume the entire parent Row's max width and
+                // pushed Shuffle / Download off-screen. The pills now wrap
+                // their content intrinsically and rely on the parent's
+                // `weight(1f)` to allocate width.
                 onPlay?.let { play ->
                     PillActionButton(
                         text = stringResource(moe.rukamori.archivetune.R.string.play),
@@ -154,6 +189,7 @@ fun AppleMusicPlaylistHero(
                         accent = accent,
                         primary = true,
                         onClick = play,
+                        modifier = Modifier.weight(1f),
                     )
                 }
                 onShuffle?.let { shuffle ->
@@ -163,6 +199,7 @@ fun AppleMusicPlaylistHero(
                         accent = accent,
                         primary = false,
                         onClick = shuffle,
+                        modifier = Modifier.weight(1f),
                     )
                 }
                 additionalActions?.invoke()
@@ -187,11 +224,20 @@ private fun PillActionButton(
     accent: Color,
     primary: Boolean,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val containerColor = Color.White.copy(alpha = if (primary) 0.10f else 0.06f)
+    // The pill container color is a low-alpha tint of `onBackground` so it
+    // reads as a subtle frosted surface against both the dark and light page
+    // surface. Previously this was a `Color.White.copy(alpha = ...)` tint
+    // which on a light-mode page made the pill almost invisible (white on
+    // off-white) and on a dark-mode page made it look like a solid white
+    // slab — neither matched the reference's subtle translucent pill.
+    val onBackgroundColor = MaterialTheme.colorScheme.onBackground
+    val containerColor = onBackgroundColor.copy(alpha = if (primary) 0.10f else 0.06f)
     Surface(
+        onClick = onClick,
         modifier =
-            Modifier
+            modifier
                 .clip(RoundedCornerShape(percent = 50))
                 .height(46.dp),
         shape = RoundedCornerShape(percent = 50),
@@ -200,8 +246,7 @@ private fun PillActionButton(
         Row(
             modifier =
                 Modifier
-                    .padding(horizontal = 22.dp)
-                    .fillMaxWidth(),
+                    .padding(horizontal = 22.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -230,7 +275,8 @@ private fun TrailingIconButton(
     onClick: () -> Unit,
     accent: Color,
 ) {
-    val containerColor = Color.White.copy(alpha = 0.06f)
+    val onBackgroundColor = MaterialTheme.colorScheme.onBackground
+    val containerColor = onBackgroundColor.copy(alpha = 0.06f)
     Surface(
         modifier =
             Modifier
@@ -247,7 +293,7 @@ private fun TrailingIconButton(
                 Icon(
                     painter = painterResource(icon),
                     contentDescription = description?.let { stringResource(it) },
-                    tint = Color.White.copy(alpha = 0.78f),
+                    tint = onBackgroundColor.copy(alpha = 0.78f),
                     modifier = Modifier.size(22.dp),
                 )
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LibraryChromeComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LibraryChromeComponents.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -73,7 +72,12 @@ fun LibraryBackPill(
 ) {
     FrostedHeaderPill(modifier = modifier) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            AppIconButton(
+            // The local `IconButton` (in the same package) supports both
+            // onClick and onLongClick — matching the back-button semantics
+            // used elsewhere in the app (tap to navigate up, long-press to
+            // jump to the Home tab). The Material3 `IconButton` is shadowed
+            // here, so we reference the local overload directly.
+            IconButton(
                 onClick = onClick,
                 onLongClick = onLongClick ?: {},
             ) {
@@ -145,7 +149,13 @@ fun LibraryHomeDockButton(
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center,
         ) {
-            IconButton(onClick = onClick) {
+            // Use the local `IconButton` (same package) which supports both
+            // onClick and onLongClick — pass an empty long-click since the
+            // Home dock only needs the tap action.
+            IconButton(
+                onClick = onClick,
+                onLongClick = {},
+            ) {
                 Icon(
                     painter = painterResource(iconRes),
                     contentDescription = stringResource(R.string.home),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LibraryChromeComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LibraryChromeComponents.kt
@@ -1,0 +1,210 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package moe.rukamori.archivetune.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import moe.rukamori.archivetune.R
+
+/**
+ * A frosted-glass pill that sits at the top-start of the redesigned History,
+ * Liked Songs, Cached Songs, and Playlist pages.
+ *
+ * Visually it matches the user's iOS Music reference screenshot: a translucent
+ * dark pill containing a left-pointing chevron followed by the text
+ * "Library". Tapping it calls [onClick] (typically `navController.navigateUp()`
+ * to pop back to the Library tab); long-pressing it calls [onLongClick]
+ * (typically `navController.backToMain()` to jump straight to the Home tab).
+ *
+ * The pill is built on top of [FrostedHeaderPill] so it inherits the same
+ * translucent `surfaceContainer` background that the rest of the app's
+ * header pills use — keeping the visual language consistent across the
+ * redesigned screens and the existing Library / Apple Music player surfaces.
+ *
+ * The "Library" label is hardcoded to the `R.string.library` resource so
+ * callers don't have to thread a string through. If a screen needs a
+ * different back-label (e.g. "Home" or "Search"), it should pass a different
+ * composable as its `navigationIcon` rather than reuse this pill.
+ *
+ * @param onClick Tap action — typically `navController.navigateUp()`.
+ * @param onLongClick Long-press action — typically `navController.backToMain()`.
+ *                   Pass null to disable long-press (no ripple effect).
+ * @param modifier Modifier for the outer pill layout.
+ */
+@Composable
+fun LibraryBackPill(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
+) {
+    FrostedHeaderPill(modifier = modifier) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            AppIconButton(
+                onClick = onClick,
+                onLongClick = onLongClick ?: {},
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.arrow_back),
+                    contentDescription = stringResource(R.string.library),
+                )
+            }
+            // Tight, non-tappable "Library" label sitting immediately to the
+            // right of the back chevron. The whole pill is rendered on top of
+            // the page's scrolling content via a translucent surface, so the
+            // text color should match the page's foreground color to stay
+            // readable on both dark and light backgrounds.
+            Text(
+                text = stringResource(R.string.library),
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                modifier = Modifier.padding(end = 4.dp),
+            )
+        }
+    }
+}
+
+/**
+ * A circular floating Home-icon dock button rendered in the same frosted
+ * liquid-glass style as [FrostedHeaderPill]. Designed to sit at the
+ * bottom-start corner of the redesigned History / Liked / Cached / Playlist
+ * pages, matching the iOS Music reference screenshot that shows a circular
+ * frosted "Home" pill at the bottom-left.
+ *
+ * Tapping it calls [onClick] — typically `navController.backToMain()` so the
+ * user can jump straight back to the Home tab from anywhere in a long
+ * playlist or history list, without having to scroll back to the top to
+ * reach the top-start back pill.
+ *
+ * The icon color is the same pink/red accent ([AppleMusicStyleAccentColor])
+ * used across the redesigned hero surfaces so the Home pill visually pairs
+ * with the Play/Shuffle pill accents in the hero above.
+ *
+ * The pill is a fixed 48dp circle so it matches the touch-target size of
+ * the other liquid-glass icon buttons in the app. Callers should position it
+ * (e.g. with `Modifier.align(Alignment.BottomStart)`) and apply their own
+ * bottom inset padding so the button sits above the floating navigation
+ * toolbar / mini-player.
+ *
+ * @param onClick Tap action — typically `navController.backToMain()`.
+ * @param modifier Modifier for the outer layout.
+ * @param iconRes The home icon drawable. Defaults to `R.drawable.home_filled`
+ *                so the dock button reads as a filled pink home glyph at
+ *                rest, matching the reference.
+ */
+@Composable
+fun LibraryHomeDockButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    iconRes: Int = R.drawable.home_filled,
+) {
+    val baseColor = MaterialTheme.colorScheme.surfaceContainer
+    Surface(
+        modifier =
+            modifier
+                .size(48.dp)
+                .clip(CircleShape),
+        shape = CircleShape,
+        color = baseColor.copy(alpha = 0.55f),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            IconButton(onClick = onClick) {
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = stringResource(R.string.home),
+                    tint = AppleMusicStyleAccentColor,
+                    modifier = Modifier.size(22.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A scroll-aware vertical gradient overlay that fades the bottom edge of a
+ * scrolling list into the page background. The gradient is anchored to the
+ * bottom of the host Box, has a fixed height (default 96dp), and is only
+ * visible while the user is actively scrolling — matching the iOS Music
+ * reference where the bottom of the song list gently blurs/fades into the
+ * floating navigation area as the user scrolls.
+ *
+ * Behavior:
+ *   • When [visible] is `true`, the gradient paints from transparent at the
+ *     top to [fadeColor] (default: page surface color) at the bottom.
+ *   • When [visible] is `false`, the overlay is fully transparent and
+ *     consumes no input events.
+ *
+ * Caller is responsible for computing the [visible] flag from the host
+ * LazyListState (e.g. `lazyListState.firstVisibleItemIndex > 0 ||
+ * lazyListState.firstVisibleItemScrollOffset > 0`).
+ *
+ * @param visible Whether the fade should currently be visible.
+ * @param fadeColor The color the fade should blend into. Default is the page
+ *                  surface color, which makes the bottom of the scrolling
+ *                  list dissolve into the page background.
+ * @param height The height of the gradient band.
+ * @param modifier Modifier for the overlay (caller should usually pass
+ *                  `Modifier.align(Alignment.BottomCenter).fillMaxWidth()`).
+ */
+@Composable
+fun BottomFadeOverlay(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+    fadeColor: Color = MaterialTheme.colorScheme.surface,
+    height: Dp = 96.dp,
+) {
+    if (!visible) return
+    Box(
+        modifier =
+            modifier
+                .height(height)
+                .background(
+                    brush =
+                        Brush.verticalGradient(
+                            colors =
+                                listOf(
+                                    fadeColor.copy(alpha = 0f),
+                                    fadeColor.copy(alpha = 0.6f),
+                                    fadeColor,
+                                ),
+                        ),
+                ),
+    )
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -121,9 +122,11 @@ import moe.rukamori.archivetune.models.toMediaMetadata
 import moe.rukamori.archivetune.playback.queues.ListQueue
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
 import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
+import moe.rukamori.archivetune.ui.component.BottomFadeOverlay
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.HideOnScrollFAB
+import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.TopSearch
@@ -587,6 +590,12 @@ fun HistoryScreen(
                         }
                     },
                     navigationIcon = {
+                        // iOS-inspired back pill: translucent frosted capsule
+                        // containing a left-pointing chevron followed by the
+                        // text "Library", matching the user's reference
+                        // screenshot. Tapping it pops back to the previous
+                        // destination (or clears the multi-selection);
+                        // long-pressing it jumps straight to the Home tab.
                         FrostedHeaderPill {
                             AppIconButton(
                                 onClick = {
@@ -610,6 +619,13 @@ fun HistoryScreen(
                                     contentDescription = null,
                                 )
                             }
+                            Text(
+                                text = stringResource(R.string.library),
+                                color = MaterialTheme.colorScheme.onBackground,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                modifier = Modifier.padding(end = 4.dp),
+                            )
                         }
                     },
                     actions = {
@@ -640,6 +656,53 @@ fun HistoryScreen(
         Box(modifier = Modifier.fillMaxSize()) {
             if (!showSearchBar) {
                 historyContent(innerPadding.calculateTopPadding(), false)
+            }
+
+            // Bottom fade overlay — a vertical gradient that fades the bottom
+            // of the scrolling history list into the page background, matching
+            // the iOS Music reference screenshot. Only visible when the user
+            // has scrolled past the hero header, so the first frame (hero
+            // visible, list not yet scrolling) doesn't show a stray fade band
+            // overlapping the hero's Play/Shuffle/Clear pills.
+            val isListScrolling by remember {
+                derivedStateOf {
+                    val activeState = if (historySource == HistorySource.REMOTE) remoteListState else localListState
+                    activeState.firstVisibleItemIndex > 0 ||
+                        activeState.firstVisibleItemScrollOffset > 0
+                }
+            }
+            val bottomInset = LocalPlayerAwareWindowInsets.current
+                .asPaddingValues()
+                .calculateBottomPadding()
+            if (!showSearchBar && isListScrolling) {
+                BottomFadeOverlay(
+                    visible = true,
+                    fadeColor = MaterialTheme.colorScheme.surface,
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .fillMaxWidth()
+                            .padding(bottom = bottomInset),
+                )
+            }
+
+            // Floating Home dock button — circular frosted-glass pill at the
+            // bottom-start corner, matching the iOS Music reference
+            // screenshot. Visible only when the user has scrolled past the
+            // hero header so it doesn't compete with the hero's action row
+            // when the user is at the top of the page. Tapping it jumps
+            // straight to the Home tab.
+            if (!showSearchBar && isListScrolling) {
+                LibraryHomeDockButton(
+                    onClick = { navController.backToMain() },
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomStart)
+                            .padding(
+                                start = 16.dp,
+                                bottom = bottomInset + 12.dp,
+                            ),
+                )
             }
 
             AnimatedVisibility(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -63,8 +63,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastSumBy
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -85,10 +87,13 @@ import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.playback.queues.ListQueue
 import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
+import moe.rukamori.archivetune.ui.component.BottomFadeOverlay
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.DraggableScrollbar
 import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
 import moe.rukamori.archivetune.ui.component.SongListItem
@@ -633,37 +638,57 @@ fun AutoPlaylistScreen(
                 }
             },
             navigationIcon = {
-                IconButton(
-                    onClick = {
-                        when {
-                            isSearching -> {
-                                isSearching = false
-                                query = TextFieldValue()
-                                focusManager.clearFocus()
-                            }
+                // iOS-inspired back pill: translucent frosted capsule containing
+                // a left-pointing chevron followed by the text "Library",
+                // matching the user's reference screenshot. Tapping it pops
+                // back to the previous destination (or clears selection /
+                // closes search); long-pressing it jumps straight to the
+                // Home tab. The pill is only rendered when the TopAppBar is
+                // active (selection / search / scrolled-past-hero /
+                // liquid-glass off); when the Liquid Glass header is
+                // active and the hero is fully visible, the persistent
+                // LiquidGlass back button at the top-start handles back
+                // navigation instead.
+                FrostedHeaderPill {
+                    IconButton(
+                        onClick = {
+                            when {
+                                isSearching -> {
+                                    isSearching = false
+                                    query = TextFieldValue()
+                                    focusManager.clearFocus()
+                                }
 
-                            selection -> {
-                                selection = false
-                                wrappedSongs.forEach { it.isSelected = false }
-                            }
+                                selection -> {
+                                    selection = false
+                                    wrappedSongs.forEach { it.isSelected = false }
+                                }
 
-                            else -> {
-                                navController.navigateUp()
+                                else -> {
+                                    navController.navigateUp()
+                                }
                             }
-                        }
-                    },
-                    onLongClick = {
-                        if (!isSearching && !selection) {
-                            navController.backToMain()
-                        }
-                    },
-                ) {
-                    Icon(
-                        painter =
-                            painterResource(
-                                if (selection) R.drawable.close else R.drawable.arrow_back,
-                            ),
-                        contentDescription = null,
+                        },
+                        onLongClick = {
+                            if (!isSearching && !selection) {
+                                navController.backToMain()
+                            }
+                        },
+                    ) {
+                        Icon(
+                            painter =
+                                painterResource(
+                                    if (selection) R.drawable.close else R.drawable.arrow_back,
+                                ),
+                            contentDescription = null,
+                        )
+                    }
+                    Text(
+                        text = stringResource(R.string.library),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        modifier = Modifier.padding(end = 4.dp),
                     )
                 }
             },
@@ -740,6 +765,50 @@ fun AutoPlaylistScreen(
                 }
             },
         )
+
+        // Bottom fade overlay — vertical gradient that fades the bottom of the
+        // scrolling song list into the page background, matching the iOS Music
+        // reference screenshot. Only rendered while the user has scrolled
+        // past the hero header so the first frame doesn't show a stray fade
+        // band over the hero's Play/Shuffle/Download pills.
+        val isListScrolling by remember {
+            derivedStateOf {
+                lazyListState.firstVisibleItemIndex > 0 ||
+                    lazyListState.firstVisibleItemScrollOffset > 0
+            }
+        }
+        val bottomInset = LocalPlayerAwareWindowInsets.current
+            .asPaddingValues()
+            .calculateBottomPadding()
+        if (isListScrolling) {
+            BottomFadeOverlay(
+                visible = true,
+                fadeColor = MaterialTheme.colorScheme.surface,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(bottom = bottomInset),
+            )
+        }
+
+        // Floating Home dock button — circular frosted-glass pill at the
+        // bottom-start corner, matching the iOS Music reference screenshot.
+        // Visible only while the user has scrolled past the hero header so it
+        // doesn't compete with the hero's action row. Tapping it jumps
+        // straight to the Home tab.
+        if (isListScrolling) {
+            LibraryHomeDockButton(
+                onClick = { navController.backToMain() },
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(
+                            start = 16.dp,
+                            bottom = bottomInset + 12.dp,
+                        ),
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -65,8 +65,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -89,11 +91,14 @@ import moe.rukamori.archivetune.constants.SongSortTypeKey
 import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.playback.queues.ListQueue
+import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
+import moe.rukamori.archivetune.ui.component.BottomFadeOverlay
 import moe.rukamori.archivetune.ui.component.DraggableScrollbar
 import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
-import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
 import moe.rukamori.archivetune.ui.component.MediaDetailHero
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
@@ -551,33 +556,48 @@ fun CachePlaylistScreen(
                 }
             },
             navigationIcon = {
-                IconButton(onClick = {
-                    when {
-                        isSearching -> {
-                            isSearching = false
-                            query = TextFieldValue()
-                            focusManager.clearFocus()
-                        }
+                // iOS-inspired back pill: translucent frosted capsule containing
+                // a left-pointing chevron followed by the text "Library",
+                // matching the user's reference screenshot. Tapping it pops
+                // back to the previous destination (or clears selection /
+                // closes search); long-pressing it jumps straight to the
+                // Home tab.
+                FrostedHeaderPill {
+                    IconButton(onClick = {
+                        when {
+                            isSearching -> {
+                                isSearching = false
+                                query = TextFieldValue()
+                                focusManager.clearFocus()
+                            }
 
-                        selection -> {
-                            selection = false
-                        }
+                            selection -> {
+                                selection = false
+                            }
 
-                        else -> {
-                            navController.navigateUp()
+                            else -> {
+                                navController.navigateUp()
+                            }
                         }
+                    }, onLongClick = {
+                        if (!isSearching && !selection) {
+                            navController.backToMain()
+                        }
+                    }) {
+                        Icon(
+                            painter =
+                                painterResource(
+                                    if (selection) R.drawable.close else R.drawable.arrow_back,
+                                ),
+                            contentDescription = null,
+                        )
                     }
-                }, onLongClick = {
-                    if (!isSearching && !selection) {
-                        navController.backToMain()
-                    }
-                }) {
-                    Icon(
-                        painter =
-                            painterResource(
-                                if (selection) R.drawable.close else R.drawable.arrow_back,
-                            ),
-                        contentDescription = null,
+                    Text(
+                        text = stringResource(R.string.library),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        modifier = Modifier.padding(end = 4.dp),
                     )
                 }
             },
@@ -663,6 +683,50 @@ fun CachePlaylistScreen(
                 }
             },
         )
+
+        // Bottom fade overlay — vertical gradient that fades the bottom of
+        // the scrolling cache list into the page background, matching the
+        // iOS Music reference screenshot. Only rendered while the user has
+        // scrolled past the hero header so the first frame doesn't show a
+        // stray fade band over the hero's Play/Shuffle pills.
+        val isListScrolling by remember {
+            derivedStateOf {
+                lazyListState.firstVisibleItemIndex > 0 ||
+                    lazyListState.firstVisibleItemScrollOffset > 0
+            }
+        }
+        val bottomInset = LocalPlayerAwareWindowInsets.current
+            .asPaddingValues()
+            .calculateBottomPadding()
+        if (isListScrolling) {
+            BottomFadeOverlay(
+                visible = true,
+                fadeColor = MaterialTheme.colorScheme.surface,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(bottom = bottomInset),
+            )
+        }
+
+        // Floating Home dock button — circular frosted-glass pill at the
+        // bottom-start corner, matching the iOS Music reference screenshot.
+        // Visible only while the user has scrolled past the hero header so
+        // it doesn't compete with the hero's action row. Tapping it jumps
+        // straight to the Home tab.
+        if (isListScrolling) {
+            LibraryHomeDockButton(
+                onClick = { navController.backToMain() },
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(
+                            start = 16.dp,
+                            bottom = bottomInset + 12.dp,
+                        ),
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -78,8 +78,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastSumBy
@@ -112,13 +114,16 @@ import moe.rukamori.archivetune.playback.queues.ListQueue
 import moe.rukamori.archivetune.playback.queues.LocalMixQueue
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
 import moe.rukamori.archivetune.ui.component.AssignTagsDialog
+import moe.rukamori.archivetune.ui.component.BottomFadeOverlay
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.DraggableScrollbar
 import moe.rukamori.archivetune.ui.component.EditPlaylistDialog
 import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
+import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
 import moe.rukamori.archivetune.ui.component.LiquidGlassIconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
@@ -1085,17 +1090,41 @@ fun LocalPlaylistScreen(
         // compiler can't smart-cast the property directly).
         val currentPlaylist = playlist
         if (layerBackdropActive && !selection && !isSearching && currentPlaylist != null) {
-            LiquidGlassIconButton(
+            // iOS-inspired back pill: persistent translucent liquid-glass
+            // capsule containing a left-pointing chevron followed by the
+            // text "Library", matching the user's reference screenshot.
+            // The pill samples the artworkBackdrop (the entire scrolling
+            // content) to render the liquid-glass blur. Tapping it pops
+            // back to the previous destination; long-pressing it jumps
+            // straight to the Home tab.
+            LiquidGlassActionPill(
                 backdrop = artworkBackdrop,
-                painter = painterResource(R.drawable.arrow_back),
-                contentDescription = null,
+                interactive = true,
                 modifier =
                     Modifier
                         .align(Alignment.TopStart)
-                        .padding(start = 12.dp, top = systemBarsTopPadding + 12.dp)
-                        .size(48.dp),
-                onClick = { navController.navigateUp() },
-            )
+                        .padding(start = 12.dp, top = systemBarsTopPadding + 12.dp),
+            ) {
+                IconButton(
+                    onClick = { navController.navigateUp() },
+                    onLongClick = { navController.backToMain() },
+                    modifier = Modifier.size(48.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.arrow_back),
+                        contentDescription = stringResource(R.string.library),
+                        tint = Color.White,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.library),
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(end = 12.dp),
+                )
+            }
             LiquidGlassActionPill(
                 backdrop = artworkBackdrop,
                 modifier =
@@ -1379,6 +1408,53 @@ fun LocalPlaylistScreen(
             },
         )
         } // end if (!liquidGlassHeaderActive || selection || isSearching)
+
+        // Bottom fade overlay — vertical gradient that fades the bottom of
+        // the scrolling playlist list into the page background, matching
+        // the iOS Music reference screenshot. Only rendered while the user
+        // has scrolled past the hero header so the first frame doesn't
+        // show a stray fade band over the hero's Play/Shuffle/Download
+        // pills. Skipped during search/selection so the overlay doesn't
+        // interfere with the search/selection toolbar at the bottom.
+        val isListScrolling by remember {
+            derivedStateOf {
+                lazyListState.firstVisibleItemIndex > 0 ||
+                    lazyListState.firstVisibleItemScrollOffset > 0
+            }
+        }
+        val bottomInset = LocalPlayerAwareWindowInsets.current
+            .asPaddingValues()
+            .calculateBottomPadding()
+        if (!isSearching && !selection && isListScrolling) {
+            BottomFadeOverlay(
+                visible = true,
+                fadeColor = MaterialTheme.colorScheme.surface,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(bottom = bottomInset),
+            )
+        }
+
+        // Floating Home dock button — circular frosted-glass pill at the
+        // bottom-start corner, matching the iOS Music reference screenshot.
+        // Visible only while the user has scrolled past the hero header so
+        // it doesn't compete with the hero's action row. Tapping it jumps
+        // straight to the Home tab. Skipped during search/selection so it
+        // doesn't overlap the selection toolbar.
+        if (!isSearching && !selection && isListScrolling) {
+            LibraryHomeDockButton(
+                onClick = { navController.backToMain() },
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(
+                            start = 16.dp,
+                            bottom = bottomInset + 12.dp,
+                        ),
+            )
+        }
 
         SnackbarHost(
             hostState = snackbarHostState,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <string name="home">Home</string>
+    <string name="library">Library</string>
     <string name="songs">Songs</string>
     <string name="artists">Artists</string>
     <string name="albums">Albums</string>


### PR DESCRIPTION
## Summary

Fixes for the iOS-inspired playlist/hero redesign based on user feedback:

### 1. Play button does nothing (critical bug)
`PillActionButton` in `AppleMusicPlaylistHero` declared an `onClick` parameter but never wired it to the underlying `Surface` — so the Play button rendered but did nothing when tapped. The inner `Row` also wrapped its content in `Modifier.fillMaxWidth()`, which forced Play to consume the entire parent `Row` width and pushed Shuffle / Download off-screen.

**Fix:** Surface now takes `onClick = onClick`; inner Row wraps content intrinsically; Play and Shuffle pills each take `Modifier.weight(1f)` so they share horizontal space evenly with the trailing circular Download action.

### 2. Light-mode text visibility
Hero title and subtitle were hardcoded to `Color.White`, which on a light-mode page made the title invisible. Now derived from `MaterialTheme.colorScheme.onBackground` / `onSurfaceVariant` so they stay legible against both dark and light surfaces. The pink accent is intentionally kept constant — it has acceptable contrast against both backgrounds and matches the iOS Music reference.

### 3. "Library" back pill (top-left) — matches reference image
The redesigned History / Liked / Cached / Playlist pages now show a translucent frosted capsule containing a left-pointing chevron followed by the text "Library". HistoryScreen, AutoPlaylistScreen, and CachePlaylistScreen wrap their existing `navigationIcon` in `FrostedHeaderPill`; LocalPlaylistScreen uses `LiquidGlassActionPill` so it can sample the page layer-backdrop for a true blur.

### 4. Floating Home dock button (bottom-left) — matches reference image
A circular frosted-glass pill containing a pink home glyph, rendered as a sibling of the scrolling list. Visible only after the user scrolls past the hero header so it does not compete with the hero action row. Tapping it jumps straight to the Home tab via `navController.backToMain()`.

### 5. Bottom fade overlay (scroll-aware) — matches reference image
A vertical gradient that fades the bottom of the scrolling list into the page background. Visible only while `isListScrolling` (firstVisibleItemIndex > 0 or firstVisibleItemScrollOffset > 0) so the first frame does not show a stray fade band over the hero Play/Shuffle/Download pills.

## New shared component file
`LibraryChromeComponents.kt` groups `LibraryBackPill`, `LibraryHomeDockButton`, and `BottomFadeOverlay` so the four redesigned screens share one visual language.

## Files changed
- `ui/component/AppleMusicPlaylistHero.kt` — onClick wiring, layout fix, theme-aware text colors
- `ui/component/LibraryChromeComponents.kt` (new) — shared Library back pill, Home dock button, bottom fade overlay
- `ui/screens/HistoryScreen.kt` — Library back pill text + bottom fade + Home dock
- `ui/screens/playlist/AutoPlaylistScreen.kt` — FrostedHeaderPill + Library text + bottom fade + Home dock
- `ui/screens/playlist/CachePlaylistScreen.kt` — FrostedHeaderPill + Library text + bottom fade + Home dock
- `ui/screens/playlist/LocalPlaylistScreen.kt` — LiquidGlassActionPill with Library text + bottom fade + Home dock
- `res/values/strings.xml` — new `library` string

## Compatibility
No functional behavior changes — only the visual hero / chrome treatment is updated. All existing navigation, playback, shuffle, downloads, selection, search, sort, and overflow menu logic is unchanged.