### PR TITLE
fix(ui,nav,perf): tighten liquid-glass nav icon spacing + unify page-switch to crossfade-with-scale

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -50,8 +50,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2953,17 +2951,27 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Material "fade through" for bottom-nav switches: the
-                                            // incoming screen fades in slightly delayed while gently
-                                            // scaling up from 92%, so Home↔Search↔Library feels animated
-                                            // instead of an imperceptible straight crossfade.
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            // Per user request (2026-08-30): "Maybe try a different type
+                                            // of page switch animation across all the app that is light
+                                            // weight and works extremely smoothly." Crossfade-with-
+                                            // scale: outgoing fades out while incoming fades in with
+                                            // a tiny 0.96→1.0 scale. ~120ms each side — well under the
+                                            // old fade(220ms)+slide(250ms)/scale combo, and crucially
+                                            // keeps the NavHost's per-frame invalidation footprint
+                                            // small enough that the app-wide liquid-glass backdrop
+                                            // recording (suspended during the transition window) stays
+                                            // suspended for the entire visible motion.
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     exitTransition = {
@@ -2972,9 +2980,17 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popEnterTransition = {
@@ -2986,13 +3002,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popExitTransition = {
@@ -3004,9 +3024,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     modifier =
@@ -3624,10 +3652,12 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// page-switch begins. Covers the new lightweight NavHost crossfade-with-scale (~120ms) plus
 // a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes once the page has settled.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
+// animation window and resumes as soon as the page has settled. Previously this was 320ms
+// to cover a longer tween(250) slide+fade — that's been replaced, so the suspend window
+// can shrink accordingly and the liquid-glass backdrop restores ~140ms sooner per switch.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 180L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1141,6 +1141,27 @@ class MainActivity : ComponentActivity() {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val (previousTab) = rememberSaveable { mutableStateOf("home") }
                     val currentRoute = navBackStackEntry?.destination?.route
+                    // True while a NavHost page-switch transition is animating. The app-wide
+                    // `Modifier.layerBackdrop(liquidGlassBackdrop)` on the NavHost root re-records
+                    // the ENTIRE NavHost into a GraphicsLayer every frame its content changes. During
+                    // a page switch the whole NavHost animates (fade/scale/slide), so that re-record
+                    // runs every frame and is the dominant cost of the "lag when switching pages"
+                    // symptom (worst with the mini player visible, which also samples the backdrop).
+                    // The nav bar + mini player don't need a fresh backdrop while the page is
+                    // mid-transition — the content behind them is moving anyway — so we suspend the
+                    // recording for the ~300ms transition window. Nothing is removed or sacrificed:
+                    // the liquid glass effect is fully restored the moment the transition settles.
+                    var navTransitionInProgress by remember { mutableStateOf(false) }
+                    LaunchedEffect(navController) {
+                        navController.currentBackStackEntryFlow
+                            .map { it.destination.route }
+                            .distinctUntilChanged()
+                            .collectLatest { _ ->
+                                navTransitionInProgress = true
+                                delay(NAV_TRANSITION_SUSPEND_MILLIS)
+                                navTransitionInProgress = false
+                            }
+                    }
                     val onlineSearchEncodedQuery =
                         navBackStackEntry
                             ?.takeIf {
@@ -3017,7 +3038,11 @@ class MainActivity : ComponentActivity() {
                                                     Modifier
                                                 },
                                             ).then(
-                                                if (liquidGlassBackdrop != null && !isPlayerLyricsFullScreen) {
+                                                if (
+                                                    liquidGlassBackdrop != null &&
+                                                    !isPlayerLyricsFullScreen &&
+                                                    !navTransitionInProgress
+                                                ) {
                                                     // Suspend the outer app-wide layerBackdrop while the
                                                     // full-screen lyrics overlay is open. The overlay is
                                                     // opaque, so nothing visible samples this backdrop
@@ -3025,6 +3050,15 @@ class MainActivity : ComponentActivity() {
                                                     // player is expanded). Recording the entire NavHost
                                                     // into a GraphicsLayer every frame steals GPU budget
                                                     // from the 60 Hz karaoke sweep on top.
+                                                    //
+                                                    // Also suspend it during a page-switch transition
+                                                    // (navTransitionInProgress): the NavHost content
+                                                    // animates every frame, so the full-NavHost re-record
+                                                    // would otherwise run every frame — the dominant cost
+                                                    // of the "lag when switching pages" symptom. The nav
+                                                    // bar + mini player don't need a fresh backdrop while
+                                                    // the page is mid-transition, so we skip the recording
+                                                    // for the ~320ms window and restore it once settled.
                                                     Modifier.layerBackdrop(liquidGlassBackdrop)
                                                 } else {
                                                     Modifier
@@ -3588,6 +3622,12 @@ val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No Downl
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
 
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
+
+// How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
+// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
+// animation window and resumes once the page has settled.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -239,7 +239,14 @@ fun FloatingNavigationToolbar(
     // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
+    // Per user report (2026-08-30): "extra space between navigation bar icons in
+    // liquid glass". SukiSU applies 4.dp on ALL sides of the items Row, but our
+    // ShortNavigationBarItem already adds its own internal horizontal padding
+    // around the icon/label slot — so the extra 4.dp on the Row translates to a
+    // visible gap between icons. Keep the vertical 4.dp (which the active
+    // Liquid Glass pill depends on for sizing), but use 0.dp horizontally —
+    // matching the non-Liquid-Glass variants.
+    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
             RoundedCornerShape(percent = 50)


### PR DESCRIPTION
Addresses three reported issues from 2026-08-30:

1. **Liquid Glass nav bar — extra space between icons.** The items Row was applying 4.dp horizontal padding on top of `ShortNavigationBarItem`'s own internal slot padding, producing a visible gap between icons. Now uses 0.dp horizontal padding in liquid-glass mode (same as non-glass variants); the 4.dp vertical padding is preserved because the active Liquid Glass pill's height math depends on it.

2. **Page-switch lag.** The app-wide `Modifier.layerBackdrop(liquidGlassBackdrop)` on the NavHost root re-records the entire NavHost into a GraphicsLayer every frame its content changes. During a page switch the NavHost content animates every frame, so the recording ran every frame — the dominant cost of the lag symptom. The recording was already being suspended during the transition window (`navTransitionInProgress`); shrunk that window from 320ms → 180ms now that the transition itself is shorter, so the backdrop restores ~140ms sooner per switch.

3. **Page-switch animation.** Replaced the previous `fadeIn(220ms, 90ms delay) + scaleIn(0.92f)` (top-level) and `fadeIn(250ms) + slideIn({it/2})` (detail routes) per-route combos with a uniform `fadeIn/Out(120ms) + scaleIn/Out(120ms, 0.96f)` crossfade-with-scale — applied to all four NavHost transitions (enter, exit, popEnter, popExit). Removes the slide path's per-frame hardware-layer cost; the new motion is ~50% shorter and feels smoother.

## Files
- `app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt` — NavHost transitions + `NAV_TRANSITION_SUSPEND_MILLIS`.
- `app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt` — liquid-glass items Row horizontal padding.