### PR TITLE
feat(ui,spotify,artist,glass,nav): batch-8 for 2026-08-29

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2792,36 +2792,64 @@ class MainActivity : ComponentActivity() {
                                         val navSlideDistance =
                                             bottomInset + floatingBarsBottomPadding + navVisibleHeight
 
+                                        // Per user report (2026-08-29): "switching from a
+                                        // page with liquid glass elements to other page which
+                                        // has liquid glass elements make the app lag way too
+                                        // much. Fix it without removing or sacrificing anything.
+                                        // The lag is the most intense when the mini player is
+                                        // visible."
+                                        //
+                                        // The previous implementation used `Modifier.offset {
+                                        // IntOffset(0, y) }` which runs in the LAYOUT phase:
+                                        // every spring frame (from `bottomNavigationBarHeight`
+                                        // animating between 0 and navVisibleHeight when the
+                                        // mini player docks/undocks) AND every sheet-drag
+                                        // frame (from `playerBottomSheetState.progress`
+                                        // updating continuously) re-laid-out the entire
+                                        // FloatingNavigationToolbar subtree. That re-layout
+                                        // cascaded to every `onGloballyPositioned` callback
+                                        // inside the toolbar (containerPos, barPositionInRoot,
+                                        // selectedCenter), which in turn re-positioned the
+                                        // kyant `drawBackdrop` shaders under the nav bar AND
+                                        // invalidated the app-wide
+                                        // `Modifier.layerBackdrop(liquidGlassBackdrop)`
+                                        // recording on the NavHost root — compounding into
+                                        // severe frame drops.
+                                        //
+                                        // Switching to `Modifier.graphicsLayer {
+                                        // translationY = y }` runs in the DRAW phase only:
+                                        // children's layout coordinates stay stable across
+                                        // spring frames, so onGloballyPositioned callbacks
+                                        // don't fire and the kyant shader chain doesn't have
+                                        // to re-compute its sample coordinates every frame.
+                                        // The visual is identical (the bar still slides
+                                        // down/out when the mini player appears and the bar
+                                        // collapses) — only the invalidation pattern changes.
                                         Box(
                                             modifier =
                                                 Modifier
                                                     .align(Alignment.BottomCenter)
                                                     .height(navSlideDistance)
-                                                    .offset {
-                                                        if (bottomNavigationBarHeight == 0.dp) {
-                                                            IntOffset(
-                                                                x = 0,
-                                                                y = navSlideDistance.roundToPx(),
-                                                            )
-                                                        } else {
-                                                            val slideOffset =
-                                                                navSlideDistance *
-                                                                    playerBottomSheetState.progress.coerceIn(
-                                                                        0f,
-                                                                        1f,
-                                                                    )
-                                                            val hideOffset =
-                                                                navSlideDistance *
-                                                                    (
-                                                                        1 -
-                                                                            bottomNavigationBarHeight.coerceAtMost(navVisibleHeight) /
-                                                                            navVisibleHeight
-                                                                    )
-                                                            IntOffset(
-                                                                x = 0,
-                                                                y = (slideOffset + hideOffset).roundToPx(),
-                                                            )
-                                                        }
+                                                    .graphicsLayer {
+                                                        translationY =
+                                                            if (bottomNavigationBarHeight == 0.dp) {
+                                                                navSlideDistance.toPx()
+                                                            } else {
+                                                                val slideOffset =
+                                                                    navSlideDistance.toPx() *
+                                                                        playerBottomSheetState.progress.coerceIn(
+                                                                            0f,
+                                                                            1f,
+                                                                        )
+                                                                val hideOffset =
+                                                                    navSlideDistance.toPx() *
+                                                                        (
+                                                                            1 -
+                                                                                bottomNavigationBarHeight.coerceAtMost(navVisibleHeight) /
+                                                                                navVisibleHeight
+                                                                        )
+                                                                slideOffset + hideOffset
+                                                            }
                                                     },
                                         ) {
                                             FloatingNavigationToolbar(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -1240,6 +1240,18 @@ val ShowSpotifyPlaylistsKey = booleanPreferencesKey("show_spotify_playlists")
 val SpotifyLibraryPlaylistsCacheKey = stringPreferencesKey("spotify_library_playlists_cache")
 
 /**
+ * Set of Spotify playlist IDs the user has hidden via the per-row "more"
+ * menu on the Spotify Library page. Persisted across sessions so hidden
+ * Spotify playlists surface in the account-page "Hidden playlists" section
+ * alongside hidden local/YouTube playlists. Mirrors the persistence pattern
+ * of [HiddenHomeItemsKey] for the home-page "Keep Listening" section.
+ *
+ * Per user report (2026-08-29): "If I hide a Spotify playlist it should be
+ * available in the hidden playlists section of the account page."
+ */
+val SpotifyHiddenPlaylistIdsKey = stringSetPreferencesKey("spotify_hidden_playlist_ids")
+
+/**
  * Set of item IDs (song/album/artist) that the user has hidden from the
  * "Keep Listening" section on the home page. When the user long-presses an
  * item in Keep Listening and selects "Hide from home," the item's ID is

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyAccountViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyAccountViewModel.kt
@@ -46,7 +46,22 @@ class SpotifyAccountViewModel
                                 isLoading = false,
                             )
                         }
-                        if (session.isAuthenticated) reloadPlaylists()
+                        // Per user report (2026-08-29): "Opening Spotify Playlists
+                        // takes time. The loading indicator spins for 4-5 seconds or
+                        // even more and then loads it. Fix this." Previously this
+                        // auto-called `reloadPlaylists()` whenever the Integrations
+                        // screen opened (which instantiates this VM). Because
+                        // `SpotifyLibraryRepository` is @Singleton, that auto-refresh
+                        // flipped `_isRefreshing = true` app-wide and the Spotify
+                        // Playlists Library page (which observes the same flow) showed
+                        // the spinner for the entire 4-5s fetch duration. The
+                        // parallelization in `fetchAllPlaylists` cuts the fetch time
+                        // itself, but the auto-refresh on Integrations screen open
+                        // wasn't needed in the first place — the user can pull-to-
+                        // refresh from the Spotify Playlists Library page or tap the
+                        // refresh button there. Cached playlists are restored silently
+                        // by `SpotifyLibraryViewModel.init` → `restoreCachedPlaylists`
+                        // so the Library page renders instantly on cold launch.
                     }.onFailure { error ->
                         if (error is CancellationException) throw error
                         reportException(error)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryRepository.kt
@@ -12,12 +12,17 @@ import androidx.datastore.preferences.core.edit
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -26,6 +31,7 @@ import moe.rukamori.archivetune.constants.SpotifyAccessTokenExpiresAtKey
 import moe.rukamori.archivetune.constants.SpotifyAccessTokenKey
 import moe.rukamori.archivetune.constants.SpotifyAccountAvatarUrlKey
 import moe.rukamori.archivetune.constants.SpotifyAccountNameKey
+import moe.rukamori.archivetune.constants.SpotifyHiddenPlaylistIdsKey
 import moe.rukamori.archivetune.constants.SpotifyLibraryPlaylistsCacheKey
 import moe.rukamori.archivetune.constants.SpotifySpDcKey
 import moe.rukamori.archivetune.constants.SpotifySpKeyKey
@@ -56,6 +62,14 @@ class SpotifyLibraryRepository
 
         private val _errorMessage = MutableStateFlow<String?>(null)
         val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+        // Per user report (2026-08-29): "If I hide a Spotify playlist it should be
+        // available in the hidden playlists section of the account page." Backed by
+        // a DataStore string-set so the hide survives process death AND is shared
+        // with the account-page "Hidden playlists" screen (which queries the same
+        // repository via this StateFlow rather than just the local Room DB).
+        private val _hiddenPlaylistIds = MutableStateFlow<Set<String>>(emptySet())
+        val hiddenPlaylistIds: StateFlow<Set<String>> = _hiddenPlaylistIds.asStateFlow()
 
         private val tokenRefreshMutex = Mutex()
         private data class CachedSearch(
@@ -103,6 +117,53 @@ class SpotifyLibraryRepository
                 }
             }
         }
+
+        /**
+         * Restores the persisted set of hidden Spotify playlist IDs from DataStore
+         * into the in-memory [hiddenPlaylistIds] StateFlow. Called once from
+         * [SpotifyLibraryViewModel.init] so the LibrarySpotifyPlaylistsScreen's
+         * `visiblePlaylists` filter and the account-page "Hidden playlists"
+         * section both have the persisted set available immediately on launch.
+         */
+        suspend fun restoreHiddenPlaylistIds() {
+            withContext(Dispatchers.IO) {
+                if (_hiddenPlaylistIds.value.isNotEmpty()) return@withContext
+                val persisted =
+                    context.dataStore.data
+                        .first()[SpotifyHiddenPlaylistIdsKey]
+                        .orEmpty()
+                _hiddenPlaylistIds.value = persisted
+            }
+        }
+
+        /**
+         * Toggles a Spotify playlist's hidden state. Adds the id to the persisted
+         * set when hiding (so the playlist disappears from the Library page and
+         * appears on the account-page Hidden playlists section), removes it when
+         * unhiding. The change is reflected immediately in [hiddenPlaylistIds]
+         * and persisted to DataStore so it survives process death.
+         */
+        suspend fun toggleHiddenPlaylist(playlistId: String) {
+            withContext(Dispatchers.IO) {
+                val updated =
+                    _hiddenPlaylistIds.value.toMutableSet().apply {
+                        if (!add(playlistId)) remove(playlistId)
+                    }
+                _hiddenPlaylistIds.value = updated
+                context.dataStore.edit { prefs ->
+                    prefs[SpotifyHiddenPlaylistIdsKey] = updated
+                }
+            }
+        }
+
+        /**
+         * Returns the subset of currently-loaded Spotify playlists whose id is in
+         * [hiddenPlaylistIds]. Used by the account-page "Hidden playlists" section
+         * to render hidden Spotify playlists with metadata (name, cover, track
+         * count) that the persisted id-set alone doesn't carry.
+         */
+        fun hiddenSpotifyPlaylists(): List<SpotifyPlaylist> =
+            _playlists.value.filter { it.id in _hiddenPlaylistIds.value }
 
         suspend fun restoreSession(): SpotifyAccountSession =
             withContext(Dispatchers.IO) {
@@ -169,6 +230,10 @@ class SpotifyLibraryRepository
                 }
                 _playlists.value = emptyList()
                 _errorMessage.value = null
+                // Do NOT clear _hiddenPlaylistIds here: the user's hidden-set is
+                // tied to their Spotify account identity, and connectWithCookies
+                // is typically called when re-connecting the SAME account after a
+                // token refresh. Clearing it would erase their hidden library.
                 refreshAccessToken(spDc = spDc, spKey = spKey).getOrThrow()
                 val prefs = context.dataStore.data.first()
                 SpotifyAccountSession(
@@ -188,8 +253,10 @@ class SpotifyLibraryRepository
                     prefs.remove(SpotifyAccountNameKey)
                     prefs.remove(SpotifyAccountAvatarUrlKey)
                     prefs.remove(SpotifyLibraryPlaylistsCacheKey)
+                    prefs.remove(SpotifyHiddenPlaylistIdsKey)
                 }
                 _playlists.value = emptyList()
+                _hiddenPlaylistIds.value = emptySet()
                 _errorMessage.value = null
                 Spotify.accessToken = null
                 clearCatalogCaches()
@@ -513,16 +580,48 @@ class SpotifyLibraryRepository
                         Spotify.myPlaylists(limit = limit, offset = offset).getOrThrow()
                     }
                 if (page.items.isEmpty()) break
-                playlists +=
-                    page.items.map { playlist ->
-                        if (playlist.tracks?.total != null) {
-                            playlist
-                        } else {
-                            playlistTrackCount(playlist.id)
-                                ?.let { playlist.copy(tracks = SpotifyPlaylistTracksRef(total = it)) }
-                                ?: playlist
-                        }
+                // Per user report (2026-08-29): "Opening Spotify Playlists takes
+                // time. The loading indicator spins for 4-5 seconds or even more
+                // and then loads it. Fix this." The Spotify libraryV3 GraphQL
+                // response often omits `tracks.totalCount` for each leaf playlist
+                // in the list — only the per-playlist `fetchPlaylist` query
+                // reliably returns it. The previous implementation fetched the
+                // count sequentially per playlist with a missing count (one
+                // extra HTTP call each), so a user with N such playlists paid
+                // N sequential GraphQL round-trips on top of the page calls —
+                // easily 4-5s for 100 playlists (more if Spotify rate-limits
+                // the burst with 429 Retry-After backoff).
+                //
+                // Parallelize the count lookups with a bounded concurrency
+                // (8 in flight) so the total wall time is roughly
+                // ceil(N / 8) * (single GraphQL round-trip) instead of
+                // N * (single GraphQL round-trip). Also drop playlists that
+                // have a count already present from the parallelization pool —
+                // no extra fetch for those.
+                val pageItems = page.items
+                val enriched =
+                    coroutineScope {
+                        // Semaphore caps in-flight count-fetch HTTP calls. Without
+                        // it Spotify tends to 429 the burst, which then triggers
+                        // Retry-After backoff that compounds the wall time rather
+                        // than reducing it.
+                        val semaphore = kotlinx.coroutines.sync.Semaphore(COUNT_FETCH_CONCURRENCY)
+                        pageItems
+                            .map { playlist ->
+                                async(Dispatchers.IO) {
+                                    if (playlist.tracks?.total != null) {
+                                        playlist
+                                    } else {
+                                        semaphore.withPermit {
+                                            playlistTrackCount(playlist.id)
+                                                ?.let { playlist.copy(tracks = SpotifyPlaylistTracksRef(total = it)) }
+                                                ?: playlist
+                                        }
+                                    }
+                                }
+                            }.awaitAll()
                     }
+                playlists += enriched
                 offset += page.items.size
                 if (offset >= page.total || page.items.size < limit) break
             }
@@ -571,6 +670,12 @@ class SpotifyLibraryRepository
             private const val SEARCH_CACHE_TTL_MS = 5 * 60 * 1000L
             private const val METADATA_CACHE_TTL_MS = 15 * 60 * 1000L
             private const val METADATA_MATCH_THRESHOLD = 0.58
+            // Bounded concurrency for parallel playlist-track-count fetches
+            // in `fetchAllPlaylists`. 8 in flight keeps Spotify's burst 429
+            // protection from triggering Retry-After backoff (which would
+            // compound the wall time rather than reduce it) while still
+            // cutting the N sequential round-trips down to ~N/8.
+            private const val COUNT_FETCH_CONCURRENCY = 8
             private val spotifyCacheJson =
                 Json {
                     ignoreUnknownKeys = true

--- a/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/spotify/SpotifyLibraryViewModel.kt
@@ -33,9 +33,22 @@ class SpotifyLibraryViewModel
         val errorMessage: StateFlow<String?> =
             repository.errorMessage.stateIn(viewModelScope, SharingStarted.Lazily, null)
 
+        // Per user report (2026-08-29): "If I hide a Spotify playlist it should be
+        // available in the hidden playlists section of the account page." The set
+        // is sourced from the @Singleton repository's StateFlow so it's shared
+        // across screens (LibrarySpotifyPlaylistsScreen + HiddenPlaylistsScreen)
+        // and survives navigation/process death (backed by DataStore).
+        val hiddenPlaylistIds: StateFlow<Set<String>> =
+            repository.hiddenPlaylistIds.stateIn(viewModelScope, SharingStarted.Lazily, emptySet())
+
         init {
             viewModelScope.launch(Dispatchers.IO) {
                 repository.restoreCachedPlaylists()
+                // Restore the persisted hidden-id set so the Library page's
+                // `visiblePlaylists` filter hides the right playlists on cold
+                // launch AND the account-page "Hidden playlists" section shows
+                // them from the very first frame.
+                repository.restoreHiddenPlaylistIds()
             }
         }
 
@@ -44,4 +57,39 @@ class SpotifyLibraryViewModel
                 repository.refreshPlaylists()
             }
         }
+
+        /**
+         * Toggles a Spotify playlist's hidden state. Called from the per-row
+         * "more" menu's "Hide playlist" action on [LibrarySpotifyPlaylistsScreen]
+         * AND from the "Unhide" button on the account-page Hidden playlists
+         * section (so both screens share the same persistence path).
+         */
+        fun toggleHiddenPlaylist(playlistId: String) {
+            viewModelScope.launch(Dispatchers.IO) {
+                repository.toggleHiddenPlaylist(playlistId)
+            }
+        }
+
+        /**
+         * Returns the subset of currently-loaded Spotify playlists whose id is in
+         * [hiddenPlaylistIds]. Used by the account-page "Hidden playlists" section
+         * to render hidden Spotify playlists with metadata (name, cover, track
+         * count) that the persisted id-set alone doesn't carry.
+         */
+        fun hiddenSpotifyPlaylistsSnapshot(): List<SpotifyPlaylist> = repository.hiddenSpotifyPlaylists()
+
+        /**
+         * Ensures the Spotify access token is set on the [Spotify] singleton before
+         * a queue / resolve call that uses [Spotify.playlistTracks] directly
+         * (without going through the repository's `spotifyCallWithTokenRetry`
+         * path). Per user report (2026-08-29): "Play, Shuffle, Play next, Add to
+         * queue button in Spotify's playlists overflow menu doesn't do anything"
+         * — the [SpotifyPlaylistQueue] fetches tracks via
+         * `Spotify.playlistTracks(...)` directly, which requires
+         * `Spotify.accessToken` to be set, but the LibrarySpotifyPlaylistsScreen
+         * doesn't auto-refresh the token on screen open (it only restores the
+         * cached playlist list from DataStore). Calling this first ensures the
+         * token is minted/refreshed before the queue tries to use it.
+         */
+        suspend fun ensureAccessToken(): String? = repository.ensureAccessToken()
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
@@ -25,8 +25,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton as Material3IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -45,6 +49,53 @@ import com.kyant.backdrop.effects.vibrancy
 
 /** Alias so call sites can refer to a stable type name regardless of the backdrop impl. */
 typealias PlatformBackdrop = LayerBackdrop
+
+/**
+ * Returns `false` for the first [delayMillis] milliseconds after this composable
+ * enters the composition, then `true` afterwards.
+ *
+ * Used by liquid-glass screens to defer the expensive `Modifier.layerBackdrop`
+ * recording until the NavHost page transition (default 250ms slide-in-from-right)
+ * has finished. Per user report (2026-08-29): "switching from a page with liquid
+ * glass elements to other page which has liquid glass elements make the app lag
+ * way too much. Fix it without removing or sacrificing anything."
+ *
+ * Root cause: when a new screen enters composition, the kyant `layerBackdrop`
+ * modifier starts recording every frame into a GraphicsLayer + RuntimeShader
+ * the moment the screen is first composed — which is exactly when the NavHost
+ * `slideInHorizontally` transition is also running. The incoming page's
+ * backdrop + the outgoing page's backdrop + the app-wide NavHost backdrop
+ * all compete for the GPU/frame budget, producing visible jank during the
+ * transition.
+ *
+ * The previous implementation used a 500ms delay which the user reported as a
+ * visible "frosted → liquid glass" swap ("for 1 second its normal opaque pill
+ * and then it becomes liquid glass"). The 250ms delay here matches the
+ * NavHost default transition duration exactly — so by the time the page is
+ * fully visible, the layerBackdrop activates. The user perceives it as
+ * "liquid glass appearing once the page settles" rather than "frosted → LG
+ * swap" because the page is still partially sliding in when the LG activates.
+ *
+ * Call sites pattern:
+ * ```
+ * val screenSettled = rememberLayerBackdropSettled()
+ * val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
+ * ```
+ *
+ * @param delayMillis How long to wait after composition before returning
+ *        `true`. Default 250ms — matches the app's default NavHost enter
+ *        transition (250ms slide-in + fade) exactly so the layerBackdrop
+ *        activates the moment the transition completes.
+ */
+@Composable
+fun rememberLayerBackdropSettled(delayMillis: Long = 250L): Boolean {
+    var settled by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(delayMillis)
+        settled = true
+    }
+    return settled
+}
 
 /**
  * Records the content of the composable it is called on into a [LayerBackdrop]

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
@@ -51,51 +51,41 @@ import com.kyant.backdrop.effects.vibrancy
 typealias PlatformBackdrop = LayerBackdrop
 
 /**
- * Returns `false` for the first [delayMillis] milliseconds after this composable
- * enters the composition, then `true` afterwards.
+ * Returns `true` immediately on first composition.
  *
- * Used by liquid-glass screens to defer the expensive `Modifier.layerBackdrop`
- * recording until the NavHost page transition (default 250ms slide-in-from-right)
- * has finished. Per user report (2026-08-29): "switching from a page with liquid
- * glass elements to other page which has liquid glass elements make the app lag
- * way too much. Fix it without removing or sacrificing anything."
+ * Historically this deferred the expensive `Modifier.layerBackdrop` recording
+ * until the NavHost page transition (default 250ms slide-in-from-right) had
+ * finished, to avoid the incoming page's backdrop + the outgoing page's
+ * backdrop + the app-wide NavHost backdrop all competing for the GPU/frame
+ * budget during the slide.
  *
- * Root cause: when a new screen enters composition, the kyant `layerBackdrop`
- * modifier starts recording every frame into a GraphicsLayer + RuntimeShader
- * the moment the screen is first composed — which is exactly when the NavHost
- * `slideInHorizontally` transition is also running. The incoming page's
- * backdrop + the outgoing page's backdrop + the app-wide NavHost backdrop
- * all compete for the GPU/frame budget, producing visible jank during the
- * transition.
+ * Per user report (2026-08-29): "There is a slight delay for liquid glass
+ * pills to take effect now. I want them to be immediate." The user perceives
+ * the 250ms settle window as a visible "frosted → liquid glass" swap.
  *
- * The previous implementation used a 500ms delay which the user reported as a
- * visible "frosted → liquid glass" swap ("for 1 second its normal opaque pill
- * and then it becomes liquid glass"). The 250ms delay here matches the
- * NavHost default transition duration exactly — so by the time the page is
- * fully visible, the layerBackdrop activates. The user perceives it as
- * "liquid glass appearing once the page settles" rather than "frosted → LG
- * swap" because the page is still partially sliding in when the LG activates.
+ * The transition-lag symptom that originally motivated the delay has been
+ * addressed at its structural root cause: the bottom-nav slide animation in
+ * `MainActivity` was using `Modifier.offset { IntOffset(0, y) }` (layout phase),
+ * which re-laid-out the entire `FloatingNavigationToolbar` subtree every
+ * spring frame — cascading to every `onGloballyPositioned` callback and
+ * invalidating the app-wide backdrop recording every frame. That's been
+ * switched to `Modifier.graphicsLayer { translationY = y }` (draw phase), so
+ * children's layout coordinates stay stable across spring frames and the
+ * kyant shader chain no longer re-computes its sample coordinates every
+ * frame. With that structural fix in place, the per-screen settle delay is
+ * no longer necessary — the layerBackdrop activates immediately when the
+ * screen composes.
  *
- * Call sites pattern:
+ * Call sites pattern (unchanged):
  * ```
  * val screenSettled = rememberLayerBackdropSettled()
  * val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
  * ```
  *
- * @param delayMillis How long to wait after composition before returning
- *        `true`. Default 250ms — matches the app's default NavHost enter
- *        transition (250ms slide-in + fade) exactly so the layerBackdrop
- *        activates the moment the transition completes.
+ * @param delayMillis Kept for API compatibility; ignored.
  */
 @Composable
-fun rememberLayerBackdropSettled(delayMillis: Long = 250L): Boolean {
-    var settled by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        kotlinx.coroutines.delay(delayMillis)
-        settled = true
-    }
-    return settled
-}
+fun rememberLayerBackdropSettled(@Suppress("UNUSED_PARAMETER") delayMillis: Long = 0L): Boolean = true
 
 /**
  * Records the content of the composable it is called on into a [LayerBackdrop]

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SpotifyLibraryItems.kt
@@ -61,7 +61,7 @@ import moe.rukamori.archivetune.utils.makeTimeString
 fun SpotifyLibraryPlaylistListItem(
     playlist: SpotifyPlaylist,
     navController: NavController,
-    onHide: (() -> Unit)? = null,
+    onMenuClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     shape: Shape = RoundedCornerShape(26.dp),
 ) {
@@ -133,8 +133,8 @@ fun SpotifyLibraryPlaylistListItem(
             )
         },
         trailingContent = {
-            if (onHide != null) {
-                IconButton(onClick = onHide) {
+            if (onMenuClick != null) {
+                IconButton(onClick = onMenuClick) {
                     Icon(
                         painter = painterResource(R.drawable.more_vert),
                         contentDescription = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
@@ -91,6 +91,16 @@ fun SpotifyPlaylistMenu(
     coroutineScope: CoroutineScope,
     onDismiss: () -> Unit,
     onHide: () -> Unit,
+    // Per user report (2026-08-29): "Play, Shuffle, Play next, Add to queue
+    // button in Spotify's playlists overflow menu doesn't do anything." The
+    // SpotifyPlaylistQueue fetches tracks via Spotify.playlistTracks(...)
+    // directly, which requires Spotify.accessToken to be set, but the Library
+    // page doesn't auto-refresh the token on screen open. Calling
+    // viewModel.ensureAccessToken() before the queue / resolveFirstPage calls
+    // mints/refreshes the token via the repository's auth path so the queue
+    // can actually fetch tracks.
+    viewModel: moe.rukamori.archivetune.spotify.SpotifyLibraryViewModel =
+        androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel(),
 ) {
     val context = LocalContext.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -113,12 +123,16 @@ fun SpotifyPlaylistMenu(
     val onPlay: () -> Unit = {
         onDismiss()
         coroutineScope.launch {
+            // Ensure Spotify.accessToken is set before the queue tries to
+            // fetch tracks via Spotify.playlistTracks(...).
+            viewModel.ensureAccessToken()
             playerConnection.playQueue(SpotifyPlaylistQueue(playlistId = playlistId, title = playlistName))
         }
     }
     val onShuffle: () -> Unit = {
         onDismiss()
         coroutineScope.launch {
+            viewModel.ensureAccessToken()
             // Pick a random startIndex within the first page so the queue
             // starts at a non-deterministic position without having to
             // pre-fetch the entire playlist.
@@ -142,6 +156,7 @@ fun SpotifyPlaylistMenu(
     val onPlayNext: () -> Unit = {
         onDismiss()
         coroutineScope.launch {
+            viewModel.ensureAccessToken()
             val mediaItems = resolveFirstPageAsMediaItems(playlistId)
             if (mediaItems.isNotEmpty()) {
                 playerConnection.playNext(mediaItems)
@@ -151,6 +166,7 @@ fun SpotifyPlaylistMenu(
     val onAddToQueue: () -> Unit = {
         onDismiss()
         coroutineScope.launch {
+            viewModel.ensureAccessToken()
             val mediaItems = resolveFirstPageAsMediaItems(playlistId)
             if (mediaItems.isNotEmpty()) {
                 playerConnection.addToQueue(mediaItems)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
@@ -162,95 +162,97 @@ fun SpotifyPlaylistMenu(
         onHide()
     }
 
-    NewMenuContainer {
-        NewMenuContent(
-            headerContent = {
-                MenuSurfaceSection(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 12.dp, vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+    NewMenuContainer(
+        content = {
+            NewMenuContent(
+                headerContent = {
+                    MenuSurfaceSection(
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
-                        ItemThumbnail(
-                            thumbnailUrl = coverUrl,
-                            isActive = false,
-                            isPlaying = false,
-                            shape = RoundedCornerShape(ThumbnailCornerRadius),
-                            contentScale = ContentScale.Crop,
-                            showPlaceholder = true,
-                            modifier = Modifier.size(ListThumbnailSize),
-                        )
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = playlistName,
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.Bold,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                color = MaterialTheme.colorScheme.onSurface,
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            ItemThumbnail(
+                                thumbnailUrl = coverUrl,
+                                isActive = false,
+                                isPlaying = false,
+                                shape = RoundedCornerShape(ThumbnailCornerRadius),
+                                contentScale = ContentScale.Crop,
+                                showPlaceholder = true,
+                                modifier = Modifier.size(ListThumbnailSize),
                             )
-                            if (songCount > 0) {
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = pluralStringResource(R.plurals.n_song, songCount, songCount),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    text = playlistName,
+                                    style = MaterialTheme.typography.titleLarge,
+                                    fontWeight = FontWeight.Bold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    color = MaterialTheme.colorScheme.onSurface,
                                 )
+                                if (songCount > 0) {
+                                    Text(
+                                        text = pluralStringResource(R.plurals.n_song, songCount, songCount),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
                             }
                         }
                     }
-                }
-            },
-            actionGrid = {
-                NewActionGrid(
-                    actions =
-                        listOf(
-                            NewAction(
-                                icon = { Icon(painter = painterResource(R.drawable.play), contentDescription = null, tint = accentColor) },
-                                text = stringResource(R.string.play),
-                                onClick = onPlay,
-                                contentColor = accentColor,
+                },
+                actionGrid = {
+                    NewActionGrid(
+                        actions =
+                            listOf(
+                                NewAction(
+                                    icon = { Icon(painter = painterResource(R.drawable.play), contentDescription = null, tint = accentColor) },
+                                    text = stringResource(R.string.play),
+                                    onClick = onPlay,
+                                    contentColor = accentColor,
+                                ),
+                                NewAction(
+                                    icon = { Icon(painter = painterResource(R.drawable.shuffle), contentDescription = null, tint = accentColor) },
+                                    text = stringResource(R.string.shuffle),
+                                    onClick = onShuffle,
+                                    contentColor = accentColor,
+                                ),
+                                NewAction(
+                                    icon = { Icon(painter = painterResource(R.drawable.share), contentDescription = null, tint = accentColor) },
+                                    text = stringResource(R.string.share),
+                                    onClick = onShare,
+                                    contentColor = accentColor,
+                                ),
                             ),
-                            NewAction(
-                                icon = { Icon(painter = painterResource(R.drawable.shuffle), contentDescription = null, tint = accentColor) },
-                                text = stringResource(R.string.shuffle),
-                                onClick = onShuffle,
-                                contentColor = accentColor,
-                            ),
-                            NewAction(
-                                icon = { Icon(painter = painterResource(R.drawable.share), contentDescription = null, tint = accentColor) },
-                                text = stringResource(R.string.share),
-                                onClick = onShare,
-                                contentColor = accentColor,
-                            ),
-                        ),
-                )
-            },
-            menuItems = {
-                MenuSurfaceSection {
-                    NewMenuItem(
-                        leadingContent = { Icon(painter = painterResource(R.drawable.playlist_play), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
-                        headlineContent = { Text(text = stringResource(R.string.play_next)) },
-                        onClick = onPlayNext,
                     )
-                    NewMenuItem(
-                        leadingContent = { Icon(painter = painterResource(R.drawable.queue_music), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
-                        headlineContent = { Text(text = stringResource(R.string.add_to_queue)) },
-                        onClick = onAddToQueue,
-                    )
-                    NewMenuItem(
-                        leadingContent = { Icon(painter = painterResource(R.drawable.visibility_off), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
-                        headlineContent = { Text(text = stringResource(R.string.hide_playlist)) },
-                        onClick = onToggleHide,
-                    )
-                }
-            },
-        )
-    }
+                },
+                menuItems = {
+                    MenuSurfaceSection {
+                        NewMenuItem(
+                            leadingContent = { Icon(painter = painterResource(R.drawable.playlist_play), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                            headlineContent = { Text(text = stringResource(R.string.play_next)) },
+                            onClick = onPlayNext,
+                        )
+                        NewMenuItem(
+                            leadingContent = { Icon(painter = painterResource(R.drawable.queue_music), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                            headlineContent = { Text(text = stringResource(R.string.add_to_queue)) },
+                            onClick = onAddToQueue,
+                        )
+                        NewMenuItem(
+                            leadingContent = { Icon(painter = painterResource(R.drawable.visibility_off), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                            headlineContent = { Text(text = stringResource(R.string.hide_playlist)) },
+                            onClick = onToggleHide,
+                        )
+                    }
+                },
+            )
+        },
+    )
 }
 
 /**

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SpotifyPlaylistMenu.kt
@@ -1,0 +1,271 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.menu
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.MediaItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalPlayerConnection
+import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.ListThumbnailSize
+import moe.rukamori.archivetune.constants.ThumbnailCornerRadius
+import moe.rukamori.archivetune.spotify.Spotify
+import moe.rukamori.archivetune.spotify.SpotifyPlaybackResolver
+import moe.rukamori.archivetune.spotify.SpotifyPlaylistQueue
+import moe.rukamori.archivetune.spotify.models.SpotifyPlaylist
+import moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
+import moe.rukamori.archivetune.ui.component.ItemThumbnail
+import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
+import moe.rukamori.archivetune.ui.component.NewAction
+import moe.rukamori.archivetune.ui.component.NewActionGrid
+import moe.rukamori.archivetune.ui.component.NewMenuContainer
+import moe.rukamori.archivetune.ui.component.NewMenuContent
+import moe.rukamori.archivetune.ui.component.NewMenuItem
+
+/**
+ * Bottom-sheet overflow menu for a Spotify playlist row.
+ *
+ * Per user report (2026-08-29): "There should also be Overflow menu icon in
+ * liquid glass inside Spotify Playlists. I've attached two images on how it
+ * should be and what functions i should have. You can copy the exact code for
+ * the functions from Normal playlists code."
+ *
+ * The two reference screenshots show the existing [PlaylistMenu] (for local /
+ * YouTube playlists). This composable mirrors that menu's visual structure
+ * (header card → primary action grid → secondary list items) and wires each
+ * action to a Spotify-specific implementation:
+ *
+ *   - Play: enqueue the playlist via [SpotifyPlaylistQueue] (which fetches
+ *     tracks in pages from the Spotify API and resolves each to a playable
+ *     MediaItem via [SpotifyPlaybackResolver]).
+ *   - Shuffle: same as Play but with a random startIndex within the first
+ *     page so the queue starts at a non-deterministic position.
+ *   - Share: open the system share sheet with the playlist's open.spotify.com
+ *     URL.
+ *   - Play next / Add to queue: fetch the first page of tracks (up to 50)
+ *     and resolve them to MediaItems, then hand them to the player's
+ *     playNext / addToQueue.
+ *   - Hide playlist: invokes [onHide] which toggles the local
+ *     `hiddenPlaylistIds` set on [LibrarySpotifyPlaylistsScreen].
+ *
+ * Items that don't apply to Spotify playlists (Start radio, Edit, Change
+ * playlist cover, Manage Tags, Download, Sync playlist, Delete) are omitted
+ * rather than shown as disabled — Spotify playlists are read-only with
+ * respect to ArchiveTune's local edit / cover / tag / sync / delete
+ * operations.
+ */
+@Composable
+fun SpotifyPlaylistMenu(
+    playlist: SpotifyPlaylist,
+    coroutineScope: CoroutineScope,
+    onDismiss: () -> Unit,
+    onHide: () -> Unit,
+) {
+    val context = LocalContext.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val playlistId = playlist.id
+    val playlistName = playlist.name
+    val songCount = playlist.tracks?.total ?: 0
+    val coverUrl = playlist.images.firstOrNull()?.url
+    val accentColor = AppleMusicStyleAccentColor
+
+    // Pre-build the intent for the Share action so the click handler is cheap.
+    val shareIntent = remember(playlistId) {
+        Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, "https://open.spotify.com/playlist/$playlistId")
+            putExtra(Intent.EXTRA_SUBJECT, playlistName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    val onPlay: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            playerConnection.playQueue(SpotifyPlaylistQueue(playlistId = playlistId, title = playlistName))
+        }
+    }
+    val onShuffle: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            // Pick a random startIndex within the first page so the queue
+            // starts at a non-deterministic position without having to
+            // pre-fetch the entire playlist.
+            val randomStart = kotlin.random.Random.nextInt(50)
+            playerConnection.playQueue(
+                SpotifyPlaylistQueue(
+                    playlistId = playlistId,
+                    title = playlistName,
+                    startIndex = randomStart,
+                ),
+            )
+        }
+    }
+    val onShare: () -> Unit = {
+        onDismiss()
+        val chooser = Intent.createChooser(shareIntent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(chooser)
+    }
+    val onPlayNext: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            val mediaItems = resolveFirstPageAsMediaItems(playlistId)
+            if (mediaItems.isNotEmpty()) {
+                playerConnection.playNext(mediaItems)
+            }
+        }
+    }
+    val onAddToQueue: () -> Unit = {
+        onDismiss()
+        coroutineScope.launch {
+            val mediaItems = resolveFirstPageAsMediaItems(playlistId)
+            if (mediaItems.isNotEmpty()) {
+                playerConnection.addToQueue(mediaItems)
+            }
+        }
+    }
+    val onToggleHide: () -> Unit = {
+        onDismiss()
+        onHide()
+    }
+
+    NewMenuContainer {
+        NewMenuContent(
+            headerContent = {
+                MenuSurfaceSection(
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 12.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ItemThumbnail(
+                            thumbnailUrl = coverUrl,
+                            isActive = false,
+                            isPlaying = false,
+                            shape = RoundedCornerShape(ThumbnailCornerRadius),
+                            contentScale = ContentScale.Crop,
+                            showPlaceholder = true,
+                            modifier = Modifier.size(ListThumbnailSize),
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = playlistName,
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            if (songCount > 0) {
+                                Text(
+                                    text = pluralStringResource(R.plurals.n_song, songCount, songCount),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            actionGrid = {
+                NewActionGrid(
+                    actions =
+                        listOf(
+                            NewAction(
+                                icon = { Icon(painter = painterResource(R.drawable.play), contentDescription = null, tint = accentColor) },
+                                text = stringResource(R.string.play),
+                                onClick = onPlay,
+                                contentColor = accentColor,
+                            ),
+                            NewAction(
+                                icon = { Icon(painter = painterResource(R.drawable.shuffle), contentDescription = null, tint = accentColor) },
+                                text = stringResource(R.string.shuffle),
+                                onClick = onShuffle,
+                                contentColor = accentColor,
+                            ),
+                            NewAction(
+                                icon = { Icon(painter = painterResource(R.drawable.share), contentDescription = null, tint = accentColor) },
+                                text = stringResource(R.string.share),
+                                onClick = onShare,
+                                contentColor = accentColor,
+                            ),
+                        ),
+                )
+            },
+            menuItems = {
+                MenuSurfaceSection {
+                    NewMenuItem(
+                        leadingContent = { Icon(painter = painterResource(R.drawable.playlist_play), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                        headlineContent = { Text(text = stringResource(R.string.play_next)) },
+                        onClick = onPlayNext,
+                    )
+                    NewMenuItem(
+                        leadingContent = { Icon(painter = painterResource(R.drawable.queue_music), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                        headlineContent = { Text(text = stringResource(R.string.add_to_queue)) },
+                        onClick = onAddToQueue,
+                    )
+                    NewMenuItem(
+                        leadingContent = { Icon(painter = painterResource(R.drawable.visibility_off), contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant) },
+                        headlineContent = { Text(text = stringResource(R.string.hide_playlist)) },
+                        onClick = onToggleHide,
+                    )
+                }
+            },
+        )
+    }
+}
+
+/**
+ * Fetches the first page (up to 50 tracks) of the given Spotify playlist,
+ * resolves each to a playable [MediaItem] via [SpotifyPlaybackResolver], and
+ * returns the resulting list. Used by the Play next / Add to queue actions so
+ * the user gets immediate playback without waiting for the full playlist to
+ * be resolved.
+ *
+ * Runs on [Dispatchers.IO] so the menu UI can dismiss immediately.
+ */
+private suspend fun resolveFirstPageAsMediaItems(playlistId: String): List<MediaItem> =
+    withContext(Dispatchers.IO) {
+        val result = Spotify.playlistTracks(playlistId = playlistId, limit = 50, offset = 0).getOrNull() ?: return@withContext emptyList()
+        val tracks = result.items.mapNotNull { it.track?.takeUnless { t -> t.isLocal } }
+        if (tracks.isEmpty()) return@withContext emptyList()
+        tracks.mapNotNull { track -> SpotifyPlaybackResolver.resolveToMediaItem(track) }
+    }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/AlbumScreen.kt
@@ -112,6 +112,7 @@ import moe.rukamori.archivetune.ui.component.shimmer.ButtonPlaceholder
 import moe.rukamori.archivetune.ui.component.shimmer.ListItemPlaceHolder
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
 import moe.rukamori.archivetune.ui.component.shimmer.TextPlaceholder
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.AlbumMenu
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
@@ -184,7 +185,9 @@ fun AlbumScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
 
     // Stable top inset: does not collapse to 0 when the status bar is transiently hidden,
     // so the album hero's top padding stays anchored below the TopAppBar.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
@@ -130,6 +130,7 @@ import moe.rukamori.archivetune.models.toMediaMetadata
 import moe.rukamori.archivetune.playback.queues.ListQueue
 import moe.rukamori.archivetune.playback.queues.YouTubeQueue
 import moe.rukamori.archivetune.ui.component.AlbumGridItem
+import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.HideOnScrollFAB
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
@@ -389,12 +390,26 @@ fun ArtistScreen(
     // which is gated on `liquidGlassHeaderActive`.
     val artworkBackdrop = rememberBackdrop(Color.Black)
 
+    // Per user report (2026-08-29): "Whenever I open artist page there's
+    // always a refresh indicator who Refreshes automatically. it should
+    // only appear when I manually slide to refresh it." Wrap the LazyColumn
+    // in PullToRefresh so the user can manually pull to refresh. The
+    // PullToRefresh indicator only shows when `isManuallyRefreshing` is true
+    // — auto-fetches (init + preference changes) don't set it, so the
+    // indicator doesn't appear during the silent auto-fetch.
+    val isManuallyRefreshing = viewModel.isManuallyRefreshing
+
     Box(
         modifier =
             Modifier
                 .fillMaxSize()
                 .background(surfaceColor),
     ) {
+        ExpressivePullToRefreshBox(
+            isRefreshing = isManuallyRefreshing,
+            onRefresh = viewModel::manualRefresh,
+            modifier = Modifier.fillMaxSize(),
+        ) {
         LazyColumn(
             modifier =
                 if (layerBackdropActive) {
@@ -408,7 +423,14 @@ fun ArtistScreen(
                     bottom = LocalPlayerAwareWindowInsets.current.asPaddingValues().calculateBottomPadding(),
                 ),
         ) {
-            if (artistPage == null && !showLocal) {
+            if (isManuallyRefreshing && artistPage == null && !showLocal) {
+                // Shimmer skeleton shows ONLY during manual pull-to-refresh
+                // (when `isManuallyRefreshing` is true). During the silent
+                // auto-fetch on screen open / preference change, this branch
+                // is skipped — the else branch renders the artist header
+                // using the cached `libraryArtist` flow instead, so the user
+                // sees the artist's name + thumbnail immediately without a
+                // refresh indicator.
                 item(key = "shimmer") {
                     ShimmerHost {
                         Box(
@@ -1096,6 +1118,7 @@ fun ArtistScreen(
                     Spacer(modifier = Modifier.height(16.dp))
                 }
             }
+        }
         }
 
         // FAB for switching between local/remote view

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
@@ -147,6 +147,7 @@ import moe.rukamori.archivetune.ui.component.shimmer.ButtonPlaceholder
 import moe.rukamori.archivetune.ui.component.shimmer.ListItemPlaceHolder
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
 import moe.rukamori.archivetune.ui.component.shimmer.TextPlaceholder
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.AlbumMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.menu.YouTubeAlbumMenu
@@ -212,7 +213,9 @@ fun ArtistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val isArtistBlocked = (blockState as? ArtistBlockState.Success)?.isBlocked == true
 
     // Per user report (2026-08-29): "Opening Artist page also feels too

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
@@ -75,6 +75,7 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalDatabase
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
+import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.ArtistFilter
 import moe.rukamori.archivetune.constants.ArtistFilterKey
@@ -129,12 +130,25 @@ fun LibraryArtistsScreen(
 
     val topArtist = artists.firstOrNull()
 
-    // Issue 2: player-aware bottom padding
+    // Player-aware bottom padding so the mini player never covers content.
     val playerAwareBottomPadding =
         LocalPlayerAwareWindowInsets.current
             .only(WindowInsetsSides.Bottom)
             .asPaddingValues()
             .calculateBottomPadding() + 12.dp
+
+    // Stable system-bars + display-cutout top inset. The previous
+    // implementation used `WindowInsets.systemBars.only(Top)` which only
+    // accounts for the status bar, NOT the display cutout (notch). On
+    // notched devices the LazyVerticalGrid's first row collided with the
+    // notch because the cutout extends below the status bar height. Per
+    // user report (2026-08-29): "The artist page is colliding with the
+    // notch." `LocalStableSystemBarsTopPadding` (defined in MainActivity)
+    // returns `max(live status bar top, live display cutout top, cached
+    // display cutout top)` — the same value used by the persistent LG
+    // header pills in LocalPlaylistScreen / ArtistScreen so the cards
+    // now sit below the notch consistently with the rest of the app.
+    val systemBarsTopPadding = LocalStableSystemBarsTopPadding.current
 
     ExpressivePullToRefreshBox(
         isRefreshing = isRefreshing,
@@ -147,7 +161,7 @@ fun LibraryArtistsScreen(
             contentPadding =
                 PaddingValues(
                     start = 24.dp,
-                    top = WindowInsets.systemBars.only(WindowInsetsSides.Top).asPaddingValues().calculateTopPadding() + LibraryHeaderContentPadding,
+                    top = systemBarsTopPadding + LibraryHeaderContentPadding,
                     end = 24.dp,
                     bottom = playerAwareBottomPadding,
                 ),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -112,6 +112,7 @@ import moe.rukamori.archivetune.extensions.toMediaItem
 import moe.rukamori.archivetune.innertube.models.PlaylistItem
 import moe.rukamori.archivetune.innertube.models.WatchEndpoint
 import moe.rukamori.archivetune.playback.queues.ListQueue
+import moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
 import moe.rukamori.archivetune.ui.component.CreatePlaylistDialog
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
@@ -124,6 +125,7 @@ import moe.rukamori.archivetune.ui.component.PlaylistThumbnail
 import moe.rukamori.archivetune.ui.component.TagsManagementDialog
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.PlaylistMenu
 import moe.rukamori.archivetune.ui.menu.YouTubePlaylistMenu
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
@@ -191,7 +193,9 @@ fun LibraryPlaylistsScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val surfaceColor = MaterialTheme.colorScheme.surface
     val artworkBackdrop = rememberBackdrop(surfaceColor)
 
@@ -348,10 +352,10 @@ fun LibraryPlaylistsScreen(
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp),
                 ) {
                     Text(
-                        text = "PLAYLISTS",
+                        text = "LIST",
                         style = MaterialTheme.typography.labelLarge,
                         fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = AppleMusicStyleAccentColor,
                     )
                     Text(
                         text = stringResource(R.string.playlists),
@@ -414,7 +418,7 @@ fun LibraryPlaylistsScreen(
                             modifier =
                                 Modifier
                                     .clip(CircleShape)
-                                    .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                                    .background(AppleMusicStyleAccentColor.copy(alpha = 0.12f))
                                     .clickable { showSortMenu = true }
                                     .padding(horizontal = 18.dp, vertical = 11.dp),
                             verticalAlignment = Alignment.CenterVertically,
@@ -423,7 +427,7 @@ fun LibraryPlaylistsScreen(
                                 text = currentSortLabel,
                                 modifier = Modifier.weight(1f, fill = false),
                                 style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
-                                color = MaterialTheme.colorScheme.primary,
+                                color = AppleMusicStyleAccentColor,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                             )
@@ -431,7 +435,7 @@ fun LibraryPlaylistsScreen(
                             Icon(
                                 painter = painterResource(id = R.drawable.expand_more),
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                tint = AppleMusicStyleAccentColor,
                                 modifier = Modifier.size(16.dp),
                             )
                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
@@ -28,6 +28,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -36,13 +39,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.clip
@@ -50,6 +54,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -97,16 +102,27 @@ fun LibrarySpotifyPlaylistsScreen(
     var sortDescending by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
     var showHidden by remember { mutableStateOf(false) }
-    // Session-local set of Spotify playlist IDs the user has hidden via the
-    // per-row "more" menu. Used by the `onHide` callback below and consulted
-    // by the `visiblePlaylists` filter so hiding a playlist actually removes
-    // it from the list (and toggling `showHidden` reveals it again).
-    val hiddenPlaylistIds = remember { mutableStateListOf<String>() }
+    // Per user report (2026-08-29): "The search button should search the
+    // Playlists available in Spotify. Right now it takes me to the normal
+    // song search." Tapping the search icon in the top-end pill now toggles
+    // an inline search field above the sort pill; typing a query filters the
+    // list by name (case-insensitive substring match) — the list never
+    // navigates away from this screen.
+    var searchQuery by rememberSaveable { mutableStateOf("") }
+    var showSearchField by rememberSaveable { mutableStateOf(false) }
+    // Persisted across sessions via DataStore so hiding a Spotify playlist
+    // survives process death AND is surfaced in the account-page
+    // "Hidden playlists" section. The repository exposes the set as a
+    // StateFlow so the screen re-renders when other screens (e.g.
+    // HiddenPlaylistsScreen) unhide a playlist.
+    val hiddenPlaylistIds by viewModel.hiddenPlaylistIds.collectAsStateWithLifecycle()
     val visiblePlaylists =
-        remember(playlists, sortByRecent, sortByName, sortByTrackCount, sortDescending, showHidden, hiddenPlaylistIds.size) {
-            val hiddenSnapshot = hiddenPlaylistIds.toList()
+        remember(playlists, sortByRecent, sortByName, sortByTrackCount, sortDescending, showHidden, hiddenPlaylistIds.size, searchQuery) {
+            val hiddenSnapshot = hiddenPlaylistIds
+            val query = searchQuery.trim()
             playlists
                 .filter { playlist -> showHidden || playlist.id !in hiddenSnapshot }
+                .filter { playlist -> query.isBlank() || playlist.name.contains(query, ignoreCase = true) }
                 .let { source ->
                     when {
                         sortByName -> if (sortDescending) source.sortedByDescending { it.name.lowercase() } else source.sortedBy { it.name.lowercase() }
@@ -259,6 +275,52 @@ fun LibrarySpotifyPlaylistsScreen(
                         // Sort options live in the DropdownMenu wired to
                         // `showSortMenu` (also triggered by the more_vert
                         // icon in the top-end liquid glass pill).
+                        // Inline search field — only visible when the user
+                        // taps the search icon in the top-end pill. Mirrors the
+                        // Playlists page's pill visual language so the
+                        // transition between collapsed and expanded search
+                        // doesn't shift the sort pill's position.
+                        if (showSearchField) {
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Row(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clip(CircleShape)
+                                        .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f))
+                                        .padding(horizontal = 18.dp, vertical = 11.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.search),
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                androidx.compose.foundation.text.BasicTextField(
+                                    value = searchQuery,
+                                    onValueChange = { searchQuery = it },
+                                    singleLine = true,
+                                    textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                                    cursorBrush = SolidColor(AppleMusicStyleAccentColor),
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                                    keyboardActions = KeyboardActions(onSearch = { /* no-op; live filter */ }),
+                                    modifier = Modifier.weight(1f),
+                                )
+                                if (searchQuery.isNotEmpty()) {
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    androidx.compose.material3.IconButton(onClick = { searchQuery = "" }) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.close),
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.size(18.dp),
+                                        )
+                                    }
+                                }
+                            }
+                        }
                         Spacer(modifier = Modifier.height(12.dp))
                         Box {
                             Row(
@@ -329,13 +391,25 @@ fun LibrarySpotifyPlaylistsScreen(
                                     },
                                 )
                                 // Hidden playlists toggle — mirrors the Playlists
-                                // page's "Hidden playlists" entry. Per user report:
+                                // page's "Hidden playlists" entry (same leadingIcon
+                                // + conditional check trailingIcon). Per user report:
                                 // "Also i should be able to hide Spotify playlists too."
+                                // Per user report (2026-08-29): "Also the hidden
+                                // playlist category from sort drop-down in Spotify
+                                // page doesn't do anything. Fix it" — now wired to
+                                // the persisted `hiddenPlaylistIds` set + has a
+                                // visual check indicator like the Playlists page.
                                 DropdownMenuItem(
                                     text = { Text(stringResource(R.string.hidden_playlists)) },
                                     onClick = {
                                         showHidden = !showHidden
                                         showSortMenu = false
+                                    },
+                                    leadingIcon = { Icon(painter = painterResource(R.drawable.visibility_off), contentDescription = null) },
+                                    trailingIcon = {
+                                        if (showHidden) {
+                                            Icon(painter = painterResource(R.drawable.check), contentDescription = null)
+                                        }
                                     },
                                 )
                             }
@@ -380,11 +454,11 @@ fun LibrarySpotifyPlaylistsScreen(
                                     coroutineScope = coroutineScope,
                                     onDismiss = menuState::dismiss,
                                     onHide = {
-                                        if (playlist.id in hiddenPlaylistIds) {
-                                            hiddenPlaylistIds.remove(playlist.id)
-                                        } else {
-                                            hiddenPlaylistIds.add(playlist.id)
-                                        }
+                                        // Persisted via SpotifyLibraryRepository's
+                                        // DataStore-backed hidden-playlist-id set so
+                                        // the hide survives process death and surfaces
+                                        // on the account-page "Hidden playlists" section.
+                                        viewModel.toggleHiddenPlaylist(playlist.id)
                                     },
                                 )
                             }
@@ -486,9 +560,27 @@ fun LibrarySpotifyPlaylistsScreen(
                         .align(Alignment.TopEnd)
                         .padding(end = 12.dp, top = systemBarsTopPadding + 12.dp),
             ) {
+                // Per user report (2026-08-29): "Remove the ... overflow
+                // liquid glass icon on the top right in Spotify page" — the
+                // more_vert overflow icon has been removed. The sort menu is
+                // still reachable via the sort pill in the heading block.
+                //
+                // Per user report (2026-08-29): "The search button should
+                // search the Playlists available in Spotify. Right now it
+                // takes me to the normal song search." The search icon now
+                // toggles an inline search field above the sort pill that
+                // filters `visiblePlaylists` by name (case-insensitive
+                // substring match). No navigation away from the screen.
                 Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
-                    androidx.compose.material3.IconButton(onClick = { navController.navigate("search") }) {
-                        Icon(painter = painterResource(R.drawable.search), contentDescription = stringResource(R.string.search), tint = Color.White)
+                    androidx.compose.material3.IconButton(onClick = {
+                        showSearchField = !showSearchField
+                        if (!showSearchField) searchQuery = ""
+                    }) {
+                        Icon(
+                            painter = painterResource(if (showSearchField) R.drawable.close else R.drawable.search),
+                            contentDescription = stringResource(R.string.search),
+                            tint = Color.White,
+                        )
                     }
                 }
                 Box(
@@ -504,11 +596,6 @@ fun LibrarySpotifyPlaylistsScreen(
                             contentDescription = stringResource(R.string.refresh),
                             tint = Color.White,
                         )
-                    }
-                }
-                Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
-                    androidx.compose.material3.IconButton(onClick = { showSortMenu = true }) {
-                        Icon(painter = painterResource(R.drawable.more_vert), contentDescription = null, tint = Color.White)
                     }
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibrarySpotifyPlaylistsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,14 +60,18 @@ import moe.rukamori.archivetune.LocalStableSystemBarsTopPadding
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.spotify.SpotifyLibraryViewModel
+import moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
 import moe.rukamori.archivetune.ui.component.ExpressivePullToRefreshBox
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.LiquidGlassActionPill
+import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.SpotifyLikedSongsListItem
 import moe.rukamori.archivetune.ui.component.SpotifyLibraryPlaylistListItem
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
+import moe.rukamori.archivetune.ui.menu.SpotifyPlaylistMenu
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.rememberPreference
@@ -78,7 +83,17 @@ fun LibrarySpotifyPlaylistsScreen(
 ) {
     val playlists by viewModel.playlists.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
+    val menuState = LocalMenuState.current
+    val coroutineScope = rememberCoroutineScope()
+    // Sort mode for the Spotify list. Mirrors the Playlists page's
+    // PlaylistSortType but reduced to the options Spotify's API exposes
+    // (no Last Updated, no Custom order — Spotify returns its own ordering
+    // we can't reorder). Per user report (2026-08-29): "Also Add a sorting
+    // button below the number of playlists in Pink/red accent like history
+    // page which lets me sort playlists."
+    var sortByRecent by remember { mutableStateOf(true) }     // true = Recently added (default API order)
     var sortByName by remember { mutableStateOf(false) }
+    var sortByTrackCount by remember { mutableStateOf(false) }
     var sortDescending by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
     var showHidden by remember { mutableStateOf(false) }
@@ -88,15 +103,23 @@ fun LibrarySpotifyPlaylistsScreen(
     // it from the list (and toggling `showHidden` reveals it again).
     val hiddenPlaylistIds = remember { mutableStateListOf<String>() }
     val visiblePlaylists =
-        remember(playlists, sortByName, sortDescending, showHidden, hiddenPlaylistIds.size) {
+        remember(playlists, sortByRecent, sortByName, sortByTrackCount, sortDescending, showHidden, hiddenPlaylistIds.size) {
             val hiddenSnapshot = hiddenPlaylistIds.toList()
             playlists
                 .filter { playlist -> showHidden || playlist.id !in hiddenSnapshot }
                 .let { source ->
-                    if (sortByName) source.sortedBy { it.name.lowercase() } else source
+                    when {
+                        sortByName -> if (sortDescending) source.sortedByDescending { it.name.lowercase() } else source.sortedBy { it.name.lowercase() }
+                        sortByTrackCount -> if (sortDescending) source.sortedByDescending { it.tracks?.total ?: 0 } else source.sortedBy { it.tracks?.total ?: 0 }
+                        else -> source // Recently added — keep Spotify's default API order
+                    }
                 }
-                .let { source -> if (sortDescending) source.reversed() else source }
         }
+    val currentSortLabel = when {
+        sortByName -> if (sortDescending) stringResource(R.string.sort_z_to_a) else stringResource(R.string.sort_a_to_z)
+        sortByTrackCount -> stringResource(R.string.tracks_count_label)
+        else -> stringResource(R.string.recently_added)
+    }
     val playerAwareBottomPadding =
         LocalPlayerAwareWindowInsets.current
             .only(WindowInsetsSides.Bottom)
@@ -141,7 +164,9 @@ fun LibrarySpotifyPlaylistsScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     val surfaceColor = MaterialTheme.colorScheme.surface
     val artworkBackdrop = rememberBackdrop(surfaceColor)
 
@@ -186,7 +211,13 @@ fun LibrarySpotifyPlaylistsScreen(
                 // song rows.
                 contentPadding =
                     PaddingValues(
-                        top = systemBarsTopPadding + 150.dp,
+                        // Per user report (2026-08-29): "Fix empty space in Spotify
+                        // page." The previous 150.dp top padding left a large empty
+                        // gap between the header pill and the first row. Reduced
+                        // to systemBarsTopPadding + 64.dp so the heading block
+                        // sits just below the persistent header pill — matching
+                        // the LocalPlaylistScreen / LibraryPlaylistsScreen spacing.
+                        top = systemBarsTopPadding + 64.dp,
                         bottom = playerAwareBottomPadding,
                     ),
                 verticalArrangement = Arrangement.spacedBy(0.dp),
@@ -207,7 +238,7 @@ fun LibrarySpotifyPlaylistsScreen(
                             text = "LIST",
                             style = MaterialTheme.typography.labelLarge,
                             fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = AppleMusicStyleAccentColor,
                         )
                         Text(
                             text = stringResource(R.string.spotify),
@@ -219,6 +250,96 @@ fun LibrarySpotifyPlaylistsScreen(
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
                         )
+                        // Per user report (2026-08-29): "Also Add a sorting
+                        // button below the number of playlists in Pink/red
+                        // accent like history page which lets me sort
+                        // playlists." Visual language mirrors the Playlists
+                        // page sort pill: pill-shaped with `accent.copy(0.12f)`
+                        // background, accent text, accent expand_more icon.
+                        // Sort options live in the DropdownMenu wired to
+                        // `showSortMenu` (also triggered by the more_vert
+                        // icon in the top-end liquid glass pill).
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Box {
+                            Row(
+                                modifier =
+                                    Modifier
+                                        .clip(CircleShape)
+                                        .background(AppleMusicStyleAccentColor.copy(alpha = 0.12f))
+                                        .clickable { showSortMenu = true }
+                                        .padding(horizontal = 18.dp, vertical = 11.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    text = currentSortLabel,
+                                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                                    color = AppleMusicStyleAccentColor,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Icon(
+                                    painter = painterResource(id = R.drawable.expand_more),
+                                    contentDescription = null,
+                                    tint = AppleMusicStyleAccentColor,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                            DropdownMenu(
+                                expanded = showSortMenu,
+                                onDismissRequest = { showSortMenu = false },
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.recently_added)) },
+                                    onClick = {
+                                        sortByRecent = true
+                                        sortByName = false
+                                        sortByTrackCount = false
+                                        showSortMenu = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.sort_a_to_z)) },
+                                    onClick = {
+                                        sortByRecent = false
+                                        sortByName = true
+                                        sortByTrackCount = false
+                                        sortDescending = false
+                                        showSortMenu = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.sort_z_to_a)) },
+                                    onClick = {
+                                        sortByRecent = false
+                                        sortByName = true
+                                        sortByTrackCount = false
+                                        sortDescending = true
+                                        showSortMenu = false
+                                    },
+                                )
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.tracks_count_label)) },
+                                    onClick = {
+                                        sortByRecent = false
+                                        sortByName = false
+                                        sortByTrackCount = true
+                                        sortDescending = false
+                                        showSortMenu = false
+                                    },
+                                )
+                                // Hidden playlists toggle — mirrors the Playlists
+                                // page's "Hidden playlists" entry. Per user report:
+                                // "Also i should be able to hide Spotify playlists too."
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(R.string.hidden_playlists)) },
+                                    onClick = {
+                                        showHidden = !showHidden
+                                        showSortMenu = false
+                                    },
+                                )
+                            }
+                        }
                     }
                 }
                 item(key = "spotify_liked_songs", contentType = "spotify_liked_songs") {
@@ -244,9 +365,29 @@ fun LibrarySpotifyPlaylistsScreen(
                     SpotifyLibraryPlaylistListItem(
                         playlist = playlist,
                         navController = navController,
-                        onHide = {
-                            if (playlist.id in hiddenPlaylistIds) hiddenPlaylistIds.remove(playlist.id)
-                            else hiddenPlaylistIds.add(playlist.id)
+                        onMenuClick = {
+                            // Per user report (2026-08-29): "There should also be
+                            // Overflow menu icon in liquid glass inside Spotify
+                            // Playlists. I've attached two images on how it should be
+                            // and what functions i should have. You can copy the exact
+                            // code for the functions from Normal playlists code." The
+                            // per-row 3-dot menu now opens a SpotifyPlaylistMenu
+                            // bottom sheet (mirrors PlaylistMenu's structure + actions
+                            // adapted for Spotify playlists).
+                            menuState.show {
+                                SpotifyPlaylistMenu(
+                                    playlist = playlist,
+                                    coroutineScope = coroutineScope,
+                                    onDismiss = menuState::dismiss,
+                                    onHide = {
+                                        if (playlist.id in hiddenPlaylistIds) {
+                                            hiddenPlaylistIds.remove(playlist.id)
+                                        } else {
+                                            hiddenPlaylistIds.add(playlist.id)
+                                        }
+                                    },
+                                )
+                            }
                         },
                     )
                 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LocalSongScreen.kt
@@ -127,6 +127,7 @@ import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
@@ -192,7 +193,9 @@ fun LocalSongScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -105,6 +105,7 @@ import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.component.MediaDetailAction
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
 import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
@@ -362,7 +363,9 @@ fun AutoPlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -108,6 +108,7 @@ import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
 import moe.rukamori.archivetune.ui.component.layerBackdrop
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.player.LocalMiniPlayerDocked
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
@@ -340,7 +341,9 @@ fun CachePlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Created unconditionally (cheap — just a GraphicsLayer handle). Actual
     // content recording only happens when `Modifier.layerBackdrop(backdrop)`
     // is applied to the LazyColumn below, gated on `layerBackdropActive`.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -137,6 +137,7 @@ import moe.rukamori.archivetune.ui.component.rememberBackdrop
 import moe.rukamori.archivetune.ui.component.MediaDetailIconAction
 import moe.rukamori.archivetune.ui.component.SongListItem
 import moe.rukamori.archivetune.ui.component.SortHeader
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.PlaylistMenu
 import moe.rukamori.archivetune.ui.menu.SelectionSongMenu
 import moe.rukamori.archivetune.ui.menu.SongMenu
@@ -220,7 +221,9 @@ fun LocalPlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     var showAssignTagsDialog by remember { mutableStateOf(false) }
 
     if (showAssignTagsDialog && playlist != null) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -127,6 +127,7 @@ import moe.rukamori.archivetune.ui.component.shimmer.ButtonPlaceholder
 import moe.rukamori.archivetune.ui.component.shimmer.ListItemPlaceHolder
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
 import moe.rukamori.archivetune.ui.component.shimmer.TextPlaceholder
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.menu.SelectionMediaMetadataMenu
 import moe.rukamori.archivetune.ui.menu.YouTubePlaylistMenu
 import moe.rukamori.archivetune.ui.menu.YouTubeSongMenu
@@ -222,7 +223,9 @@ fun OnlinePlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
 
     // Stable top inset: does not collapse to 0 when the status bar is transiently hidden,
     // so the search bar offset and the playlist header always stay anchored below the TopAppBar.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/playlist/SpotifyPlaylistScreen.kt
@@ -109,6 +109,7 @@ import moe.rukamori.archivetune.constants.LiquidGlassEnabledKey
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.ui.player.LocalPlayerLyricsFullScreen
 import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.component.rememberLayerBackdropSettled
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadItem
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadProgressIndicator
 import moe.rukamori.archivetune.ui.utils.HeaderDownloadState
@@ -414,7 +415,9 @@ fun SpotifyPlaylistScreen(
     // backdrop, no per-frame recording) until the screen has settled, then swap
     // to the real LiquidGlassActionPill + layerBackdrop. Liquid glass itself is
     // NOT removed — only delayed.
-    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen
+    val screenSettled = rememberLayerBackdropSettled()
+
+    val layerBackdropActive = liquidGlassHeaderActive && !lyricsFullScreen && screenSettled
     // Use the theme surface color (not Color.Black) so the initial frame, before
     // any scrolling content is recorded into the backdrop, blends with the page
     // background instead of flashing solid black. Matches the LocalPlaylistScreen

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
@@ -34,17 +34,20 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.LocalDatabase
@@ -52,6 +55,9 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.PlaylistSortType
 import moe.rukamori.archivetune.db.entities.Playlist
+import moe.rukamori.archivetune.spotify.SpotifyLibraryViewModel
+import moe.rukamori.archivetune.spotify.models.SpotifyPlaylist
+import moe.rukamori.archivetune.ui.component.AppleMusicStyleAccentColor
 import moe.rukamori.archivetune.ui.component.FrostedHeaderPill
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.utils.backToMain
@@ -61,13 +67,29 @@ import androidx.compose.foundation.layout.asPaddingValues
 @Composable
 fun HiddenPlaylistsScreen(navController: NavController) {
     val database = LocalDatabase.current
+    // Per user report (2026-08-29): "If I hide a Spotify playlist it should be
+    // available in the hidden playlists section of the account page." The
+    // SpotifyLibraryViewModel is @HiltViewModel-scoped to this NavBackStackEntry
+    // — it shares the @Singleton repository's hiddenPlaylistIds StateFlow with
+    // the LibrarySpotifyPlaylistsScreen, so when the user hides a Spotify
+    // playlist there, the same id appears here, and tapping "Unhide" here
+    // re-enables it on the Library page on the next screen entry.
+    val spotifyLibraryViewModel: SpotifyLibraryViewModel = hiltViewModel()
+    val spotifyPlaylists by spotifyLibraryViewModel.playlists.collectAsStateWithLifecycle()
+    val hiddenSpotifyPlaylistIds by spotifyLibraryViewModel.hiddenPlaylistIds.collectAsStateWithLifecycle()
+    val hiddenSpotifyPlaylists =
+        remember(spotifyPlaylists, hiddenSpotifyPlaylistIds) {
+            spotifyPlaylists.filter { it.id in hiddenSpotifyPlaylistIds }
+        }
+
     val allPlaylists by database
         .playlists(
             PlaylistSortType.CREATE_DATE,
             descending = true,
         ).collectAsStateWithLifecycle(initialValue = emptyList())
 
-    val hiddenPlaylists = allPlaylists.filter { it.playlist.isHidden }
+    val hiddenLocalPlaylists = allPlaylists.filter { it.playlist.isHidden }
+    val isEmpty = hiddenLocalPlaylists.isEmpty() && hiddenSpotifyPlaylists.isEmpty()
 
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
@@ -102,7 +124,7 @@ fun HiddenPlaylistsScreen(navController: NavController) {
                 .only(WindowInsetsSides.Bottom)
                 .asPaddingValues()
                 .calculateBottomPadding()
-        if (hiddenPlaylists.isEmpty()) {
+        if (isEmpty) {
             Column(
                 modifier =
                     Modifier
@@ -144,7 +166,7 @@ fun HiddenPlaylistsScreen(navController: NavController) {
                     ),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                items(hiddenPlaylists, key = { it.id }) { playlist ->
+                items(hiddenLocalPlaylists, key = { it.id }) { playlist ->
                     HiddenPlaylistCard(
                         playlist = playlist,
                         onUnhide = {
@@ -153,6 +175,29 @@ fun HiddenPlaylistsScreen(navController: NavController) {
                             }
                         },
                     )
+                }
+                // Hidden Spotify playlists section — mirrors the local
+                // HiddenPlaylistCard visual but pulls data from the
+                // @Singleton SpotifyLibraryRepository instead of Room.
+                if (hiddenSpotifyPlaylists.isNotEmpty()) {
+                    item(key = "spotify_section_header") {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = stringResource(R.string.spotify),
+                            style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                            color = AppleMusicStyleAccentColor,
+                            modifier = Modifier.padding(start = 4.dp, bottom = 4.dp),
+                        )
+                    }
+                    items(
+                        hiddenSpotifyPlaylists,
+                        key = { "spotify_${it.id}" },
+                    ) { playlist ->
+                        HiddenSpotifyPlaylistCard(
+                            playlist = playlist,
+                            onUnhide = { spotifyLibraryViewModel.toggleHiddenPlaylist(playlist.id) },
+                        )
+                    }
                 }
             }
         }
@@ -199,6 +244,88 @@ private fun HiddenPlaylistCard(
             Spacer(modifier = Modifier.height(2.dp))
             Text(
                 text = "${playlist.songCount} ${stringResource(R.string.tracks_label)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        FilledTonalButton(
+            onClick = onUnhide,
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.visibility_off),
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = stringResource(R.string.unhide),
+                style = MaterialTheme.typography.labelLarge,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HiddenSpotifyPlaylistCard(
+    playlist: SpotifyPlaylist,
+    onUnhide: () -> Unit,
+) {
+    val cardShape = RoundedCornerShape(20.dp)
+    val trackCount = playlist.tracks?.total ?: 0
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(cardShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val coverUrl = playlist.images.firstOrNull()?.url
+        if (coverUrl != null) {
+            AsyncImage(
+                model = coverUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+        } else {
+            Spacer(
+                modifier =
+                    Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(14.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = playlist.name,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text =
+                    if (trackCount > 0) {
+                        pluralStringResource(R.plurals.n_song, trackCount, trackCount)
+                    } else {
+                        stringResource(R.string.tracks_label)
+                    },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
             )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/ScrobbleManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/ScrobbleManager.kt
@@ -30,12 +30,40 @@ class ScrobbleManager(
     private var songStarted = false
     var useNowPlaying = true
 
+    // Track the metadata + threshold for the currently-playing song so that
+    // `flushPendingScrobbleIfNeeded()` can decide whether to submit a final
+    // scrobble when the user switches songs before the timer fires.
+    // Per user report (2026-08-29): "I've heard a song more than 50 times but
+    // still I don't see it [in the Last.fm dashboard]. The only time I see it
+    // is while I'm listening to it ... once I start playing a different song
+    // it disappears from the stats page."
+    //
+    // Root cause: `track.updateNowPlaying` fires immediately on song start,
+    // so Last.fm's "Now Playing" widget shows the song. But `track.scrobble`
+    // is only sent by the `scrobbleJob` coroutine after `scrobbleRemainingMillis`
+    // — and that job is cancelled (NOT flushed) whenever the user switches
+    // songs, pauses for too long, or `onPlayerStateChanged(isPlaying=true)`
+    // fires repeatedly (each call reset the timer without decrementing the
+    // remaining time, so the timer never completed).
+    private var currentMetadata: MediaMetadata? = null
+    private var currentThresholdMillis: Long = 0L
+    // Whether the timer is currently RUNNING (vs paused). Guards against
+    // `resumeScrobbleTimer` resetting the timer on every redundant
+    // `isPlaying=true` callback — previously each callback cancelled and
+    // restarted the job with the same `scrobbleRemainingMillis`, so a
+    // stream of `isPlaying=true` events would prevent the timer from ever
+    // completing.
+    private var scrobbleTimerRunning: Boolean = false
+
     fun destroy() {
         scrobbleJob?.cancel()
         scrobbleRemainingMillis = 0L
         scrobbleTimerStartedAt = 0L
         songStartedAt = 0L
         songStarted = false
+        currentMetadata = null
+        currentThresholdMillis = 0L
+        scrobbleTimerRunning = false
     }
 
     fun onSongStart(
@@ -43,6 +71,12 @@ class ScrobbleManager(
         duration: Long? = null,
     ) {
         if (metadata == null) return
+        // Before starting the new song's timer, check if the PREVIOUS song
+        // had met its scrobble threshold. If so, submit the final scrobble
+        // for it now — Last.fm's rule is "scrobble if the user listened for
+        // at least half the track duration OR 4 minutes". Previously, the
+        // pending scrobble was silently dropped on every song switch.
+        flushPendingScrobbleIfNeeded()
         songStartedAt = System.currentTimeMillis() / 1000
         songStarted = true
         startScrobbleTimer(metadata, duration)
@@ -60,6 +94,10 @@ class ScrobbleManager(
     }
 
     fun onSongStop() {
+        // On explicit stop, also flush — the user may have listened past
+        // the threshold before stopping. If the threshold wasn't met, the
+        // flush is a no-op.
+        flushPendingScrobbleIfNeeded()
         stopScrobbleTimer()
         songStarted = false
     }
@@ -71,25 +109,39 @@ class ScrobbleManager(
         scrobbleJob?.cancel()
         val resolvedDuration = duration?.toInt()?.div(1000) ?: metadata.duration
 
-        if (resolvedDuration <= minSongDuration) return
+        if (resolvedDuration <= minSongDuration) {
+            // Song too short to scrobble — record metadata so flush logic
+            // knows there's nothing pending, but don't start a timer.
+            currentMetadata = metadata
+            currentThresholdMillis = 0L
+            scrobbleTimerRunning = false
+            return
+        }
 
         val threshold = resolvedDuration * 1000L * scrobbleDelayPercent
         scrobbleRemainingMillis = min(threshold.toLong(), scrobbleDelaySeconds * 1000L)
+        currentThresholdMillis = scrobbleRemainingMillis
+        currentMetadata = metadata
 
         if (scrobbleRemainingMillis <= 0) {
             scrobbleSong(metadata)
+            scrobbleTimerRunning = false
             return
         }
         scrobbleTimerStartedAt = System.currentTimeMillis()
+        scrobbleTimerRunning = true
         scrobbleJob =
             scope.launch {
                 delay(scrobbleRemainingMillis)
                 scrobbleSong(metadata)
                 scrobbleJob = null
+                scrobbleTimerRunning = false
+                scrobbleTimerStartedAt = 0L
             }
     }
 
     private fun pauseScrobbleTimer() {
+        if (!scrobbleTimerRunning) return
         scrobbleJob?.cancel()
         if (scrobbleTimerStartedAt != 0L) {
             val elapsed = System.currentTimeMillis() - scrobbleTimerStartedAt
@@ -97,17 +149,34 @@ class ScrobbleManager(
             if (scrobbleRemainingMillis < 0) scrobbleRemainingMillis = 0
             scrobbleTimerStartedAt = 0L
         }
+        scrobbleTimerRunning = false
     }
 
     private fun resumeScrobbleTimer(metadata: MediaMetadata) {
+        // Guard against redundant `isPlaying=true` callbacks resetting the
+        // timer. Previously, every call cancelled and restarted the job
+        // with the same `scrobbleRemainingMillis` — so if the player fired
+        // `onPlayerStateChanged(isPlaying=true, ...)` repeatedly during
+        // playback (e.g. on buffer updates or metadata refreshes), the
+        // timer never completed and the scrobble was silently dropped.
+        if (scrobbleTimerRunning) return
         if (scrobbleRemainingMillis <= 0) return
+        // Only resume if the metadata matches the song we were tracking.
+        // If the player has moved on to a different song without an
+        // `onSongStart` call (shouldn't happen, but defensive), don't
+        // resume a stale timer for the wrong song.
+        val current = currentMetadata
+        if (current != null && !sameSong(current, metadata)) return
         scrobbleJob?.cancel()
         scrobbleTimerStartedAt = System.currentTimeMillis()
+        scrobbleTimerRunning = true
         scrobbleJob =
             scope.launch {
                 delay(scrobbleRemainingMillis)
-                scrobbleSong(metadata)
+                scrobbleSong(current ?: metadata)
                 scrobbleJob = null
+                scrobbleTimerRunning = false
+                scrobbleTimerStartedAt = 0L
             }
     }
 
@@ -115,6 +184,64 @@ class ScrobbleManager(
         scrobbleJob?.cancel()
         scrobbleJob = null
         scrobbleRemainingMillis = 0
+        scrobbleTimerRunning = false
+        scrobbleTimerStartedAt = 0L
+    }
+
+    /**
+     * Submit a final scrobble for the currently-tracked song IF the user
+     * has listened past the threshold (50% of duration OR 4 minutes, per
+     * Last.fm's spec). This is the "scrobble on skip" path that was missing
+     * — previously, switching songs before the timer fired silently dropped
+     * the scrobble even if the threshold was met.
+     *
+     * Safe to call repeatedly; no-ops if there's no pending scrobble or
+     * the threshold wasn't met.
+     */
+    private fun flushPendingScrobbleIfNeeded() {
+        val metadata = currentMetadata ?: return
+        if (currentThresholdMillis <= 0L) {
+            // Song was too short to scrobble, or no timer was ever started.
+            // Reset state and return.
+            currentMetadata = null
+            currentThresholdMillis = 0L
+            return
+        }
+        if (scrobbleTimerRunning && scrobbleTimerStartedAt != 0L) {
+            val elapsed = System.currentTimeMillis() - scrobbleTimerStartedAt
+            // Compute total elapsed (including any paused time that was
+            // already subtracted from scrobbleRemainingMillis). The total
+            // elapsed listening time = (threshold - remaining) + (now - timerStartedAt).
+            val totalElapsed = (currentThresholdMillis - scrobbleRemainingMillis) + elapsed
+            if (totalElapsed >= currentThresholdMillis) {
+                // Threshold met — submit the final scrobble.
+                scrobbleSong(metadata)
+            }
+        } else if (!scrobbleTimerRunning && scrobbleRemainingMillis <= 0L) {
+            // Timer had already completed (or never started because threshold
+            // was 0). The scrobbleSong coroutine may have already fired.
+            // To avoid double-scrobbling, we DON'T re-submit here. Last.fm
+            // deduplicates by timestamp, so even if we did, it would be a no-op.
+        }
+        // Cancel any pending job so it doesn't double-fire after we submit.
+        scrobbleJob?.cancel()
+        scrobbleJob = null
+        scrobbleTimerRunning = false
+        scrobbleTimerStartedAt = 0L
+        scrobbleRemainingMillis = 0L
+        currentMetadata = null
+        currentThresholdMillis = 0L
+    }
+
+    private fun sameSong(a: MediaMetadata, b: MediaMetadata): Boolean {
+        // Compare by id first; fall back to title+artist string match for
+        // cases where id is missing or differs across metadata refreshes.
+        if (a.id == b.id) return true
+        if (a.title == b.title &&
+            a.artists.size == b.artists.size &&
+            a.artists.zip(b.artists).all { (x, y) -> x.name == y.name }
+        ) return true
+        return false
     }
 
     private fun scrobbleSong(metadata: MediaMetadata) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ArtistViewModel.kt
@@ -108,6 +108,16 @@ class ArtistViewModel
     ) : ViewModel() {
         val artistId = savedStateHandle.get<String>("artistId")!!
         var artistPage by mutableStateOf<ArtistPage?>(null)
+        // Per user report (2026-08-29): "Whenever I open artist page there's
+        // always a refresh indicator who Refreshes automatically. it should
+        // only appear when I manually slide to refresh it." Splits the
+        // auto-fetch (silent, runs in `init` from preference changes) from
+        // the manual pull-to-refresh (loud — shows the PullToRefresh
+        // indicator and the shimmer skeleton). When `isManuallyRefreshing`
+        // is `false`, the screen renders cached/local content without any
+        // refresh indicator; when `true` (set only by `manualRefresh()`),
+        // the PullToRefresh indicator + shimmer show.
+        var isManuallyRefreshing by mutableStateOf(false)
         private val eventChannel = Channel<ArtistEvent>(capacity = Channel.BUFFERED)
         val events = eventChannel.receiveAsFlow()
         private var blockJob: Job? = null
@@ -147,6 +157,15 @@ class ArtistViewModel
                 }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
         init {
+            // Auto-fetch on first composition AND on hide-explicit /
+            // hide-video preference changes. Per user report (2026-08-29):
+            // "Whenever I open artist page there's always a refresh indicator
+            // who Refreshes automatically. it should only appear when I
+            // manually slide to refresh it." This auto-fetch is SILENT —
+            // it does NOT set `isManuallyRefreshing`, so the PullToRefresh
+            // indicator + shimmer skeleton do NOT appear during this fetch.
+            // The user perceives it as the page populating itself, not as a
+            // refresh.
             viewModelScope.launch {
                 context.dataStore.data
                     .map { preferences ->
@@ -159,7 +178,24 @@ class ArtistViewModel
             }
         }
 
-        fun fetchArtistsFromYTM() {
+        /**
+         * Manual pull-to-refresh entry point. Sets `isManuallyRefreshing`
+         * so the PullToRefresh indicator + shimmer skeleton show during the
+         * fetch, then clears it on completion (success or failure).
+         */
+        fun manualRefresh() {
+            if (isManuallyRefreshing) return
+            isManuallyRefreshing = true
+            viewModelScope.launch {
+                try {
+                    fetchArtistsFromYTM(manual = true)
+                } finally {
+                    isManuallyRefreshing = false
+                }
+            }
+        }
+
+        fun fetchArtistsFromYTM(manual: Boolean = false) {
             viewModelScope.launch {
                 val hideExplicit = context.dataStore.get(HideExplicitKey, false)
                 val hideVideo = context.dataStore.get(HideVideoKey, false)
@@ -189,6 +225,12 @@ class ArtistViewModel
                     }.onFailure {
                         reportException(it)
                     }
+                if (manual) {
+                    // Cleared by the caller (manualRefresh) — kept here as a
+                    // safety net in case the caller's finally block doesn't run
+                    // (e.g. CancellationException on the outer scope).
+                    isManuallyRefreshing = false
+                }
             }
         }
 


### PR DESCRIPTION
Addresses 5 user-reported issues (2026-08-29):

1. **Mini-player + nav-bar transition lag** — MainActivity bottom-nav slide switched from layout-phase `Modifier.offset` to draw-phase `Modifier.graphicsLayer { translationY }`. Children no longer re-lay-out every spring frame; kyant drawBackdrop shaders don't recompute per frame. Liquid glass NOT removed.

2. **Slight delay for liquid glass pills** — `rememberLayerBackdropSettled()` short-circuits to `true` immediately. The structural lag fix from #1 makes the 250ms settle window unnecessary.

3. **Spotify playlist overflow menu + hide + search** — Play/Shuffle/PlayNext/AddToQueue now call `viewModel.ensureAccessToken()` before queue starts. Hidden Spotify playlists persist via DataStore string-set and surface on the account-page Hidden playlists section. Removed top-right `...` overflow icon. Search button toggles inline search filtering visiblePlaylists by name. Sort dropdown Hidden playlists toggle has leadingIcon + check indicator.

4. **Artist page auto-refresh** — Added `isManuallyRefreshing` state + `manualRefresh()` entry. Wrapped LazyColumn in `ExpressivePullToRefreshBox`. Shimmer only shows during manual pull-to-refresh; the silent auto-fetch on init renders the artist header from the cached `libraryArtist` flow without an indicator.

5. **Spotify Playlists 4-5s loading** — Removed auto-refresh from `SpotifyAccountViewModel.init`. Parallelized the N+1 `playlistTrackCount` GraphQL lookups in `fetchAllPlaylists` with `Semaphore(8)`-bounded concurrency.