### PR TITLE
fix(lyrics): add missing imports and draw provider header above lyrics

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
@@ -9,6 +9,7 @@
 
 package moe.rukamori.archivetune.ui.component
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -17,6 +17,9 @@ import android.app.Activity
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -1203,37 +1206,6 @@ fun LyricsEnhanced(
                 // gate is never armed and this is a no-op.
                 .graphicsLayer { alpha = firstFocusAlpha.value },
     ) {
-        // "Lyrics from [provider]" header — mirrors the legacy Lyrics.kt
-        // pattern (L808-841). Per user request (2026-08-28): "just like
-        // written by is on the bottom of lyrics page there's should be
-        // Lyrics from 'The lyrics provider name' on the top of the lyrics
-        // too". The header is rendered as an overlay aligned to the top
-        // of the lyrics Box; the karaoke list has enough top padding for
-        // active-line centering that the header sits in the empty space
-        // above the first visible lyric line. `providerName` comes from
-        // the LyricsEntity row persisted by LyricsHelper (e.g. "LrcLib",
-        // "Musixmatch", "BiniLyrics", etc.).
-        val lyricsProviderName = currentLyrics?.providerName.orEmpty()
-        if (lyricsProviderName.isNotBlank()) {
-            Box(
-                modifier =
-                    Modifier
-                        .align(Alignment.TopCenter)
-                        .fillMaxWidth()
-                        .padding(top = 12.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
-                    fontSize = 12.sp,
-                    color = MaterialTheme.colorScheme.secondary,
-                    textAlign = TextAlign.Center,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        }
         when {
             lyrics == LYRICS_NOT_FOUND -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -1422,6 +1394,36 @@ fun LyricsEnhanced(
                         }
                     }
                 }
+            }
+        }
+
+        // "Lyrics from [provider]" header — mirrors the legacy Lyrics.kt
+        // pattern (L808-841). Per user request (2026-08-28): "just like
+        // written by is on the bottom of lyrics page there's should be
+        // Lyrics from 'The lyrics provider name' on the top of the lyrics
+        // too". Draw this after the lyrics list so it stays on top of the
+        // scrolling content instead of being covered by the LazyColumn.
+        // `providerName` comes from the LyricsEntity row persisted by
+        // LyricsHelper (e.g. "LrcLib", "Musixmatch", "BiniLyrics", etc.).
+        val lyricsProviderName = currentLyrics?.providerName.orEmpty()
+        if (lyricsProviderName.isNotBlank() && lyrics != null && lyrics != LYRICS_NOT_FOUND) {
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.TopCenter)
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.secondary,
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
         }
 


### PR DESCRIPTION
### Motivation
- Fix a release build failure caused by missing Compose animation and UI imports used by `LyricsEnhanced` and `FrostedHeaderPill`. 
- Ensure the "Lyrics from <provider>" label is rendered on top of the lyrics content (user requested the provider label at the top rather than being covered by the scrolling list).

### Description
- Added `AnimatedVisibility`, `fadeIn`, and `fadeOut` imports to `app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt` to satisfy compile-time references to Compose animation APIs. 
- Added `BorderStroke` import to `app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt` to fix the missing symbol in that component. 
- Moved the "Lyrics from [provider]" overlay rendering to after the lyrics list in `LyricsEnhanced` and guarded its display so it is presented above the scrolling content only when lyrics are available and not `LYRICS_NOT_FOUND`.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues (success). 
- Attempted `./gradlew :app:compileGmsTvUniversalReleaseKotlin`, but Gradle configuration failed because the `lyrics/betterlyrics` submodule directory is missing and causes project configuration to abort (build blocked). 
- Attempted `git submodule update --init --recursive lyrics`, but initialization failed due to network access returning `CONNECT tunnel failed, response 403`, so the submodule could not be cloned and the full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91b5086cb48325a5e162a6d40fb699)