### PR TITLE
fix(player,lyrics,download): remove text edge fade, fix romanisation positioning, purge corrupt downloads

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -8213,10 +8213,39 @@ class MusicService :
             val mediaItemIndex = player.currentMediaItemIndex
             val resumePosition = player.currentPosition.coerceAtLeast(0L)
 
+            // Detect "the offline download itself is corrupt" so we can purge
+            // the download cache too — otherwise the player re-reads the same
+            // corrupt bytes, fails the same way, exhausts the retry budget,
+            // and the user sees a stuck error with no way to recover without
+            // manually removing the download. The signature is a
+            // ParserException cause whose message contains "Skipping atom
+            // with length" (the MP4 container parser bailing on a length
+            // field that exceeds Int.MAX_VALUE — typical of a truncated or
+            // mid-stream-corrupted file). Any other cache-corruption
+            // signature (EOFException, "unexpected end of stream", etc.)
+            // falls back to the conservative behavior of keeping the
+            // offline download in place.
+            val isOfflineDownloadCorrupt =
+                isFullyDownloadedMedia && run {
+                    var t: Throwable? = error.cause
+                    while (t != null) {
+                        val msg = t.message
+                        if (t is ParserException &&
+                            msg != null &&
+                            msg.contains("Skipping atom with length", ignoreCase = true)
+                        ) {
+                            break
+                        }
+                        t = t.cause
+                    }
+                    t != null
+                }
+
             Timber.tag("MusicService").w(
-                "Cache corruption / truncated stream for %s (fullyCached=%b); purging caches then retrying",
+                "Cache corruption / truncated stream for %s (fullyCached=%b, downloadCorrupt=%b); purging caches then retrying",
                 currentMediaId,
                 isFullyDownloadedMedia,
+                isOfflineDownloadCorrupt,
             )
 
             playbackUrlCache.remove(currentMediaId)
@@ -8227,9 +8256,28 @@ class MusicService :
                 // Always purge the streaming/player cache.
                 runCatching { playerCache.removeResource(currentMediaId) }
                 // Keep a complete offline download in place; deleting a user's saved download
-                // to recover from a read error is surprising. Only purge partial entries.
-                if (!isFullyDownloadedMedia) {
+                // to recover from a read error is surprising. Only purge partial entries —
+                // UNLESS the download itself is the source of the corruption (a ParserException
+                // with "Skipping atom with length" against a fully-cached file), in which case
+                // keeping it would mean re-reading the same corrupt bytes on every retry until
+                // the retry budget is exhausted and the user is stuck. Purge and let the next
+                // prepare fall through to a fresh download.
+                if (!isFullyDownloadedMedia || isOfflineDownloadCorrupt) {
                     runCatching { downloadCache.removeResource(currentMediaId) }
+                    if (isOfflineDownloadCorrupt) {
+                        // Also clear any source-prefixed download cache entries
+                        // (qobuz:, tidal:, deezer:) so a fresh download is forced
+                        // from the respective source.
+                        for (sourcePrefix in listOf("qobuz:", "tidal:", "deezer:")) {
+                            runCatching {
+                                downloadCache.removeResource("$sourcePrefix$currentMediaId")
+                            }
+                        }
+                        Timber.tag("MusicService").w(
+                            "Purged corrupt offline download for %s; will re-download on next prepare",
+                            currentMediaId,
+                        )
+                    }
                 } else {
                     Timber.tag("MusicService").w(
                         "Keeping offline download for %s; corruption may require manual re-download",

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -1229,20 +1229,22 @@ fun LyricsEnhanced(
                     // [KaraokeBuild].
                     key(lyricsSessionKey, positionResetCounter, karaokeGeneration) {
                         // ── Force the translation slot to use the small phonetic style ──
-                        // The mocharealm KaraokeLineText renders the `translation` slot with
-                        // `LocalTextStyle.current` (no explicit style), while the `phonetic`
-                        // slot uses `phoneticTextStyle`. With the romanisation swap in
-                        // buildSyncedLyrics / buildLineSyncedLrcLine (translation field carries
-                        // romanisation, phonetic field carries actual translation), the
-                        // translation slot would render at the ambient bodyLarge size — much
-                        // larger than the translation below it. Pinning LocalTextStyle to the
-                        // same small phoneticTextStyle makes both rows visually consistent —
-                        // "romanisation should be small text just like translation" — and is
-                        // local to this lyrics subtree so the rest of the app is unaffected.
-                        // KaraokeLyricsView's explicit `normalLineTextStyle` /
-                        // `accompanimentLineTextStyle` / `phoneticTextStyle` parameters all
-                        // bypass LocalTextStyle, so the active karaoke line itself is not
-                        // affected.
+                        // The mocharealm KaraokeLineText / SyncedLineText renderers
+                        // render the `translation` slot with `LocalTextStyle.current`
+                        // (no explicit style), while per-syllable `phonetic` slots use
+                        // `phoneticTextStyle`. For word-synced lyrics the translation
+                        // slot carries the actual translation; for line-synced lyrics
+                        // it carries the folded romanisation + translation (see
+                        // buildLineSyncedLrcLine). In both cases the translation slot
+                        // would otherwise render at the ambient bodyLarge size — much
+                        // larger than the per-syllable phonetics above. Pinning
+                        // LocalTextStyle to the same small phoneticTextStyle keeps the
+                        // translation row visually consistent with the per-syllable
+                        // phonetic row, and is local to this lyrics subtree so the
+                        // rest of the app is unaffected. KaraokeLyricsView's explicit
+                        // `normalLineTextStyle` / `accompanimentLineTextStyle` /
+                        // `phoneticTextStyle` parameters all bypass LocalTextStyle, so
+                        // the active karaoke line itself is not affected.
                         androidx.compose.runtime.CompositionLocalProvider(
                             androidx.compose.material3.LocalTextStyle provides phoneticTextStyle,
                         ) {
@@ -1277,14 +1279,20 @@ fun LyricsEnhanced(
                                 // this view; drop it when animations are disabled (low-RAM default).
                                 useBlurEffect = lyricsLineBlur && !animationsDisabled,
                                 showTranslation = showTranslations,
-                                // Per-syllable phonetics in the KaraokeLineText renderer are drawn
-                                // ABOVE each glyph. The user wants romanisation BELOW the lyric, as
-                                // small text just like the translation, sitting between translation
-                                // and active line. We achieve that by folding romanisation into the
-                                // translation slot (see buildLineSyncedLrcLine and the word-synced
-                                // branch in buildSyncedLyrics), so per-syllable phonetics must be
-                                // turned off entirely.
-                                showPhonetic = false,
+                                // Per-syllable phonetics in the KaraokeLineText
+                                // renderer are drawn ABOVE each glyph — this is
+                                // what the user wants for word-synced lyrics
+                                // ("romanisation should also display word by
+                                // word above the active words like before").
+                                //
+                                // For line-synced lyrics the renderer uses
+                                // SyncedLineText (which has no per-syllable
+                                // phonetic slot), so this flag has no effect
+                                // there — romanisation still folds into the
+                                // translation slot below the lyric, between
+                                // the active line and the actual translation
+                                // (see buildLineSyncedLrcLine).
+                                showPhonetic = true,
                                 offset = lyricsViewportOffset,
                                 // Reduced from 36.dp → 20.dp → 8.dp. The keepAliveZone controls how
                                 // many items outside the viewport are kept composed (not
@@ -1873,34 +1881,25 @@ private fun buildSyncedLyrics(
             val lineEnd = mainSyllables.last().end
             if (lineEnd <= lineStart) return@forEachIndexed
 
-            // Romanisation for word-synced lyrics: the user wants it BELOW the lyric,
-            // between translation and the active line, as small text just like the
-            // translation. The library's KaraokeLineText renders `line.translation`
-            // (small dim text) below the karaoke canvas, and `line.phonetic` (also
-            // small) below that. We fold romanisation into the translation slot so
-            // it appears first (just below the lyric), and the actual translation
-            // follows on the next line:
-            //   LYRIC
-            //   romanisation (small)
-            //   translation (small)
-            // Per-syllable phonetics above each glyph are turned off via
-            // `showPhonetic = false` at the KaraokeLyricsView call site.
+            // Romanisation for word-synced lyrics: the user wants it ABOVE
+            // each active word — rendered as small per-syllable phonetics
+            // by the library's KaraokeLineText renderer when
+            // `showPhonetic = true` is set at the KaraokeLyricsView call
+            // site. Each syllable in [mainSyllables] already carries its
+            // phonetic text (populated by `toKaraokeSyllables(wordPhonetics)`
+            // above), so the only remaining job here is to NOT fold the
+            // romanisation into the translation slot. The translation slot
+            // is reserved for the actual translation (if any), rendered as
+            // small dim text BELOW the lyric — keeping the two slots
+            // visually distinct: per-syllable phonetic above, translation
+            // below.
             //
-            // The romanizationMap carries both built-in (provider + on-the-fly)
-            // and AI romanisation as a per-word list (one entry per non-background
-            // word, in order). Joining with spaces reconstructs the per-line string.
-            val lineRomanization =
-                romanizationMap[index]
-                    ?.filterNotNull()
-                    ?.filter { it.isNotBlank() }
-                    ?.joinToString(" ")
-                    ?.takeIf { it.isNotEmpty() }
-            val combinedTranslation =
-                when {
-                    lineRomanization == null -> translation
-                    translation.isNullOrBlank() -> lineRomanization
-                    else -> "$lineRomanization\n$translation"
-                }
+            // The romanizationMap carries both built-in (provider +
+            // on-the-fly) and AI romanisation as a per-word list (one entry
+            // per non-background word, in order). `toKaraokeSyllables`
+            // already mapped these onto the per-syllable `phonetic` field,
+            // so there is no per-line romanisation string to assemble here.
+            val lineTranslation = translation
 
             val accompanimentLines =
                 if (mainWords.isNotEmpty() && bgWords.isNotEmpty()) {
@@ -1928,7 +1927,7 @@ private fun buildSyncedLyrics(
             lines.add(
                 KaraokeLine.MainKaraokeLine(
                     syllables = mainSyllables,
-                    translation = combinedTranslation,
+                    translation = lineTranslation,
                     alignment = alignment,
                     start = lineStart,
                     end = lineEnd,
@@ -1999,13 +1998,20 @@ private fun buildLineSyncedLrcLine(
     // wants romanisation BELOW the lyric, between translation and the active line, as
     // small text just like the translation. SyncedLine has no `phonetic` field, so the
     // only path that puts romanisation below is to fold it into the translation slot:
-    //   translation = "<romanised>\n<translation>"
-    // The library's SyncedLineText renders translation as small dim text below the
-    // content; the embedded newline puts romanisation first (just below the lyric) and
-    // the actual translation second, matching the requested order:
+    //   translation = "<romanised>\n\n<translation>"
+    // The library's SyncedLineText renders translation as a single `Text` (with the
+    // ambient LocalTextStyle — pinned to phoneticTextStyle at the KaraokeLyricsView
+    // call site so it renders small). The embedded "\n\n" puts romanisation first
+    // (just below the lyric), then a blank line, then the actual translation — giving
+    // clear visual separation between the two:
     //   LYRIC
     //   romanisation (small)
+    //   <blank line>
     //   translation (small)
+    //
+    // The user explicitly requested increased spacing between romanisation and
+    // translation in line-synced lyrics; the previous single "\n" put them on
+    // consecutive lines with only the ambient line-height between them.
     if (normalizedRomanizedText == null) {
         return SyncedLine(
             content = entry.text,
@@ -2018,7 +2024,7 @@ private fun buildLineSyncedLrcLine(
     val combinedTranslation =
         when {
             translation.isNullOrBlank() -> normalizedRomanizedText
-            else -> "$normalizedRomanizedText\n$translation"
+            else -> "$normalizedRomanizedText\n\n$translation"
         }
 
     return SyncedLine(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -133,7 +133,6 @@ import moe.rukamori.archivetune.ui.menu.PlayerMenu
 import moe.rukamori.archivetune.ui.theme.PlayerBackgroundColorUtils
 import moe.rukamori.archivetune.ui.theme.PlayerSliderColors
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
-import moe.rukamori.archivetune.ui.utils.fadingEdge
 import moe.rukamori.archivetune.ui.utils.highRes
 import moe.rukamori.archivetune.utils.isLocalMediaId
 import moe.rukamori.archivetune.utils.makeTimeString
@@ -209,15 +208,16 @@ internal fun PlayerTitleText(
 internal fun PlayerTextBackdrop(
     textColor: Color,
     modifier: Modifier = Modifier,
-    edgeFadeWidth: Dp = 24.dp,
+    @Suppress("UNUSED_PARAMETER") edgeFadeWidth: Dp = 24.dp,
     content: @Composable () -> Unit,
 ) {
-    // Keep the fade on the bounded wrapper, not after basicMarquee(). The shared helper uses
-    // explicit viewport coordinates for both edges, so scrolling text fades into any backdrop
-    // instead of placing the gradient at the marquee's unbounded intrinsic width.
-    Box(
-        modifier = modifier.fadingEdge(left = edgeFadeWidth, right = edgeFadeWidth),
-    ) {
+    // The user explicitly asked to remove the player text edge fade — the
+    // gradient mask that faded scrolling marquee text into the player
+    // background at both ends. The parameter is retained so existing call
+    // sites compile unchanged, but the [fadingEdge] modifier is no longer
+    // applied. The wrapper Box is kept so the marquee measurement still has
+    // a stable bounded container (see the comment in PlayerTitleSection).
+    Box(modifier = modifier) {
         content()
     }
 }


### PR DESCRIPTION
## Summary

Follow-up fixes addressing the latest user feedback. Committed directly on `dev` per the new workflow.

### 1. Remove player text edge fade
The marquee text wrapper (`PlayerTextBackdrop` in `PlayerComponents.kt`) was applying a `fadingEdge` gradient mask that faded scrolling player text into the background at both left and right edges. Per the user request (referencing PR #164 file), the edge fade is removed entirely. The wrapper `Box` is kept so marquee measurement still has a stable bounded container; the `edgeFadeWidth` parameter is retained (suppressed) so existing call sites compile unchanged.

### 2. Romanisation positioning (word-synced vs line-synced)

**Word-synced lyrics (Enhanced style):** Romanisation now displays word-by-word ABOVE each active glyph, restoring the previous behavior the user preferred. Achieved by:
- Re-enabling `showPhonetic = true` at the `KaraokeLyricsView` call site — the library renders per-syllable phonetics ABOVE each glyph for `KaraokeLine` instances.
- NOT folding romanisation into the translation slot for word-synced lyrics. The translation slot now carries just the actual translation, keeping the two slots visually distinct: per-syllable phonetic above, translation below.

**Line-synced lyrics (LRC):** Romanisation still appears BELOW the lyric, between the active line and the actual translation, as small text. The combined translation string now uses double newline to add a blank line of separation between romanisation and translation, addressing the user request for increased spacing in line-synced lyrics.

### 3. Fix parser error: purge corrupt offline downloads

**Symptom:** Playing a fully-downloaded song throws `ParserException: Skipping atom with length > 2147483647 (unsupported)` (Code 3003). The error is shown to the user as a modal dialog with no automatic recovery.

**Root cause:** When `isFullyDownloadedMedia` is true (the song is fully cached as an offline download) AND the cause is a `ParserException` with the Skipping atom with length signature (truncated or mid-stream-corrupted MP4 container), the cache-corruption recovery path previously KEPT the offline download in place (to avoid surprising users by deleting their saved downloads). The player would then re-prepare, re-read the same corrupt bytes, fail the same way, exhaust the 3-attempt retry budget, and surface the error to the user.

**Fix:** When `isFullyDownloadedMedia` is true AND the cause chain contains a `ParserException` with the Skipping atom with length message, also purge `downloadCache` entries including source-prefixed keys (qobuz, tidal, deezer) so a fresh download is forced on the next `prepare()`. Other cache corruption signatures (EOFException, unexpected end of stream, etc.) keep the conservative behavior of preserving offline downloads.

## Files changed
- `ui/player/PlayerComponents.kt` — remove `fadingEdge` from `PlayerTextBackdrop`; drop unused import
- `ui/component/LyricsEnhanced.kt` — `showPhonetic = true` at call site; word-synced branch no longer folds romanisation into translation slot; line-synced branch uses double newline for more spacing; updated comments
- `playback/MusicService.kt` — detect corrupt offline download (ParserException with Skipping atom with length); purge downloadCache including source-prefixed keys

## Workflow change
Per user request, all future PRs will commit directly on `dev` and open PR `dev -> main` instead of using feature branches.