### PR TITLE
fix(build,history,lyrics): resolve compile errors + history dropdown shows remote correctly + smaller Lyrics-from attribution

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FrostedHeaderPill.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.BorderStroke
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Lyrics.kt
@@ -894,7 +894,7 @@ fun Lyrics(
                             ) {
                                 Text(
                                     text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
-                                    fontSize = lyricsTextSize.sp,
+                                    fontSize = (lyricsTextSize * 0.8f).sp,
                                     color = lyricsBaseColor.copy(alpha = 0.52f),
                                     textAlign = attributionAlignment,
                                     fontWeight = FontWeight.SemiBold,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -17,9 +17,6 @@ import android.app.Activity
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -1172,30 +1169,13 @@ fun LyricsEnhanced(
             ) {
                 Text(
                     text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
-                    fontSize = lyricsTextSize.sp,
+                    fontSize = (lyricsTextSize * 0.8f).sp,
                     color = textColor.copy(alpha = 0.52f),
                     textAlign = TextAlign.Center,
                     fontWeight = FontWeight.SemiBold,
-                    lineHeight = (lyricsTextSize * 1.3f).sp,
+                    lineHeight = (lyricsTextSize * 1.05f).sp,
                 )
             }
-        }
-        AnimatedVisibility(
-            visible = sourceHeaderVisible,
-            enter = fadeIn(),
-            exit = fadeOut(),
-            modifier = Modifier.align(Alignment.TopCenter),
-        ) {
-            Text(
-                text = stringResource(R.string.lyrics_from_source, lyricsProviderName),
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.secondary,
-                textAlign = TextAlign.Center,
-                fontWeight = FontWeight.Medium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(top = 12.dp),
-            )
         }
         when {
             lyrics == LYRICS_NOT_FOUND -> {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsV2.kt
@@ -809,7 +809,7 @@ fun LyricsV2(
                         ) {
                             Text(
                                 text = stringResource(R.string.lyrics_from_source, providerNameV2),
-                                fontSize = lyricsTextSize.sp,
+                                fontSize = (lyricsTextSize * 0.8f).sp,
                                 color = textColor.copy(alpha = 0.52f),
                                 textAlign = TextAlign.Center,
                                 fontWeight = FontWeight.SemiBold,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -1574,7 +1574,7 @@ private fun HistorySourcePill(
                 availableSources.forEach { source ->
                     val label =
                         stringResource(
-                            if (currentSource == HistorySource.LOCAL) {
+                            if (source == HistorySource.LOCAL) {
                                 R.string.local_history
                             } else {
                                 R.string.remote_history

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,6 +371,7 @@
     <string name="undo">Undo</string>
     <string name="lyrics_not_found">Lyrics not found</string>
     <string name="lyrics_from_source">Lyrics from %1$s</string>
+    <string name="written_by">Written by %1$s</string>
     <string name="lyrics_word_sync">Word Sync</string>
     <string name="sleep_timer">Sleep timer</string>
     <string name="end_of_song">End of song</string>


### PR DESCRIPTION
## Summary

Fixes the build errors from CI run https://github.com/4nx3b/ArchiveTune/actions/runs/33190421275 and addresses two follow-up issues from the previous batch.

## Build errors fixed

1. **`FrostedHeaderPill.kt:16` — Unresolved reference `BorderStroke`**
   - Root cause: duplicate import. Line 12 imported the correct `androidx.compose.foundation.BorderStroke`, line 16 imported a non-existent `androidx.compose.material3.BorderStroke`.
   - Fix: removed the bogus material3 import.

2. **`Lyrics.kt:2505`, `LyricsEnhanced.kt:1419`, `LyricsV2.kt:1202` — Unresolved reference `written_by`**
   - Root cause: `R.string.written_by` was referenced but never declared.
   - Fix: added `<string name="written_by">Written by %1$s</string>` to `strings.xml`.

3. **`LyricsEnhanced.kt:1184` — Unresolved reference `sourceHeaderVisible`**
   - Root cause: an orphaned `AnimatedVisibility(visible = sourceHeaderVisible, ...)` overlay remained after `sourceHeaderVisible` state was removed in the prior PR. It was a leftover stationary "Lyrics from" caption that duplicated the new lyric-styled header.
   - Fix: removed the orphaned block and the now-unused `AnimatedVisibility` / `fadeIn` / `fadeOut` imports.

## Visual fixes

4. **History page source dropdown showed "Local" twice**
   - Root cause: inside the `forEach { source -> ... }` loop building the dropdown items, the label was computed as `stringResource(if (currentSource == LOCAL) local_history else remote_history)`. The check used `currentSource` (the pill's currently-selected source) instead of the loop variable `source`, so every dropdown item showed the same label.
   - Fix: use `source` (the loop variable) so each item shows its own correct label. A user on Local now sees `Local ✓ / Remote`, a user on Remote sees `Local / Remote ✓`.

5. **"Lyrics from [provider]" attribution text smaller**
   - Per user request: make the attribution text a bit smaller so it reads as a discreet lyric line, not a competing header.
   - Fix: in all three lyrics components (`Lyrics.kt`, `LyricsEnhanced.kt`, `LyricsV2.kt`), shrink the attribution `Text` from `fontSize = lyricsTextSize.sp` to `fontSize = (lyricsTextSize * 0.8f).sp`.

## Verification

- Build errors above are exactly the failures reported by CI run 33190421275 (job `Build Release APKs (gms-tv-universal)`, step `Build Release APK 9`).
- All edits are minimal and targeted; no other code paths touched.

## Testing

- Local SDK is not available in the dev container, so I could not run `./gradlew assembleDebug`. Please rely on CI to verify the build.
- Visual changes (history dropdown, smaller attribution text) should be re-tested in-app once the APK builds.