### PR TITLE
Make lyric attributions scroll with lyrics, fix frosted header fallback, restore playlist back-swipe

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
@@ -12,6 +12,7 @@ package moe.rukamori.archivetune.ui.component
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BorderStroke
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -34,9 +35,9 @@ import androidx.compose.ui.unit.dp
  * fallback those paths already used when no backdrop was available, and matches how the pill
  * behaves in rail layouts where the backdrop is null.
  *
- * The alpha is tuned low enough that the scrolling content shows through (so the header reads
- * as "transparent" rather than a solid bar) while still keeping the title/icons legible against
- * busy backgrounds like album art.
+ * The fallback deliberately uses a dense frosted material rather than a nearly transparent
+ * surface. Settings pages cannot safely sample the app-wide backdrop from inside the NavHost,
+ * but their controls must still read as a visible glass surface instead of an empty pill.
  *
  * **Liquid glass mode:** Pass a non-null [backdrop] (typically created via [rememberBackdrop]
  * and applied to a sibling `LazyColumn` via [Modifier.layerBackdrop]) to switch the pill to
@@ -82,12 +83,16 @@ fun FrostedHeaderPill(
             content()
         }
     } else {
-        // Fallback path: translucent surface (no real backdrop blur).
-        val baseColor = MaterialTheme.colorScheme.surfaceContainer
+        // Fallback path for NavHost-owned screens such as Settings. Sampling
+        // the app-wide backdrop here would create a render-feedback loop, so
+        // use Material's frosted container plus a subtle highlight instead of
+        // degrading to an almost-transparent pill.
+        val baseColor = MaterialTheme.colorScheme.surfaceContainerHigh
         Surface(
             modifier = modifier.clip(pillShape),
             shape = pillShape,
-            color = baseColor.copy(alpha = 0.55f),
+            color = baseColor.copy(alpha = 0.88f),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.surfaceBright.copy(alpha = 0.72f)),
         ) {
             Row(modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)) {
                 content()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
@@ -806,22 +806,8 @@ fun Lyrics(
                 )
             }
         } else {
-            // "Lyrics from [provider]" header is rendered as the FIRST item of
-            // the LazyColumn below (not as a floating overlay) so it scrolls
-            // naturally with the lyrics — the user requested this behave "as
-            // if it's a lyrics line itself" rather than a constant watermark
-            // that fades on scroll. The visual design matches the "Written by"
-            // footer item at the end of the list (same color, weight, size,
-            // alignment) so the two attribution labels read as a matched
-            // pair bracketing the lyrics.
-            //
-            // "Written by [artists]" is rendered as the LAST item of the
-            // LazyColumn for the same reason — it scrolls naturally with the
-            // lyrics and visually closes the lyrics block. We use the song's
-            // artist list (composer credits are not tracked in MediaMetadata)
-            // as a proxy for the "written by" attribution, matching the
-            // user's previous request to surface this credit at the bottom
-            // of the lyrics page.
+            // The source attribution is a LazyColumn item rather than a
+            // floating overlay, so it scrolls away together with the lyrics.
             LazyColumn(
                 state = lazyListState,
                 contentPadding =
@@ -870,12 +856,8 @@ fun Lyrics(
                 val displayedCurrentLineIndex =
                     if (isSeeking || isSelectionModeActive) deferredCurrentLineIndex else currentLineIndex
 
-                // "Lyrics from [provider]" header item. Rendered as a regular
-                // LazyColumn item so it scrolls naturally with the lyrics. The
-                // visual style mirrors the "Written by" footer item below:
-                // small secondary color, medium weight, centered. Skipping if
-                // the provider name is blank (e.g. embedded lyrics have no
-                // provider attribution).
+                // Render source attribution in the scrolling content, not as
+                // a persistent watermark.
                 if (lyricsProviderName.isNotBlank() && lyrics != null) {
                     item(key = "lyrics_source_header", contentType = "lyrics_attribution") {
                         Box(
@@ -2454,40 +2436,6 @@ fun Lyrics(
                     }
                 }
 
-                // "Written by [artists]" footer item. Rendered as the LAST
-                // item of the LazyColumn so it scrolls naturally with the
-                // lyrics and visually closes the lyrics block. The visual
-                // style mirrors the "Lyrics from [provider]" header item
-                // at the top of the list (small secondary color, medium
-                // weight, centered) so the two attribution labels read as
-                // a matched pair bracketing the lyrics. We use the song's
-                // artist list as the credit source — MediaMetadata does not
-                // track formal composer credits, so the artist list is the
-                // best available proxy for "who wrote this song".
-                mediaMetadata?.let { metadata ->
-                    val writersLine = metadata.artists.joinToString { it.name }.trim()
-                    if (writersLine.isNotBlank()) {
-                        item(key = "lyrics_writers_footer", contentType = "lyrics_attribution") {
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(top = 24.dp, bottom = 8.dp),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.written_by, writersLine),
-                                    fontSize = 12.sp,
-                                    color = MaterialTheme.colorScheme.secondary,
-                                    textAlign = TextAlign.Center,
-                                    fontWeight = FontWeight.Medium,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis,
-                                )
-                            }
-                        }
-                    }
-                }
             }
 
             AnimatedVisibility(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -488,23 +488,6 @@ fun LyricsEnhanced(
         // romanisation of lines already on screen has to carry a new generation with it. See
         // KaraokeBuild.
         //
-        // Composer footer ("Written by: <artists>") — built from the
-        // currently-playing MediaMetadata. Hoisted here so it lives in
-        // the same LaunchedEffect scope as the karaoke build, which
-        // means a track change (mediaMetadata.id changes) re-launches
-        // this effect and the footer is recomputed for the new track.
-        // The footer is only meaningful when there's at least one
-        // credited artist; if the track has no artists in its metadata
-        // (rare — only happens for some local files with no ID3 artist
-        // tag), the footer is suppressed rather than showing an empty
-        // "Written by: " string.
-        val composerFooter =
-            mediaMetadata
-                ?.artists
-                ?.takeIf { it.isNotEmpty() }
-                ?.joinToString { it.name }
-                ?.let { "Written by: $it" }
-
         fun publish(romanization: Map<Int, List<String?>>) {
             val previous = karaokeBuild
             val changesVisibleLines =
@@ -512,7 +495,7 @@ fun LyricsEnhanced(
                     romanization.renderedRomanization() != previous.romanization.renderedRomanization()
             karaokeBuild =
                 KaraokeBuild(
-                    lyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, romanization, composerFooter),
+                    lyrics = buildSyncedLyrics(lyricsEntries, isTtmlFormat, romanization),
                     romanization = romanization,
                     generation = if (changesVisibleLines) previous.generation + 1 else previous.generation,
                 )
@@ -1056,32 +1039,7 @@ fun LyricsEnhanced(
             )
         }
     val plainLyrics =
-        remember(lyricsEntries, isSynced, mediaMetadata?.artists) {
-            // Composer footer ("Written by: <artists>") — appended as a
-            // synthetic PlainLyricLine at the end of the non-synced
-            // lyrics list. Per user request (2026-08-28): "Add composer
-            // of the song at the end of the lyrics in apple music player
-            // style lyrics and non apple music style lyrics too." The
-            // footer is built from `MediaMetadata.artists` — there is no
-            // dedicated composer/songwriter field in the codebase, so
-            // the artist credit stands in. The footer is only added when
-            // the track has at least one credited artist; tracks with
-            // no artist metadata (rare) get no footer rather than an
-            // empty "Written by: " string.
-            val composerFooterLine =
-                mediaMetadata
-                    ?.artists
-                    ?.takeIf { it.isNotEmpty() }
-                    ?.joinToString { it.name }
-                    ?.let { "Written by: $it" }
-                    ?.let { text ->
-                        PlainLyricLine(
-                            itemId = "composer_footer",
-                            selectionId = "plain:composer_footer:${text.hashCode()}",
-                            text = text,
-                        )
-                    }
-
+        remember(lyricsEntries, isSynced) {
             val lyricItems =
                 if (isSynced) {
                     emptyList()
@@ -1100,14 +1058,7 @@ fun LyricsEnhanced(
                         }
                     }
                 }
-            PlainLyrics(
-                items =
-                    if (composerFooterLine != null && lyricItems.isNotEmpty()) {
-                        lyricItems + composerFooterLine
-                    } else {
-                        lyricItems
-                    },
-            )
+            PlainLyrics(items = lyricItems)
         }
     val selectionLines =
         remember(isSynced, syncedLyrics, plainLyrics) {
@@ -1117,34 +1068,21 @@ fun LyricsEnhanced(
                     if (text.isBlank()) {
                         null
                     } else {
-                        // Skip the composer footer in the selection sheet —
-                        // it is metadata, not a lyric the user would want
-                        // to copy/share. Identified by its very high start
-                        // time (24h, see `buildSyncedLyrics`).
-                        if (line.start >= 86_400_000) {
-                            null
-                        } else {
-                            val selectionId = line.selectionKey(text)
-                            LyricSelectionLine(
-                                itemId = "$selectionId#$index",
-                                selectionId = selectionId,
-                                text = text,
-                            )
-                        }
+                        val selectionId = line.selectionKey(text)
+                        LyricSelectionLine(
+                            itemId = "$selectionId#$index",
+                            selectionId = selectionId,
+                            text = text,
+                        )
                     }
                 }
             } else {
-                plainLyrics.items.mapNotNull { line ->
-                    // Skip the composer footer in the selection sheet.
-                    if (line.itemId == "composer_footer") {
-                        null
-                    } else {
-                        LyricSelectionLine(
-                            itemId = line.itemId,
-                            selectionId = line.selectionId,
-                            text = line.text,
-                        )
-                    }
+                plainLyrics.items.map { line ->
+                    LyricSelectionLine(
+                        itemId = line.itemId,
+                        selectionId = line.selectionId,
+                        text = line.text,
+                    )
                 }
             }
         }
@@ -1203,36 +1141,34 @@ fun LyricsEnhanced(
                 // gate is never armed and this is a no-op.
                 .graphicsLayer { alpha = firstFocusAlpha.value },
     ) {
-        // "Lyrics from [provider]" header — mirrors the legacy Lyrics.kt
-        // pattern (L808-841). Per user request (2026-08-28): "just like
-        // written by is on the bottom of lyrics page there's should be
-        // Lyrics from 'The lyrics provider name' on the top of the lyrics
-        // too". The header is rendered as an overlay aligned to the top
-        // of the lyrics Box; the karaoke list has enough top padding for
-        // active-line centering that the header sits in the empty space
-        // above the first visible lyric line. `providerName` comes from
-        // the LyricsEntity row persisted by LyricsHelper (e.g. "LrcLib",
-        // "Musixmatch", "BiniLyrics", etc.).
+        // Enhanced lyrics are rendered by a dedicated karaoke view instead of
+        // a LazyColumn. Keep the source label tied to that view's scroll state
+        // so it leaves with the lyrics (including during auto-scroll), rather
+        // than acting as a permanent top watermark.
         val lyricsProviderName = currentLyrics?.providerName.orEmpty()
-        if (lyricsProviderName.isNotBlank()) {
-            Box(
-                modifier =
-                    Modifier
-                        .align(Alignment.TopCenter)
-                        .fillMaxWidth()
-                        .padding(top = 12.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.secondary,
-                    textAlign = TextAlign.Center,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+        val sourceHeaderVisible by remember(listState, lyricsProviderName) {
+            derivedStateOf {
+                lyricsProviderName.isNotBlank() &&
+                    listState.firstVisibleItemIndex == 0 &&
+                    listState.firstVisibleItemScrollOffset == 0
             }
+        }
+        AnimatedVisibility(
+            visible = sourceHeaderVisible,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier.align(Alignment.TopCenter),
+        ) {
+            Text(
+                text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.secondary,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 12.dp),
+            )
         }
         when {
             lyrics == LYRICS_NOT_FOUND -> {
@@ -1425,52 +1361,6 @@ fun LyricsEnhanced(
             }
         }
 
-        // "Written by [artists]" footer overlay. Mirrors the design of the
-        // "Lyrics from" header overlay above: small secondary color, medium
-        // weight, centered. Rendered as an overlay at the bottom of the
-        // lyrics Box so it visually closes the lyrics block. The alpha
-        // fades in as the user scrolls toward the end of the lyrics (so it
-        // doesn't compete with the active line at the top). The artist list
-        // is used as a proxy for composer credits (MediaMetadata does not
-        // track formal composer credits).
-        mediaMetadata?.let { metadata ->
-            val writersLine = metadata.artists.joinToString { it.name }.trim()
-            if (writersLine.isNotBlank() && lyrics != null && lyrics != LYRICS_NOT_FOUND) {
-                val footerAlpha by remember {
-                    derivedStateOf {
-                        val layoutInfo = listState.layoutInfo
-                        val totalItems = layoutInfo.totalItemsCount
-                        val lastVisibleIdx = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                        if (totalItems == 0) 0f
-                        else ((lastVisibleIdx + 1).toFloat() / totalItems.toFloat()).coerceIn(0f, 1f)
-                    }
-                }
-                val animatedFooterAlpha by animateFloatAsState(
-                    targetValue = footerAlpha,
-                    animationSpec = tween(durationMillis = 220),
-                    label = "lyricsFooterAlphaEnhanced",
-                )
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .align(Alignment.BottomCenter)
-                            .padding(bottom = 16.dp)
-                            .graphicsLayer { alpha = animatedFooterAlpha },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = stringResource(R.string.written_by, writersLine),
-                        fontSize = 12.sp,
-                        color = MaterialTheme.colorScheme.secondary,
-                        textAlign = TextAlign.Center,
-                        fontWeight = FontWeight.Medium,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-        }
     }
 
     if (isSelectionModeActive && selectionLines.isNotEmpty()) {
@@ -2038,7 +1928,6 @@ private fun buildSyncedLyrics(
     entries: List<LyricsEntry>,
     isTtml: Boolean,
     romanizationMap: Map<Int, List<String?>>,
-    composerFooter: String? = null,
 ): SyncedLyrics {
     if (entries.isEmpty()) return SyncedLyrics(emptyList())
     val lines = mutableListOf<ISyncedLine>()
@@ -2160,34 +2049,6 @@ private fun buildSyncedLyrics(
                 ),
             )
         }
-    }
-
-    // "Written by: <artists>" footer — appended as a synthetic
-    // ISyncedLine at the very end of the lyrics. Per user request
-    // (2026-08-28): "Add composer of the song at the end of the lyrics
-    // in apple music player style lyrics and non apple music style
-    // lyrics too. I've attached how it should exactly look". The
-    // reference image shows a small dim "Written by: <names>" credit
-    // appearing after the last lyric line.
-    //
-    // The synthetic line's start time is set well beyond any real
-    // playback position (1 day in milliseconds) so the karaoke renderer
-    // never highlights it as the active line during normal playback.
-    // It is only visible when the user scrolls to the bottom of the
-    // lyrics list. The `SyncedLine` renderer draws `content` at the
-    // ambient text style, which we've pinned to `phoneticTextStyle`
-    // (small dim text) at the KaraokeLyricsView call site — that gives
-    // the credit a visually subdued look matching the reference image.
-    if (!composerFooter.isNullOrBlank()) {
-        val footerStart = 86_400_000 // 24h in ms — well beyond any song length
-        lines.add(
-            SyncedLine(
-                content = composerFooter,
-                translation = null,
-                start = footerStart,
-                end = footerStart + 60_000,
-            ),
-        )
     }
 
     return SyncedLyrics(lines = lines)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -779,11 +779,8 @@ fun LyricsV2(
                     },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // "Lyrics from [provider]" header item. Rendered as the FIRST
-            // LazyColumn item so it scrolls naturally with the lyrics — the
-            // user requested this behave "as if it's a lyrics line itself"
-            // rather than a constant watermark. Mirrors the design of the
-            // "Written by" footer item at the end of the list.
+            // Render the source attribution in the scrolling content rather
+            // than keeping it fixed above the lyrics.
             val providerNameV2 = currentLyrics?.providerName.orEmpty()
             if (providerNameV2.isNotBlank()) {
                 item(key = "lyrics_source_header_v2", contentType = "lyrics_attribution") {
@@ -1158,36 +1155,6 @@ fun LyricsV2(
                 Spacer(modifier = Modifier.height(300.dp))
             }
 
-            // "Written by [artists]" footer item. Rendered as the LAST
-            // LazyColumn item so it scrolls naturally with the lyrics and
-            // visually closes the lyrics block. Mirrors the design of the
-            // "Lyrics from" header item at the top. Uses the artist list as
-            // a proxy for composer credits (MediaMetadata does not track
-            // formal composer credits).
-            mediaMetadata?.let { metadata ->
-                val writersLineV2 = metadata.artists.joinToString { it.name }.trim()
-                if (writersLineV2.isNotBlank()) {
-                    item(key = "lyrics_writers_footer_v2", contentType = "lyrics_attribution") {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 8.dp, bottom = 16.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = stringResource(R.string.written_by, writersLineV2),
-                                fontSize = 12.sp,
-                                color = MaterialTheme.colorScheme.secondary,
-                                textAlign = TextAlign.Center,
-                                fontWeight = FontWeight.Medium,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                    }
-                }
-            }
         }
 
         // ── Resume auto-scroll button ──

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -12,6 +12,7 @@ package moe.rukamori.archivetune.ui.screens.playlist
 import android.annotation.SuppressLint
 import android.os.Build
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -92,6 +93,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalDatabase
@@ -303,15 +305,10 @@ fun LocalPlaylistScreen(
             selection = false
         }
     } else {
-        // Explicit BackHandler so the predictive back gesture lands on the
-        // Library tab when the previous back-stack entry is not a main
-        // screen (e.g. when the user entered this screen directly via a
-        // deep link from Home). Calling [navigateUp] first preserves the
-        // natural back stack; if that returns false (no previous entry to
-        // pop), we explicitly navigate to the Library tab so the user
-        // always lands somewhere meaningful instead of being dropped on
-        // Home. Matches the SpotifyPlaylistScreen pattern.
-        BackHandler {
+        // Register against the predictive-back dispatcher so Android's edge
+        // gesture follows the same path as the header's back button.
+        PredictiveBackHandler {
+            it.collect()
             if (!navController.navigateUp()) {
                 navController.navigate("library") {
                     launchSingleTop = true

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -10,6 +10,7 @@
 package moe.rukamori.archivetune.ui.screens.playlist
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -75,6 +76,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.google.common.collect.ImmutableList
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.LocalDownloadUtil
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
@@ -319,16 +321,10 @@ fun SpotifyPlaylistScreen(
             query = TextFieldValue()
         }
     } else {
-        // Explicit BackHandler so the predictive back gesture lands on the
-        // Library tab when the previous back-stack entry is not a main
-        // screen. Previously, when the user entered this screen directly
-        // (e.g. via a deep link from Home) the back gesture popped straight
-        // to Home, skipping the Library tab the user expected to return to.
-        // Calling [navigateUp] first preserves the natural back stack; if
-        // that returns false (no previous entry to pop), we explicitly
-        // navigate to the Library tab so the user always lands somewhere
-        // meaningful instead of being dropped on Home.
-        BackHandler {
+        // Register against the predictive-back dispatcher so Android's edge
+        // gesture follows the same path as the header's back button.
+        PredictiveBackHandler {
+            it.collect()
             if (!navController.navigateUp()) {
                 navController.navigate("library") {
                     launchSingleTop = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,7 +371,6 @@
     <string name="undo">Undo</string>
     <string name="lyrics_not_found">Lyrics not found</string>
     <string name="lyrics_from_source">Lyrics from %1$s</string>
-    <string name="written_by">Written by %1$s</string>
     <string name="lyrics_word_sync">Word Sync</string>
     <string name="sleep_timer">Sleep timer</string>
     <string name="end_of_song">End of song</string>


### PR DESCRIPTION
### Motivation
- Remove the permanent "Written by" footer watermark and make the provider attribution behave like a normal lyric line so it scrolls/auto-scrolls away with the lyrics.
- Ensure Liquid Glass header pills remain visible on Settings/NavHost-owned screens where sampling the app-wide backdrop is unsafe.
- Restore Android edge-back navigation (predictive back) for Spotify and local playlist screens so the gesture behaves like the header back button.

### Description
- Removed the synthetic composer/footer "Written by" lyric entries and their insertion paths from the various lyric renderers so the footer is no longer a constant overlay in `Lyrics`, `LyricsV2` and `LyricsEnhanced` (reworked the synced/plain lyric assembly and selection lists accordingly). Files touched: `ui/component/Lyrics.kt`, `ui/component/LyricsV2.kt`, `ui/component/LyricsEnhanced.kt`.
- Kept the `Lyrics from ...` attribution inside the scrolling content for the standard and V2 renderers, and made the Enhanced renderer tie the source header visibility to the karaoke list scroll state so it scrolls away during auto-scroll; added small animated visibility handling in `LyricsEnhanced`. Files touched: `ui/component/Lyrics.kt`, `ui/component/LyricsV2.kt`, `ui/component/LyricsEnhanced.kt`.
- Improved the fallback appearance of `FrostedHeaderPill` for NavHost-owned screens by using `surfaceContainerHigh` with a higher opacity and a subtle border so the pill reads as a visible frosted surface when a real backdrop cannot be sampled (avoids invisible/transparent pills in Settings). File touched: `ui/component/FrostedHeaderPill.kt`.
- Restored back-swipe behaviour on playlist screens by registering against the predictive back dispatcher (`PredictiveBackHandler`), collecting the predictive flow and preserving the existing `navigateUp()` / Library fallback path; added necessary imports for the new handler. Files touched: `ui/screens/playlist/SpotifyPlaylistScreen.kt`, `ui/screens/playlist/LocalPlaylistScreen.kt`.
- Removed the `written_by` string resource since the synthetic footer was removed. File touched: `app/src/main/res/values/strings.xml`.

### Testing
- Ran `git diff --check` and basic repository checks which passed without whitespace errors.
- Attempted a Kotlin compile with `./gradlew :app:compileGmsMobileUniversalDebugKotlin` but Gradle configuration failed because the `lyrics/betterlyrics` project directory is missing (multi-module configuration error), so a full build could not be completed.
- Attempted unit tests with `./gradlew :app:testGmsMobileUniversalDebugUnitTest` but the run was blocked for the same Gradle configuration reason, so automated tests could not be executed to completion.
- Performed local code inspections and `rg` searches to verify that synthetic composer/footer code paths and the `written_by` string usage were removed and that `PredictiveBackHandler` was wired into the playlist screens; these checks matched the intended edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91af8f0d0083208f28cc5e0f7ab049)