### PR TITLE
fix(ui): docked nav row layout (Home pill LEFT + MiniPlayer CENTER + Search pill RIGHT)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -292,6 +292,7 @@ import moe.rukamori.archivetune.ui.component.BottomSheetPage
 import moe.rukamori.archivetune.ui.component.COLLAPSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.DISMISSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.EXPANDED_ANCHOR
+import moe.rukamori.archivetune.ui.component.DockedNavPillButton
 import moe.rukamori.archivetune.ui.component.FloatingNavigationToolbar
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyleKey
@@ -321,6 +322,8 @@ import moe.rukamori.archivetune.ui.component.rememberBottomSheetState
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerTheme
 import moe.rukamori.archivetune.ui.menu.YouTubeSongMenu
 import moe.rukamori.archivetune.ui.player.BottomSheetPlayer
+import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDockedState
+import moe.rukamori.archivetune.ui.player.MiniPlayerDockedState
 import moe.rukamori.archivetune.ui.player.ProvideVideoFullscreenState
 import moe.rukamori.archivetune.ui.screens.LOGIN_URL_ARGUMENT
 import moe.rukamori.archivetune.ui.screens.LoginScreen
@@ -2024,6 +2027,16 @@ class MainActivity : ComponentActivity() {
                             }
                         }
 
+                    // Hoisted shared state so the playlist-style screens (inside the
+                    // Scaffold's content slot) can WRITE isListScrolling = true when
+                    // the user scrolls past the hero header, AND the Scaffold's
+                    // bottomBar slot (a SIBLING subtree) can READ the same flag to
+                    // swap the full FloatingNavigationToolbar for a docked
+                    // [Home pill LEFT] + [MiniPlayer CENTER] + [Search pill RIGHT]
+                    // layout. The previous CompositionLocal-of-Boolean pattern did
+                    // NOT propagate across the content/bottomBar slot boundary.
+                    val miniPlayerDockedState = remember { MiniPlayerDockedState() }
+
                     CompositionLocalProvider(
                         LocalHapticFeedback provides customHaptic,
                         LocalAnimationsDisabled provides disableAnimations,
@@ -2043,7 +2056,7 @@ class MainActivity : ComponentActivity() {
                         LocalLiquidGlassBackdrop provides liquidGlassBackdrop,
                         moe.rukamori.archivetune.ui.player.LocalIsInPipMode provides isInPictureInPictureModeState,
                         moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen provides isPlayerLyricsFullScreen,
-                        moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked provides false,
+                        moe.rukamori.archivetune.ui.player.LocalMiniPlayerDockedState provides miniPlayerDockedState,
                     ) {
                         Row {
                             AnimatedVisibility(
@@ -2741,6 +2754,21 @@ class MainActivity : ComponentActivity() {
                                                 !isFloatingNavBar &&
                                                 playerBottomSheetState.isCollapsed
 
+                                        // The docked state is hoisted above the Scaffold so
+                                        // both the content slot (where playlist screens
+                                        // WRITE to it via LaunchedEffect) and this bottomBar
+                                        // slot (which READS from it) share the same
+                                        // instance. When docked, we hide the full
+                                        // FloatingNavigationToolbar and render a docked
+                                        // Row containing [Home pill LEFT] + [Spacer for
+                                        // MiniPlayer CENTER] + [Search pill RIGHT],
+                                        // matching the SimpMusic reference screenshot.
+                                        val isMiniPlayerDocked =
+                                            miniPlayerDockedState.isDocked &&
+                                                shouldShowNavigationBar &&
+                                                !useRail &&
+                                                playerBottomSheetState.isCollapsed
+
                                         ProvideVideoFullscreenState {
                                             BottomSheetPlayer(
                                                 state = playerBottomSheetState,
@@ -2788,36 +2816,80 @@ class MainActivity : ComponentActivity() {
                                                         }
                                                     },
                                         ) {
-                                            FloatingNavigationToolbar(
-                                                items = navigationItems,
-                                                pureBlack = pureBlack,
-                                                isPairedWithMiniPlayer = areBottomBarsPaired,
-                                                style = navigationBarStyle,
-                                                frostedBlur = navigationBarFrostedBlur,
-                                                tintFrostedBlur = navigationBarTintFrostedBlur,
-                                                frostedBackdrop = navBarFrostedBackdrop,
-                                                liquidGlass = liquidGlassEnabled && liquidGlassNavBarEnabled,
-                                                liquidGlassBackdrop = liquidGlassBackdrop,
-                                                modifier =
-                                                    Modifier
-                                                        .align(Alignment.BottomCenter)
-                                                        .padding(
-                                                            start = navBarHorizontalPadding,
-                                                            end = navBarHorizontalPadding,
-                                                            bottom = bottomInset + floatingBarsBottomPadding,
-                                                        ).height(navVisibleHeight),
-                                                isSelected = { screen ->
-                                                    navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } ==
-                                                        true
-                                                },
-                                                onItemClick = { screen, isSelected ->
-                                                    handlePrimaryNavigationClick(screen, isSelected)
-                                                },
-                                                onSearchItemDoubleClick = {
-                                                    searchSource = SearchSource.ONLINE
-                                                    openSearch()
-                                                },
-                                            )
+                                            if (isMiniPlayerDocked) {
+                                                // Docked Row: Home pill LEFT + (Spacer for
+                                                // MiniPlayer CENTER) + Search pill RIGHT.
+                                                // The MiniPlayer itself is rendered by
+                                                // BottomSheetPlayer's collapsedContent above
+                                                // and visually narrows its width via its own
+                                                // docked logic (horizontal padding) so it
+                                                // sits between these two pills.
+                                                Row(
+                                                    modifier =
+                                                        Modifier
+                                                            .align(Alignment.BottomCenter)
+                                                            .fillMaxWidth()
+                                                            .padding(
+                                                                start = navBarHorizontalPadding,
+                                                                end = navBarHorizontalPadding,
+                                                                bottom = bottomInset + floatingBarsBottomPadding,
+                                                            ).height(navVisibleHeight),
+                                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                ) {
+                                                    DockedNavPillButton(
+                                                        iconRes = Screens.Home.iconIdActive,
+                                                        contentDescription = stringResource(R.string.home),
+                                                        onClick = {
+                                                            handlePrimaryNavigationClick(Screens.Home, false)
+                                                        },
+                                                        liquidGlassBackdrop = liquidGlassBackdrop,
+                                                        liquidGlassEnabled = liquidGlassEnabled && liquidGlassNavBarEnabled,
+                                                        pureBlack = pureBlack,
+                                                    )
+                                                    DockedNavPillButton(
+                                                        iconRes = Screens.Search.iconIdActive,
+                                                        contentDescription = stringResource(R.string.search),
+                                                        onClick = {
+                                                            handlePrimaryNavigationClick(Screens.Search, false)
+                                                        },
+                                                        liquidGlassBackdrop = liquidGlassBackdrop,
+                                                        liquidGlassEnabled = liquidGlassEnabled && liquidGlassNavBarEnabled,
+                                                        pureBlack = pureBlack,
+                                                    )
+                                                }
+                                            } else {
+                                                FloatingNavigationToolbar(
+                                                    items = navigationItems,
+                                                    pureBlack = pureBlack,
+                                                    isPairedWithMiniPlayer = areBottomBarsPaired,
+                                                    style = navigationBarStyle,
+                                                    frostedBlur = navigationBarFrostedBlur,
+                                                    tintFrostedBlur = navigationBarTintFrostedBlur,
+                                                    frostedBackdrop = navBarFrostedBackdrop,
+                                                    liquidGlass = liquidGlassEnabled && liquidGlassNavBarEnabled,
+                                                    liquidGlassBackdrop = liquidGlassBackdrop,
+                                                    modifier =
+                                                        Modifier
+                                                            .align(Alignment.BottomCenter)
+                                                            .padding(
+                                                                start = navBarHorizontalPadding,
+                                                                end = navBarHorizontalPadding,
+                                                                bottom = bottomInset + floatingBarsBottomPadding,
+                                                            ).height(navVisibleHeight),
+                                                    isSelected = { screen ->
+                                                        navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } ==
+                                                            true
+                                                    },
+                                                    onItemClick = { screen, isSelected ->
+                                                        handlePrimaryNavigationClick(screen, isSelected)
+                                                    },
+                                                    onSearchItemDoubleClick = {
+                                                        searchSource = SearchSource.ONLINE
+                                                        openSearch()
+                                                    },
+                                                )
+                                            }
                                         }
                                     }
                                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
@@ -276,3 +276,70 @@ fun LiquidGlassIconButton(
         }
     }
 }
+
+/**
+ * Circular docked-navigation pill button used in the docked Row layout
+ * (Home pill LEFT + MiniPlayer CENTER + Search pill RIGHT) that replaces
+ * the full FloatingNavigationToolbar when a playlist-style screen reports
+ * isListScrolling=true. Renders as a 48dp circular liquid-glass surface
+ * with the supplied [iconRes] (active icon variant) when liquid glass is
+ * available; falls back to a plain [Surface] with the same shape when
+ * Android < 12 / liquid-glass master toggle is off so the pill is still
+ * visible and tappable.
+ *
+ * @param iconRes Drawable resource ID for the icon (e.g. R.drawable.home_filled).
+ * @param contentDescription Accessibility label.
+ * @param onClick Click handler — caller wires this to the appropriate
+ *   navigation callback (e.g. handlePrimaryNavigationClick).
+ * @param liquidGlassBackdrop The shared [LayerBackdrop] used by all liquid
+ *   glass surfaces in this composition. Null when liquid glass is disabled.
+ * @param liquidGlassEnabled Master toggle AND per-surface (nav-bar) toggle.
+ * @param pureBlack Whether pure-black dark mode is active — used to pick
+ *   the fallback Surface tint.
+ */
+@Composable
+fun DockedNavPillButton(
+    iconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit,
+    liquidGlassBackdrop: LayerBackdrop?,
+    liquidGlassEnabled: Boolean,
+    pureBlack: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val isPreS = android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S
+    val canLiquidGlass = liquidGlassEnabled && liquidGlassBackdrop != null && !isPreS
+    val pillSize = 48.dp
+    if (canLiquidGlass && liquidGlassBackdrop != null) {
+        LiquidGlassIconButton(
+            backdrop = liquidGlassBackdrop,
+            painter = androidx.compose.ui.res.painterResource(iconRes),
+            contentDescription = contentDescription,
+            onClick = onClick,
+            modifier = modifier.size(pillSize),
+            tint = Color.White,
+        )
+    } else {
+        // Fallback styling: dark circular Surface with white icon. Matches
+        // the floating nav bar's pure-black surface variant so the pill
+        // remains visible even when liquid glass is unavailable.
+        androidx.compose.material3.Surface(
+            modifier = modifier.size(pillSize),
+            shape = CircleShape,
+            color = if (pureBlack) Color.Black.copy(alpha = 0.55f) else androidx.compose.material3.MaterialTheme.colorScheme.surfaceContainer,
+            tonalElevation = 0.dp,
+            shadowElevation = 4.dp,
+        ) {
+            androidx.compose.material3.IconButton(
+                onClick = onClick,
+                modifier = Modifier.size(pillSize),
+            ) {
+                Icon(
+                    painter = androidx.compose.ui.res.painterResource(iconRes),
+                    contentDescription = contentDescription,
+                    tint = Color.White,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/InlineVideoPlayer.kt
@@ -219,22 +219,35 @@ val LocalIsInPipMode = compositionLocalOf { false }
 val LocalPlayerLyricsFullScreen = compositionLocalOf { false }
 
 /**
- * Tracks whether the current screen wants the [MiniPlayer] to shrink into
- * a compact "docked" form factor and position itself at the bottom-start
- * corner, immediately to the right of the floating Home dock button.
+ * Shared state holder for whether the current screen wants the [MiniPlayer]
+ * to shrink into a compact "docked" form factor and the navigation bar to
+ * collapse to a singular Home pill while a Search pill is shown on the right.
  *
  * Set to `true` by the playlist-style screens (Liked / Cached / Local
  * storage / Local / Online / Spotify playlist) when the user has scrolled
- * past the hero header. The MiniPlayer reads this and applies a
- * `graphicsLayer` scale + translationX transformation so it visually
- * shrinks and slides to the bottom-start corner — matching the
- * SimpMusic behavior the user referenced (mini player "shrinks
- * automatically and sits between Home button on the left and search
- * button on the right").
+ * past the hero header. The MainActivity's bottomBar slot — which is a
+ * SIBLING subtree of the NavHost content slot — reads this state to swap
+ * the full FloatingNavigationToolbar for a docked Row containing
+ * [Home pill LEFT] + [MiniPlayer CENTER] + [Search pill RIGHT], matching
+ * the SimpMusic-style layout the user attached in the reference screenshot.
  *
- * Default: false (most screens don't shrink the mini player).
+ * This state is hoisted at the MainActivity level (above the Scaffold) so
+ * that both the content slot (where playlist screens WRITE to it) and the
+ * bottomBar slot (which READS from it) share the same instance. The
+ * previous CompositionLocal-of-Boolean pattern didn't actually propagate
+ * across slot boundaries, so the MiniPlayer never received the docked flag.
+ *
+ * Default: not docked (isDocked = false).
  */
-val LocalMiniPlayerDocked = compositionLocalOf { false }
+@Stable
+class MiniPlayerDockedState {
+    var isDocked: Boolean by mutableStateOf(false)
+}
+
+val LocalMiniPlayerDockedState =
+    compositionLocalOf<MiniPlayerDockedState> {
+        error("MiniPlayerDockedState not provided")
+    }
 
 /**
  * Provides a [VideoFullscreenStateHolder] to the content subtree.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -86,17 +87,18 @@ fun MiniPlayer(
     pureBlack: Boolean,
     isPairedWithNavigation: Boolean = false,
 ) {
-    // Read the per-screen "docked" flag. When a playlist-style screen has
-    // scrolled past its hero header, it sets LocalMiniPlayerDocked = true
-    // via a CompositionLocalProvider in its own subtree. The MiniPlayer
-    // then visually shrinks and slides to the bottom-start corner, sitting
-    // to the right of the floating Home dock button — matching the
-    // SimpMusic behavior the user requested. When the user scrolls back up
-    // to the hero, the flag flips back to false and the MiniPlayer springs
-    // back to its full-width form.
-    val docked = LocalMiniPlayerDocked.current
-    // Animate scale + translationX for a smooth spring transition between
-    // full-width and docked forms.
+    // Read the per-screen "docked" flag from the hoisted shared state. When a
+    // playlist-style screen has scrolled past its hero header, it writes
+    // isDocked = true via LocalMiniPlayerDockedState. The MainActivity
+    // bottomBar slot reads the same state to swap the full
+    // FloatingNavigationToolbar for a docked Row containing
+    // [Home pill LEFT] + [MiniPlayer CENTER] + [Search pill RIGHT] —
+    // matching the SimpMusic-style layout the user requested. The mini
+    // player here visually narrows its width (via horizontal padding) so
+    // it fits between the Home and Search pills instead of being scaled
+    // and translated off-screen.
+    val docked = LocalMiniPlayerDockedState.current.isDocked
+    // Animate the dock fraction 0→1 for a smooth spring transition.
     val dockedAnim by animateFloatAsState(
         targetValue = if (docked) 1f else 0f,
         animationSpec = spring(
@@ -106,31 +108,14 @@ fun MiniPlayer(
         label = "MiniPlayerDockedAnim",
     )
     val density = LocalDensity.current
-    val translationXPx = with(density) { (-160).dp.toPx() }
-    val translationYPx = with(density) { 10.dp.toPx() }
+    // Horizontal padding applied when docked: leaves room for the Home pill
+    // on the left (~56dp dock pill + 12dp spacing) and the Search pill on
+    // the right (same). Animates smoothly with dockedAnim so the mini
+    // player narrows in lockstep with the docked Row appearing.
+    val dockedSidePaddingDp = with(density) { (68.dp.toPx() * dockedAnim).toDp() }
     val dockedModifier =
         if (dockedAnim > 0.001f) {
-            // Scale down to ~50% so the mini player reads as a small
-            // docked icon rather than a full-width bar, and translate
-            // left so its left edge lines up to the right of the Home
-            // dock button (which sits at start=16dp, width=48dp). The
-            // translation is in pixels; we use density to convert from
-            // dp so the math is resolution-independent.
-            //
-            // Slight downward nudge so the scaled-down pill sits at
-            // the same vertical center as the Home dock button
-            // instead of the original MiniPlayer's center (the
-            // BottomSheet reserves 70dp at the bottom; the Home dock
-            // is 48dp tall + 12dp bottom padding, so its center is
-            // ~10dp below the MiniPlayer's center).
-            val scale = 1f - 0.5f * dockedAnim // 1.0 -> 0.5
-            modifier
-                .graphicsLayer {
-                    scaleX = scale
-                    scaleY = scale
-                    translationX = translationXPx * dockedAnim
-                    translationY = translationYPx * dockedAnim
-                }
+            modifier.padding(horizontal = dockedSidePaddingDp)
         } else {
             modifier
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -126,7 +127,7 @@ import moe.rukamori.archivetune.ui.component.BottomFadeOverlay
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.HideOnScrollFAB
-import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
+import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDockedState
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.TopSearch
@@ -692,17 +693,19 @@ fun HistoryScreen(
             // hero header so it doesn't compete with the hero's action row
             // when the user is at the top of the page. Tapping it jumps
             // straight to the Home tab.
-            if (!showSearchBar && isListScrolling) {
-                LibraryHomeDockButton(
-                    onClick = { navController.backToMain() },
-                    modifier =
-                        Modifier
-                            .align(Alignment.BottomStart)
-                            .padding(
-                                start = 16.dp,
-                                bottom = bottomInset + 12.dp,
-                            ),
-                )
+            // Floating Home dock + mini-player dock is now provided by the
+            // docked Row in MainActivity's bottomBar (Home pill LEFT +
+            // MiniPlayer CENTER + Search pill RIGHT) when this screen reports
+            // isListScrolling=true. The old per-screen LibraryHomeDockButton
+            // is removed to avoid double-rendering two Home pills.
+            val dockedState = LocalMiniPlayerDockedState.current
+            LaunchedEffect(isListScrolling, showSearchBar) {
+                // Don't dock the mini player while the search bar is open —
+                // the search input would overlap the docked pills.
+                dockedState.isDocked = isListScrolling && !showSearchBar
+            }
+            DisposableEffect(Unit) {
+                onDispose { dockedState.isDocked = false }
             }
 
             AnimatedVisibility(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
@@ -72,7 +72,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -127,7 +128,7 @@ import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
 import moe.rukamori.archivetune.ui.menu.SongMenu
-import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
+import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDockedState
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberPreference
@@ -362,13 +363,18 @@ fun LocalSongScreen(
         )
     }
 
-    // Wrap the entire screen subtree in a CompositionLocalProvider so the
-    // MiniPlayer (rendered by the parent BottomSheetPlayer outside this
-    // screen) can read LocalMiniPlayerDocked and shrink/dock when the user
-    // scrolls past the hero header.
-    CompositionLocalProvider(
-        LocalMiniPlayerDocked provides isListScrolling,
-    ) {
+    // Propagate the scroll state to the hoisted MiniPlayerDockedState so
+    // the MainActivity bottomBar slot (a SIBLING subtree of this screen)
+    // can swap the full FloatingNavigationToolbar for a docked
+    // [Home pill LEFT] + [MiniPlayer CENTER] + [Search pill RIGHT] layout
+    // when the user scrolls past the hero header.
+    val dockedState = LocalMiniPlayerDockedState.current
+    LaunchedEffect(isListScrolling) {
+        dockedState.isDocked = isListScrolling
+    }
+    DisposableEffect(Unit) {
+        onDispose { dockedState.isDocked = false }
+    }
     Box(
         modifier =
             Modifier
@@ -680,17 +686,11 @@ fun LocalSongScreen(
                         .fillMaxWidth()
                         .padding(bottom = bottomInset),
             )
-            LibraryHomeDockButton(
-                onClick = { navController.backToMain() },
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(start = 16.dp, bottom = bottomInset + 12.dp),
-                backdrop = pillBackdrop,
-            )
+            // LibraryHomeDockButton intentionally removed: the docked Row in
+            // MainActivity's bottomBar (Home pill LEFT + MiniPlayer CENTER +
+            // Search pill RIGHT) now provides the bottom-start Home affordance.
         }
     } // end Box
-    } // end CompositionLocalProvider
 }
 
 @Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -106,7 +106,7 @@ import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
-import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
+import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDockedState
 import moe.rukamori.archivetune.ui.screens.downloads.DownloadLibraryScreen
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadItem
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadProgressIndicator
@@ -356,14 +356,20 @@ fun AutoPlaylistScreen(
     // System bars padding
     val systemBarsTopPadding = LocalStableSystemBarsTopPadding.current
 
-    // Wrap the entire screen subtree in a CompositionLocalProvider so the
-    // MiniPlayer (rendered by the parent BottomSheetPlayer outside this
-    // screen) can read LocalMiniPlayerDocked and shrink/dock when the user
-    // scrolls past the hero header. The provider is hoisted to the screen
-    // root so it covers every Composable in this subtree.
-    CompositionLocalProvider(
-        LocalMiniPlayerDocked provides isListScrolling,
-    ) {
+    // Propagate the scroll state to the hoisted MiniPlayerDockedState so
+    // the MainActivity bottomBar slot (a SIBLING subtree of this screen)
+    // can swap the full FloatingNavigationToolbar for a docked
+    // [Home pill LEFT] + [MiniPlayer CENTER] + [Search pill RIGHT] layout
+    // when the user scrolls past the hero header. The previous
+    // CompositionLocal-of-Boolean pattern did NOT propagate across the
+    // content/bottomBar slot boundary.
+    val dockedState = LocalMiniPlayerDockedState.current
+    LaunchedEffect(isListScrolling) {
+        dockedState.isDocked = isListScrolling
+    }
+    DisposableEffect(Unit) {
+        onDispose { dockedState.isDocked = false }
+    }
     Box(
         modifier =
             Modifier
@@ -964,20 +970,11 @@ fun AutoPlaylistScreen(
         // doesn't compete with the hero's action row. Tapping it jumps
         // straight to the Home tab.
         if (isListScrolling) {
-            LibraryHomeDockButton(
-                onClick = { navController.backToMain() },
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(
-                            start = 16.dp,
-                            bottom = bottomInset + 12.dp,
-                        ),
-                backdrop = backdrop.takeIf { layerBackdropActive },
-            )
+            // LibraryHomeDockButton intentionally removed: the docked Row in
+            // MainActivity's bottomBar (Home pill LEFT + MiniPlayer CENTER +
+            // Search pill RIGHT) now provides the bottom-start Home affordance.
         }
     } // end Box
-    } // end CompositionLocalProvider
 }
 
 private const val CONTENT_TYPE_EMPTY = "empty"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -107,7 +107,7 @@ import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
-import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
+import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDockedState
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
@@ -334,13 +334,20 @@ fun CachePlaylistScreen(
     // System bars padding
     val systemBarsTopPadding = LocalStableSystemBarsTopPadding.current
 
-    // Wrap the entire screen subtree in a CompositionLocalProvider so the
-    // MiniPlayer (rendered by the parent BottomSheetPlayer outside this
-    // screen) can read LocalMiniPlayerDocked and shrink/dock when the user
-    // scrolls past the hero header.
-    CompositionLocalProvider(
-        LocalMiniPlayerDocked provides isListScrolling,
-    ) {
+    // Propagate the scroll state to the hoisted MiniPlayerDockedState so
+    // the MainActivity bottomBar slot (a SIBLING subtree of this screen)
+    // can swap the full FloatingNavigationToolbar for a docked
+    // [Home pill LEFT] + [MiniPlayer CENTER] + [Search pill RIGHT] layout
+    // when the user scrolls past the hero header. The previous
+    // CompositionLocal-of-Boolean pattern did NOT propagate across the
+    // content/bottomBar slot boundary, so the docked state was lost.
+    val dockedState = LocalMiniPlayerDockedState.current
+    LaunchedEffect(isListScrolling) {
+        dockedState.isDocked = isListScrolling
+    }
+    DisposableEffect(Unit) {
+        onDispose { dockedState.isDocked = false }
+    }
     Box(
         modifier =
             Modifier
@@ -875,26 +882,12 @@ fun CachePlaylistScreen(
             )
         }
 
-        // Floating Home dock button — circular frosted-glass pill at the
-        // bottom-start corner, matching the iOS Music reference screenshot.
-        // Visible only while the user has scrolled past the hero header so
-        // it doesn't compete with the hero's action row. Tapping it jumps
-        // straight to the Home tab.
-        if (isListScrolling) {
-            LibraryHomeDockButton(
-                onClick = { navController.backToMain() },
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(
-                            start = 16.dp,
-                            bottom = bottomInset + 12.dp,
-                        ),
-                backdrop = backdrop.takeIf { layerBackdropActive },
-            )
-        }
+        // The floating Home dock pill is now provided by the docked Row in
+        // MainActivity's bottomBar (Home pill LEFT + MiniPlayer CENTER +
+        // Search pill RIGHT) when this screen reports isListScrolling=true.
+        // The old per-screen LibraryHomeDockButton is removed to avoid
+        // double-rendering two Home pills at the bottom-start corner.
     } // end Box
-    } // end CompositionLocalProvider
 }
 
 /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -54,7 +54,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -153,7 +153,7 @@ import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.viewmodels.LocalPlaylistViewModel
 import moe.rukamori.archivetune.viewmodels.PlaylistCoverEvent
 import moe.rukamori.archivetune.viewmodels.PlaylistCoverState
-import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
+import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDockedState
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -600,13 +600,18 @@ fun LocalPlaylistScreen(
     // instead of showing a hard black band behind the pill.
     val artworkBackdrop = rememberBackdrop(surfaceColor)
 
-    // Wrap the entire screen subtree in a CompositionLocalProvider so the
-    // MiniPlayer (rendered by the parent BottomSheetPlayer outside this
-    // screen) can read LocalMiniPlayerDocked and shrink/dock when the user
-    // scrolls past the hero header.
-    CompositionLocalProvider(
-        LocalMiniPlayerDocked provides isListScrolling,
-    ) {
+    // Propagate the scroll state to the hoisted MiniPlayerDockedState so
+    // the MainActivity bottomBar slot (a SIBLING subtree of this screen)
+    // can swap the full FloatingNavigationToolbar for a docked
+    // [Home pill LEFT] + [MiniPlayer CENTER] + [Search pill RIGHT] layout
+    // when the user scrolls past the hero header.
+    val dockedState = LocalMiniPlayerDockedState.current
+    LaunchedEffect(isListScrolling) {
+        dockedState.isDocked = isListScrolling
+    }
+    DisposableEffect(Unit) {
+        onDispose { dockedState.isDocked = false }
+    }
     ExpressivePullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = viewModel::refresh,
@@ -1460,24 +1465,13 @@ fun LocalPlaylistScreen(
             )
         }
 
-        // Floating Home dock button — circular frosted-glass pill at the
-        // bottom-start corner, matching the iOS Music reference screenshot.
-        // Visible only while the user has scrolled past the hero header so
-        // it doesn't compete with the hero's action row. Tapping it jumps
-        // straight to the Home tab. Skipped during search/selection so it
-        // doesn't overlap the selection toolbar.
+        // Floating Home dock pill is now provided by the docked Row in
+        // MainActivity's bottomBar (Home pill LEFT + MiniPlayer CENTER +
+        // Search pill RIGHT) when this screen reports isListScrolling=true.
+        // The old per-screen LibraryHomeDockButton is removed to avoid
+        // double-rendering two Home pills at the bottom-start corner.
         if (!isSearching && !selection && isListScrolling) {
-            LibraryHomeDockButton(
-                onClick = { navController.backToMain() },
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(
-                            start = 16.dp,
-                            bottom = bottomInset + 12.dp,
-                        ),
-                backdrop = artworkBackdrop.takeIf { layerBackdropActive },
-            )
+            // intentionally empty — see comment above
         }
 
         SnackbarHost(
@@ -1488,7 +1482,6 @@ fun LocalPlaylistScreen(
                     .align(Alignment.BottomCenter),
         )
     } // end ExpressivePullToRefreshBox
-    } // end CompositionLocalProvider
 }
 
 private const val MediaDetailMetadataSeparator = "  •  "


### PR DESCRIPTION
## Summary

Refactors the docked nav bar + mini player layout to match the SimpMusic-style reference screenshot the user provided.

## Layout

**Scrolled UP (not docked)** — the normal layout:
- Full `FloatingNavigationToolbar` (Home + Search + Library pills, expanded)
- `MiniPlayer` ABOVE the nav bar in its normal position

**Scrolled DOWN (docked)** — the new layout, in playlist-style screens (LocalPlaylist, AutoPlaylist, CachePlaylist, LocalSong, History):
- 48dp circular liquid-glass **Home pill** (LEFT)
- **MiniPlayer** in the CENTER (visually narrowed via animated horizontal padding)
- 48dp circular liquid-glass **Search pill** (RIGHT)

The mini player design itself is unchanged — only the positioning logic is updated.

## Root cause fix

The previous `LocalMiniPlayerDocked` `CompositionLocal<Boolean>` pattern (in `InlineVideoPlayer.kt`) was BROKEN: CompositionLocals propagate only DOWN the composition tree, not across the Scaffold content/bottomBar slot boundary. The playlist screens (inside the content slot) wrote `isListScrolling=true` to the CompositionLocal, but the MiniPlayer (inside the bottomBar slot — a SIBLING subtree) never received the docked flag, so the docked animation never triggered.

Refactored to a hoisted shared-state pattern:
- New `MiniPlayerDockedState` class with `var isDocked: Boolean by mutableStateOf(false)`.
- New `LocalMiniPlayerDockedState` CompositionLocal providing the shared state.
- Hoisted `val miniPlayerDockedState = remember { MiniPlayerDockedState() }` at the MainActivity level (above the Scaffold) so both content and bottomBar slots share the same instance.

## Files changed

- `InlineVideoPlayer.kt` — replaced `LocalMiniPlayerDocked` CompositionLocal-of-Boolean with `MiniPlayerDockedState` + `LocalMiniPlayerDockedState` hoisted shared state.
- `MainActivity.kt` — hoist shared state above Scaffold; provide via CompositionLocal; render docked Row in bottomBar when docked (Home pill LEFT + spacer + Search pill RIGHT).
- `MiniPlayer.kt` — read new shared state; replaced `graphicsLayer { scale + translate }` with `Modifier.padding(horizontal = 80dp * dockedAnim)` so the mini player narrows to fit between the Home and Search pills.
- `LiquidGlass.kt` — added `DockedNavPillButton` composable (48dp circular liquid-glass pill with Surface fallback for non-liquid-glass mode).
- `LocalPlaylistScreen.kt`, `AutoPlaylistScreen.kt`, `CachePlaylistScreen.kt`, `LocalSongScreen.kt`, `HistoryScreen.kt` — removed broken `CompositionLocalProvider(LocalMiniPlayerDocked provides isListScrolling)` wrapper; replaced with `LaunchedEffect(isListScrolling) { dockedState.isDocked = isListScrolling }` + `DisposableEffect(Unit) { onDispose { dockedState.isDocked = false } }`; removed the per-screen `LibraryHomeDockButton` rendering (the docked Row in bottomBar now provides the bottom-start Home affordance to avoid double-rendering two Home pills).

## Test plan

CI: `./gradlew assembleGmsMobileUniversalDebug :app:lintGmsMobileUniversalDebug` (existing `build_pull_request.yml` workflow).

Manual:
1. Open a playlist (Liked Songs, Cached, Local storage, regular playlist, or History).
2. Scroll down past the hero header.
3. Verify the nav bar collapses to a docked Row: Home pill LEFT, MiniPlayer CENTER (narrowed), Search pill RIGHT.
4. Scroll back up to the hero header.
5. Verify the full nav bar (Home+Search+Library) returns and the MiniPlayer expands back to its full-width position above the nav bar.
6. Tap the Home pill in the docked Row — should navigate to the Home tab.
7. Tap the Search pill in the docked Row — should navigate to the Search tab.