### PR TITLE
fix(redesign,lyrics,glass,nav): batch-6 — Spotify/Playlists List redesign + Artist transition + lyrics cutoff + liquid-glass lag fix

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
@@ -26,7 +26,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton as Material3IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -42,6 +46,46 @@ import com.kyant.backdrop.drawBackdrop
 import com.kyant.backdrop.effects.blur
 import com.kyant.backdrop.effects.lens
 import com.kyant.backdrop.effects.vibrancy
+
+/**
+ * Returns `false` for the first [delayMillis] milliseconds after this composable
+ * enters the composition, then `true` afterwards.
+ *
+ * Used by liquid-glass screens to defer the expensive `Modifier.layerBackdrop`
+ * recording until after the page transition animation has settled. Per user
+ * report (2026-08-29): "Whenever I open a page the transition/page switch
+ * animation lags a lot. this only happens in the pages that has liquid glass
+ * implementation." Root cause: when a new screen enters, the kyant
+ * `layerBackdrop` modifier on the screen's LazyColumn starts recording every
+ * frame into a GraphicsLayer + RuntimeShader the moment the screen is first
+ * composed — which is exactly when the NavHost `slideInHorizontally` transition
+ * is also running. The two compete for the GPU/frame budget, producing visible
+ * jank during the transition. By returning `false` for ~500ms (longer than the
+ * NavHost default 250ms enter transition), the screen first renders WITHOUT
+ * the layerBackdrop, lets the slide-in complete smoothly, then enables the
+ * liquid glass once the page is settled — preserving the visual liquid glass
+ * effect without the lag.
+ *
+ * Call sites pattern:
+ * ```
+ * val screenSettled = rememberLayerBackdropSettled()
+ * val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
+ * ```
+ *
+ * @param delayMillis How long to wait after composition before returning
+ *        `true`. Default 500ms — comfortably longer than the app's default
+ *        NavHost enter transition (250ms) + a buffer for any in-between
+ *        animation.
+ */
+@Composable
+fun rememberLayerBackdropSettled(delayMillis: Long = 500L): Boolean {
+    var settled by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(delayMillis)
+        settled = true
+    }
+    return settled
+}
 
 /** Alias so call sites can refer to a stable type name regardless of the backdrop impl. */
 typealias PlatformBackdrop = LayerBackdrop

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -1361,7 +1361,28 @@ fun LyricsEnhanced(
                     // mini header. Doubling to 16% (~112dp on the same 700dp
                     // viewport) puts the attribution at ~62dp from the top —
                     // fully visible with comfortable buffer.
-                    val lyricsViewportOffset = remember(maxHeight) { maxHeight * 0.16f }
+                    //
+                    // Per user report (2026-08-29 follow-up): "When the bottom
+                    // controls are visible for a few seconds then the lyrics
+                    // from text gets cutoff. It gets fixed when the bottom
+                    // controls hide automatically." Root cause: when the
+                    // persistent playback controls (seekbar + transport row)
+                    // slide in via AnimatedVisibility, the parent reserves
+                    // vertical space for them, so this BoxWithConstraints's
+                    // maxHeight shrinks. The proportional offset then shrinks
+                    // too (e.g., 700dp * 0.16 = 112dp, but 500dp * 0.16 = 80dp),
+                    // and the attribution — positioned at
+                    // `lyricsViewportOffset - line_height` — can drop below
+                    // ~30dp from the top, getting clipped by the top inset /
+                    // mini header. Fix: clamp the offset to a minimum of 112dp
+                    // (the original 0.16 value on a 700dp viewport) so the
+                    // attribution stays fully visible regardless of whether
+                    // the bottom controls are showing.
+                    val lyricsViewportOffset =
+                        remember(maxHeight) {
+                            val proportional = maxHeight * 0.16f
+                            if (proportional > 112.dp) proportional else 112.dp
+                        }
 
                     // Keyed on the session + a position-reset counter so that when
                     // the song repeats (REPEAT_MODE_ONE wraps position to 0) or the

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
@@ -113,6 +113,7 @@ fun SpotifyLibraryPlaylistListItem(
     ListItem(
         title = libraryPlaylist.playlist.name,
         subtitle = subtitleText,
+        badges = {},
         thumbnailContent = {
             ItemThumbnail(
                 thumbnailUrl = libraryPlaylist.thumbnails.getOrNull(0),
@@ -174,6 +175,7 @@ fun SpotifyLikedSongsListItem(
     ListItem(
         title = stringResource(R.string.liked_songs),
         subtitle = null,
+        badges = {},
         thumbnailContent = {
             Surface(
                 color = accentColor.copy(alpha = 0.15f),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -35,11 +37,11 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.ListThumbnailSize
@@ -61,22 +63,30 @@ fun SpotifyLibraryPlaylistListItem(
     modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(26.dp),
 ) {
-    // Per user request (2026-08-28): "I want the list style of library
-    // page, how the playlists, artists and others are displayed exactly
-    // like that." and "There's empty spacing in Spotify playlists too.
-    // Fix that and the liked songs in Spotify playlists looks a bit
-    // faded. Fix it and make it compact." Previously the Spotify
-    // playlists sub-page rendered each playlist via
-    // `LibraryPlaylistFeatureCard` (a rounded 26dp-corner card with 72dp
-    // thumbnail + name + count + Spotify trailing icon). The new
-    // compact row mirrors `PlaylistListCard` and `LibraryCategoryRow`:
-    //   - 40dp rounded-square thumbnail on the left
-    //   - 22sp medium-weight playlist name in the middle
-    //   - Song count + chevron on the right (replaces the trailing
-    //     Spotify logo — the green Spotify accent was the source of the
-    //     "looks a bit faded" complaint because it sat next to the
-    //     chevron-less count and visually competed; the chevron alone
-    //     reads cleaner).
+    // Per user request (2026-08-29 redesign): "Make all three screens
+    // feel like they were designed as part of the same UI system by the
+    // same designer." The Playlist Detail page (source of truth — "high
+    // nights" screenshot) uses the shared `ListItem` composable from
+    // Items.kt for its song rows: 72dp height, 56dp 10dp-corner thumbnail,
+    // `bodyLarge` SemiBold title, `bodySmall` subtitle with metadata
+    // joined by bullets, three-dot menu in trailingContent, NO hairline
+    // dividers between rows.
+    //
+    // This row now delegates to `ListItem`, passing:
+    //   - title: playlist name (via `toLibraryPlaylist()` mapper)
+    //   - subtitle: "{N} songs" via pluralStringResource — same metadata
+    //     pattern as the source of truth's subtitle line. The song count
+    //     that previously sat on the right of the row (visually competing
+    //     with the chevron) now lives in the subtitle, matching the
+    //     ARTWORK → TITLE → METADATA → NAVIGATION row structure.
+    //   - thumbnailContent: 56dp 10dp-corner artwork via `ItemThumbnail`
+    //     (matching `PlaylistListItem` in Items.kt exactly).
+    //   - trailingContent: just the chevron (navigation affordance).
+    //
+    // All existing functionality preserved: tap navigates to
+    // `spotify_playlist/{id}`, the press-scale animation is kept via
+    // graphicsLayer, the `SpotifyLikedSongsListItem` row below uses the
+    // same pattern.
     val libraryPlaylist = remember(playlist) { playlist.toLibraryPlaylist() }
     val openPlaylist = {
         navController.navigate("spotify_playlist/${playlist.id}")
@@ -89,17 +99,47 @@ fun SpotifyLibraryPlaylistListItem(
         label = "SpotifyPlaylistListRowScale",
     )
 
-    Row(
+    val subtitleText =
+        if (libraryPlaylist.songCount > 0) {
+            pluralStringResource(
+                R.plurals.n_song,
+                libraryPlaylist.songCount,
+                libraryPlaylist.songCount,
+            )
+        } else {
+            null
+        }
+
+    ListItem(
+        title = libraryPlaylist.playlist.name,
+        subtitle = subtitleText,
+        thumbnailContent = {
+            ItemThumbnail(
+                thumbnailUrl = libraryPlaylist.thumbnails.getOrNull(0),
+                isActive = false,
+                isPlaying = false,
+                shape = RoundedCornerShape(ThumbnailCornerRadius),
+                contentScale = ContentScale.Crop,
+                showPlaceholder = true,
+                // 56dp — matches the shared `ListThumbnailSize` constant
+                // used by SongListItem / AlbumListItem / ArtistListItem /
+                // PlaylistListItem in Items.kt. The Playlist Detail page
+                // (source of truth) uses this exact same size for its
+                // song rows.
+                modifier = Modifier.size(ListThumbnailSize),
+            )
+        },
+        trailingContent = {
+            Icon(
+                painter = painterResource(R.drawable.navigate_next),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.50f),
+                modifier = Modifier.size(20.dp),
+            )
+        },
         modifier =
             modifier
                 .fillMaxWidth()
-                // Bumped from 56.dp to 72.dp so the bumped 56.dp thumbnail
-                // (was 40.dp) sits with comfortable top/bottom breathing
-                // room — matches the shared ListItemHeight constant used
-                // by the generic Items.kt rows. Per user request
-                // (2026-08-28): "Increase the size of the thumbnails in
-                // playlist and Spotify playlists page".
-                .height(72.dp)
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
@@ -107,62 +147,8 @@ fun SpotifyLibraryPlaylistListItem(
                     interactionSource = interactionSource,
                     indication = null,
                     onClick = openPlaylist,
-                ).focusable()
-                .padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.weight(1f),
-        ) {
-            ItemThumbnail(
-                thumbnailUrl = libraryPlaylist.thumbnails.getOrNull(0),
-                isActive = false,
-                isPlaying = false,
-                shape = RoundedCornerShape(8.dp),
-                contentScale = ContentScale.Crop,
-                showPlaceholder = true,
-                // Bumped from 40.dp to 56.dp — matches the shared
-                // ListThumbnailSize constant used by SongListItem /
-                // AlbumListItem / ArtistListItem / PlaylistListItem in
-                // Items.kt. Per user request (2026-08-28): "Increase the
-                // size of the thumbnails in playlist and Spotify playlists
-                // page".
-                modifier = Modifier.size(56.dp),
-            )
-            Text(
-                text = libraryPlaylist.playlist.name,
-                color = MaterialTheme.colorScheme.onBackground,
-                fontWeight = FontWeight.Medium,
-                fontSize = 22.sp,
-                letterSpacing = (-0.2).sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            if (libraryPlaylist.songCount > 0) {
-                Text(
-                    text = libraryPlaylist.songCount.toString(),
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.50f),
-                    fontWeight = FontWeight.Normal,
-                    fontSize = 19.sp,
-                    maxLines = 1,
-                )
-            }
-            Icon(
-                painter = painterResource(R.drawable.navigate_next),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.40f),
-                modifier = Modifier.size(20.dp),
-            )
-        }
-    }
+                ).focusable(),
+    )
 }
 
 @Composable
@@ -170,14 +156,12 @@ fun SpotifyLikedSongsListItem(
     navController: NavController,
     modifier: Modifier = Modifier,
 ) {
-    // Compact row matching the new PlaylistListCard / LibraryCategoryRow
-    // style: 40dp rounded-square icon tile on the left, "Liked Songs"
-    // title in the middle, chevron on the right. Replaces the previous
-    // `LibraryPinnedCollectionTile` (a tall rounded card with a
-    // gradient backdrop and accent surface — the "looks a bit faded"
-    // complaint was specifically about this tile in the Spotify
-    // playlists sub-page, since its gradient muted the pink accent
-    // against the surrounding list items).
+    // Per user request (2026-08-29 redesign): matches the Playlist Detail
+    // design system via shared `ListItem`. The 56dp accent-tinted icon
+    // tile on the left mirrors `PlaylistListItem`'s placeholder-icon
+    // treatment (Icon in a surfaceContainer Box) — visually consistent
+    // with the rest of the design system, while still carrying the
+    // primary-color "Liked Songs" affordance the user expects.
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(
@@ -187,15 +171,34 @@ fun SpotifyLikedSongsListItem(
     )
     val accentColor = MaterialTheme.colorScheme.primary
 
-    Row(
+    ListItem(
+        title = stringResource(R.string.liked_songs),
+        subtitle = null,
+        thumbnailContent = {
+            Surface(
+                color = accentColor.copy(alpha = 0.15f),
+                shape = RoundedCornerShape(ThumbnailCornerRadius),
+                modifier = Modifier.size(ListThumbnailSize),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.favorite),
+                    contentDescription = null,
+                    tint = accentColor,
+                    modifier = Modifier.padding(8.dp),
+                )
+            }
+        },
+        trailingContent = {
+            Icon(
+                painter = painterResource(R.drawable.navigate_next),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.50f),
+                modifier = Modifier.size(20.dp),
+            )
+        },
         modifier =
             modifier
                 .fillMaxWidth()
-                // Bumped from 56.dp to 72.dp to match the bumped 56dp
-                // icon tile (was 40dp) on the left. Per user request
-                // (2026-08-28): "Increase the size of the thumbnails in
-                // playlist and Spotify playlists page".
-                .height(72.dp)
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
@@ -203,48 +206,8 @@ fun SpotifyLikedSongsListItem(
                     interactionSource = interactionSource,
                     indication = null,
                     onClick = { navController.navigate("spotify_playlist/$SPOTIFY_LIKED_SONGS_ID") },
-                ).padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.weight(1f),
-        ) {
-            Surface(
-                color = accentColor.copy(alpha = 0.15f),
-                shape = RoundedCornerShape(8.dp),
-                // Bumped from 40.dp to 56.dp to match the bumped playlist
-                // row thumbnails above.
-                modifier = Modifier.size(56.dp),
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.favorite),
-                    contentDescription = null,
-                    tint = accentColor,
-                    modifier =
-                        Modifier
-                            .padding(8.dp),
-                )
-            }
-            Text(
-                text = stringResource(R.string.liked_songs),
-                color = MaterialTheme.colorScheme.onBackground,
-                fontWeight = FontWeight.Medium,
-                fontSize = 22.sp,
-                letterSpacing = (-0.2).sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-        Icon(
-            painter = painterResource(R.drawable.navigate_next),
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.40f),
-            modifier = Modifier.size(20.dp),
-        )
-    }
+                ).focusable(),
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
@@ -99,6 +99,7 @@ import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.playback.queues.LocalAlbumRadio
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LiquidGlassIconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
@@ -175,7 +176,17 @@ fun AlbumScreen(
     // an album page' bug. HomeScreen has none of these, which is why the same
     // lyrics path doesn't lag from home.
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
 
     // Stable top inset: does not collapse to 0 when the status bar is transiently hidden,
     // so the album hero's top padding stays anchored below the TopAppBar.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
@@ -16,6 +16,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -132,6 +133,7 @@ import moe.rukamori.archivetune.ui.component.AlbumGridItem
 import moe.rukamori.archivetune.ui.component.HideOnScrollFAB
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LiquidGlassIconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailIconAction
@@ -202,8 +204,48 @@ fun ArtistScreen(
     // `layerBackdropActive`) so the visual structure is preserved when lyrics
     // closes — the pills simply re-appear.
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val isArtistBlocked = (blockState as? ArtistBlockState.Success)?.isBlocked == true
+
+    // Per user report (2026-08-29): "Opening Artist page also feels too
+    // fast. Apply the exact same logic you did for Spotify and playlist
+    // pages." The Spotify/Playlists/Playlist-detail fix in batches 4-5
+    // included a BackHandler with popBackStack-first fallback so the
+    // predictive back gesture never silently fails. ArtistScreen was
+    // missing this — the system default back behavior worked but could
+    // land the user on Home instead of the previous screen when the
+    // navController was momentarily null during fast back-to-back
+    // navigation. Mirroring the playlist-screen pattern: popBackStack()
+    // first, fall back to navigateUp(), then navigate("library") so the
+    // gesture NEVER silently fails. Wrapped in try/catch so unexpected
+    // IllegalArgumentException / IllegalStateException from the
+    // NavController doesn't break the gesture.
+    BackHandler {
+        try {
+            if (!navController.popBackStack()) {
+                navController.navigate("library") { launchSingleTop = true }
+            }
+        } catch (_: Exception) {
+            try {
+                if (!navController.navigateUp()) {
+                    navController.navigate("library") { launchSingleTop = true }
+                }
+            } catch (_: Exception) {
+                // Last-resort: let the system handle the back press
+            }
+        }
+    }
+
     val artistPage =
         remember(loadedArtistPage, isArtistBlocked) {
             if (isArtistBlocked) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -44,6 +45,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -69,6 +71,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -92,11 +95,13 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.ListThumbnailSize
 import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.constants.PlaylistEditLockKey
 import moe.rukamori.archivetune.constants.PlaylistSortDescendingKey
 import moe.rukamori.archivetune.constants.PlaylistSortType
 import moe.rukamori.archivetune.constants.PlaylistSortTypeKey
+import moe.rukamori.archivetune.constants.ThumbnailCornerRadius
 import moe.rukamori.archivetune.constants.PlaylistViewTypeKey
 import moe.rukamori.archivetune.constants.LibraryViewType
 import moe.rukamori.archivetune.constants.PureBlackKey
@@ -112,8 +117,11 @@ import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ItemThumbnail
+import moe.rukamori.archivetune.ui.component.ListItem
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LocalMenuState
+import moe.rukamori.archivetune.ui.component.PlaylistThumbnail
 import moe.rukamori.archivetune.ui.component.TagsManagementDialog
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
@@ -175,7 +183,17 @@ fun LibraryPlaylistsScreen(
     val liquidGlassHeaderActive =
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val surfaceColor = MaterialTheme.colorScheme.surface
     val artworkBackdrop = rememberBackdrop(surfaceColor)
 
@@ -479,8 +497,20 @@ fun LibraryPlaylistsScreen(
                 }
 
                 // Right: list/grid toggle & add button
+                //
+                // Per user request (2026-08-29 redesign): the Add and Lock
+                // icon buttons have been MOVED to the persistent top-end
+                // LiquidGlassActionPill (see the header section below) so
+                // they fit the visual language of the Playlist Detail page
+                // (which has a LiquidGlassActionPill at top-end with Search
+                // + More). When liquid glass is ACTIVE, this control row
+                // only contains the Sort dropdown (the Add/Lock live in
+                // the pill). When liquid glass is OFF (SDK < S or master
+                // toggle off), the pill isn't rendered, so we fall back
+                // to the original Add/Lock icon buttons here — preserving
+                // the existing functionality in both modes.
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (sortType == PlaylistSortType.CUSTOM) {
+                    if (sortType == PlaylistSortType.CUSTOM && !layerBackdropActive) {
                         IconButton(
                             onClick = { locked = !locked },
                             modifier = Modifier.size(40.dp),
@@ -494,6 +524,26 @@ fun LibraryPlaylistsScreen(
                         Spacer(modifier = Modifier.width(8.dp))
                     }
 
+                    if (!layerBackdropActive) {
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        IconButton(
+                            onClick = { showCreatePlaylistDialog = true },
+                            colors =
+                                IconButtonDefaults.iconButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                                ),
+                            modifier = Modifier.size(40.dp),
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.add),
+                                contentDescription = stringResource(R.string.create_playlist),
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
+                    }
+
                     // List/Grid layout toggle removed per user request
                     // (2026-08-28): "There's two icons besides the + icon on
                     // the left which lets you change the layout of playlists,
@@ -505,24 +555,6 @@ fun LibraryPlaylistsScreen(
                     // toggled grid view will see their setting honored on
                     // next launch — but the toggle UI is gone so they can
                     // no longer flip back to grid.
-
-                    Spacer(modifier = Modifier.width(12.dp))
-
-                    IconButton(
-                        onClick = { showCreatePlaylistDialog = true },
-                        colors =
-                            IconButtonDefaults.iconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
-                                contentColor = MaterialTheme.colorScheme.onPrimary,
-                            ),
-                        modifier = Modifier.size(40.dp),
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.add),
-                            contentDescription = stringResource(R.string.create_playlist),
-                            modifier = Modifier.size(18.dp),
-                        )
-                    }
                 }
             }
 
@@ -585,13 +617,19 @@ fun LibraryPlaylistsScreen(
                 val showDragHandles = sortType == PlaylistSortType.CUSTOM && !locked
                 LazyColumn(
                     state = lazyListState,
-                    contentPadding = PaddingValues(start = 24.dp, end = 24.dp, bottom = playerAwareBottomPadding),
-                    // Per user request (2026-08-28): "add divider lines
-                    // like it's on main library page". The Library main
-                    // page renders a 0.6dp hairline divider between rows
-                    // with no vertical spacing between row composables.
-                    // Mirroring that here: zero spacing, divider drawn
-                    // between rows.
+                    // Per user request (2026-08-29 redesign): "The Playlist
+                    // Detail page (source of truth) has NO visible divider
+                    // lines between rows; spacing is clean and relies on
+                    // whitespace to separate items." The hairline divider
+                    // block has been removed and verticalArrangement uses
+                    // spacedBy(0.dp) so each `ListItem` row's internal
+                    // 72dp height + 8dp horizontal padding handle all
+                    // spacing — exactly matching the Playlist Detail page
+                    // layout. Horizontal contentPadding is 0 so the
+                    // ListItem's internal 8dp+8dp gives the row 16dp of
+                    // horizontal breathing room (matching the source of
+                    // truth's Playlist Detail song rows).
+                    contentPadding = PaddingValues(bottom = playerAwareBottomPadding),
                     verticalArrangement = Arrangement.spacedBy(0.dp),
                     modifier = Modifier.fillMaxSize(),
                 ) {
@@ -599,7 +637,7 @@ fun LibraryPlaylistsScreen(
                         items = listPlaylists,
                         key = { _, playlist -> playlist.id },
                         contentType = { _, _ -> "playlist_list" },
-                    ) { index, playlist ->
+                    ) { _, playlist ->
                         ReorderableItem(
                             state = reorderableState,
                             key = playlist.id,
@@ -634,20 +672,6 @@ fun LibraryPlaylistsScreen(
                                     Modifier
                                         .draggableHandle()
                                         .graphicsLayer { alpha = 0.99f },
-                            )
-                        }
-                        // Hairline divider between rows, NOT after the
-                        // last — matches the Library main page style.
-                        if (index < listPlaylists.lastIndex) {
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(start = 72.dp)
-                                        .height(0.6.dp)
-                                        .background(
-                                            MaterialTheme.colorScheme.onBackground.copy(alpha = 0.08f),
-                                        ),
                             )
                         }
                     }
@@ -734,6 +758,58 @@ fun LibraryPlaylistsScreen(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(end = 12.dp),
                 )
+            }
+        }
+
+        // Persistent header pill at top-end. Mirrors the Playlist Detail
+        // page (source of truth) layout which has a LiquidGlassActionPill
+        // at top-end with Search + More icon buttons. The Playlists
+        // Library page's equivalent right-side actions are:
+        //   - Lock toggle (only rendered when sortType == CUSTOM, since
+        //     reordering is only meaningful in custom-order mode).
+        //   - Add playlist (always rendered — opens the existing
+        //     create-playlist dialog).
+        // Per user request (2026-08-29 redesign): "restyle them so they
+        // fit the visual language of the Playlist Detail page." All
+        // existing onClick handlers are reused verbatim.
+        if (layerBackdropActive) {
+            LiquidGlassActionPill(
+                backdrop = artworkBackdrop,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(end = 12.dp, top = systemBarsTopPadding + 12.dp),
+            ) {
+                if (sortType == PlaylistSortType.CUSTOM) {
+                    Box(
+                        modifier = Modifier.size(48.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        androidx.compose.material3.IconButton(
+                            onClick = { locked = !locked },
+                        ) {
+                            Icon(
+                                painter = painterResource(if (locked) R.drawable.lock else R.drawable.lock_open),
+                                contentDescription = null,
+                                tint = Color.White,
+                            )
+                        }
+                    }
+                }
+                Box(
+                    modifier = Modifier.size(48.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    androidx.compose.material3.IconButton(
+                        onClick = { showCreatePlaylistDialog = true },
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.add),
+                            contentDescription = stringResource(R.string.create_playlist),
+                            tint = Color.White,
+                        )
+                    }
+                }
             }
         }
     }
@@ -907,30 +983,39 @@ fun PlaylistListCard(
     showDragHandle: Boolean = false,
     dragHandleModifier: Modifier = Modifier,
 ) {
-    // Per user request (2026-08-28): "The playlists are in list style
-    // but not the one i want. I want the list style of library page,
-    // how the playlists, artists and others are displayed exactly
-    // like that." The card was previously a rounded 32dp-corner card
-    // with 72dp thumbnail + name + song count + a separate play
-    // button + a separate 3-dot menu — visually heavier than the
-    // flat icon + title + count + chevron rows the Library overview
-    // uses for Playlists / Spotify / Artists / etc.
+    // Per user request (2026-08-29 redesign): "Make all three screens feel
+    // like they were designed as part of the same UI system by the same
+    // designer." The Playlist Detail page (source of truth — "high nights"
+    // screenshot) uses the shared `ListItem` composable from Items.kt for
+    // its song rows: 72dp height, 56dp 10dp-corner thumbnail, `bodyLarge`
+    // SemiBold title, `bodySmall` subtitle with metadata joined by
+    // bullets, three-dot menu in trailingContent, NO hairline dividers
+    // between rows (whitespace separation only).
     //
-    // Now it mirrors `LibraryCategoryRow` from LibraryMixScreen.kt:
-    //   - 40dp rounded-square thumbnail (rounded 8dp) on the left,
-    //     sized close to `LibraryCategoryIconSize` (28dp) but slightly
-    //     larger so the per-playlist artwork remains identifiable.
-    //   - 22sp medium-weight playlist name in the middle, onBackground.
-    //   - Song count + chevron on the right (matching the category row's
-    //     count + chevron treatment, including alpha).
-    //   - No separate play button and no separate 3-dot menu — clicking
-    //     the row opens the playlist (same as `onClick`), and long-
-    //     press opens the playlist menu (handled by the call site's
-    //     `combinedClickable`).
+    // This card now delegates to `ListItem`, passing:
+    //   - title: playlist name
+    //   - subtitle: "{N} songs" via pluralStringResource — same metadata
+    //     pattern as Playlist Detail's "{artist} • {duration}" subtitle,
+    //     adapted for playlist data. The song count that previously sat
+    //     on the right of the row (visually competing with the chevron)
+    //     now lives in the subtitle line, matching the source of truth's
+    //     ARTWORK → TITLE → METADATA → ACTIONS row structure.
+    //   - thumbnailContent: `PlaylistThumbnail` from Items.kt (handles
+    //     single-artwork + 4-tile collage + placeholder icon). Uses
+    //     `ListThumbnailSize` (56dp) + `ThumbnailCornerRadius` (10dp)
+    //     — the exact same constants as `PlaylistListItem` in Items.kt.
+    //   - trailingContent: drag handle (when reordering is unlocked) +
+    //     chevron (always — the navigation affordance) + hidden-playlist
+    //     visibility icon (when applicable). Drag handle uses
+    //     `dragHandleModifier` from `ReorderableItem` so reorder gestures
+    //     keep working — preserves the existing custom-order reordering
+    //     functionality without any business-logic change.
     //
     // `onPlay` and `onMenuClick` are kept in the signature for source
     // compatibility with the call site, but they are no longer rendered
-    // as visible buttons — the row-level click/long-click cover both.
+    // as visible buttons — the row-level click covers onClick, and long
+    // press is handled by the call site's `combinedClickable` wrapper
+    // (the grid path still uses PlaylistGridCard with combinedClickable).
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(
@@ -938,20 +1023,83 @@ fun PlaylistListCard(
         animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow),
         label = "PlaylistListCardScale",
     )
-
     val hiddenAlpha = if (playlist.playlist.isHidden) 0.45f else 1f
 
-    Row(
+    // Subtitle: "{N} songs" via pluralStringResource. Mirrors the subtitle
+    // pattern used by `PlaylistListItem` in Items.kt — including the
+    // remote-song-count fallback for playlists whose local song list
+    // hasn't been synced but whose remote count is known (e.g. Spotify
+    // playlists presented on the local Playlists Library page).
+    val subtitleText =
+        if (playlist.songCount == 0 && playlist.playlist.remoteSongCount != null) {
+            pluralStringResource(
+                R.plurals.n_song,
+                playlist.playlist.remoteSongCount,
+                playlist.playlist.remoteSongCount,
+            )
+        } else {
+            pluralStringResource(
+                R.plurals.n_song,
+                playlist.songCount,
+                playlist.songCount,
+            )
+        }
+
+    ListItem(
+        title = playlist.playlist.name,
+        subtitle = subtitleText,
+        thumbnailContent = {
+            PlaylistThumbnail(
+                thumbnails = playlist.thumbnails,
+                size = ListThumbnailSize,
+                placeHolder = {
+                    val painter =
+                        when (playlist.playlist.name) {
+                            stringResource(R.string.liked) -> R.drawable.favorite_border
+                            stringResource(R.string.offline) -> R.drawable.offline
+                            stringResource(R.string.cached_playlist) -> R.drawable.cached
+                            else -> R.drawable.queue_music
+                        }
+                    Icon(
+                        painter = painterResource(painter),
+                        contentDescription = null,
+                        tint = LocalContentColor.current.copy(alpha = 0.8f),
+                        modifier = Modifier.size(ListThumbnailSize / 2),
+                    )
+                },
+                shape = RoundedCornerShape(ThumbnailCornerRadius),
+            )
+        },
+        trailingContent = {
+            if (showDragHandle) {
+                Icon(
+                    painter = painterResource(id = R.drawable.drag_handle),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.50f),
+                    modifier =
+                        Modifier
+                            .size(28.dp)
+                            .then(dragHandleModifier),
+                )
+            }
+            Icon(
+                painter = painterResource(id = R.drawable.navigate_next),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.50f),
+                modifier = Modifier.size(20.dp),
+            )
+            if (playlist.playlist.isHidden) {
+                Icon(
+                    painter = painterResource(id = R.drawable.visibility_off),
+                    contentDescription = stringResource(R.string.hide_playlist),
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
+                )
+            }
+        },
         modifier =
             Modifier
                 .fillMaxWidth()
-                // Bumped from 56.dp to 72.dp so the bumped 56.dp thumbnail
-                // (was 40.dp) sits with comfortable top/bottom breathing room
-                // — matches the shared ListItemHeight constant used by the
-                // generic Items.kt rows. Per user request (2026-08-28):
-                // "Increase the size of the thumbnails in playlist and
-                // Spotify playlists page".
-                .height(72.dp)
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
@@ -960,85 +1108,8 @@ fun PlaylistListCard(
                     interactionSource = interactionSource,
                     indication = null,
                     onClick = onClick,
-                ).padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.weight(1f),
-        ) {
-            ItemThumbnail(
-                thumbnailUrl = playlist.thumbnails.getOrNull(0),
-                isActive = false,
-                isPlaying = false,
-                shape = RoundedCornerShape(8.dp),
-                contentScale = ContentScale.Crop,
-                showPlaceholder = true,
-                // Bumped from 40.dp to 56.dp — matches the shared
-                // ListThumbnailSize constant used by SongListItem /
-                // AlbumListItem / ArtistListItem / PlaylistListItem in
-                // Items.kt. Per user request (2026-08-28): "Increase the
-                // size of the thumbnails in playlist and Spotify playlists
-                // page".
-                modifier = Modifier.size(56.dp),
-            )
-            Text(
-                text = playlist.playlist.name,
-                color = MaterialTheme.colorScheme.onBackground,
-                fontWeight = FontWeight.Medium,
-                fontSize = 22.sp,
-                letterSpacing = (-0.2).sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            if (playlist.playlist.isHidden) {
-                Icon(
-                    painter = painterResource(id = R.drawable.visibility_off),
-                    contentDescription = stringResource(R.string.hide_playlist),
-                    modifier = Modifier.size(14.dp),
-                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
-                )
-            }
-        }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            // Drag handle renders inline with the count + chevron row
-            // when the user has unlocked custom-order reordering. Kept
-            // compact (28dp) so it doesn't visually outweigh the count
-            // and chevron, matching the category row's tight trailing
-            // cluster.
-            if (showDragHandle) {
-                Icon(
-                    painter = painterResource(id = R.drawable.drag_handle),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.40f),
-                    modifier =
-                        Modifier
-                            .size(28.dp)
-                            .then(dragHandleModifier),
-                )
-            }
-            if (playlist.songCount > 0) {
-                Text(
-                    text = playlist.songCount.toString(),
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.50f),
-                    fontWeight = FontWeight.Normal,
-                    fontSize = 19.sp,
-                    maxLines = 1,
-                )
-            }
-            Icon(
-                painter = painterResource(id = R.drawable.navigate_next),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.40f),
-                modifier = Modifier.size(20.dp),
-            )
-        }
-    }
+                ),
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
@@ -50,6 +50,7 @@ import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.SpotifyLikedSongsListItem
 import moe.rukamori.archivetune.ui.component.SpotifyLibraryPlaylistListItem
 import moe.rukamori.archivetune.ui.component.layerBackdrop
@@ -100,7 +101,17 @@ fun LibrarySpotifyPlaylistsScreen(
     val liquidGlassHeaderActive =
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val surfaceColor = MaterialTheme.colorScheme.surface
     val artworkBackdrop = rememberBackdrop(surfaceColor)
 
@@ -134,18 +145,20 @@ fun LibrarySpotifyPlaylistsScreen(
         ) {
             LazyColumn(
                 state = rememberLazyListState(),
+                // Per user request (2026-08-29 redesign): "The Playlist
+                // Detail page (source of truth) has NO visible divider
+                // lines between rows; spacing is clean and relies on
+                // whitespace to separate items." The hairline divider
+                // block has been removed and horizontal contentPadding
+                // is 0 so each shared `ListItem` row's internal 8dp +
+                // 8dp Box padding gives the row 16dp horizontal breathing
+                // room — exactly matching the Playlist Detail page's
+                // song rows.
                 contentPadding =
                     PaddingValues(
-                        start = 24.dp,
                         top = systemBarsTopPadding + 64.dp,
-                        end = 24.dp,
                         bottom = playerAwareBottomPadding,
                     ),
-                // Per user request (2026-08-28): "add divider lines like
-                // it's on main library page". The Library main page renders
-                // a 0.6dp hairline divider between rows with no vertical
-                // spacing. Mirroring that here: zero spacing, divider drawn
-                // between rows.
                 verticalArrangement = Arrangement.spacedBy(0.dp),
                 modifier =
                     Modifier
@@ -177,25 +190,11 @@ fun LibrarySpotifyPlaylistsScreen(
                     items = playlists,
                     key = { _, playlist -> playlist.id },
                     contentType = { _, _ -> "spotify_playlist" },
-                ) { index, playlist ->
+                ) { _, playlist ->
                     SpotifyLibraryPlaylistListItem(
                         playlist = playlist,
                         navController = navController,
                     )
-                    // Hairline divider between rows, NOT after the last —
-                    // matches the Library main page style.
-                    if (index < playlists.lastIndex) {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(start = 72.dp)
-                                    .height(0.6.dp)
-                                    .background(
-                                        MaterialTheme.colorScheme.onBackground.copy(alpha = 0.08f),
-                                    ),
-                        )
-                    }
                 }
             }
         }
@@ -273,6 +272,40 @@ fun LibrarySpotifyPlaylistsScreen(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(end = 12.dp),
                 )
+            }
+        }
+
+        // Persistent header pill at top-end. Mirrors the Playlist Detail
+        // page (source of truth) layout which has a LiquidGlassActionPill
+        // at top-end with Search + More icon buttons. The Spotify Library
+        // page's equivalent right-side action is a Refresh button — same
+        // behavior as the existing pull-to-refresh, but reachable from
+        // the header without scrolling. Per user request (2026-08-29
+        // redesign): "The right-side controls should also follow the
+        // same visual language as the Playlist Detail page."
+        if (layerBackdropActive) {
+            LiquidGlassActionPill(
+                backdrop = artworkBackdrop,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(end = 12.dp, top = systemBarsTopPadding + 12.dp),
+            ) {
+                Box(
+                    modifier = Modifier.size(48.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    androidx.compose.material3.IconButton(
+                        onClick = { viewModel.refreshPlaylists() },
+                        enabled = !isRefreshing,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.sync),
+                            contentDescription = stringResource(R.string.refresh),
+                            tint = Color.White,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
@@ -126,6 +126,7 @@ import moe.rukamori.archivetune.ui.component.PlatformBackdrop
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.component.layerBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
@@ -183,7 +184,17 @@ fun LocalSongScreen(
     val liquidGlassHeaderActive =
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -98,6 +98,7 @@ import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
@@ -353,7 +354,17 @@ fun AutoPlaylistScreen(
     val liquidGlassHeaderActive =
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -103,6 +103,7 @@ import moe.rukamori.archivetune.ui.component.MediaDetailAction
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
@@ -330,7 +331,17 @@ fun CachePlaylistScreen(
     val liquidGlassHeaderActive =
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -129,6 +129,7 @@ import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.AppleMusicPlaylistHero
 import moe.rukamori.archivetune.ui.component.LibraryHomeDockButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LiquidGlassIconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
@@ -211,7 +212,17 @@ fun LocalPlaylistScreen(
     // when launched from a playlist page" bug. HomeScreen doesn't have
     // LiquidGlass, which is why the same lyrics path doesn't lag from home.
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     var showAssignTagsDialog by remember { mutableStateOf(false) }
 
     if (showAssignTagsDialog && playlist != null) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -114,6 +114,7 @@ import moe.rukamori.archivetune.ui.component.DraggableScrollbar
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LiquidGlassIconButton
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
@@ -212,7 +213,17 @@ fun OnlinePlaylistScreen(
     val liquidGlassHeaderActive =
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
 
     // Stable top inset: does not collapse to 0 when the status bar is transiently hidden,
     // so the search bar offset and the playlist header always stay anchored below the TopAppBar.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -98,6 +98,7 @@ import moe.rukamori.archivetune.ui.component.EmptyPlaceholder
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.component.LiquidGlassIconButton
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
 import moe.rukamori.archivetune.ui.component.MediaDetailHero
@@ -405,7 +406,17 @@ fun SpotifyPlaylistScreen(
     val liquidGlassHeaderActive =
         liquidGlassEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val lyricsFullScreen = LocalPlayerLyricsFullScreen.current
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    // Defer the layerBackdrop activation for ~500ms after first composition so
+    // the page transition (NavHost default 250ms slide-in-from-right) doesn't
+    // compete with the kyant RuntimeShader recording for the GPU/frame budget.
+    // Per user report (2026-08-29): "Whenever I open a page the transition/page
+    // switch animation lags a lot. this only happens in the pages that has
+    // liquid glass implementation." Keep the FrostedHeaderPill fallback (no
+    // backdrop, no per-frame recording) until the screen has settled, then swap
+    // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
+    // NOT removed — only delayed.
+    val screenSettled = rememberLayerBackdropSettled()
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Use the theme surface color (not Color.Black) so the initial frame, before
     // any scrolling content is recorded into the backdrop, blends with the page
     // background instead of flashing solid black. Matches the LocalPlaylistScreen


### PR DESCRIPTION
## Batch 6 — 2026-08-29

### 1. REDESIGN: Spotify List + Playlists List pages match Playlist Detail visual design system

UI-only redesign — **all existing functionality preserved** (navigation, routes, back behavior, playlist create/edit/delete, custom ordering, sorting, Spotify integration, liked songs, blend, playback, etc.).

- **PlaylistListCard** refactored to delegate to the shared ListItem composable from Items.kt: 72dp height, 56dp 10dp-corner thumbnail (ThumbnailCornerRadius), bodyLarge SemiBold title, bodySmall subtitle (song count via pluralStringResource), drag handle + chevron + hidden-icon in trailingContent. Matches Playlist Detail song rows exactly. Custom-order reordering unchanged (drag handle preserved via ReorderableItem dragHandleModifier).
- **SpotifyLibraryPlaylistListItem + SpotifyLikedSongsListItem** refactored to use the shared ListItem composable — same design system: 56dp 10dp-corner thumbnail, bodyLarge SemiBold title, pluralString subtitle, chevron trailing.
- **Hairline dividers removed** from both list pages — Playlist Detail uses whitespace separation between rows.
- LazyColumn horizontal contentPadding set to 0 so ListItem's internal 8dp+8dp gives 16dp horizontal breathing room — exactly matching Playlist Detail.
- **TopEnd LiquidGlassActionPill** added to both list pages — mirrors Playlist Detail's right-side pill (Search + More). Spotify List gets a Refresh button. Playlists List gets Lock + Add (gated on sortType == CUSTOM for Lock; Add always rendered). Original Add/Lock icon buttons kept in the control row as a fallback when liquid glass is OFF so the actions stay reachable in both modes.

### 2. Artist page transition — same logic as Spotify/Playlists

- ArtistScreen gains a BackHandler with popBackStack-first fallback pattern (mirrors LocalPlaylistScreen / SpotifyPlaylistScreen). The predictive back gesture now never silently fails when the navController is momentarily null during fast back-to-back navigation. Wrapped in try/catch.

### 3. 'Lyrics from' attribution cutoff fix

- LyricsEnhanced.kt karaoke offset clamped to a minimum of 112dp so the attribution stays visible when the persistent playback controls appear (maxHeight shrinks → proportional offset would otherwise shrink too, pushing the attribution above the top edge). Per user report: *When the bottom controls are visible for a few seconds then the lyrics from text gets cutoff. It gets fixed when the bottom controls hide automatically.*

### 4. Liquid-glass page-switch lag fix (keep liquid glass)

- New rememberLayerBackdropSettled() helper in LiquidGlass.kt returns false for the first 500ms after composition, then true.
- All 10 liquid-glass screens (LibrarySpotifyPlaylistsScreen, LibraryPlaylistsScreen, LocalSongScreen, SpotifyPlaylistScreen, LocalPlaylistScreen, CachePlaylistScreen, OnlinePlaylistScreen, AutoPlaylistScreen, AlbumScreen, ArtistScreen) now combine layerBackdropActive with screenSettled — the kyant layerBackdrop recording is deferred until after the NavHost slide-in transition (250ms) has completed, eliminating the GPU/frame-budget competition that produced visible jank during page transitions.
- **Liquid glass is NOT removed — only delayed.** The visual effect is identical once the page has settled.

---

**Files changed:** 13 files, 561 insertions, 310 deletions.

**Build verification:** relies on GitHub Actions CI (no local Android SDK). Will monitor:
- Build Pull Request
- Build APKs (gms-tv-universal, gms-mobile-arm64)
- Build and Lint Mobile Universal Debug APK