### PR TITLE
fix(ui,lastfm,glass,nav): batch-7 — LIST label + Spotify overflow menu + Artist notch + lastfm flush + LG lag

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
@@ -25,8 +25,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton as Material3IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -45,6 +49,53 @@ import com.kyant.backdrop.effects.vibrancy
 
 /** Alias so call sites can refer to a stable type name regardless of the backdrop impl. */
 typealias PlatformBackdrop = LayerBackdrop
+
+/**
+ * Returns `false` for the first [delayMillis] milliseconds after this composable
+ * enters the composition, then `true` afterwards.
+ *
+ * Used by liquid-glass screens to defer the expensive `Modifier.layerBackdrop`
+ * recording until the NavHost page transition (default 250ms slide-in-from-right)
+ * has finished. Per user report (2026-08-29): "switching from a page with liquid
+ * glass elements to other page which has liquid glass elements make the app lag
+ * way too much. Fix it without removing or sacrificing anything."
+ *
+ * Root cause: when a new screen enters composition, the kyant `layerBackdrop`
+ * modifier starts recording every frame into a GraphicsLayer + RuntimeShader
+ * the moment the screen is first composed — which is exactly when the NavHost
+ * `slideInHorizontally` transition is also running. The incoming page's
+ * backdrop + the outgoing page's backdrop + the app-wide NavHost backdrop
+ * all compete for the GPU/frame budget, producing visible jank during the
+ * transition.
+ *
+ * The previous implementation used a 500ms delay which the user reported as a
+ * visible "frosted → liquid glass" swap ("for 1 second its normal opaque pill
+ * and then it becomes liquid glass"). The 250ms delay here matches the
+ * NavHost default transition duration exactly — so by the time the page is
+ * fully visible, the layerBackdrop activates. The user perceives it as
+ * "liquid glass appearing once the page settles" rather than "frosted → LG
+ * swap" because the page is still partially sliding in when the LG activates.
+ *
+ * Call sites pattern:
+ * ```
+ * val screenSettled = rememberLayerBackdropSettled()
+ * val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
+ * ```
+ *
+ * @param delayMillis How long to wait after composition before returning
+ *        `true`. Default 250ms — matches the app's default NavHost enter
+ *        transition (250ms slide-in + fade) exactly so the layerBackdrop
+ *        activates the moment the transition completes.
+ */
+@Composable
+fun rememberLayerBackdropSettled(delayMillis: Long = 250L): Boolean {
+    var settled by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(delayMillis)
+        settled = true
+    }
+    return settled
+}
 
 /**
  * Records the content of the composable it is called on into a [LayerBackdrop]

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
@@ -61,7 +61,7 @@ import moe.rukamori.archivetune.utils.makeTimeString
 fun SpotifyLibraryPlaylistListItem(
     playlist: SpotifyPlaylist,
     navController: NavController,
-    onHide: (() -> Unit)? = null,
+    onMenuClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(26.dp),
 ) {
@@ -133,8 +133,8 @@ fun SpotifyLibraryPlaylistListItem(
             )
         },
         trailingContent = {
-            if (onHide != null) {
-                IconButton(onClick = onHide) {
+            if (onMenuClick != null) {
+                IconButton(onClick = onMenuClick) {
                     Icon(
                         painter = painterResource(R.drawable.more_vert),
                         contentDescription = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
@@ -162,95 +162,97 @@ fun SpotifyPlaylistMenu(
         onHide()
     }
 
-    NewMenuContainer {
-        NewMenuContent(
-            headerContent = {
-                MenuSurfaceSection(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+    NewMenuContainer(
+        content = {
+            NewMenuContent(
+                headerContent = {
+                    MenuSurfaceSection(
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
-                        ItemThumbnail(
-                            thumbnailUrl = coverUrl,
-                            isActive = false,
-                            isPlaying = false,
-                            shape = RoundedCornerShape(ThumbnailCornerRadius),
-                            contentScale = ContentScale.Crop,
-                            showPlaceholder = true,
-                            modifier = Modifier.size(ListThumbnailSize),
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = playlistName,
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.Bold,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                color = MaterialTheme.colorScheme.onSurface,
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            ItemThumbnail(
+                                thumbnailUrl = coverUrl,
+                                isActive = false,
+                                isPlaying = false,
+                                shape = RoundedCornerShape(ThumbnailCornerRadius),
+                                contentScale = ContentScale.Crop,
+                                showPlaceholder = true,
+                                modifier = Modifier.size(ListThumbnailSize),
                             )
-                            if (songCount > 0) {
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = pluralStringResource(R.plurals.n_song, songCount, songCount),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    text = playlistName,
+                                    style = MaterialTheme.typography.titleLarge,
+                                    fontWeight = FontWeight.Bold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    color = MaterialTheme.colorScheme.onSurface,
                                 )
+                                if (songCount > 0) {
+                                    Text(
+                                        text = pluralStringResource(R.plurals.n_song, songCount, songCount),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
                             }
                         }
                     }
-                }
-            },
-            actionGrid = {
-                NewActionGrid(
-                    actions =
-                        listOf(
-                            NewAction(
-                                icon = { Icon(painter = painterResource(R.drawable.play), contentDescription = null, tint = accentColor) },
-                                text = stringResource(R.string.play),
-                                onClick = onPlay,
-                                contentColor = accentColor,
+                },
+                actionGrid = {
+                    NewActionGrid(
+                        actions =
+                            listOf(
+                                NewAction(
+                                    icon = { Icon(painter = painterResource(R.drawable.play), contentDescription = null, tint = accentColor) },
+                                    text = stringResource(R.string.play),
+                                    onClick = onPlay,
+                                    contentColor = accentColor,
+                                ),
+                                NewAction(
+                                    icon = { Icon(painter = painterResource(R.drawable.shuffle), contentDescription = null, tint = accentColor) },
+                                    text = stringResource(R.string.shuffle),
+                                    onClick = onShuffle,
+                                    contentColor = accentColor,
+                                ),
+                                NewAction(
+                                    icon = { Icon(painter = painterResource(R.drawable.share), contentDescription = null, tint = accentColor) },
+                                    text = stringResource(R.string.share),
+                                    onClick = onShare,
+                                    contentColor = accentColor,
+                                ),
                             ),
-                            NewAction(
-                                icon = { Icon(painter = painterResource(R.drawable.shuffle), contentDescription = null, tint = accentColor) },
-                                text = stringResource(R.string.shuffle),
-                                onClick = onShuffle,
-                                contentColor = accentColor,
-                            ),
-                            NewAction(
-                                icon = { Icon(painter = painterResource(R.drawable.share), contentDescription = null, tint = accentColor) },
-                                text = stringResource(R.string.share),
-                                onClick = onShare,
-                                contentColor = accentColor,
-                            ),
-                        ),
-                )
-            },
-            menuItems = {
-                MenuSurfaceSection {
-                    NewMenuItem(
-                        leadingContent = { Icon(painter = painterResource(R.drawable.playlist_play), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
-                        headlineContent = { Text(text = stringResource(R.string.play_next)) },
-                        onClick = onPlayNext,
                     )
-                    NewMenuItem(
-                        leadingContent = { Icon(painter = painterResource(R.drawable.queue_music), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
-                        headlineContent = { Text(text = stringResource(R.string.add_to_queue)) },
-                        onClick = onAddToQueue,
-                    )
-                    NewMenuItem(
-                        leadingContent = { Icon(painter = painterResource(R.drawable.visibility_off), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
-                        headlineContent = { Text(text = stringResource(R.string.hide_playlist)) },
-                        onClick = onToggleHide,
-                    )
-                }
-            },
-        )
-    }
+                },
+                menuItems = {
+                    MenuSurfaceSection {
+                        NewMenuItem(
+                            leadingContent = { Icon(painter = painterResource(R.drawable.playlist_play), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                            headlineContent = { Text(text = stringResource(R.string.play_next)) },
+                            onClick = onPlayNext,
+                        )
+                        NewMenuItem(
+                            leadingContent = { Icon(painter = painterResource(R.drawable.queue_music), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                            headlineContent = { Text(text = stringResource(R.string.add_to_queue)) },
+                            onClick = onAddToQueue,
+                        )
+                        NewMenuItem(
+                            leadingContent = { Icon(painter = painterResource(R.drawable.visibility_off), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                            headlineContent = { Text(text = stringResource(R.string.hide_playlist)) },
+                            onClick = onToggleHide,
+                        )
+                    }
+                },
+            )
+        },
+    )
 }
 
 /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
@@ -1,0 +1,271 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.menu
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.MediaItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalPlayerConnection
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.ListThumbnailSize
+import moe.rukamori.archivetune.constants.ThumbnailCornerRadius
+import moe.rukamori.archivetune.spotify.Spotify
+import moe.rukamori.archivetune.spotify.SpotifyPlaybackResolver
+import moe.rukamori.archivetune.spotify.SpotifyPlaylistQueue
+import moe.rukamori.archivetune.spotify.models.SpotifyPlaylist
+import moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
+import moe.rukamori.archivetune.ui.component.ItemThumbnail
+import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
+import moe.rukamori.archivetune.ui.component.NewAction
+import moe.rukamori.archivetune.ui.component.NewActionGrid
+import moe.rukamori.archivetune.ui.component.NewMenuContainer
+import moe.rukamori.archivetune.ui.component.NewMenuContent
+import moe.rukamori.archivetune.ui.component.NewMenuItem
+
+/**
+ * Bottom-sheet overflow menu for a Spotify playlist row.
+ *
+ * Per user report (2026-08-29): "There should also be Overflow menu icon in
+ * liquid glass inside Spotify Playlists. I've attached two images on how it
+ * should be and what functions i should have. You can copy the exact code for
+ * the functions from Normal playlists code."
+ *
+ * The two reference screenshots show the existing [PlaylistMenu] (for local /
+ * YouTube playlists). This composable mirrors that menu's visual structure
+ * (header card → primary action grid → secondary list items) and wires each
+ * action to a Spotify-specific implementation:
+ *
+ *   - Play: enqueue the playlist via [SpotifyPlaylistQueue] (which fetches
+ *     tracks in pages from the Spotify API and resolves each to a playable
+ *     MediaItem via [SpotifyPlaybackResolver]).
+ *   - Shuffle: same as Play but with a random startIndex within the first
+ *     page so the queue starts at a non-deterministic position.
+ *   - Share: open the system share sheet with the playlist's open.spotify.com
+ *     URL.
+ *   - Play next / Add to queue: fetch the first page of tracks (up to 50)
+ *     and resolve them to MediaItems, then hand them to the player's
+ *     playNext / addToQueue.
+ *   - Hide playlist: invokes [onHide] which toggles the local
+ *     `hiddenPlaylistIds` set on [LibrarySpotifyPlaylistsScreen].
+ *
+ * Items that don't apply to Spotify playlists (Start radio, Edit, Change
+ * playlist cover, Manage Tags, Download, Sync playlist, Delete) are omitted
+ * rather than shown as disabled — Spotify playlists are read-only with
+ * respect to ArchiveTune's local edit / cover / tag / sync / delete
+ * operations.
+ */
+@Composable
+fun SpotifyPlaylistMenu(
+    playlist: SpotifyPlaylist,
+    coroutineScope: CoroutineScope,
+    onDismiss: () -> Unit,
+    onHide: () -> Unit,
+) {
+    val context = LocalContext.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val playlistId = playlist.id
+    val playlistName = playlist.name
+    val songCount = playlist.tracks?.total ?: 0
+    val coverUrl = playlist.images.firstOrNull()?.url
+    val accentColor = AppleMusicStyleAccentColor
+
+    // Pre-build the intent for the Share action so the click handler is cheap.
+    val shareIntent = remember(playlistId) {
+        Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, "https://open.spotify.com/playlist/$playlistId")
+            putExtra(Intent.EXTRA_SUBJECT, playlistName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    val onPlay: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            playerConnection.playQueue(SpotifyPlaylistQueue(playlistId = playlistId, title = playlistName))
+        }
+    }
+    val onShuffle: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            // Pick a random startIndex within the first page so the queue
+            // starts at a non-deterministic position without having to
+            // pre-fetch the entire playlist.
+            val randomStart = kotlin.random.Random.nextInt(50)
+            playerConnection.playQueue(
+                SpotifyPlaylistQueue(
+                    playlistId = playlistId,
+                    title = playlistName,
+                    startIndex = randomStart,
+                ),
+            )
+        }
+    }
+    val onShare: () -> Unit = {
+        onDismiss()
+        val chooser = Intent.createChooser(shareIntent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(chooser)
+    }
+    val onPlayNext: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            val mediaItems = resolveFirstPageAsMediaItems(playlistId)
+            if (mediaItems.isNotEmpty()) {
+                playerConnection.playNext(mediaItems)
+            }
+        }
+    }
+    val onAddToQueue: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            val mediaItems = resolveFirstPageAsMediaItems(playlistId)
+            if (mediaItems.isNotEmpty()) {
+                playerConnection.addToQueue(mediaItems)
+            }
+        }
+    }
+    val onToggleHide: () -> Unit = {
+        onDismiss()
+        onHide()
+    }
+
+    NewMenuContainer {
+        NewMenuContent(
+            headerContent = {
+                MenuSurfaceSection(
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ItemThumbnail(
+                            thumbnailUrl = coverUrl,
+                            isActive = false,
+                            isPlaying = false,
+                            shape = RoundedCornerShape(ThumbnailCornerRadius),
+                            contentScale = ContentScale.Crop,
+                            showPlaceholder = true,
+                            modifier = Modifier.size(ListThumbnailSize),
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = playlistName,
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            if (songCount > 0) {
+                                Text(
+                                    text = pluralStringResource(R.plurals.n_song, songCount, songCount),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            actionGrid = {
+                NewActionGrid(
+                    actions =
+                        listOf(
+                            NewAction(
+                                icon = { Icon(painter = painterResource(R.drawable.play), contentDescription = null, tint = accentColor) },
+                                text = stringResource(R.string.play),
+                                onClick = onPlay,
+                                contentColor = accentColor,
+                            ),
+                            NewAction(
+                                icon = { Icon(painter = painterResource(R.drawable.shuffle), contentDescription = null, tint = accentColor) },
+                                text = stringResource(R.string.shuffle),
+                                onClick = onShuffle,
+                                contentColor = accentColor,
+                            ),
+                            NewAction(
+                                icon = { Icon(painter = painterResource(R.drawable.share), contentDescription = null, tint = accentColor) },
+                                text = stringResource(R.string.share),
+                                onClick = onShare,
+                                contentColor = accentColor,
+                            ),
+                        ),
+                )
+            },
+            menuItems = {
+                MenuSurfaceSection {
+                    NewMenuItem(
+                        leadingContent = { Icon(painter = painterResource(R.drawable.playlist_play), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                        headlineContent = { Text(text = stringResource(R.string.play_next)) },
+                        onClick = onPlayNext,
+                    )
+                    NewMenuItem(
+                        leadingContent = { Icon(painter = painterResource(R.drawable.queue_music), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                        headlineContent = { Text(text = stringResource(R.string.add_to_queue)) },
+                        onClick = onAddToQueue,
+                    )
+                    NewMenuItem(
+                        leadingContent = { Icon(painter = painterResource(R.drawable.visibility_off), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                        headlineContent = { Text(text = stringResource(R.string.hide_playlist)) },
+                        onClick = onToggleHide,
+                    )
+                }
+            },
+        )
+    }
+}
+
+/**
+ * Fetches the first page (up to 50 tracks) of the given Spotify playlist,
+ * resolves each to a playable [MediaItem] via [SpotifyPlaybackResolver], and
+ * returns the resulting list. Used by the Play next / Add to queue actions so
+ * the user gets immediate playback without waiting for the full playlist to
+ * be resolved.
+ *
+ * Runs on [Dispatchers.IO] so the menu UI can dismiss immediately.
+ */
+private suspend fun resolveFirstPageAsMediaItems(playlistId: String): List<MediaItem> =
+    withContext(Dispatchers.IO) {
+        val result = Spotify.playlistTracks(playlistId = playlistId, limit = 50, offset = 0).getOrNull() ?: return@withContext emptyList()
+        val tracks = result.items.mapNotNull { it.track?.takeUnless { t -> t.isLocal } }
+        if (tracks.isEmpty()) return@withContext emptyList()
+        tracks.mapNotNull { track -> SpotifyPlaybackResolver.resolveToMediaItem(track) }
+    }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
@@ -112,6 +112,7 @@ import moe.rukamori.archivetune.ui.component.shimmer.ButtonPlaceholder
 import moe.rukamori.archivetune.ui.component.shimmer.ListItemPlaceHolder
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
 import moe.rukamori.archivetune.ui.component.shimmer.TextPlaceholder
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.AlbumMenu
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
@@ -184,7 +185,9 @@ fun AlbumScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
 
     // Stable top inset: does not collapse to 0 when the status bar is transiently hidden,
     // so the album hero's top padding stays anchored below the TopAppBar.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
@@ -147,6 +147,7 @@ import moe.rukamori.archivetune.ui.component.shimmer.ButtonPlaceholder
 import moe.rukamori.archivetune.ui.component.shimmer.ListItemPlaceHolder
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
 import moe.rukamori.archivetune.ui.component.shimmer.TextPlaceholder
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.AlbumMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.menu.YouTubeAlbumMenu
@@ -212,7 +213,9 @@ fun ArtistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val isArtistBlocked = (blockState as? ArtistBlockState.Success)?.isBlocked == true
 
     // Per user report (2026-08-29): "Opening Artist page also feels too

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
+import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.ArtistFilter
 import moe.rukamori.archivetune.constants.ArtistFilterKey
@@ -129,12 +130,25 @@ fun LibraryArtistsScreen(
 
     val topArtist = artists.firstOrNull()
 
-    // Issue 2: player-aware bottom padding
+    // Player-aware bottom padding so the mini player never covers content.
     val playerAwareBottomPadding =
         LocalPlayerAwareWindowInsets.current
             .only(WindowInsetsSides.Bottom)
             .asPaddingValues()
             .calculateBottomPadding() + 12.dp
+
+    // Stable system-bars + display-cutout top inset. The previous
+    // implementation used `WindowInsets.systemBars.only(Top)` which only
+    // accounts for the status bar, NOT the display cutout (notch). On
+    // notched devices the LazyVerticalGrid's first row collided with the
+    // notch because the cutout extends below the status bar height. Per
+    // user report (2026-08-29): "The artist page is colliding with the
+    // notch." `LocalStableSystemBarsTopPadding` (defined in MainActivity)
+    // returns `max(live status bar top, live display cutout top, cached
+    // display cutout top)` — the same value used by the persistent LG
+    // header pills in LocalPlaylistScreen / ArtistScreen so the cards
+    // now sit below the notch consistently with the rest of the app.
+    val systemBarsTopPadding = LocalStableSystemBarsTopPadding.current
 
     ExpressivePullToRefreshBox(
         isRefreshing = isRefreshing,
@@ -147,7 +161,7 @@ fun LibraryArtistsScreen(
             contentPadding =
                 PaddingValues(
                     start = 24.dp,
-                    top = WindowInsets.systemBars.only(WindowInsetsSides.Top).asPaddingValues().calculateTopPadding() + LibraryHeaderContentPadding,
+                    top = systemBarsTopPadding + LibraryHeaderContentPadding,
                     end = 24.dp,
                     bottom = playerAwareBottomPadding,
                 ),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -112,6 +112,7 @@ import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.innertube.models.PlaylistItem
 import moe.rukamori.archivetune.innertube.models.WatchEndpoint
 import moe.rukamori.archivetune.playback.queues.ListQueue
+import moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
 import moe.rukamori.archivetune.ui.component.CreatePlaylistDialog
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
@@ -124,6 +125,7 @@ import moe.rukamori.archivetune.ui.component.PlaylistThumbnail
 import moe.rukamori.archivetune.ui.component.TagsManagementDialog
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.PlaylistMenu
 import moe.rukamori.archivetune.ui.menu.YouTubePlaylistMenu
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
@@ -191,7 +193,9 @@ fun LibraryPlaylistsScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val surfaceColor = MaterialTheme.colorScheme.surface
     val artworkBackdrop = rememberBackdrop(surfaceColor)
 
@@ -348,10 +352,10 @@ fun LibraryPlaylistsScreen(
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
                 ) {
                     Text(
-                        text = "PLAYLISTS",
+                        text = "LIST",
                         style = MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = AppleMusicStyleAccentColor,
                     )
                     Text(
                         text = stringResource(R.string.playlists),
@@ -414,7 +418,7 @@ fun LibraryPlaylistsScreen(
                             modifier =
                                 Modifier
                                     .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                                    .background(AppleMusicStyleAccentColor.copy(alpha = 0.12f))
                                     .clickable { showSortMenu = true }
                                     .padding(horizontal = 18.dp, vertical = 11.dp),
                             verticalAlignment = Alignment.CenterVertically,
@@ -423,7 +427,7 @@ fun LibraryPlaylistsScreen(
                                 text = currentSortLabel,
                                 modifier = Modifier.weight(1f, fill = false),
                                 style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
-                                color = MaterialTheme.colorScheme.primary,
+                                color = AppleMusicStyleAccentColor,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
@@ -431,7 +435,7 @@ fun LibraryPlaylistsScreen(
                             Icon(
                                 painter = painterResource(id = R.drawable.expand_more),
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                tint = AppleMusicStyleAccentColor,
                                 modifier = Modifier.size(16.dp),
                             )
                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,14 +60,18 @@ import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.spotify.SpotifyLibraryViewModel
+import moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.SpotifyLikedSongsListItem
 import moe.rukamori.archivetune.ui.component.SpotifyLibraryPlaylistListItem
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
+import moe.rukamori.archivetune.ui.menu.SpotifyPlaylistMenu
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberPreference
@@ -78,7 +83,17 @@ fun LibrarySpotifyPlaylistsScreen(
 ) {
     val playlists by viewModel.playlists.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    val menuState = LocalMenuState.current
+    val coroutineScope = rememberCoroutineScope()
+    // Sort mode for the Spotify list. Mirrors the Playlists page's
+    // PlaylistSortType but reduced to the options Spotify's API exposes
+    // (no Last Updated, no Custom order — Spotify returns its own ordering
+    // we can't reorder). Per user report (2026-08-29): "Also Add a sorting
+    // button below the number of playlists in Pink/red accent like history
+    // page which lets me sort playlists."
+    var sortByRecent by remember { mutableStateOf(true) }     // true = Recently added (default API order)
     var sortByName by remember { mutableStateOf(false) }
+    var sortByTrackCount by remember { mutableStateOf(false) }
     var sortDescending by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
     var showHidden by remember { mutableStateOf(false) }
@@ -88,15 +103,23 @@ fun LibrarySpotifyPlaylistsScreen(
     // it from the list (and toggling `showHidden` reveals it again).
     val hiddenPlaylistIds = remember { mutableStateListOf<String>() }
     val visiblePlaylists =
-        remember(playlists, sortByName, sortDescending, showHidden, hiddenPlaylistIds.size) {
+        remember(playlists, sortByRecent, sortByName, sortByTrackCount, sortDescending, showHidden, hiddenPlaylistIds.size) {
             val hiddenSnapshot = hiddenPlaylistIds.toList()
             playlists
                 .filter { playlist -> showHidden || playlist.id !in hiddenSnapshot }
                 .let { source ->
-                    if (sortByName) source.sortedBy { it.name.lowercase() } else source
+                    when {
+                        sortByName -> if (sortDescending) source.sortedByDescending { it.name.lowercase() } else source.sortedBy { it.name.lowercase() }
+                        sortByTrackCount -> if (sortDescending) source.sortedByDescending { it.tracks?.total ?: 0 } else source.sortedBy { it.tracks?.total ?: 0 }
+                        else -> source // Recently added — keep Spotify's default API order
+                    }
                 }
-                .let { source -> if (sortDescending) source.reversed() else source }
         }
+    val currentSortLabel = when {
+        sortByName -> if (sortDescending) stringResource(R.string.sort_z_to_a) else stringResource(R.string.sort_a_to_z)
+        sortByTrackCount -> stringResource(R.string.tracks_count_label)
+        else -> stringResource(R.string.recently_added)
+    }
     val playerAwareBottomPadding =
         LocalPlayerAwareWindowInsets.current
             .only(WindowInsetsSides.Bottom)
@@ -141,7 +164,9 @@ fun LibrarySpotifyPlaylistsScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val surfaceColor = MaterialTheme.colorScheme.surface
     val artworkBackdrop = rememberBackdrop(surfaceColor)
 
@@ -186,7 +211,13 @@ fun LibrarySpotifyPlaylistsScreen(
                 // song rows.
                 contentPadding =
                     PaddingValues(
-                        top = systemBarsTopPadding + 150.dp,
+                        // Per user report (2026-08-29): "Fix empty space in Spotify
+                        // page." The previous 150.dp top padding left a large empty
+                        // gap between the header pill and the first row. Reduced
+                        // to systemBarsTopPadding + 64.dp so the heading block
+                        // sits just below the persistent header pill — matching
+                        // the LocalPlaylistScreen / LibraryPlaylistsScreen spacing.
+                        top = systemBarsTopPadding + 64.dp,
                         bottom = playerAwareBottomPadding,
                     ),
                 verticalArrangement = Arrangement.spacedBy(0.dp),
@@ -207,7 +238,7 @@ fun LibrarySpotifyPlaylistsScreen(
                             text = "LIST",
                             style = MaterialTheme.typography.labelLarge,
                             fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = AppleMusicStyleAccentColor,
                         )
                         Text(
                             text = stringResource(R.string.spotify),
@@ -219,6 +250,96 @@ fun LibrarySpotifyPlaylistsScreen(
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
                         )
+                        // Per user report (2026-08-29): "Also Add a sorting
+                        // button below the number of playlists in Pink/red
+                        // accent like history page which lets me sort
+                        // playlists." Visual language mirrors the Playlists
+                        // page sort pill: pill-shaped with `accent.copy(0.12f)`
+                        // background, accent text, accent expand_more icon.
+                        // Sort options live in the DropdownMenu wired to
+                        // `showSortMenu` (also triggered by the more_vert
+                        // icon in the top-end liquid glass pill).
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Box {
+                            Row(
+                                modifier =
+                                    Modifier
+                                        .clip(CircleShape)
+                                        .background(AppleMusicStyleAccentColor.copy(alpha = 0.12f))
+                                        .clickable { showSortMenu = true }
+                                        .padding(horizontal = 18.dp, vertical = 11.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = currentSortLabel,
+                                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                                    color = AppleMusicStyleAccentColor,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Icon(
+                                    painter = painterResource(id = R.drawable.expand_more),
+                                    contentDescription = null,
+                                    tint = AppleMusicStyleAccentColor,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = showSortMenu,
+                                onDismissRequest = { showSortMenu = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.recently_added)) },
+                                    onClick = {
+                                        sortByRecent = true
+                                        sortByName = false
+                                        sortByTrackCount = false
+                                        showSortMenu = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.sort_a_to_z)) },
+                                    onClick = {
+                                        sortByRecent = false
+                                        sortByName = true
+                                        sortByTrackCount = false
+                                        sortDescending = false
+                                        showSortMenu = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.sort_z_to_a)) },
+                                    onClick = {
+                                        sortByRecent = false
+                                        sortByName = true
+                                        sortByTrackCount = false
+                                        sortDescending = true
+                                        showSortMenu = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.tracks_count_label)) },
+                                    onClick = {
+                                        sortByRecent = false
+                                        sortByName = false
+                                        sortByTrackCount = true
+                                        sortDescending = false
+                                        showSortMenu = false
+                                    },
+                                )
+                                // Hidden playlists toggle — mirrors the Playlists
+                                // page's "Hidden playlists" entry. Per user report:
+                                // "Also i should be able to hide Spotify playlists too."
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.hidden_playlists)) },
+                                    onClick = {
+                                        showHidden = !showHidden
+                                        showSortMenu = false
+                                    },
+                                )
+                            }
+                        }
                     }
                 }
                 item(key = "spotify_liked_songs", contentType = "spotify_liked_songs") {
@@ -244,9 +365,29 @@ fun LibrarySpotifyPlaylistsScreen(
                     SpotifyLibraryPlaylistListItem(
                         playlist = playlist,
                         navController = navController,
-                        onHide = {
-                            if (playlist.id in hiddenPlaylistIds) hiddenPlaylistIds.remove(playlist.id)
-                            else hiddenPlaylistIds.add(playlist.id)
+                        onMenuClick = {
+                            // Per user report (2026-08-29): "There should also be
+                            // Overflow menu icon in liquid glass inside Spotify
+                            // Playlists. I've attached two images on how it should be
+                            // and what functions i should have. You can copy the exact
+                            // code for the functions from Normal playlists code." The
+                            // per-row 3-dot menu now opens a SpotifyPlaylistMenu
+                            // bottom sheet (mirrors PlaylistMenu's structure + actions
+                            // adapted for Spotify playlists).
+                            menuState.show {
+                                SpotifyPlaylistMenu(
+                                    playlist = playlist,
+                                    coroutineScope = coroutineScope,
+                                    onDismiss = menuState::dismiss,
+                                    onHide = {
+                                        if (playlist.id in hiddenPlaylistIds) {
+                                            hiddenPlaylistIds.remove(playlist.id)
+                                        } else {
+                                            hiddenPlaylistIds.add(playlist.id)
+                                        }
+                                    },
+                                )
+                            }
                         },
                     )
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
@@ -127,6 +127,7 @@ import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
@@ -192,7 +193,9 @@ fun LocalSongScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -105,6 +105,7 @@ import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
@@ -362,7 +363,9 @@ fun AutoPlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -108,6 +108,7 @@ import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
@@ -340,7 +341,9 @@ fun CachePlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -137,6 +137,7 @@ import moe.rukamori.archivetune.ui.component.rememberBackdrop
 import moe.rukamori.archivetune.ui.component.MediaDetailIconAction
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.PlaylistMenu
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
@@ -220,7 +221,9 @@ fun LocalPlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     var showAssignTagsDialog by remember { mutableStateOf(false) }
 
     if (showAssignTagsDialog && playlist != null) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -127,6 +127,7 @@ import moe.rukamori.archivetune.ui.component.shimmer.ButtonPlaceholder
 import moe.rukamori.archivetune.ui.component.shimmer.ListItemPlaceHolder
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
 import moe.rukamori.archivetune.ui.component.shimmer.TextPlaceholder
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.SelectionMediaMetadataMenu
 import moe.rukamori.archivetune.ui.menu.YouTubePlaylistMenu
 import moe.rukamori.archivetune.ui.menu.YouTubeSongMenu
@@ -222,7 +223,9 @@ fun OnlinePlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
 
     // Stable top inset: does not collapse to 0 when the status bar is transiently hidden,
     // so the search bar offset and the playlist header always stay anchored below the TopAppBar.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -109,6 +109,7 @@ import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadItem
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadProgressIndicator
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadState
@@ -414,7 +415,9 @@ fun SpotifyPlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Use the theme surface color (not Color.Black) so the initial frame, before
     // any scrolling content is recorded into the backdrop, blends with the page
     // background instead of flashing solid black. Matches the LocalPlaylistScreen

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/ScrobbleManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/ScrobbleManager.kt
@@ -30,12 +30,40 @@ class ScrobbleManager(
     private var songStarted = false
     var useNowPlaying = true
 
+    // Track the metadata + threshold for the currently-playing song so that
+    // `flushPendingScrobbleIfNeeded()` can decide whether to submit a final
+    // scrobble when the user switches songs before the timer fires.
+    // Per user report (2026-08-29): "I've heard a song more than 50 times but
+    // still I don't see it [in the Last.fm dashboard]. The only time I see it
+    // is while I'm listening to it ... once I start playing a different song
+    // it disappears from the stats page."
+    //
+    // Root cause: `track.updateNowPlaying` fires immediately on song start,
+    // so Last.fm's "Now Playing" widget shows the song. But `track.scrobble`
+    // is only sent by the `scrobbleJob` coroutine after `scrobbleRemainingMillis`
+    // — and that job is cancelled (NOT flushed) whenever the user switches
+    // songs, pauses for too long, or `onPlayerStateChanged(isPlaying=true)`
+    // fires repeatedly (each call reset the timer without decrementing the
+    // remaining time, so the timer never completed).
+    private var currentMetadata: MediaMetadata? = null
+    private var currentThresholdMillis: Long = 0L
+    // Whether the timer is currently RUNNING (vs paused). Guards against
+    // `resumeScrobbleTimer` resetting the timer on every redundant
+    // `isPlaying=true` callback — previously each callback cancelled and
+    // restarted the job with the same `scrobbleRemainingMillis`, so a
+    // stream of `isPlaying=true` events would prevent the timer from ever
+    // completing.
+    private var scrobbleTimerRunning: Boolean = false
+
     fun destroy() {
         scrobbleJob?.cancel()
         scrobbleRemainingMillis = 0L
         scrobbleTimerStartedAt = 0L
         songStartedAt = 0L
         songStarted = false
+        currentMetadata = null
+        currentThresholdMillis = 0L
+        scrobbleTimerRunning = false
     }
 
     fun onSongStart(
@@ -43,6 +71,12 @@ class ScrobbleManager(
         duration: Long? = null,
     ) {
         if (metadata == null) return
+        // Before starting the new song's timer, check if the PREVIOUS song
+        // had met its scrobble threshold. If so, submit the final scrobble
+        // for it now — Last.fm's rule is "scrobble if the user listened for
+        // at least half the track duration OR 4 minutes". Previously, the
+        // pending scrobble was silently dropped on every song switch.
+        flushPendingScrobbleIfNeeded()
         songStartedAt = System.currentTimeMillis() / 1000
         songStarted = true
         startScrobbleTimer(metadata, duration)
@@ -60,6 +94,10 @@ class ScrobbleManager(
     }
 
     fun onSongStop() {
+        // On explicit stop, also flush — the user may have listened past
+        // the threshold before stopping. If the threshold wasn't met, the
+        // flush is a no-op.
+        flushPendingScrobbleIfNeeded()
         stopScrobbleTimer()
         songStarted = false
     }
@@ -71,25 +109,39 @@ class ScrobbleManager(
         scrobbleJob?.cancel()
         val resolvedDuration = duration?.toInt()?.div(1000) ?: metadata.duration
 
-        if (resolvedDuration <= minSongDuration) return
+        if (resolvedDuration <= minSongDuration) {
+            // Song too short to scrobble — record metadata so flush logic
+            // knows there's nothing pending, but don't start a timer.
+            currentMetadata = metadata
+            currentThresholdMillis = 0L
+            scrobbleTimerRunning = false
+            return
+        }
 
         val threshold = resolvedDuration * 1000L * scrobbleDelayPercent
         scrobbleRemainingMillis = min(threshold.toLong(), scrobbleDelaySeconds * 1000L)
+        currentThresholdMillis = scrobbleRemainingMillis
+        currentMetadata = metadata
 
         if (scrobbleRemainingMillis <= 0) {
             scrobbleSong(metadata)
+            scrobbleTimerRunning = false
             return
         }
         scrobbleTimerStartedAt = System.currentTimeMillis()
+        scrobbleTimerRunning = true
         scrobbleJob =
             scope.launch {
                 delay(scrobbleRemainingMillis)
                 scrobbleSong(metadata)
                 scrobbleJob = null
+                scrobbleTimerRunning = false
+                scrobbleTimerStartedAt = 0L
             }
     }
 
     private fun pauseScrobbleTimer() {
+        if (!scrobbleTimerRunning) return
         scrobbleJob?.cancel()
         if (scrobbleTimerStartedAt != 0L) {
             val elapsed = System.currentTimeMillis() - scrobbleTimerStartedAt
@@ -97,17 +149,34 @@ class ScrobbleManager(
             if (scrobbleRemainingMillis < 0) scrobbleRemainingMillis = 0
             scrobbleTimerStartedAt = 0L
         }
+        scrobbleTimerRunning = false
     }
 
     private fun resumeScrobbleTimer(metadata: MediaMetadata) {
+        // Guard against redundant `isPlaying=true` callbacks resetting the
+        // timer. Previously, every call cancelled and restarted the job
+        // with the same `scrobbleRemainingMillis` — so if the player fired
+        // `onPlayerStateChanged(isPlaying=true, ...)` repeatedly during
+        // playback (e.g. on buffer updates or metadata refreshes), the
+        // timer never completed and the scrobble was silently dropped.
+        if (scrobbleTimerRunning) return
         if (scrobbleRemainingMillis <= 0) return
+        // Only resume if the metadata matches the song we were tracking.
+        // If the player has moved on to a different song without an
+        // `onSongStart` call (shouldn't happen, but defensive), don't
+        // resume a stale timer for the wrong song.
+        val current = currentMetadata
+        if (current != null && !sameSong(current, metadata)) return
         scrobbleJob?.cancel()
         scrobbleTimerStartedAt = System.currentTimeMillis()
+        scrobbleTimerRunning = true
         scrobbleJob =
             scope.launch {
                 delay(scrobbleRemainingMillis)
-                scrobbleSong(metadata)
+                scrobbleSong(current ?: metadata)
                 scrobbleJob = null
+                scrobbleTimerRunning = false
+                scrobbleTimerStartedAt = 0L
             }
     }
 
@@ -115,6 +184,64 @@ class ScrobbleManager(
         scrobbleJob?.cancel()
         scrobbleJob = null
         scrobbleRemainingMillis = 0
+        scrobbleTimerRunning = false
+        scrobbleTimerStartedAt = 0L
+    }
+
+    /**
+     * Submit a final scrobble for the currently-tracked song IF the user
+     * has listened past the threshold (50% of duration OR 4 minutes, per
+     * Last.fm's spec). This is the "scrobble on skip" path that was missing
+     * — previously, switching songs before the timer fired silently dropped
+     * the scrobble even if the threshold was met.
+     *
+     * Safe to call repeatedly; no-ops if there's no pending scrobble or
+     * the threshold wasn't met.
+     */
+    private fun flushPendingScrobbleIfNeeded() {
+        val metadata = currentMetadata ?: return
+        if (currentThresholdMillis <= 0L) {
+            // Song was too short to scrobble, or no timer was ever started.
+            // Reset state and return.
+            currentMetadata = null
+            currentThresholdMillis = 0L
+            return
+        }
+        if (scrobbleTimerRunning && scrobbleTimerStartedAt != 0L) {
+            val elapsed = System.currentTimeMillis() - scrobbleTimerStartedAt
+            // Compute total elapsed (including any paused time that was
+            // already subtracted from scrobbleRemainingMillis). The total
+            // elapsed listening time = (threshold - remaining) + (now - timerStartedAt).
+            val totalElapsed = (currentThresholdMillis - scrobbleRemainingMillis) + elapsed
+            if (totalElapsed >= currentThresholdMillis) {
+                // Threshold met — submit the final scrobble.
+                scrobbleSong(metadata)
+            }
+        } else if (!scrobbleTimerRunning && scrobbleRemainingMillis <= 0L) {
+            // Timer had already completed (or never started because threshold
+            // was 0). The scrobbleSong coroutine may have already fired.
+            // To avoid double-scrobbling, we DON'T re-submit here. Last.fm
+            // deduplicates by timestamp, so even if we did, it would be a no-op.
+        }
+        // Cancel any pending job so it doesn't double-fire after we submit.
+        scrobbleJob?.cancel()
+        scrobbleJob = null
+        scrobbleTimerRunning = false
+        scrobbleTimerStartedAt = 0L
+        scrobbleRemainingMillis = 0L
+        currentMetadata = null
+        currentThresholdMillis = 0L
+    }
+
+    private fun sameSong(a: MediaMetadata, b: MediaMetadata): Boolean {
+        // Compare by id first; fall back to title+artist string match for
+        // cases where id is missing or differs across metadata refreshes.
+        if (a.id == b.id) return true
+        if (a.title == b.title &&
+            a.artists.size == b.artists.size &&
+            a.artists.zip(b.artists).all { (x, y) -> x.name == y.name }
+        ) return true
+        return false
     }
 
     private fun scrobbleSong(metadata: MediaMetadata) {


### PR DESCRIPTION
Address 5 user-reported issues:

1. **Label rename + color match** — `PLAYLISTS` → `LIST` on Playlists page; both Spotify + Playlists labels use `AppleMusicStyleAccentColor = Color(0xFFFF375C)` (the exact pink-red used by HistoryScreen via `AppleMusicPlaylistHero`). Playlists page sort pill background/text/icon also switched to the accent color.

2. **Spotify page UI overhaul** — fixed empty space (LazyColumn contentPadding top 150dp → 64dp); added sort pill below count with full DropdownMenu (Recently added / A→Z / Z→A / Tracks count / Hidden playlists); per-row 3-dot menu now opens `SpotifyPlaylistMenu` bottom sheet (Play/Shuffle/Share/Play next/Add to queue/Hide playlist) — mirrors PlaylistMenu structure with Spotify-specific actions.

3. **Artist notch collision** — `LibraryArtistsScreen` was using `WindowInsets.systemBars.only(Top)` which doesn’t include the display cutout. Switched to `LocalStableSystemBarsTopPadding.current` so the LazyVerticalGrid cards sit below the notch consistently with the rest of the app.

4. **Lastfm scrobbles dropped on song switch** — ScrobbleManager now flushes the pending scrobble on song start/stop if the threshold was met (50% of duration OR 180s). Added `scrobbleTimerRunning` guard so redundant `isPlaying=true` callbacks (e.g. on buffer updates) don’t reset the timer and prevent it from ever completing.

5. **Liquid-glass page-to-page transition lag** — re-added `rememberLayerBackdropSettled(delayMillis = 250L)` to LiquidGlass.kt (the codex branch had removed the helper AND all 9 call sites). Reduced delay 500ms → 250ms to match the NavHost transition duration exactly — eliminates the visible “frosted → LG” swap the user reported with the previous 500ms delay. Restored the `screenSettled = rememberLayerBackdropSettled()` wiring in all 10 LG screens. Liquid glass is NOT removed — only delayed by 250ms.

**Files changed:** 15 files (14 modified + 1 new `SpotifyPlaylistMenu.kt`).