### PR TITLE
fix(lyrics): shift attribution down so it's always visible

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -1342,7 +1342,26 @@ fun LyricsEnhanced(
                             .fillMaxSize()
                             .nestedScroll(nestedScrollConnection),
                 ) {
-                    val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.08f }
+                    // Offset of the active karaoke line from the top of the lyrics
+                    // viewport. Doubled from 0.08f → 0.16f per the user's
+                    // "The lyrics from text is always cutoff. Shift it down a
+                    // bit so that it's always visible" report.
+                    //
+                    // The "Lyrics from [provider]" attribution is injected as the
+                    // FIRST SyncedLine of the karaoke stream (see
+                    // `buildSyncedLyrics`), so it sits ABOVE the active line in
+                    // the karaoke list. The mocharealm library positions lines
+                    // above the active line at `offset - N * line_height`. With
+                    // the original 8% offset (~56dp on a typical 700dp lyrics
+                    // viewport), the attribution — at offset - line_height ≈
+                    // 56 - 50 = 6dp from the top — was barely inside the
+                    // viewport, and depending on the line-height the library
+                    // measured for the Bold lyricsTextSize line, was often
+                    // partially clipped above the top edge / overlapped by the
+                    // mini header. Doubling to 16% (~112dp on the same 700dp
+                    // viewport) puts the attribution at ~62dp from the top —
+                    // fully visible with comfortable buffer.
+                    val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.16f }
 
                     // Keyed on the session + a position-reset counter so that when
                     // the song repeats (REPEAT_MODE_ONE wraps position to 0) or the


### PR DESCRIPTION
## Summary

Fixes the single lyrics attribution issue the user reported on 2026-08-29:

> The lyrics from text is always cutoff. Shift it down a bit so that it's always visible. I've to scroll manually right now to see the complete text.

## Root cause

The `Lyrics from [provider]` attribution is injected as the FIRST `SyncedLine` of the karaoke stream (see `buildSyncedLyrics` in `LyricsEnhanced.kt`), so it sits ABOVE the active line in the karaoke list. The mocharealm `KaraokeLyricsView` positions the active line at `offset` from the top of the lyrics viewport, and lines above the active line at `offset - N * line_height`. 

With the original `8%` offset (`~56dp` on a typical 700dp lyrics viewport), the attribution line — at `offset - line_height ≈ 56 - 50 = 6dp from the top` — was barely inside the viewport. Depending on the line-height the library measured for the Bold `lyricsTextSize` line, it was often **partially clipped above the top edge** / overlapped by the mini header above the lyrics area. That's exactly the "cutoff" symptom the user saw.

## Fix

**One-line change**: double the karaoke view's `lyricsViewportOffset` from `maxHeight * 0.08f` → `maxHeight * 0.16f` (~112dp on the same 700dp viewport). The attribution now sits at ~62dp from the top — fully visible with comfortable buffer.

The active line is also shifted down by the same amount, which is a moderate layout change but matches the user's "shift it down a bit" request verbatim. The Apple Music karaoke layout typically has the active line at ~30-40% from the top, so 16% is still relatively high.

## Scope

ONLY the karaoke path in `LyricsEnhanced.kt` is touched (one line + a comment explaining the rationale).

- The plain-lyrics path (`PlainLyricsView`) already has `top=120.dp` contentPadding so its first item is well below the top edge — no change needed.
- Legacy `Lyrics.kt` and `LyricsV2.kt` paths are not used by the player or standalone `LyricsScreen` — left alone.

## Files changed

- `app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt` (1 line + comment)

---

**Note**: This PR supersedes the closed PR #190, which contained additional changes (font-size reductions, pinned overlays, legacy-path fixes) that the user did not want. The closed PR's commit has been dropped from `dev` so the diff vs `main` is now just the one-line offset fix.
