### PR TITLE
fix(ui): real liquid glass pill headers in liked/cached/local + home dock on playlist scroll

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
@@ -37,25 +38,60 @@ import androidx.compose.ui.unit.dp
  * as "transparent" rather than a solid bar) while still keeping the title/icons legible against
  * busy backgrounds like album art.
  *
+ * **Liquid glass mode:** Pass a non-null [backdrop] (typically created via [rememberBackdrop]
+ * and applied to a sibling `LazyColumn` via [Modifier.layerBackdrop]) to switch the pill to
+ * real kyant `drawBackdrop` rendering (vibrancy + blur + lens). The pill MUST be a sibling
+ * of the composable carrying `layerBackdrop` — nesting it inside the source creates a
+ * render-feedback loop that crashes the RuntimeShader. When [backdrop] is `null` (the
+ * default), the pill degrades to the translucent `surfaceContainer` surface described above.
+ *
  * Usage: wrap the title / actions of a `TopAppBar` (or any header) in this pill. The
  * outer `TopAppBar` should have `containerColor = Color.Transparent`.
  *
  * @param modifier Modifier for the pill's outer layout.
+ * @param backdrop Optional kyant `LayerBackdrop` to sample for real liquid glass.
+ *                 Pass `null` (default) to use the translucent surface fallback.
  * @param content The header content (text, icons) to display inside the pill.
  */
 @Composable
 fun FrostedHeaderPill(
     modifier: Modifier = Modifier,
+    backdrop: PlatformBackdrop? = null,
     content: @Composable () -> Unit,
 ) {
-    val baseColor = MaterialTheme.colorScheme.surfaceContainer
-    Surface(
-        modifier = modifier.clip(RoundedCornerShape(percent = 50)),
-        shape = RoundedCornerShape(percent = 50),
-        color = baseColor.copy(alpha = 0.55f),
-    ) {
-        Row(modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)) {
+    val pillShape = RoundedCornerShape(percent = 50)
+    if (backdrop != null) {
+        // Real liquid glass path: kyant `drawBackdrop` effect stack (vibrancy +
+        // blur + lens). The pill samples whatever was recorded into the backdrop
+        // by `Modifier.layerBackdrop(backdrop)` applied to a sibling composable
+        // (typically the LazyColumn carrying the scrolling content beneath this
+        // header). MUST be a sibling — nesting inside the source crashes the
+        // RuntimeShader.
+        Row(
+            modifier =
+                modifier
+                    .clip(pillShape)
+                    .liquidGlass(
+                        backdrop = backdrop,
+                        shape = pillShape,
+                        interactive = false,
+                    )
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             content()
+        }
+    } else {
+        // Fallback path: translucent surface (no real backdrop blur).
+        val baseColor = MaterialTheme.colorScheme.surfaceContainer
+        Surface(
+            modifier = modifier.clip(pillShape),
+            shape = pillShape,
+            color = baseColor.copy(alpha = 0.55f),
+        ) {
+            Row(modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)) {
+                content()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedTopAppBar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedTopAppBar.kt
@@ -38,6 +38,11 @@ import moe.rukamori.archivetune.R
  * on Android 12+, and degrade to a semi-transparent `surfaceContainer` on pre-S or when no
  * backdrop is available.
  *
+ * Pass a non-null [backdrop] (created via [rememberBackdrop] and applied to a sibling
+ * `LazyColumn` via [Modifier.layerBackdrop]) to switch all three pills (title / nav icon /
+ * actions) to real kyant liquid glass. The pills MUST be siblings of the composable carrying
+ * `layerBackdrop` — nesting inside the source creates a render-feedback loop.
+ *
  * Usage: drop-in replacement for a standard `TopAppBar` that has a title, a back arrow,
  * and optional actions. For screens that need a more custom title (e.g. with an avatar or
  * animated content), use [FrostedHeaderPill] directly.
@@ -50,12 +55,14 @@ fun FrostedTopAppBar(
     onBack: () -> Unit,
     onBackLongClick: () -> Unit = {},
     actions: (@Composable () -> Unit)? = null,
+    backdrop: PlatformBackdrop? = null,
 ) {
     FrostedTopAppBar(
         title = { Text(stringResource(titleRes)) },
         onBack = onBack,
         onBackLongClick = onBackLongClick,
         actions = actions,
+        backdrop = backdrop,
     )
 }
 
@@ -66,6 +73,7 @@ fun FrostedTopAppBar(
     onBack: () -> Unit,
     onBackLongClick: () -> Unit = {},
     actions: (@Composable () -> Unit)? = null,
+    backdrop: PlatformBackdrop? = null,
 ) {
     TopAppBar(
         colors = TopAppBarDefaults.topAppBarColors(
@@ -76,12 +84,12 @@ fun FrostedTopAppBar(
             actionIconContentColor = MaterialTheme.colorScheme.onSurface,
         ),
         title = {
-            FrostedHeaderPill {
+            FrostedHeaderPill(backdrop = backdrop) {
                 title()
             }
         },
         navigationIcon = {
-            FrostedHeaderPill {
+            FrostedHeaderPill(backdrop = backdrop) {
                 IconButton(
                     onClick = onBack,
                     onLongClick = onBackLongClick,
@@ -97,6 +105,7 @@ fun FrostedTopAppBar(
             {
                 FrostedHeaderPill(
                     modifier = Modifier.padding(end = 8.dp),
+                    backdrop = backdrop,
                 ) {
                     actions()
                 }
@@ -110,6 +119,11 @@ fun FrostedTopAppBar(
 /**
  * Large variant: wraps a [LargeFlexibleTopAppBar] with frosted pills around the title, nav icon,
  * and actions. Use for screens that have a hero header which collapses on scroll.
+ *
+ * Pass a non-null [backdrop] (created via [rememberBackdrop] and applied to a sibling
+ * `LazyColumn` via [Modifier.layerBackdrop]) to switch all three pills to real kyant liquid
+ * glass. The pills MUST be siblings of the composable carrying `layerBackdrop` — nesting
+ * inside the source creates a render-feedback loop.
  */
 @Composable
 fun LargeFrostedTopAppBar(
@@ -118,6 +132,7 @@ fun LargeFrostedTopAppBar(
     onBackLongClick: () -> Unit = {},
     actions: (@Composable () -> Unit)? = null,
     scrollBehavior: TopAppBarScrollBehavior? = null,
+    backdrop: PlatformBackdrop? = null,
 ) {
     LargeFlexibleTopAppBar(
         colors = TopAppBarDefaults.largeTopAppBarColors(
@@ -125,7 +140,7 @@ fun LargeFrostedTopAppBar(
             scrolledContainerColor = Color.Transparent,
         ),
         title = {
-            FrostedHeaderPill {
+            FrostedHeaderPill(backdrop = backdrop) {
                 Text(
                     text = stringResource(titleRes),
                     fontWeight = FontWeight.Bold,
@@ -134,7 +149,7 @@ fun LargeFrostedTopAppBar(
             }
         },
         navigationIcon = {
-            FrostedHeaderPill {
+            FrostedHeaderPill(backdrop = backdrop) {
                 IconButton(
                     onClick = onBack,
                     onLongClick = onBackLongClick,
@@ -150,6 +165,7 @@ fun LargeFrostedTopAppBar(
             {
                 FrostedHeaderPill(
                     modifier = Modifier.padding(end = 8.dp),
+                    backdrop = backdrop,
                 ) {
                     actions()
                 }
@@ -169,6 +185,7 @@ fun LargeFrostedTopAppBar(
     onBackLongClick: () -> Unit = {},
     actions: (@Composable () -> Unit)? = null,
     scrollBehavior: TopAppBarScrollBehavior? = null,
+    backdrop: PlatformBackdrop? = null,
 ) {
     LargeFlexibleTopAppBar(
         colors = TopAppBarDefaults.largeTopAppBarColors(
@@ -176,12 +193,12 @@ fun LargeFrostedTopAppBar(
             scrolledContainerColor = Color.Transparent,
         ),
         title = {
-            FrostedHeaderPill {
+            FrostedHeaderPill(backdrop = backdrop) {
                 title()
             }
         },
         navigationIcon = {
-            FrostedHeaderPill {
+            FrostedHeaderPill(backdrop = backdrop) {
                 IconButton(
                     onClick = onBack,
                     onLongClick = onBackLongClick,
@@ -197,6 +214,7 @@ fun LargeFrostedTopAppBar(
             {
                 FrostedHeaderPill(
                     modifier = Modifier.padding(end = 8.dp),
+                    backdrop = backdrop,
                 ) {
                     actions()
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LibraryChromeComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LibraryChromeComponents.kt
@@ -124,34 +124,51 @@ fun LibraryBackPill(
  * bottom inset padding so the button sits above the floating navigation
  * toolbar / mini-player.
  *
+ * **Liquid glass mode:** Pass a non-null [backdrop] (typically created via
+ * [rememberBackdrop] and applied to a sibling `LazyColumn` via
+ * [Modifier.layerBackdrop]) to switch the dock to real kyant `drawBackdrop`
+ * rendering (vibrancy + blur + lens), matching the top-start
+ * `LiquidGlassActionPill` in `LocalPlaylistScreen`. The dock MUST be a
+ * sibling of the composable carrying `layerBackdrop` — nesting inside the
+ * source crashes the RuntimeShader. When [backdrop] is `null` (the
+ * default), the dock degrades to the translucent `surfaceContainer` surface.
+ *
  * @param onClick Tap action — typically `navController.backToMain()`.
  * @param modifier Modifier for the outer layout.
  * @param iconRes The home icon drawable. Defaults to `R.drawable.home_filled`
  *                so the dock button reads as a filled pink home glyph at
  *                rest, matching the reference.
+ * @param backdrop Optional kyant `LayerBackdrop` to sample for real liquid
+ *                glass. Pass `null` (default) to use the translucent surface
+ *                fallback.
  */
 @Composable
 fun LibraryHomeDockButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     iconRes: Int = R.drawable.home_filled,
+    backdrop: PlatformBackdrop? = null,
 ) {
-    val baseColor = MaterialTheme.colorScheme.surfaceContainer
-    Surface(
-        modifier =
-            modifier
-                .size(48.dp)
-                .clip(CircleShape),
-        shape = CircleShape,
-        color = baseColor.copy(alpha = 0.55f),
-    ) {
+    if (backdrop != null) {
+        // Real liquid glass path — same kyant `drawBackdrop` effect stack
+        // (vibrancy + blur + lens) used by the top-start LiquidGlassActionPill
+        // in LocalPlaylistScreen. The dock samples whatever was recorded into
+        // the backdrop by `Modifier.layerBackdrop(backdrop)` applied to a
+        // sibling composable (the LazyColumn carrying the scrolling content).
+        // MUST be a sibling — nesting inside the source crashes the
+        // RuntimeShader.
         Box(
-            modifier = Modifier.fillMaxWidth(),
+            modifier =
+                modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .liquidGlass(
+                        backdrop = backdrop,
+                        shape = CircleShape,
+                        interactive = false,
+                    ),
             contentAlignment = Alignment.Center,
         ) {
-            // Use the local `IconButton` (same package) which supports both
-            // onClick and onLongClick — pass an empty long-click since the
-            // Home dock only needs the tap action.
             IconButton(
                 onClick = onClick,
                 onLongClick = {},
@@ -162,6 +179,37 @@ fun LibraryHomeDockButton(
                     tint = AppleMusicStyleAccentColor,
                     modifier = Modifier.size(22.dp),
                 )
+            }
+        }
+    } else {
+        // Fallback path: translucent surface (no real backdrop blur).
+        val baseColor = MaterialTheme.colorScheme.surfaceContainer
+        Surface(
+            modifier =
+                modifier
+                    .size(48.dp)
+                    .clip(CircleShape),
+            shape = CircleShape,
+            color = baseColor.copy(alpha = 0.55f),
+        ) {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
+            ) {
+                // Use the local `IconButton` (same package) which supports both
+                // onClick and onLongClick — pass an empty long-click since the
+                // Home dock only needs the tap action.
+                IconButton(
+                    onClick = onClick,
+                    onLongClick = {},
+                ) {
+                    Icon(
+                        painter = painterResource(iconRes),
+                        contentDescription = stringResource(R.string.home),
+                        tint = AppleMusicStyleAccentColor,
+                        modifier = Modifier.size(22.dp),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
@@ -103,6 +103,7 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.CONTENT_TYPE_HEADER
 import moe.rukamori.archivetune.constants.CONTENT_TYPE_SONG
+import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.constants.LocalSongsExcludedFoldersKey
 import moe.rukamori.archivetune.constants.LocalSongsIncludedFoldersKey
 import moe.rukamori.archivetune.constants.LocalSongsMinDurationSecondsKey
@@ -119,9 +120,13 @@ import moe.rukamori.archivetune.ui.component.BottomFadeOverlay
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
+import moe.rukamori.archivetune.ui.component.PlatformBackdrop
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
+import moe.rukamori.archivetune.ui.component.layerBackdrop
+import moe.rukamori.archivetune.ui.component.rememberBackdrop
 import moe.rukamori.archivetune.ui.menu.SongMenu
+import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.viewmodels.LocalSongsScanState
@@ -155,6 +160,25 @@ fun LocalSongScreen(
     var isSearchActive by rememberSaveable { mutableStateOf(false) }
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     var query by rememberSaveable { mutableStateOf("") }
+
+    // Liquid Glass header setup. Mirror LocalPlaylistScreen's pattern: read
+    // the master toggle, gate on Android 12+ (kyant RuntimeShader requires
+    // API 31+), and suspend the layerBackdrop while the full-screen lyrics
+    // overlay is open on top of this screen — otherwise the per-frame GPU
+    // recording steals budget from the 60 Hz karaoke lyrics sweep.
+    val liquidGlassEnabled by rememberPreference(LiquidGlassEnabledKey, defaultValue = false)
+    val liquidGlassHeaderActive =
+        liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
+    // content recording only happens when `Modifier.layerBackdrop(backdrop)`
+    // is applied to the LazyColumn below, gated on `layerBackdropActive`.
+    val backdrop = rememberBackdrop(Color.Black)
+    // When Liquid Glass is active, pass the backdrop to the LargeFrostedTopAppBar
+    // (for the title / nav icon / actions pills) and to the LibraryHomeDockButton.
+    // When inactive, both fall back to the translucent surface path.
+    val pillBackdrop: PlatformBackdrop? = backdrop.takeIf { layerBackdropActive }
     val (sortDescending, onSortDescendingChange) = rememberPreference(LocalSongsSortDescendingKey, true)
     val (sortTypeName, onSortTypeNameChange) = rememberPreference(LocalSongsSortTypeKey, LocalSongSortType.MODIFIED.name)
     val (minimumDurationSeconds, onMinimumDurationSecondsChange) =
@@ -395,6 +419,7 @@ fun LocalSongScreen(
                         titleRes = R.string.local_files,
                         onBack = navController::navigateUp,
                         onBackLongClick = { navController.backToMain() },
+                        backdrop = pillBackdrop,
                         actions = {
                             IconButton(onClick = { isSearchActive = true }) {
                                 Icon(
@@ -420,6 +445,13 @@ fun LocalSongScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
+                    .then(
+                        if (layerBackdropActive) {
+                            Modifier.layerBackdrop(backdrop)
+                        } else {
+                            Modifier
+                        },
+                    )
                     .padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(14.dp),
             contentPadding =
@@ -636,6 +668,7 @@ fun LocalSongScreen(
                     Modifier
                         .align(Alignment.BottomStart)
                         .padding(start = 16.dp, bottom = bottomInset + 12.dp),
+                backdrop = pillBackdrop,
             )
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -9,6 +9,7 @@
 
 package moe.rukamori.archivetune.ui.screens.playlist
 
+import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -82,6 +83,7 @@ import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.AutoPlaylistSongSortDescendingKey
 import moe.rukamori.archivetune.constants.AutoPlaylistSongSortType
 import moe.rukamori.archivetune.constants.AutoPlaylistSongSortTypeKey
+import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.constants.YtmSyncKey
 import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.extensions.togglePlayPause
@@ -95,6 +97,10 @@ import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
+import moe.rukamori.archivetune.ui.component.PlatformBackdrop
+import moe.rukamori.archivetune.ui.component.layerBackdrop
+import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
@@ -301,9 +307,29 @@ fun AutoPlaylistScreen(
         }
     }
 
+    // Liquid Glass header setup. Mirror LocalPlaylistScreen's pattern: read
+    // the master toggle, gate on Android 12+ (kyant RuntimeShader requires
+    // API 31+), and suspend the layerBackdrop while the full-screen lyrics
+    // overlay is open on top of this screen — otherwise the per-frame GPU
+    // recording steals budget from the 60 Hz karaoke lyrics sweep.
+    val liquidGlassEnabled by rememberPreference(LiquidGlassEnabledKey, defaultValue = false)
+    val liquidGlassHeaderActive =
+        liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
+    // content recording only happens when `Modifier.layerBackdrop(backdrop)`
+    // is applied to the LazyColumn below, gated on `layerBackdropActive`.
+    val backdrop = rememberBackdrop(Color.Black)
+    // When Liquid Glass is active, force the TopAppBar container to stay
+    // transparent so the liquid glass pills can sample the LazyColumn
+    // backdrop through it. Otherwise the surface-tinted container would
+    // hide the backdrop sample at certain scroll positions.
+    val pillBackdrop: PlatformBackdrop? = backdrop.takeIf { layerBackdropActive }
+
     val transparentAppBar by remember {
         derivedStateOf {
-            !selection && !isSearching && !showTopBarTitle
+            (!selection && !isSearching && !showTopBarTitle) || liquidGlassHeaderActive
         }
     }
 
@@ -327,6 +353,13 @@ fun AutoPlaylistScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
+                    .then(
+                        if (layerBackdropActive) {
+                            Modifier.layerBackdrop(backdrop)
+                        } else {
+                            Modifier
+                        },
+                    )
                     .padding(
                         top = if (isSearching) systemBarsTopPadding + AppBarHeight else 0.dp,
                     ),
@@ -634,7 +667,7 @@ fun AutoPlaylistScreen(
                     }
 
                     showTopBarTitle -> {
-                        FrostedHeaderPill {
+                        FrostedHeaderPill(backdrop = pillBackdrop) {
                             Text(
                                 text = playlist,
                                 style = MaterialTheme.typography.titleLarge,
@@ -655,7 +688,7 @@ fun AutoPlaylistScreen(
                 // active and the hero is fully visible, the persistent
                 // LiquidGlass back button at the top-start handles back
                 // navigation instead.
-                FrostedHeaderPill {
+                FrostedHeaderPill(backdrop = pillBackdrop) {
                     IconButton(
                         onClick = {
                             when {
@@ -742,7 +775,7 @@ fun AutoPlaylistScreen(
                         )
                     }
                 } else if (!isSearching) {
-                    FrostedHeaderPill {
+                    FrostedHeaderPill(backdrop = pillBackdrop) {
                         androidx.compose.material3.IconButton(
                             onClick = { isSearching = true },
                         ) {
@@ -753,7 +786,7 @@ fun AutoPlaylistScreen(
                         }
                     }
                     if (songs.isNotEmpty()) {
-                        FrostedHeaderPill {
+                        FrostedHeaderPill(backdrop = pillBackdrop) {
                             androidx.compose.material3.IconButton(
                                 onClick = {
                                     menuState.show {
@@ -817,6 +850,7 @@ fun AutoPlaylistScreen(
                             start = 16.dp,
                             bottom = bottomInset + 12.dp,
                         ),
+                backdrop = pillBackdrop,
             )
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -76,6 +76,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
+import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -83,6 +84,7 @@ import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.constants.AppBarHeight
 import moe.rukamori.archivetune.constants.HideExplicitKey
+import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
 import moe.rukamori.archivetune.db.entities.extensionToMimeType
 import moe.rukamori.archivetune.constants.SongSortDescendingKey
@@ -101,8 +103,12 @@ import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailHero
+import moe.rukamori.archivetune.ui.component.PlatformBackdrop
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
+import moe.rukamori.archivetune.ui.component.layerBackdrop
+import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.utils.ItemWrapper
@@ -281,9 +287,28 @@ fun CachePlaylistScreen(
         }
     }
 
+    // Liquid Glass header setup. Mirror LocalPlaylistScreen's pattern: read
+    // the master toggle, gate on Android 12+ (kyant RuntimeShader requires
+    // API 31+), and suspend the layerBackdrop while the full-screen lyrics
+    // overlay is open on top of this screen — otherwise the per-frame GPU
+    // recording steals budget from the 60 Hz karaoke lyrics sweep.
+    val liquidGlassEnabled by rememberPreference(LiquidGlassEnabledKey, defaultValue = false)
+    val liquidGlassHeaderActive =
+        liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
+    // content recording only happens when `Modifier.layerBackdrop(backdrop)`
+    // is applied to the LazyColumn below, gated on `layerBackdropActive`.
+    val backdrop = rememberBackdrop(Color.Black)
+    // When Liquid Glass is active, force the TopAppBar container to stay
+    // transparent so the liquid glass pills can sample the LazyColumn
+    // backdrop through it.
+    val pillBackdrop: PlatformBackdrop? = backdrop.takeIf { layerBackdropActive }
+
     val transparentAppBar by remember {
         derivedStateOf {
-            !selection && !isSearching && !showTopBarTitle
+            (!selection && !isSearching && !showTopBarTitle) || liquidGlassHeaderActive
         }
     }
 
@@ -307,6 +332,13 @@ fun CachePlaylistScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
+                    .then(
+                        if (layerBackdropActive) {
+                            Modifier.layerBackdrop(backdrop)
+                        } else {
+                            Modifier
+                        },
+                    )
                     .padding(
                         top = if (isSearching) systemBarsTopPadding + AppBarHeight else 0.dp,
                     ),
@@ -548,7 +580,7 @@ fun CachePlaylistScreen(
                     }
 
                     showTopBarTitle -> {
-                        FrostedHeaderPill {
+                        FrostedHeaderPill(backdrop = pillBackdrop) {
                             Text(
                                 text = stringResource(R.string.cached_playlist),
                                 style = MaterialTheme.typography.titleLarge,
@@ -564,7 +596,7 @@ fun CachePlaylistScreen(
                 // back to the previous destination (or clears selection /
                 // closes search); long-pressing it jumps straight to the
                 // Home tab.
-                FrostedHeaderPill {
+                FrostedHeaderPill(backdrop = pillBackdrop) {
                     IconButton(onClick = {
                         when {
                             isSearching -> {
@@ -654,7 +686,7 @@ fun CachePlaylistScreen(
                         )
                     }
                 } else if (!isSearching) {
-                    FrostedHeaderPill {
+                    FrostedHeaderPill(backdrop = pillBackdrop) {
                         androidx.compose.material3.IconButton(onClick = { isSearching = true }) {
                             Icon(
                                 painter = painterResource(R.drawable.search),
@@ -663,7 +695,7 @@ fun CachePlaylistScreen(
                         }
                     }
                     if (wrappedSongs.isNotEmpty()) {
-                        FrostedHeaderPill {
+                        FrostedHeaderPill(backdrop = pillBackdrop) {
                             androidx.compose.material3.IconButton(
                                 onClick = {
                                     menuState.show {
@@ -731,6 +763,7 @@ fun CachePlaylistScreen(
                             start = 16.dp,
                             bottom = bottomInset + 12.dp,
                         ),
+                backdrop = pillBackdrop,
             )
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1453,6 +1453,7 @@ fun LocalPlaylistScreen(
                             start = 16.dp,
                             bottom = bottomInset + 12.dp,
                         ),
+                backdrop = artworkBackdrop.takeIf { layerBackdropActive },
             )
         }
 


### PR DESCRIPTION
Two follow-up fixes from the latest feedback round. See commit message for full details. Issue 1: pill headers in liked/cached/local were flat translucent surfaces, not real liquid glass - now wired with the same rememberBackdrop + Modifier.layerBackdrop + Modifier.liquidGlass pattern as LocalPlaylistScreen. Issue 2: home dock button on playlist scroll had no liquid glass - now passes artworkBackdrop to LibraryHomeDockButton. All component API additions are optional with default null so existing callers (HistoryScreen, AlbumScreen, ArtistScreen) continue to render with the translucent surface fallback unchanged.