### PR TITLE
fix(ui,perf): make page-switch transitions fluid and smooth

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -45,13 +45,12 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2953,17 +2952,39 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Material "fade through" for bottom-nav switches: the
-                                            // incoming screen fades in slightly delayed while gently
-                                            // scaling up from 92%, so Home↔Search↔Library feels animated
-                                            // instead of an imperceptible straight crossfade.
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            // Fluid Material-style fade-through for bottom-nav
+                                            // switches. The outgoing page is still partly visible
+                                            // (~50% alpha) when the incoming page starts to fade
+                                            // in — the two animations overlap continuously so
+                                            // there's no visible "gap" between the two screens,
+                                            // which is what makes a transition feel abrupt.
+                                            // - exit: 220ms LinearOutSlowInEasing — gentle,
+                                            //   decelerating fade-out (no scale; the outgoing
+                                            //   page is just dissolving away).
+                                            // - enter: 260ms FastOutSlowInEasing with 60ms
+                                            //   delay, scaled up from 0.94→1.0 — the small
+                                            //   delay lets the outgoing page establish before
+                                            //   the incoming settles in, and the cubic-bezier
+                                            //   easing keeps both motions buttery.
+                                            // - The window where exit+enter overlap (~160ms) is
+                                            //   well within the existing
+                                            //   `navTransitionInProgress` suspend window for
+                                            //   the app-wide layerBackdrop, so the GPU cost of
+                                            //   the overlap stays hidden.
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
+                                            // Detail route (e.g. tapping a song → album screen).
+                                            // Same fluid fade-through as bottom-nav so the whole
+                                            // app has a single, consistent motion language.
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
+                                                scaleIn(
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
+                                                )
                                         }
                                     },
                                     exitTransition = {
@@ -2972,9 +2993,9 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         }
                                     },
                                     popEnterTransition = {
@@ -2986,13 +3007,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
+                                                scaleIn(
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
+                                                )
                                         }
                                     },
                                     popExitTransition = {
@@ -3004,9 +3029,9 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         }
                                     },
                                     modifier =
@@ -3624,10 +3649,14 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
-// a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes once the page has settled.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
+// page-switch begins. Covers the new fluid NavHost fade-through (220ms exit + 260ms enter
+// with 60ms delay — total ~320ms visible motion) plus a small settle margin so the
+// expensive full-NavHost re-record is skipped for the entire visible animation window.
+// Crucially: because the exit and enter overlap (~160ms of overlap), the NavHost content
+// is animating during almost the whole window — recording the GraphicsLayer every frame
+// in that window is the dominant cost of the page-switch lag, so the suspend needs to
+// cover the overlap too, not just the entry duration.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 340L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -50,6 +50,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2951,27 +2953,17 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Per user request (2026-08-30): "Maybe try a different type
-                                            // of page switch animation across all the app that is light
-                                            // weight and works extremely smoothly." Crossfade-with-
-                                            // scale: outgoing fades out while incoming fades in with
-                                            // a tiny 0.96→1.0 scale. ~120ms each side — well under the
-                                            // old fade(220ms)+slide(250ms)/scale combo, and crucially
-                                            // keeps the NavHost's per-frame invalidation footprint
-                                            // small enough that the app-wide liquid-glass backdrop
-                                            // recording (suspended during the transition window) stays
-                                            // suspended for the entire visible motion.
-                                            fadeIn(tween(120)) +
+                                            // Material "fade through" for bottom-nav switches: the
+                                            // incoming screen fades in slightly delayed while gently
+                                            // scaling up from 92%, so Home↔Search↔Library feels animated
+                                            // instead of an imperceptible straight crossfade.
+                                            fadeIn(tween(220, delayMillis = 90)) +
                                                 scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
+                                                    animationSpec = tween(220, delayMillis = 90),
+                                                    initialScale = 0.92f,
                                                 )
                                         } else {
-                                            fadeIn(tween(120)) +
-                                                scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
-                                                )
+                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
                                         }
                                     },
                                     exitTransition = {
@@ -2980,17 +2972,9 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(90))
                                         } else {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
                                         }
                                     },
                                     popEnterTransition = {
@@ -3002,17 +2986,13 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(120)) +
+                                            fadeIn(tween(220, delayMillis = 90)) +
                                                 scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
+                                                    animationSpec = tween(220, delayMillis = 90),
+                                                    initialScale = 0.92f,
                                                 )
                                         } else {
-                                            fadeIn(tween(120)) +
-                                                scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
-                                                )
+                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
                                         }
                                     },
                                     popExitTransition = {
@@ -3024,17 +3004,9 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(90))
                                         } else {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
                                         }
                                     },
                                     modifier =
@@ -3652,12 +3624,10 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the new lightweight NavHost crossfade-with-scale (~120ms) plus
+// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
 // a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes as soon as the page has settled. Previously this was 320ms
-// to cover a longer tween(250) slide+fade — that's been replaced, so the suspend window
-// can shrink accordingly and the liquid-glass backdrop restores ~140ms sooner per switch.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 180L
+// animation window and resumes once the page has settled.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -50,8 +50,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2953,17 +2951,27 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Material "fade through" for bottom-nav switches: the
-                                            // incoming screen fades in slightly delayed while gently
-                                            // scaling up from 92%, so Home↔Search↔Library feels animated
-                                            // instead of an imperceptible straight crossfade.
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            // Per user request (2026-08-30): "Maybe try a different type
+                                            // of page switch animation across all the app that is light
+                                            // weight and works extremely smoothly." Crossfade-with-
+                                            // scale: outgoing fades out while incoming fades in with
+                                            // a tiny 0.96→1.0 scale. ~120ms each side — well under the
+                                            // old fade(220ms)+slide(250ms)/scale combo, and crucially
+                                            // keeps the NavHost's per-frame invalidation footprint
+                                            // small enough that the app-wide liquid-glass backdrop
+                                            // recording (suspended during the transition window) stays
+                                            // suspended for the entire visible motion.
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     exitTransition = {
@@ -2972,9 +2980,17 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popEnterTransition = {
@@ -2986,13 +3002,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popExitTransition = {
@@ -3004,9 +3024,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     modifier =
@@ -3624,10 +3652,12 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// page-switch begins. Covers the new lightweight NavHost crossfade-with-scale (~120ms) plus
 // a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes once the page has settled.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
+// animation window and resumes as soon as the page has settled. Previously this was 320ms
+// to cover a longer tween(250) slide+fade — that's been replaced, so the suspend window
+// can shrink accordingly and the liquid-glass backdrop restores ~140ms sooner per switch.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 180L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1141,6 +1141,27 @@ class MainActivity : ComponentActivity() {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val (previousTab) = rememberSaveable { mutableStateOf("home") }
                     val currentRoute = navBackStackEntry?.destination?.route
+                    // True while a NavHost page-switch transition is animating. The app-wide
+                    // `Modifier.layerBackdrop(liquidGlassBackdrop)` on the NavHost root re-records
+                    // the ENTIRE NavHost into a GraphicsLayer every frame its content changes. During
+                    // a page switch the whole NavHost animates (fade/scale/slide), so that re-record
+                    // runs every frame and is the dominant cost of the "lag when switching pages"
+                    // symptom (worst with the mini player visible, which also samples the backdrop).
+                    // The nav bar + mini player don't need a fresh backdrop while the page is
+                    // mid-transition — the content behind them is moving anyway — so we suspend the
+                    // recording for the ~300ms transition window. Nothing is removed or sacrificed:
+                    // the liquid glass effect is fully restored the moment the transition settles.
+                    var navTransitionInProgress by remember { mutableStateOf(false) }
+                    LaunchedEffect(navController) {
+                        navController.currentBackStackEntryFlow
+                            .map { it.destination.route }
+                            .distinctUntilChanged()
+                            .collectLatest { _ ->
+                                navTransitionInProgress = true
+                                delay(NAV_TRANSITION_SUSPEND_MILLIS)
+                                navTransitionInProgress = false
+                            }
+                    }
                     val onlineSearchEncodedQuery =
                         navBackStackEntry
                             ?.takeIf {
@@ -3017,7 +3038,11 @@ class MainActivity : ComponentActivity() {
                                                     Modifier
                                                 },
                                             ).then(
-                                                if (liquidGlassBackdrop != null && !isPlayerLyricsFullScreen) {
+                                                if (
+                                                    liquidGlassBackdrop != null &&
+                                                    !isPlayerLyricsFullScreen &&
+                                                    !navTransitionInProgress
+                                                ) {
                                                     // Suspend the outer app-wide layerBackdrop while the
                                                     // full-screen lyrics overlay is open. The overlay is
                                                     // opaque, so nothing visible samples this backdrop
@@ -3025,6 +3050,15 @@ class MainActivity : ComponentActivity() {
                                                     // player is expanded). Recording the entire NavHost
                                                     // into a GraphicsLayer every frame steals GPU budget
                                                     // from the 60 Hz karaoke sweep on top.
+                                                    //
+                                                    // Also suspend it during a page-switch transition
+                                                    // (navTransitionInProgress): the NavHost content
+                                                    // animates every frame, so the full-NavHost re-record
+                                                    // would otherwise run every frame — the dominant cost
+                                                    // of the "lag when switching pages" symptom. The nav
+                                                    // bar + mini player don't need a fresh backdrop while
+                                                    // the page is mid-transition, so we skip the recording
+                                                    // for the ~320ms window and restore it once settled.
                                                     Modifier.layerBackdrop(liquidGlassBackdrop)
                                                 } else {
                                                     Modifier
@@ -3588,6 +3622,12 @@ val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No Downl
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
 
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
+
+// How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
+// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
+// animation window and resumes once the page has settled.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -239,14 +239,7 @@ fun FloatingNavigationToolbar(
     // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    // Per user report (2026-08-30): "extra space between navigation bar icons in
-    // liquid glass". SukiSU applies 4.dp on ALL sides of the items Row, but our
-    // ShortNavigationBarItem already adds its own internal horizontal padding
-    // around the icon/label slot — so the extra 4.dp on the Row translates to a
-    // visible gap between icons. Keep the vertical 4.dp (which the active
-    // Liquid Glass pill depends on for sizing), but use 0.dp horizontally —
-    // matching the non-Liquid-Glass variants.
-    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
+    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
             RoundedCornerShape(percent = 50)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -239,7 +239,14 @@ fun FloatingNavigationToolbar(
     // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
+    // Per user report (2026-08-30): "extra space between navigation bar icons in
+    // liquid glass". SukiSU applies 4.dp on ALL sides of the items Row, but our
+    // ShortNavigationBarItem already adds its own internal horizontal padding
+    // around the icon/label slot — so the extra 4.dp on the Row translates to a
+    // visible gap between icons. Keep the vertical 4.dp (which the active
+    // Liquid Glass pill depends on for sizing), but use 0.dp horizontally —
+    // matching the non-Liquid-Glass variants.
+    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
             RoundedCornerShape(percent = 50)


### PR DESCRIPTION
Reverts PR #199 and replaces the previous abrupt crossfade-with-scale with a fluid fade-through across both bottom-nav and detail routes.

## What changed

**Before:** A mix of three different transition styles:
- bottom-nav: `fadeIn(220ms, 90ms delay) + scaleIn(0.92f)` with `fadeOut(90ms)`
- detail: `fadeIn(250ms) + slideIn({it/2})` with `fadeOut(200ms) + slideOut({-it/2})`

**After:** A single, consistent fade-through applied to every route:
- **exit:** `fadeOut(220ms, LinearOutSlowInEasing)` — gentle, decelerating fade. No scale, no slide; the outgoing page just dissolves.
- **enter:** `fadeIn(260ms, FastOutSlowInEasing, 60ms delay) + scaleIn(260ms, FastOutSlowInEasing, 0.94f)` — small delay so the outgoing page establishes first, then the incoming page settles in with a tiny scale-up.

## Why it feels fluid (not abrupt)

- The 220ms exit and 260ms enter overlap by **~160ms** — both pages are visible simultaneously throughout the transition, no 'gap' between them where neither page reads. (This is the dominant cause of the 'abrupt' feeling — the old 90ms exit + 90ms delay + 220ms enter left a ~90ms window with no visible content.)
- Cubic-bezier easings (LinearOutSlowIn + FastOutSlowIn) replace the default tween easing so both motions are gentle at the start and end rather than linear.
- Initial scale softened (0.92f → 0.94f) so the incoming page settles in more subtly.

## Performance

The window where exit+enter overlap is fully covered by the existing `navTransitionInProgress` suspend window for the app-wide `layerBackdrop(liquidGlassBackdrop)` recording — bumped 320ms → 340ms to cover the new total motion window. The GPU cost of the overlap stays hidden behind the suspension, so the page-switch stays lag-free even with the longer visible animation.

## Files
- `app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt` — all four NavHost transitions (enter, exit, popEnter, popExit) and `NAV_TRANSITION_SUSPEND_MILLIS`.