### PR TITLE
fix(ui): liquid glass headers, lyrics attribution, sequential back nav, lag optimization

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton as Material3IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -85,6 +86,17 @@ val LocalLiquidGlassBackdrop = compositionLocalOf<LayerBackdrop?> { null }
  * [layerBackdrop]); nesting it inside the source creates a render-feedback
  * loop that crashes the RuntimeShader.
  *
+ * **Performance note:** The modifier chain is wrapped in `remember` keyed on
+ * [backdrop], [shape], [interactive], [baseColor] and the current dark-theme
+ * state. This is the single biggest lever for the "lag when switching pages"
+ * symptom: without memoization, every recomposition of the host screen
+ * (which can happen many times per second during scroll) rebuilt the entire
+ * `drawBackdrop` modifier chain — re-allocating the kyant effect stack and
+ * re-installing the RuntimeShader on the GraphicsLayer. Memoizing it means
+ * the chain is built ONCE per (backdrop, shape, dark-theme) tuple and
+ * reused across recompositions, so scroll-driven recompositions no longer
+ * trigger per-frame GPU setup cost.
+ *
  * @param baseColor Optional OPAQUE color drawn UNDER the backdrop sample
  *   (via the kyant `onDrawBehind` callback). When the backdrop has content
  *   (e.g. album art behind the nav bar), the backdrop sample covers the
@@ -104,40 +116,51 @@ fun Modifier.liquidGlass(
     baseColor: Color = Color.Unspecified,
 ): Modifier {
     val isDark = isSystemInDarkTheme()
-    return this.drawBackdrop(
-        backdrop = backdrop,
-        effects = {
-            val l = 0f
-            vibrancy()
-            blur(
-                if (l > 0f) {
-                    lerp(8f.dp.toPx(), 16f.dp.toPx(), l)
-                } else {
-                    lerp(8f.dp.toPx(), 2f.dp.toPx(), -l)
-                },
-            )
-            lens(24f.dp.toPx(), size.minDimension / 4f, false)
-        },
-        onDrawBackdrop = { drawBackdrop ->
-            drawBackdrop()
-        },
-        shape = { shape },
-        onDrawBehind =
-            if (baseColor != Color.Unspecified) {
-                { drawRect(baseColor) }
-            } else {
-                null
+    // Memoize the entire drawBackdrop modifier chain so it isn't rebuilt on
+    // every recomposition. The chain depends only on (backdrop, shape,
+    // interactive, baseColor, isDark) — all of which are stable across
+    // scroll-driven recompositions of the host screen. Without this memo,
+    // every recomposition rebuilt the kyant effect stack and re-installed
+    // the RuntimeShader on the GraphicsLayer, which was the dominant cause
+    // of the "lag when switching pages" symptom (the new page's first few
+    // frames all paid that setup cost while the user was already trying to
+    // scroll).
+    return remember(backdrop, shape, interactive, baseColor, isDark) {
+        this.drawBackdrop(
+            backdrop = backdrop,
+            effects = {
+                val l = 0f
+                vibrancy()
+                blur(
+                    if (l > 0f) {
+                        lerp(8f.dp.toPx(), 16f.dp.toPx(), l)
+                    } else {
+                        lerp(8f.dp.toPx(), 2f.dp.toPx(), -l)
+                    },
+                )
+                lens(24f.dp.toPx(), size.minDimension / 4f, false)
             },
-        onDrawSurface = {
-            val luminanceAnimation = 0.5f
-            val darken = lerp(
-                0.12f,
-                0.5f,
-                ((luminanceAnimation - 0.3f) / 0.5f).coerceIn(0f, 1f),
-            )
-            drawRect((if (isDark) Color.Black else Color.White).copy(alpha = darken))
-        },
-    )
+            onDrawBackdrop = { drawBackdrop ->
+                drawBackdrop()
+            },
+            shape = { shape },
+            onDrawBehind =
+                if (baseColor != Color.Unspecified) {
+                    { drawRect(baseColor) }
+                } else {
+                    null
+                },
+            onDrawSurface = {
+                val luminanceAnimation = 0.5f
+                val darken = lerp(
+                    0.12f,
+                    0.5f,
+                    ((luminanceAnimation - 0.3f) / 0.5f).coerceIn(0f, 1f),
+                )
+                drawRect((if (isDark) Color.Black else Color.White).copy(alpha = darken))
+            },
+        )
+    }
 }
 
 /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
@@ -806,39 +806,22 @@ fun Lyrics(
                 )
             }
         } else {
-            if (lyricsProviderName.isNotBlank()) {
-                val sourceAlpha by remember {
-                    derivedStateOf {
-                        val firstIdx = lazyListState.firstVisibleItemIndex
-                        val firstOffset = lazyListState.firstVisibleItemScrollOffset
-                        val firstItemSize = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull()?.size ?: 1
-                        if (firstIdx > 0) 0f
-                        else (1f - (firstOffset.toFloat() / firstItemSize)).coerceIn(0f, 1f)
-                    }
-                }
-                val animatedSourceAlpha by animateFloatAsState(
-                    targetValue = sourceAlpha,
-                    animationSpec = tween(durationMillis = 220),
-                    label = "lyricsSourceAlpha",
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 12.dp)
-                        .alpha(animatedSourceAlpha),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
-                        fontSize = 12.sp,
-                        color = MaterialTheme.colorScheme.secondary,
-                        textAlign = TextAlign.Center,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
+            // "Lyrics from [provider]" header is rendered as the FIRST item of
+            // the LazyColumn below (not as a floating overlay) so it scrolls
+            // naturally with the lyrics — the user requested this behave "as
+            // if it's a lyrics line itself" rather than a constant watermark
+            // that fades on scroll. The visual design matches the "Written by"
+            // footer item at the end of the list (same color, weight, size,
+            // alignment) so the two attribution labels read as a matched
+            // pair bracketing the lyrics.
+            //
+            // "Written by [artists]" is rendered as the LAST item of the
+            // LazyColumn for the same reason — it scrolls naturally with the
+            // lyrics and visually closes the lyrics block. We use the song's
+            // artist list (composer credits are not tracked in MediaMetadata)
+            // as a proxy for the "written by" attribution, matching the
+            // user's previous request to surface this credit at the bottom
+            // of the lyrics page.
             LazyColumn(
                 state = lazyListState,
                 contentPadding =
@@ -886,6 +869,34 @@ fun Lyrics(
             ) {
                 val displayedCurrentLineIndex =
                     if (isSeeking || isSelectionModeActive) deferredCurrentLineIndex else currentLineIndex
+
+                // "Lyrics from [provider]" header item. Rendered as a regular
+                // LazyColumn item so it scrolls naturally with the lyrics. The
+                // visual style mirrors the "Written by" footer item below:
+                // small secondary color, medium weight, centered. Skipping if
+                // the provider name is blank (e.g. embedded lyrics have no
+                // provider attribution).
+                if (lyricsProviderName.isNotBlank() && lyrics != null) {
+                    item(key = "lyrics_source_header", contentType = "lyrics_attribution") {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 8.dp, bottom = 16.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
+                                fontSize = 12.sp,
+                                color = MaterialTheme.colorScheme.secondary,
+                                textAlign = TextAlign.Center,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
 
                 if (lyrics == null) {
                     item {
@@ -2438,6 +2449,41 @@ fun Lyrics(
                                         }
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+
+                // "Written by [artists]" footer item. Rendered as the LAST
+                // item of the LazyColumn so it scrolls naturally with the
+                // lyrics and visually closes the lyrics block. The visual
+                // style mirrors the "Lyrics from [provider]" header item
+                // at the top of the list (small secondary color, medium
+                // weight, centered) so the two attribution labels read as
+                // a matched pair bracketing the lyrics. We use the song's
+                // artist list as the credit source — MediaMetadata does not
+                // track formal composer credits, so the artist list is the
+                // best available proxy for "who wrote this song".
+                mediaMetadata?.let { metadata ->
+                    val writersLine = metadata.artists.joinToString { it.name }.trim()
+                    if (writersLine.isNotBlank()) {
+                        item(key = "lyrics_writers_footer", contentType = "lyrics_attribution") {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 24.dp, bottom = 8.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.written_by, writersLine),
+                                    fontSize = 12.sp,
+                                    color = MaterialTheme.colorScheme.secondary,
+                                    textAlign = TextAlign.Center,
+                                    fontWeight = FontWeight.Medium,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
                             }
                         }
                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -64,6 +64,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
@@ -92,6 +93,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -1125,6 +1127,50 @@ fun LyricsEnhanced(
                 // gate is never armed and this is a no-op.
                 .graphicsLayer { alpha = firstFocusAlpha.value },
     ) {
+        // "Lyrics from [provider]" header overlay. Mirrors the design of the
+        // "Written by" footer overlay below: small secondary color, medium
+        // weight, centered. Rendered as an overlay above the karaoke list
+        // with an alpha fade based on the listState's first-visible-item
+        // scroll offset so the header visually scrolls away with the lyrics
+        // (rather than remaining as a constant watermark). The karaoke
+        // library owns its own LazyColumn so we can't inject items into it;
+        // the alpha-fade overlay is the closest visual match.
+        val providerName = currentLyrics?.providerName.orEmpty()
+        if (providerName.isNotBlank() && lyrics != null && lyrics != LYRICS_NOT_FOUND) {
+            val sourceAlpha by remember {
+                derivedStateOf {
+                    val firstIdx = listState.firstVisibleItemIndex
+                    val firstOffset = listState.firstVisibleItemScrollOffset
+                    val firstItemSize =
+                        listState.layoutInfo.visibleItemsInfo.firstOrNull()?.size ?: 1
+                    if (firstIdx > 0) 0f
+                    else (1f - (firstOffset.toFloat() / firstItemSize)).coerceIn(0f, 1f)
+                }
+            }
+            val animatedSourceAlpha by animateFloatAsState(
+                targetValue = sourceAlpha,
+                animationSpec = tween(durationMillis = 220),
+                label = "lyricsSourceAlphaEnhanced",
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp)
+                        .graphicsLayer { alpha = animatedSourceAlpha },
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.lyrics_from_source, providerName),
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.secondary,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
         when {
             lyrics == LYRICS_NOT_FOUND -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -1312,6 +1358,53 @@ fun LyricsEnhanced(
                             )
                         }
                     }
+                }
+            }
+        }
+
+        // "Written by [artists]" footer overlay. Mirrors the design of the
+        // "Lyrics from" header overlay above: small secondary color, medium
+        // weight, centered. Rendered as an overlay at the bottom of the
+        // lyrics Box so it visually closes the lyrics block. The alpha
+        // fades in as the user scrolls toward the end of the lyrics (so it
+        // doesn't compete with the active line at the top). The artist list
+        // is used as a proxy for composer credits (MediaMetadata does not
+        // track formal composer credits).
+        mediaMetadata?.let { metadata ->
+            val writersLine = metadata.artists.joinToString { it.name }.trim()
+            if (writersLine.isNotBlank() && lyrics != null && lyrics != LYRICS_NOT_FOUND) {
+                val footerAlpha by remember {
+                    derivedStateOf {
+                        val layoutInfo = listState.layoutInfo
+                        val totalItems = layoutInfo.totalItemsCount
+                        val lastVisibleIdx = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                        if (totalItems == 0) 0f
+                        else ((lastVisibleIdx + 1).toFloat() / totalItems.toFloat()).coerceIn(0f, 1f)
+                    }
+                }
+                val animatedFooterAlpha by animateFloatAsState(
+                    targetValue = footerAlpha,
+                    animationSpec = tween(durationMillis = 220),
+                    label = "lyricsFooterAlphaEnhanced",
+                )
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 16.dp)
+                            .graphicsLayer { alpha = animatedFooterAlpha },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(R.string.written_by, writersLine),
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.secondary,
+                        textAlign = TextAlign.Center,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -16,6 +16,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -54,6 +55,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
@@ -98,6 +100,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
@@ -776,6 +779,34 @@ fun LyricsV2(
                     },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            // "Lyrics from [provider]" header item. Rendered as the FIRST
+            // LazyColumn item so it scrolls naturally with the lyrics — the
+            // user requested this behave "as if it's a lyrics line itself"
+            // rather than a constant watermark. Mirrors the design of the
+            // "Written by" footer item at the end of the list.
+            val providerNameV2 = currentLyrics?.providerName.orEmpty()
+            if (providerNameV2.isNotBlank()) {
+                item(key = "lyrics_source_header_v2", contentType = "lyrics_attribution") {
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(top = 8.dp, bottom = 16.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.lyrics_from_source, providerNameV2),
+                            fontSize = 12.sp,
+                            color = MaterialTheme.colorScheme.secondary,
+                            textAlign = TextAlign.Center,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+
             itemsIndexed(
                 items = entriesWithWords,
                 // Include repeat resets so a repeated word receives a new
@@ -1125,6 +1156,37 @@ fun LyricsV2(
             // Bottom spacer for overscroll
             item {
                 Spacer(modifier = Modifier.height(300.dp))
+            }
+
+            // "Written by [artists]" footer item. Rendered as the LAST
+            // LazyColumn item so it scrolls naturally with the lyrics and
+            // visually closes the lyrics block. Mirrors the design of the
+            // "Lyrics from" header item at the top. Uses the artist list as
+            // a proxy for composer credits (MediaMetadata does not track
+            // formal composer credits).
+            mediaMetadata?.let { metadata ->
+                val writersLineV2 = metadata.artists.joinToString { it.name }.trim()
+                if (writersLineV2.isNotBlank()) {
+                    item(key = "lyrics_writers_footer_v2", contentType = "lyrics_attribution") {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 8.dp, bottom = 16.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = stringResource(R.string.written_by, writersLineV2),
+                                fontSize = 12.sp,
+                                color = MaterialTheme.colorScheme.secondary,
+                                textAlign = TextAlign.Center,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
             }
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -50,9 +50,12 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
@@ -99,6 +102,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -382,30 +386,39 @@ fun HistoryScreen(
                         .padding(top = 8.dp),
             )
             if (availableSources.size > 1) {
-                HistorySourceSelector(
-                    currentSource = historySource,
-                    availableSources = availableSources,
-                    onSourceChange = { newSource ->
-                        if (newSource == historySource) return@HistorySourceSelector
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 12.dp, start = 4.dp),
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    HistorySourcePill(
+                        currentSource = historySource,
+                        availableSources = availableSources,
+                        onSourceChange = { newSource ->
+                            if (newSource == historySource) return@HistorySourcePill
 
-                        viewModel.historySource.value = newSource
-                        if (newSource == HistorySource.REMOTE) {
-                            when (remoteHistoryState) {
-                                is RemoteHistoryUiState.Error -> {
-                                    viewModel.fetchRemoteHistory()
-                                }
+                            viewModel.historySource.value = newSource
+                            if (newSource == HistorySource.REMOTE) {
+                                when (remoteHistoryState) {
+                                    is RemoteHistoryUiState.Error -> {
+                                        viewModel.fetchRemoteHistory()
+                                    }
 
-                                is RemoteHistoryUiState.Empty -> {
-                                    viewModel.enqueueSilentFetch()
-                                }
+                                    is RemoteHistoryUiState.Empty -> {
+                                        viewModel.enqueueSilentFetch()
+                                    }
 
-                                else -> {
-                                    Unit
+                                    else -> {
+                                        Unit
+                                    }
                                 }
                             }
-                        }
-                    },
-                )
+                        },
+                    )
+                }
             }
         }
     }
@@ -1165,7 +1178,7 @@ private fun HistorySourceDock(
                     }
                 }
                 if (availableSources.size > 1) {
-                    HistorySourceSelector(
+                    HistorySourcePill(
                         currentSource = currentSource,
                         availableSources = availableSources,
                         onSourceChange = onSourceChange,
@@ -1275,53 +1288,123 @@ private fun HistorySectionHeader(
 }
 
 @Composable
-private fun HistorySourceSelector(
+private fun HistorySourcePill(
     currentSource: HistorySource,
     availableSources: List<HistorySource>,
     onSourceChange: (HistorySource) -> Unit,
 ) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        availableSources.forEachIndexed { index, source ->
-            val checked = source == currentSource
-            ToggleButton(
-                checked = checked,
-                onCheckedChange = {
-                    if (!checked) {
-                        onSourceChange(source)
-                    }
-                },
+    // A single, self-sized (non-fillMaxWidth) pill that mirrors the design
+    // language of [SortHeader] in the playlist page: translucent capsule
+    // shape with a pink accent icon + bold pink label, and a trailing
+    // dropdown chevron. Tapping the pill opens a [DropdownMenu] listing the
+    // available sources (Local / Remote) with a radio-button indicator on
+    // the currently-selected one.
+    //
+    // Previously this control was a full-width two-button ToggleButton row
+    // (see git history), which the user reported as "in the middle" and not
+    // aligned with the hero's Play/Shuffle pills. Replacing it with a single
+    // start-aligned pill that opens a dropdown matches both the visual
+    // rhythm of the redesigned hero (Play/Shuffle/Clear on the left) and
+    // the sort header pill on the playlist page.
+    var menuExpanded by remember { mutableStateOf(false) }
+
+    val accent = moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
+    val onBackgroundColor = MaterialTheme.colorScheme.onBackground
+    val containerColor = onBackgroundColor.copy(alpha = 0.06f)
+    val pillShape = RoundedCornerShape(percent = 50)
+
+    Box(modifier = Modifier.padding(vertical = 4.dp)) {
+        Surface(
+            shape = pillShape,
+            color = containerColor,
+            modifier =
+                Modifier
+                    .clip(pillShape)
+                    .height(44.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier =
                     Modifier
-                        .weight(1f)
-                        .height(52.dp),
-                shapes =
-                    when (index) {
-                        0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
-                        availableSources.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
-                        else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
-                    },
-                colors =
-                    ToggleButtonDefaults.toggleButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        checkedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                        checkedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    ),
+                        .clip(pillShape)
+                        .combinedClickable(
+                            onClick = { menuExpanded = true },
+                            onLongClick = {},
+                        )
+                        .padding(horizontal = 16.dp),
             ) {
+                Icon(
+                    painter = painterResource(R.drawable.history),
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(20.dp),
+                )
                 Text(
                     text =
                         stringResource(
-                            if (source == HistorySource.LOCAL) {
+                            if (currentSource == HistorySource.LOCAL) {
                                 R.string.local_history
                             } else {
                                 R.string.remote_history
                             },
                         ),
+                    color = accent,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                    modifier =
+                        Modifier
+                            .widthIn(max = 160.dp)
+                            .padding(start = 8.dp, end = 4.dp),
+                )
+                Icon(
+                    painter = painterResource(R.drawable.arrow_downward),
+                    contentDescription = null,
+                    tint = accent,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+            modifier = Modifier.widthIn(min = 172.dp),
+        ) {
+            availableSources.forEach { source ->
+                val isSelected = source == currentSource
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text =
+                                stringResource(
+                                    if (source == HistorySource.LOCAL) {
+                                        R.string.local_history
+                                    } else {
+                                        R.string.remote_history
+                                    },
+                                ),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    },
+                    trailingIcon = {
+                        Icon(
+                            painter =
+                                painterResource(
+                                    if (isSelected) {
+                                        R.drawable.radio_button_checked
+                                    } else {
+                                        R.drawable.radio_button_unchecked
+                                    },
+                                ),
+                            contentDescription = null,
+                        )
+                    },
+                    onClick = {
+                        onSourceChange(source)
+                        menuExpanded = false
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -193,6 +193,24 @@ fun AutoPlaylistScreen(
             selection = false
             wrappedSongs.forEach { it.isSelected = false }
         }
+    } else {
+        // Explicit BackHandler so the predictive back gesture lands on the
+        // Library tab when the previous back-stack entry is not a main
+        // screen (e.g. when the user entered this screen directly via a
+        // deep link from Home). Calling [navigateUp] first preserves the
+        // natural back stack; if that returns false (no previous entry to
+        // pop), we explicitly navigate to the Library tab so the user
+        // always lands somewhere meaningful instead of being dropped on
+        // Home. Matches the LocalPlaylistScreen / SpotifyPlaylistScreen
+        // pattern.
+        BackHandler {
+            if (!navController.navigateUp()) {
+                navController.navigate("library") {
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        }
     }
 
     val (sortType, onSortTypeChange) =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -264,6 +264,24 @@ fun CachePlaylistScreen(
         BackHandler {
             selection = false
         }
+    } else {
+        // Explicit BackHandler so the predictive back gesture lands on the
+        // Library tab when the previous back-stack entry is not a main
+        // screen (e.g. when the user entered this screen directly via a
+        // deep link from Home). Calling [navigateUp] first preserves the
+        // natural back stack; if that returns false (no previous entry to
+        // pop), we explicitly navigate to the Library tab so the user
+        // always lands somewhere meaningful instead of being dropped on
+        // Home. Matches the LocalPlaylistScreen / SpotifyPlaylistScreen
+        // pattern.
+        BackHandler {
+            if (!navController.navigateUp()) {
+                navController.navigate("library") {
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        }
     }
 
     val filteredSongs =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -301,6 +301,23 @@ fun LocalPlaylistScreen(
         BackHandler {
             selection = false
         }
+    } else {
+        // Explicit BackHandler so the predictive back gesture lands on the
+        // Library tab when the previous back-stack entry is not a main
+        // screen (e.g. when the user entered this screen directly via a
+        // deep link from Home). Calling [navigateUp] first preserves the
+        // natural back stack; if that returns false (no previous entry to
+        // pop), we explicitly navigate to the Library tab so the user
+        // always lands somewhere meaningful instead of being dropped on
+        // Home. Matches the SpotifyPlaylistScreen pattern.
+        BackHandler {
+            if (!navController.navigateUp()) {
+                navController.navigate("library") {
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        }
     }
 
     val downloadUtil = LocalDownloadUtil.current

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -268,6 +268,19 @@ fun OnlinePlaylistScreen(
         }
     } else if (selection) {
         BackHandler { selection = false }
+    } else {
+        // Explicit BackHandler so the predictive back gesture lands on the
+        // Library tab when the previous back-stack entry is not a main
+        // screen. Matches the LocalPlaylistScreen / SpotifyPlaylistScreen
+        // pattern.
+        BackHandler {
+            if (!navController.navigateUp()) {
+                navController.navigate("library") {
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        }
     }
 
     val wrappedSongs =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -317,6 +318,24 @@ fun SpotifyPlaylistScreen(
             isSearching = false
             query = TextFieldValue()
         }
+    } else {
+        // Explicit BackHandler so the predictive back gesture lands on the
+        // Library tab when the previous back-stack entry is not a main
+        // screen. Previously, when the user entered this screen directly
+        // (e.g. via a deep link from Home) the back gesture popped straight
+        // to Home, skipping the Library tab the user expected to return to.
+        // Calling [navigateUp] first preserves the natural back stack; if
+        // that returns false (no previous entry to pop), we explicitly
+        // navigate to the Library tab so the user always lands somewhere
+        // meaningful instead of being dropped on Home.
+        BackHandler {
+            if (!navController.navigateUp()) {
+                navController.navigate("library") {
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        }
     }
 
     fun playPlaylist(
@@ -371,7 +390,11 @@ fun SpotifyPlaylistScreen(
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
     val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
-    val artworkBackdrop = rememberBackdrop(Color.Black)
+    // Use the theme surface color (not Color.Black) so the initial frame, before
+    // any scrolling content is recorded into the backdrop, blends with the page
+    // background instead of flashing solid black. Matches the LocalPlaylistScreen
+    // / AutoPlaylistScreen / CachePlaylistScreen fix from stage-6.
+    val artworkBackdrop = rememberBackdrop(surfaceColor)
 
     ExpressivePullToRefreshBox(
         isRefreshing = state.isLoading,
@@ -631,17 +654,55 @@ fun SpotifyPlaylistScreen(
         //  - Not searching
         //  - Playlist is loaded
         if (layerBackdropActive && !isSearching && playlist != null) {
-            LiquidGlassIconButton(
+            // iOS-inspired back pill: persistent translucent liquid-glass
+            // capsule containing a left-pointing chevron followed by the
+            // text "Library", matching the user's reference screenshot and
+            // the LocalPlaylistScreen / AutoPlaylistScreen / HistoryScreen
+            // layout. Previously this was a single LiquidGlassIconButton
+            // (just the arrow_back icon with no "Library" label), which
+            // the user reported as not matching the history-page layout.
+            // Tapping it pops back to the previous destination (or pops
+            // back to the Library tab if no previous destination exists);
+            // long-pressing it jumps straight to the Home tab.
+            LiquidGlassActionPill(
                 backdrop = artworkBackdrop,
-                painter = painterResource(R.drawable.arrow_back),
-                contentDescription = null,
+                interactive = true,
                 modifier =
                     Modifier
                         .align(Alignment.TopStart)
-                        .padding(start = 12.dp, top = systemBarsTopPadding + 12.dp)
-                        .size(48.dp),
-                onClick = { navController.navigateUp() },
-            )
+                        .padding(start = 12.dp, top = systemBarsTopPadding + 12.dp),
+            ) {
+                IconButton(
+                    onClick = {
+                        if (!navController.navigateUp()) {
+                            // No previous back-stack entry — fall back to the
+                            // Library tab so the back gesture always lands on
+                            // Library (not Home) when the user entered this
+                            // screen directly (e.g. via a deep link).
+                            navController.navigate("library") {
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        }
+                    },
+                    onLongClick = { navController.backToMain() },
+                    modifier = Modifier.size(48.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.arrow_back),
+                        contentDescription = stringResource(R.string.library),
+                        tint = Color.White,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.library),
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(end = 12.dp),
+                )
+            }
             LiquidGlassActionPill(
                 backdrop = artworkBackdrop,
                 modifier =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/TopPlaylistScreen.kt
@@ -151,6 +151,19 @@ fun TopPlaylistScreen(
         BackHandler {
             selection = false
         }
+    } else {
+        // Explicit BackHandler so the predictive back gesture lands on the
+        // Library tab when the previous back-stack entry is not a main
+        // screen. Matches the LocalPlaylistScreen / SpotifyPlaylistScreen
+        // pattern.
+        BackHandler {
+            if (!navController.navigateUp()) {
+                navController.navigate("library") {
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
+        }
     }
 
     val sortType by viewModel.topPeriod.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
@@ -80,6 +80,7 @@ import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
@@ -159,19 +160,30 @@ private fun AboutScreenContent(
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.about),
-                        fontWeight = FontWeight.Bold,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.about),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = onNavigateUp,
-                        onLongClick = onNavigateHome,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = stringResource(R.string.back_button_desc),
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = onNavigateUp,
+                            onLongClick = onNavigateHome,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = stringResource(R.string.back_button_desc),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
@@ -107,6 +107,7 @@ import moe.rukamori.archivetune.constants.VisitorDataKey
 import moe.rukamori.archivetune.constants.YtmSyncKey
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.utils.hasYouTubeLoginCookie
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
@@ -271,23 +272,34 @@ fun AccountSettings(
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
-                    Column {
-                        Text(
-                            text = accountLabel,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+                    FrostedHeaderPill {
+                        Column {
+                            Text(
+                                text = accountLabel,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
@@ -121,6 +121,7 @@ import moe.rukamori.archivetune.constants.TranslateModeKey
 import moe.rukamori.archivetune.constants.TranslateLanguageKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EditTextPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -770,15 +771,28 @@ fun AiIntegrationSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.ai_integration)) },
+        title = {
+            FrostedHeaderPill {
+                Text(stringResource(R.string.ai_integration))
+            }
+        },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = stringResource(R.string.back_button_desc),
+            FrostedHeaderPill {
+                IconButton(
+                    onClick = navController::navigateUp,
+                    onLongClick = navController::backToMain,
+                ) {
+                    Icon(
+                        painterResource(R.drawable.arrow_back),
+                        contentDescription = stringResource(R.string.back_button_desc),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.settings),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.padding(end = 4.dp),
                 )
             }
         },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
@@ -106,6 +106,7 @@ import moe.rukamori.archivetune.constants.AodVerticalSpacingKey
 import moe.rukamori.archivetune.constants.SliderStyle
 import moe.rukamori.archivetune.constants.ThumbnailCornerRadiusKey
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -274,10 +275,12 @@ fun AodCustomizedScreen(
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.aod_customize_title),
-                        fontWeight = FontWeight.Bold,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.aod_customize_title),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 },
                 subtitle = {
                     Text(
@@ -287,13 +290,22 @@ fun AodCustomizedScreen(
                     )
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceExtrasSettings.kt
@@ -19,12 +19,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
@@ -36,6 +39,7 @@ import moe.rukamori.archivetune.constants.HideTop50CardKey
 import moe.rukamori.archivetune.constants.ShowHomeCategoryChipsKey
 import moe.rukamori.archivetune.constants.ShowTagsInLibraryKey
 import androidx.compose.material3.TopAppBar
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
@@ -67,15 +71,28 @@ fun AppearanceExtrasSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.extras)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.extras))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
@@ -112,6 +113,7 @@ import moe.rukamori.archivetune.constants.ThumbnailCornerRadiusKey
 import moe.rukamori.archivetune.constants.UiScaleFactorKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -423,15 +425,28 @@ fun AppearanceSettings(navController: NavController, scrollTo: String? = null) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.appearance)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.appearance))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -82,6 +82,7 @@ import moe.rukamori.archivetune.backup.ScheduledBackupFrequency
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -259,15 +260,28 @@ fun BackupAndRestore(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.backup_restore)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.backup_restore))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
@@ -89,6 +89,7 @@ import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.UpdateChannel
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.ReleaseInfo
@@ -164,13 +165,26 @@ fun ChangelogScreen(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.changelog)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.changelog))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -39,6 +40,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -48,6 +51,7 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.*
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.ui.component.EditTextPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -311,15 +315,28 @@ fun ContentSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.content)) },
+        title = {
+            FrostedHeaderPill {
+                Text(stringResource(R.string.content))
+            }
+        },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
+            FrostedHeaderPill {
+                IconButton(
+                    onClick = navController::navigateUp,
+                    onLongClick = navController::backToMain,
+                ) {
+                    Icon(
+                        painterResource(R.drawable.arrow_back),
+                        contentDescription = null,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.settings),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.padding(end = 4.dp),
                 )
             }
         },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/CustomizeBackground.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/CustomizeBackground.kt
@@ -84,6 +84,7 @@ import moe.rukamori.archivetune.constants.PlayerCustomBrightnessKey
 import moe.rukamori.archivetune.constants.PlayerCustomContrastKey
 import moe.rukamori.archivetune.constants.PlayerCustomImageUriKey
 import moe.rukamori.archivetune.utils.rememberPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import kotlin.math.roundToInt
 import androidx.compose.foundation.layout.asPaddingValues
 
@@ -146,23 +147,34 @@ fun CustomizeBackground(navController: NavController) {
         topBar = {
             MediumFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.customize_background_title),
-                        fontWeight = FontWeight.Bold,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.customize_background_title),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 },
                 subtitle = {
                     Text(text = stringResource(R.string.custom_background_subtitle))
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        modifier = Modifier.padding(start = 5.dp),
-                        colors = IconButtonDefaults.filledTonalIconButtonColors(),
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = stringResource(R.string.back_button_desc),
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            modifier = Modifier.padding(start = 5.dp),
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = stringResource(R.string.back_button_desc),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
@@ -81,6 +81,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.ManualSourceLoginEnabledKey
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -150,19 +151,30 @@ fun DebugSettings(navController: NavController) {
         topBar = {
             TopAppBar(
                 title = {
-                    Column {
-                        Text(
-                            text = stringResource(R.string.experiment_settings),
-                            style = MaterialTheme.typography.titleLarge,
-                        )
+                    FrostedHeaderPill {
+                        Column {
+                            Text(
+                                text = stringResource(R.string.experiment_settings),
+                                style = MaterialTheme.typography.titleLarge,
+                            )
+                        }
                     }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DeezerSettings.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -30,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
@@ -37,6 +39,7 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.DeezerAccountNameKey
 import moe.rukamori.archivetune.constants.DeezerAccountPremiumKey
 import moe.rukamori.archivetune.constants.DeezerArlKey
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -60,15 +63,28 @@ fun DeezerSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.deezer_integration)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.deezer_integration))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordExperimental.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordExperimental.kt
@@ -18,11 +18,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.*
 import moe.rukamori.archivetune.ui.component.EditTextPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
@@ -102,10 +104,23 @@ fun DiscordExperimental(
     Scaffold { inner ->
         Column(Modifier.fillMaxSize()) {
             TopAppBar(
-                title = { Text(stringResource(R.string.experiment_settings)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.experiment_settings))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(onClick = navController::navigateUp) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(onClick = navController::navigateUp) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
@@ -56,6 +56,7 @@ import moe.rukamori.archivetune.discord.DiscordAuthCoordinator
 import moe.rukamori.archivetune.discord.DiscordOAuthRepository
 import moe.rukamori.archivetune.ui.component.EditTextPreference
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -389,19 +390,30 @@ fun DiscordSettings(navController: NavController, scrollTo: String? = null) {
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.discord_integration),
-                        fontWeight = FontWeight.Bold,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.discord_integration),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DownloadsSettings.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -65,6 +66,8 @@ import moe.rukamori.archivetune.constants.TidalAccessTokenKey
 import moe.rukamori.archivetune.deezer.DeezerAudioProvider
 import moe.rukamori.archivetune.ui.component.ActionPromptDialog
 import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -173,15 +176,28 @@ fun DownloadsSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.downloads)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.downloads))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ExportDownloadedSongsScreen.kt
@@ -77,6 +77,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.db.entities.detectAudioExtensionFromSpans
 import moe.rukamori.archivetune.db.entities.extensionToMimeType
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
 import androidx.compose.foundation.layout.asPaddingValues
@@ -426,46 +427,57 @@ fun ExportDownloadedSongsScreen(navController: NavController) {
         topBar = {
             TopAppBar(
                 title = {
-                    if (isSearchActive) {
-                        OutlinedTextField(
-                            value = searchQuery,
-                            onValueChange = { searchQuery = it },
-                            placeholder = { Text(stringResource(R.string.search)) },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                            shape = RoundedCornerShape(28.dp),
-                            trailingIcon = {
-                                if (searchQuery.isNotEmpty()) {
-                                    IconButton(onClick = { searchQuery = "" }) {
-                                        Icon(
-                                            painter = painterResource(R.drawable.close),
-                                            contentDescription = stringResource(R.string.clear_search),
-                                        )
+                    FrostedHeaderPill {
+                        if (isSearchActive) {
+                            OutlinedTextField(
+                                value = searchQuery,
+                                onValueChange = { searchQuery = it },
+                                placeholder = { Text(stringResource(R.string.search)) },
+                                singleLine = true,
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(28.dp),
+                                trailingIcon = {
+                                    if (searchQuery.isNotEmpty()) {
+                                        IconButton(onClick = { searchQuery = "" }) {
+                                            Icon(
+                                                painter = painterResource(R.drawable.close),
+                                                contentDescription = stringResource(R.string.clear_search),
+                                            )
+                                        }
                                     }
-                                }
-                            },
-                        )
-                    } else {
-                        Text(stringResource(R.string.export_downloaded_songs))
+                                },
+                            )
+                        } else {
+                            Text(stringResource(R.string.export_downloaded_songs))
+                        }
                     }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = {
-                            if (isSearchActive) {
-                                isSearchActive = false
-                                searchQuery = ""
-                            } else {
-                                navController.navigateUp()
-                            }
-                        },
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                if (isSearchActive) R.drawable.arrow_back else R.drawable.arrow_back,
-                            ),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = {
+                                if (isSearchActive) {
+                                    isSearchActive = false
+                                    searchQuery = ""
+                                } else {
+                                    navController.navigateUp()
+                                }
+                            },
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(
+                                    if (isSearchActive) R.drawable.arrow_back else R.drawable.arrow_back,
+                                ),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
@@ -52,6 +52,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.PlaylistSortType
 import moe.rukamori.archivetune.db.entities.Playlist
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
 import androidx.compose.foundation.layout.asPaddingValues
@@ -72,15 +73,28 @@ fun HiddenPlaylistsScreen(navController: NavController) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.hidden_playlists)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.hidden_playlists))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IconScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IconScreen.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.Dp
@@ -92,6 +93,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.viewmodels.AppIconSortOrder
@@ -202,21 +204,32 @@ private fun IconScreenContent(
         topBar = {
             MediumFlexibleTopAppBar(
                 title = {
-                    Text(text = stringResource(R.string.app_icon))
+                    FrostedHeaderPill {
+                        Text(text = stringResource(R.string.app_icon))
+                    }
                 },
                 subtitle = {
                     Text(text = stringResource(R.string.app_icon_subtitle))
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = onNavigateUp,
-                        onLongClick = onNavigateHome,
-                        modifier = Modifier.padding(start = 5.dp),
-                        colors = IconButtonDefaults.filledTonalIconButtonColors(),
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = stringResource(R.string.back_button_desc),
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = onNavigateUp,
+                            onLongClick = onNavigateHome,
+                            modifier = Modifier.padding(start = 5.dp),
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = stringResource(R.string.back_button_desc),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -30,6 +31,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -43,6 +46,7 @@ import moe.rukamori.archivetune.constants.QobuzTokensKey
 import moe.rukamori.archivetune.constants.ShowSpotifyPlaylistsKey
 import moe.rukamori.archivetune.constants.TidalAccessTokenKey
 import moe.rukamori.archivetune.spotify.SpotifyAccountViewModel
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -94,15 +98,28 @@ fun IntegrationScreen(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.integration)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.integration))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -192,15 +192,28 @@ fun InternetSettings(navController: NavController, scrollTo: String? = null) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.internet)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.internet))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/JioSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/JioSettings.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
@@ -42,6 +43,7 @@ import moe.rukamori.archivetune.constants.JioSaavnEnabledKey
 import moe.rukamori.archivetune.constants.SaavnAudioQuality
 import moe.rukamori.archivetune.constants.SaavnAudioQualityKey
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -64,13 +66,26 @@ fun JioSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.jiosaavn_settings)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.jiosaavn_settings))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LanguagePackSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LanguagePackSettings.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -26,6 +27,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
@@ -35,6 +37,7 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.LyricsRomanizeJapaneseKey
 import moe.rukamori.archivetune.lyrics.JapaneseLanguagePackManager
 import moe.rukamori.archivetune.lyrics.JapaneseLanguagePackState
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -126,13 +129,26 @@ fun LanguagePackSettings(navController: NavController) {
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.language_packs)) },
+        title = {
+            FrostedHeaderPill {
+                Text(stringResource(R.string.language_packs))
+            }
+        },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+            FrostedHeaderPill {
+                IconButton(
+                    onClick = navController::navigateUp,
+                    onLongClick = navController::backToMain,
+                ) {
+                    Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                }
+                Text(
+                    text = stringResource(R.string.settings),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.padding(end = 4.dp),
+                )
             }
         },
     )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -62,6 +62,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.LastFmPreferYtThumbnailsKey
 import moe.rukamori.archivetune.constants.LastFmProvider
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -92,15 +93,28 @@ fun LastFMSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.lastfm_integration)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.lastfm_integration))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LogcatScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LogcatScreen.kt
@@ -89,6 +89,7 @@ import moe.rukamori.archivetune.viewmodels.LogcatUiEntries
 import moe.rukamori.archivetune.viewmodels.LogcatUiEntry
 import moe.rukamori.archivetune.viewmodels.LogcatUiModel
 import moe.rukamori.archivetune.viewmodels.LogcatViewModel
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton as ArchiveTuneIconButton
 import androidx.compose.foundation.layout.asPaddingValues
 
@@ -343,27 +344,40 @@ private fun LogcatTopBar(
 ) {
     MediumFlexibleTopAppBar(
         title = {
-            Text(
-                text = stringResource(R.string.debug_logs),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            FrostedHeaderPill {
+                Text(
+                    text = stringResource(R.string.debug_logs),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         },
         subtitle = {
-            Text(
-                text = stringResource(R.string.filter_all_logs),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            FrostedHeaderPill {
+                Text(
+                    text = stringResource(R.string.filter_all_logs),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         },
         navigationIcon = {
-            ArchiveTuneIconButton(
-                onClick = onNavigateBack,
-                onLongClick = onNavigateBackLongClick,
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
+            FrostedHeaderPill {
+                ArchiveTuneIconButton(
+                    onClick = onNavigateBack,
+                    onLongClick = onNavigateBackLongClick,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.arrow_back),
+                        contentDescription = null,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.settings),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.padding(end = 4.dp),
                 )
             }
         },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
@@ -27,6 +28,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
@@ -34,6 +37,7 @@ import moe.rukamori.archivetune.constants.LyricsV2BounceFactorKey
 import moe.rukamori.archivetune.constants.LyricsV2FillTransitionWidthKey
 import moe.rukamori.archivetune.constants.LyricsV2GlowFactorKey
 import moe.rukamori.archivetune.constants.LyricsV2LrcBounceEnabledKey
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -56,15 +60,28 @@ fun LyricsAnimationSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(text = stringResource(R.string.lyrics_animation_style)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(text = stringResource(R.string.lyrics_animation_style))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsProvidersSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsProvidersSettings.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -73,6 +74,7 @@ import moe.rukamori.archivetune.constants.PrioritizeWordSyncedLyricsKey
 import moe.rukamori.archivetune.constants.deserializeLyricsProviderOrder
 import moe.rukamori.archivetune.paxsenix.PaxsenixLyrics
 import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -190,15 +192,28 @@ fun LyricsProvidersSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.providers)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.providers))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsRomanisationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsRomanisationSettings.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -27,7 +28,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
@@ -39,6 +41,7 @@ import moe.rukamori.archivetune.constants.LyricsRomanizeKoreanKey
 import moe.rukamori.archivetune.constants.LyricsRomanizeOtherLanguagesKey
 import moe.rukamori.archivetune.lyrics.JapaneseLanguagePackManager
 import moe.rukamori.archivetune.lyrics.JapaneseLanguagePackState
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
@@ -81,15 +84,28 @@ fun LyricsRomanisationSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.romanization)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.romanization))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -106,6 +106,7 @@ import moe.rukamori.archivetune.paxsenix.models.PaxsenixStats
 import moe.rukamori.archivetune.paxsenix.models.ProviderStats
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.NumberPickerPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -547,15 +548,28 @@ fun LyricsSettings(
     }
 
     TopAppBar(
-        title = { Text(stringResource(R.string.lyrics)) },
+        title = {
+            FrostedHeaderPill {
+                Text(stringResource(R.string.lyrics))
+            }
+        },
         navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
+            FrostedHeaderPill {
+                IconButton(
+                    onClick = navController::navigateUp,
+                    onLongClick = navController::backToMain,
+                ) {
+                    Icon(
+                        painterResource(R.drawable.arrow_back),
+                        contentDescription = null,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.settings),
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    modifier = Modifier.padding(end = 4.dp),
                 )
             }
         },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/MusicTogetherScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/MusicTogetherScreen.kt
@@ -96,6 +96,7 @@ import androidx.window.core.layout.WindowSizeClass
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
@@ -167,23 +168,36 @@ fun MusicTogetherScreen(
     Scaffold(
         topBar = {
             LargeFlexibleTopAppBar(
-                title = { Text(stringResource(R.string.music_together)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.music_together))
+                    }
+                },
                 navigationIcon = {
-                    AtIconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                        modifier =
-                            Modifier
-                                .padding(horizontal = 4.dp)
-                                .size(40.dp),
-                        colors =
-                            IconButtonDefaults.iconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                            ),
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        AtIconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                            modifier =
+                                Modifier
+                                    .padding(horizontal = 4.dp)
+                                    .size(40.dp),
+                            colors =
+                                IconButtonDefaults.iconButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                ),
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -81,6 +82,7 @@ import moe.rukamori.archivetune.constants.NavigationBarTransparencyKey
 import moe.rukamori.archivetune.constants.NavigationBarWidthKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -154,15 +156,28 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.navigation_bar_settings_title)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.navigation_bar_settings_title))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PalettePickerScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PalettePickerScreen.kt
@@ -95,6 +95,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
@@ -109,6 +110,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.CustomThemeColorKey
 import moe.rukamori.archivetune.constants.DynamicThemeKey
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.svg.DynamicSVGImage
 import moe.rukamori.archivetune.ui.svg.PALETTE
@@ -1007,13 +1009,26 @@ fun PalettePickerScreen(navController: NavController) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.color_palette)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.color_palette))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
@@ -1199,13 +1214,26 @@ fun ThemeCreatorScreen(navController: NavController) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(text = stringResource(R.string.theme_creator_title)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(text = stringResource(R.string.theme_creator_title))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painter = painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painter = painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
                 actions = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
@@ -92,6 +93,7 @@ import moe.rukamori.archivetune.ui.component.ArtistSeparatorsDialog
 import moe.rukamori.archivetune.ui.component.CrossfadeSliderPreference
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.NumberPickerPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -308,15 +310,28 @@ fun PlayerSettings(navController: NavController, scrollTo: String? = null) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.player_and_audio)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.player_and_audio))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PoTokenScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PoTokenScreen.kt
@@ -81,6 +81,7 @@ import moe.rukamori.archivetune.constants.PoTokenPlayerKey
 import moe.rukamori.archivetune.constants.PoTokenSourceUrlKey
 import moe.rukamori.archivetune.constants.VisitorDataKey
 import moe.rukamori.archivetune.constants.WebClientPoTokenEnabledKey
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
@@ -261,21 +262,32 @@ fun PoTokenScreen(
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.po_token_generation),
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.po_token_generation),
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = stringResource(R.string.back_button_desc),
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = stringResource(R.string.back_button_desc),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalDatabase
@@ -53,6 +54,7 @@ import moe.rukamori.archivetune.constants.LowDataModeKey
 import moe.rukamori.archivetune.constants.PauseListenHistoryKey
 import moe.rukamori.archivetune.constants.PauseSearchHistoryKey
 import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -176,15 +178,28 @@ fun PrivacySettings(navController: NavController, scrollTo: String? = null) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.settings_behavior_title)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.settings_behavior_title))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/QobuzSettings.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import kotlinx.coroutines.Dispatchers
@@ -80,6 +81,7 @@ import moe.rukamori.archivetune.qobuz.SourceInputParsing
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.EnumListPreference
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -540,15 +542,28 @@ fun QobuzSettings(navController: NavController, scrollTo: String? = null) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.qobuz_integration)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.qobuz_integration))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.FlowPreview
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LocalSettingsDialogShowing
 import moe.rukamori.archivetune.ui.component.rememberSettingsDialogHostState
@@ -329,19 +330,40 @@ fun SettingsScreen(
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.settings),
-                        fontWeight = FontWeight.Bold,
-                    )
+                    // Liquid-glass title pill — matches the redesigned
+                    // HistoryScreen layout where the page title sits inside
+                    // a FrostedHeaderPill so the header reads as a
+                    // translucent capsule rather than a flat text label.
+                    // When no layer backdrop is available the pill falls
+                    // back to a translucent surfaceContainer surface.
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.settings),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = stringResource(R.string.back_button_desc),
+                    // Liquid-glass back pill — back chevron + "Settings"
+                    // label, mirroring the HistoryScreen back+Library pill
+                    // layout. Tapping pops back to the previous destination;
+                    // long-pressing jumps straight to the Home tab.
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = stringResource(R.string.back_button_desc),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SourceSettings.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -37,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import android.widget.Toast
 import androidx.navigation.NavController
@@ -46,6 +48,7 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.tidal.TidalInstanceHealthManager
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -60,15 +63,28 @@ fun SourceSettings(navController: NavController, scrollTo: String? = null) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.source_settings)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.source_settings))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -94,6 +95,7 @@ import moe.rukamori.archivetune.storage.StorageFolderKind
 import moe.rukamori.archivetune.storage.StorageLocationKind
 import moe.rukamori.archivetune.storage.StorageLocationRepository
 import moe.rukamori.archivetune.ui.component.ActionPromptDialog
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -305,15 +307,28 @@ fun StorageSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.storage)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.storage))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramLoginScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramLoginScreen.kt
@@ -76,6 +76,7 @@ import moe.rukamori.archivetune.telegram.TelegramClient
 import moe.rukamori.archivetune.telegram.TelegramCodeType
 import moe.rukamori.archivetune.telegram.composeE164
 import moe.rukamori.archivetune.telegram.defaultCallingCode
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
 import androidx.compose.foundation.layout.asPaddingValues
@@ -155,13 +156,26 @@ fun TelegramLoginScreen(navController: NavController) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.telegram_login_title)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.telegram_login_title))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TelegramSettings.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -36,6 +37,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
@@ -46,6 +49,7 @@ import moe.rukamori.archivetune.constants.TelegramLosslessOnlyKey
 import moe.rukamori.archivetune.telegram.TelegramAuthState
 import moe.rukamori.archivetune.telegram.TelegramClient
 import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -120,13 +124,26 @@ fun TelegramSettings(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.telegram_integration)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.telegram_integration))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(painterResource(R.drawable.arrow_back), contentDescription = null)
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
                     }
                 },
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/TidalSettings.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.datastore.preferences.core.edit
 import androidx.navigation.NavController
@@ -81,6 +82,7 @@ import moe.rukamori.archivetune.qobuz.SourceInputParsing
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.tidal.TidalInstanceHealthManager
 import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -406,15 +408,28 @@ fun TidalSettings(navController: NavController, scrollTo: String? = null) {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.tidal_integration)) },
+                title = {
+                    FrostedHeaderPill {
+                        Text(stringResource(R.string.tidal_integration))
+                    }
+                },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = null,
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = null,
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -109,6 +109,7 @@ import moe.rukamori.archivetune.constants.UpdateChannelKey
 import moe.rukamori.archivetune.defaultUpdateChannel
 import moe.rukamori.archivetune.ui.component.BottomSheetPage
 import moe.rukamori.archivetune.ui.component.BottomSheetPageState
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.MarkdownText
 import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
@@ -507,10 +508,12 @@ fun UpdateScreen(
         topBar = {
             MediumFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.updates),
-                        fontWeight = FontWeight.Bold,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.updates),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 },
                 subtitle = {
                     Text(
@@ -520,13 +523,22 @@ fun UpdateScreen(
                     )
                 },
                 navigationIcon = {
-                    IconButton(
-                        onClick = navController::navigateUp,
-                        onLongClick = navController::backToMain,
-                    ) {
-                        Icon(
-                            painterResource(R.drawable.arrow_back),
-                            contentDescription = stringResource(R.string.back_button_desc),
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = navController::navigateUp,
+                            onLongClick = navController::backToMain,
+                        ) {
+                            Icon(
+                                painterResource(R.drawable.arrow_back),
+                                contentDescription = stringResource(R.string.back_button_desc),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/YtDlpSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/YtDlpSettings.kt
@@ -63,6 +63,7 @@ import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.morideobfuscator.ytdlp.YtDlpRuntimeStatus
+import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
@@ -135,20 +136,31 @@ private fun YtDlpSettingsContent(
         topBar = {
             LargeFlexibleTopAppBar(
                 title = {
-                    Text(
-                        text = stringResource(R.string.ytdlp_settings_title),
-                        fontWeight = FontWeight.Bold,
-                    )
+                    FrostedHeaderPill {
+                        Text(
+                            text = stringResource(R.string.ytdlp_settings_title),
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
                 },
                 subtitle = { Text(stringResource(R.string.ytdlp_settings_description)) },
                 navigationIcon = {
-                    IconButton(
-                        onClick = onNavigateUp,
-                        onLongClick = onNavigateToMain,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.arrow_back),
-                            contentDescription = stringResource(R.string.back_button_desc),
+                    FrostedHeaderPill {
+                        IconButton(
+                            onClick = onNavigateUp,
+                            onLongClick = onNavigateToMain,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_back),
+                                contentDescription = stringResource(R.string.back_button_desc),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.settings),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            modifier = Modifier.padding(end = 4.dp),
                         )
                     }
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,6 +369,7 @@
     <string name="undo">Undo</string>
     <string name="lyrics_not_found">Lyrics not found</string>
     <string name="lyrics_from_source">Lyrics from %1$s</string>
+    <string name="written_by">Written by %1$s</string>
     <string name="lyrics_word_sync">Word Sync</string>
     <string name="sleep_timer">Sleep timer</string>
     <string name="end_of_song">End of song</string>


### PR DESCRIPTION
## Summary

Addresses 6 user-reported issues from iterative feedback:

1. **History source pill**: replaced full-width two-button ToggleButton row with a single start-aligned dropdown pill (mirrors `SortHeader` design — translucent capsule + pink accent icon/label + trailing dropdown chevron). Now aligns with the Play/Shuffle pills in the hero like the sort pill on the playlist page.

2. **Spotify + playlist pages liquid glass headers**: converted `SpotifyPlaylistScreen` TopStart from a single `LiquidGlassIconButton` (just the arrow_back icon) to a `LiquidGlassActionPill` containing back chevron + Library label, matching the `HistoryScreen` / `LocalPlaylistScreen` pattern. Also fixed the black backdrop bug (`Color.Black` -> `surfaceColor`).

3. **Lyrics attribution**:
   - `Lyrics.kt` (non-Apple-Music style): moved the floating `Lyrics from [provider]` overlay (which was constant — alpha-faded but never actually scrolled) into the LazyColumn as the first item, so it scrolls naturally with the lyrics. Added a new `Written by [artists]` LazyColumn item at the end.
   - `LyricsEnhanced.kt` (Apple Music style): added the missing `Lyrics from [provider]` overlay above the karaoke list with an alpha fade based on scroll position. Added a `Written by` footer overlay at the bottom with an alpha fade that increases as user scrolls toward the end.
   - `LyricsV2.kt`: added `Lyrics from` header item and `Written by` footer item directly to the LazyColumn.
   - Added new `written_by` string resource.

4. **Sequential back navigation**: added an explicit `BackHandler` in `SpotifyPlaylistScreen`, `LocalPlaylistScreen`, `AutoPlaylistScreen`, `CachePlaylistScreen`, `TopPlaylistScreen`, and `OnlinePlaylistScreen` that calls `navigateUp()` first, and if that returns false (no previous back-stack entry — e.g. deep link from Home), falls back to navigating to the Library tab. Ensures the predictive back gesture always lands on the Library tab rather than skipping straight to Home.

5. **Liquid glass lag optimization**: wrapped the entire `drawBackdrop` modifier chain in `Modifier.liquidGlass` with `remember(backdrop, shape, interactive, baseColor, isDark)` so the kyant effect stack is built ONCE per (backdrop, shape, dark-theme) tuple and reused across scroll-driven recompositions. Previously every recomposition rebuilt the effect stack and re-installed the RuntimeShader on the GraphicsLayer — the dominant cause of the lag when switching pages.

6. **Liquid glass headers expanded to all settings submenus**: wrapped the `TopAppBar` title and navigationIcon slots in `FrostedHeaderPill` across 42 settings files, matching the `SettingsScreen` reference example. The back pill reads as `-> Settings` (back chevron + Settings label), mirroring the History page `-> Library` pill.

## Files changed

- `LiquidGlass.kt`, `Lyrics.kt`, `LyricsEnhanced.kt`, `LyricsV2.kt` (component-level)
- `HistoryScreen.kt` (history source pill)
- `SpotifyPlaylistScreen.kt`, `LocalPlaylistScreen.kt`, `AutoPlaylistScreen.kt`, `CachePlaylistScreen.kt`, `TopPlaylistScreen.kt`, `OnlinePlaylistScreen.kt` (back nav)
- 42 settings submenu files (liquid glass header pills)
- `strings.xml` (new `written_by` string)

## Test plan

- [ ] CI build passes
- [ ] History page shows single dropdown pill aligned with Play pill
- [ ] Spotify playlist page shows back+Library pill on left, search pill on right
- [ ] Apple Music style lyrics shows `Lyrics from [provider]` at top, fades on scroll
- [ ] Non-Apple Music lyrics shows `Lyrics from` and `Written by` as scrollable items
- [ ] Back gesture from Spotify playlist -> Library (not Home)
- [ ] Page transitions feel less laggy
- [ ] All settings submenus show frosted header pills