### PR TITLE
Revert "fix(nav): suspend app-wide NavHost liquid-glass backdrop during page switches"

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -59,6 +59,7 @@ import moe.rukamori.archivetune.storage.StorageLocationRepository
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.tidal.TidalInstanceHealthManager
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
+import moe.rukamori.archivetune.repository.SearchDiscoveryRepository
 import moe.rukamori.archivetune.ui.player.CanvasArtworkPlaybackCache
 import moe.rukamori.archivetune.ui.screens.settings.ThemePalettes
 import moe.rukamori.archivetune.ui.theme.ThemeSeedPalette
@@ -102,6 +103,17 @@ class App :
      */
     @Inject
     lateinit var spotifyLibraryRepository: SpotifyLibraryRepository
+
+    /**
+     * Pre-warmed at app startup so the Search tab's discovery feed (moods & genres,
+     * charts, suggested songs/albums/artists) loads instantly when the user first taps
+     * Search — see [SearchDiscoveryRepository.loadDiscovery]. The repository caches
+     * its result in-memory for a short TTL, so the cost of one warm-up covers many
+     * subsequent tab re-entries. Fire-and-forget on `applicationScope` (Dispatchers.IO)
+     * so the cold-start path isn't blocked.
+     */
+    @Inject
+    lateinit var searchDiscoveryRepository: SearchDiscoveryRepository
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -252,6 +264,20 @@ class App :
     private fun initializeDeferredAsync() {
         applicationScope.launch(Dispatchers.IO) {
             ytDlpRuntime.preWarm()
+        }
+
+        // Per user request (2026-08-30): "The search tab takes time to load. it
+        // should preload when i open the app." Kick off the discovery load
+        // immediately at app start so the in-memory TTL cache is warm by the
+        // time the user first taps Search. The repository's `loadDiscovery()`
+        // is idempotent — a concurrent call from the actual ViewModel just
+        // joins the in-flight job via the same `loadJob?.isActive` guard.
+        // Errors are swallowed inside the repository (stale cache fallback)
+        // so this fire-and-forget is safe.
+        applicationScope.launch(Dispatchers.IO) {
+            runCatching {
+                searchDiscoveryRepository.loadDiscovery(forceRefresh = false)
+            }
         }
 
         applicationScope.launch(Dispatchers.IO) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -45,13 +45,12 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2953,17 +2952,39 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Material "fade through" for bottom-nav switches: the
-                                            // incoming screen fades in slightly delayed while gently
-                                            // scaling up from 92%, so Home↔Search↔Library feels animated
-                                            // instead of an imperceptible straight crossfade.
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            // Fluid Material-style fade-through for bottom-nav
+                                            // switches. The outgoing page is still partly visible
+                                            // (~50% alpha) when the incoming page starts to fade
+                                            // in — the two animations overlap continuously so
+                                            // there's no visible "gap" between the two screens,
+                                            // which is what makes a transition feel abrupt.
+                                            // - exit: 220ms LinearOutSlowInEasing — gentle,
+                                            //   decelerating fade-out (no scale; the outgoing
+                                            //   page is just dissolving away).
+                                            // - enter: 260ms FastOutSlowInEasing with 60ms
+                                            //   delay, scaled up from 0.94→1.0 — the small
+                                            //   delay lets the outgoing page establish before
+                                            //   the incoming settles in, and the cubic-bezier
+                                            //   easing keeps both motions buttery.
+                                            // - The window where exit+enter overlap (~160ms) is
+                                            //   well within the existing
+                                            //   `navTransitionInProgress` suspend window for
+                                            //   the app-wide layerBackdrop, so the GPU cost of
+                                            //   the overlap stays hidden.
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
+                                            // Detail route (e.g. tapping a song → album screen).
+                                            // Same fluid fade-through as bottom-nav so the whole
+                                            // app has a single, consistent motion language.
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
+                                                scaleIn(
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
+                                                )
                                         }
                                     },
                                     exitTransition = {
@@ -2972,9 +2993,9 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         }
                                     },
                                     popEnterTransition = {
@@ -2986,13 +3007,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
+                                                scaleIn(
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
+                                                )
                                         }
                                     },
                                     popExitTransition = {
@@ -3004,9 +3029,9 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         }
                                     },
                                     modifier =
@@ -3624,10 +3649,14 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
-// a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes once the page has settled.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
+// page-switch begins. Covers the new fluid NavHost fade-through (220ms exit + 260ms enter
+// with 60ms delay — total ~320ms visible motion) plus a small settle margin so the
+// expensive full-NavHost re-record is skipped for the entire visible animation window.
+// Crucially: because the exit and enter overlap (~160ms of overlap), the NavHost content
+// is animating during almost the whole window — recording the GraphicsLayer every frame
+// in that window is the dominant cost of the page-switch lag, so the suspend needs to
+// cover the overlap too, not just the entry duration.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 340L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -50,6 +50,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2951,27 +2953,17 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Per user request (2026-08-30): "Maybe try a different type
-                                            // of page switch animation across all the app that is light
-                                            // weight and works extremely smoothly." Crossfade-with-
-                                            // scale: outgoing fades out while incoming fades in with
-                                            // a tiny 0.96→1.0 scale. ~120ms each side — well under the
-                                            // old fade(220ms)+slide(250ms)/scale combo, and crucially
-                                            // keeps the NavHost's per-frame invalidation footprint
-                                            // small enough that the app-wide liquid-glass backdrop
-                                            // recording (suspended during the transition window) stays
-                                            // suspended for the entire visible motion.
-                                            fadeIn(tween(120)) +
+                                            // Material "fade through" for bottom-nav switches: the
+                                            // incoming screen fades in slightly delayed while gently
+                                            // scaling up from 92%, so Home↔Search↔Library feels animated
+                                            // instead of an imperceptible straight crossfade.
+                                            fadeIn(tween(220, delayMillis = 90)) +
                                                 scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
+                                                    animationSpec = tween(220, delayMillis = 90),
+                                                    initialScale = 0.92f,
                                                 )
                                         } else {
-                                            fadeIn(tween(120)) +
-                                                scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
-                                                )
+                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
                                         }
                                     },
                                     exitTransition = {
@@ -2980,17 +2972,9 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(90))
                                         } else {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
                                         }
                                     },
                                     popEnterTransition = {
@@ -3002,17 +2986,13 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(120)) +
+                                            fadeIn(tween(220, delayMillis = 90)) +
                                                 scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
+                                                    animationSpec = tween(220, delayMillis = 90),
+                                                    initialScale = 0.92f,
                                                 )
                                         } else {
-                                            fadeIn(tween(120)) +
-                                                scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
-                                                )
+                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
                                         }
                                     },
                                     popExitTransition = {
@@ -3024,17 +3004,9 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(90))
                                         } else {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
                                         }
                                     },
                                     modifier =
@@ -3652,12 +3624,10 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the new lightweight NavHost crossfade-with-scale (~120ms) plus
+// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
 // a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes as soon as the page has settled. Previously this was 320ms
-// to cover a longer tween(250) slide+fade — that's been replaced, so the suspend window
-// can shrink accordingly and the liquid-glass backdrop restores ~140ms sooner per switch.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 180L
+// animation window and resumes once the page has settled.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -50,8 +50,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2953,17 +2951,27 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Material "fade through" for bottom-nav switches: the
-                                            // incoming screen fades in slightly delayed while gently
-                                            // scaling up from 92%, so Home↔Search↔Library feels animated
-                                            // instead of an imperceptible straight crossfade.
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            // Per user request (2026-08-30): "Maybe try a different type
+                                            // of page switch animation across all the app that is light
+                                            // weight and works extremely smoothly." Crossfade-with-
+                                            // scale: outgoing fades out while incoming fades in with
+                                            // a tiny 0.96→1.0 scale. ~120ms each side — well under the
+                                            // old fade(220ms)+slide(250ms)/scale combo, and crucially
+                                            // keeps the NavHost's per-frame invalidation footprint
+                                            // small enough that the app-wide liquid-glass backdrop
+                                            // recording (suspended during the transition window) stays
+                                            // suspended for the entire visible motion.
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     exitTransition = {
@@ -2972,9 +2980,17 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popEnterTransition = {
@@ -2986,13 +3002,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popExitTransition = {
@@ -3004,9 +3024,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     modifier =
@@ -3624,10 +3652,12 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// page-switch begins. Covers the new lightweight NavHost crossfade-with-scale (~120ms) plus
 // a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes once the page has settled.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
+// animation window and resumes as soon as the page has settled. Previously this was 320ms
+// to cover a longer tween(250) slide+fade — that's been replaced, so the suspend window
+// can shrink accordingly and the liquid-glass backdrop restores ~140ms sooner per switch.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 180L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1140,27 +1140,6 @@ class MainActivity : ComponentActivity() {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val (previousTab) = rememberSaveable { mutableStateOf("home") }
                     val currentRoute = navBackStackEntry?.destination?.route
-                    // True while a NavHost page-switch transition is animating. The app-wide
-                    // `Modifier.layerBackdrop(liquidGlassBackdrop)` on the NavHost root re-records
-                    // the ENTIRE NavHost into a GraphicsLayer every frame its content changes. During
-                    // a page switch the whole NavHost animates (fade/scale/slide), so that re-record
-                    // runs every frame and is the dominant cost of the "lag when switching pages"
-                    // symptom (worst with the mini player visible, which also samples the backdrop).
-                    // The nav bar + mini player don't need a fresh backdrop while the page is
-                    // mid-transition — the content behind them is moving anyway — so we suspend the
-                    // recording for the ~300ms transition window. Nothing is removed or sacrificed:
-                    // the liquid glass effect is fully restored the moment the transition settles.
-                    var navTransitionInProgress by remember { mutableStateOf(false) }
-                    LaunchedEffect(navController) {
-                        navController.currentBackStackEntryFlow
-                            .map { it.destination.route }
-                            .distinctUntilChanged()
-                            .collectLatest { _ ->
-                                navTransitionInProgress = true
-                                delay(NAV_TRANSITION_SUSPEND_MILLIS)
-                                navTransitionInProgress = false
-                            }
-                    }
                     val onlineSearchEncodedQuery =
                         navBackStackEntry
                             ?.takeIf {
@@ -2967,10 +2946,11 @@ class MainActivity : ComponentActivity() {
                                             //   the incoming settles in, and the cubic-bezier
                                             //   easing keeps both motions buttery.
                                             // - The window where exit+enter overlap (~160ms) is
-                                            //   well within the existing
-                                            //   `navTransitionInProgress` suspend window for
-                                            //   the app-wide layerBackdrop, so the GPU cost of
-                                            //   the overlap stays hidden.
+                                            //   a real per-frame GPU cost (the NavHost content
+                                            //   is animating), but the overlap is short enough
+                                            //   and the per-frame work cheap enough (just two
+                                            //   opacity tweens + one scale tween) that it's well
+                                            //   under one frame's worth of work.
                                             fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
                                                     animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
@@ -3063,11 +3043,7 @@ class MainActivity : ComponentActivity() {
                                                     Modifier
                                                 },
                                             ).then(
-                                                if (
-                                                    liquidGlassBackdrop != null &&
-                                                    !isPlayerLyricsFullScreen &&
-                                                    !navTransitionInProgress
-                                                ) {
+                                                if (liquidGlassBackdrop != null && !isPlayerLyricsFullScreen) {
                                                     // Suspend the outer app-wide layerBackdrop while the
                                                     // full-screen lyrics overlay is open. The overlay is
                                                     // opaque, so nothing visible samples this backdrop
@@ -3075,15 +3051,6 @@ class MainActivity : ComponentActivity() {
                                                     // player is expanded). Recording the entire NavHost
                                                     // into a GraphicsLayer every frame steals GPU budget
                                                     // from the 60 Hz karaoke sweep on top.
-                                                    //
-                                                    // Also suspend it during a page-switch transition
-                                                    // (navTransitionInProgress): the NavHost content
-                                                    // animates every frame, so the full-NavHost re-record
-                                                    // would otherwise run every frame — the dominant cost
-                                                    // of the "lag when switching pages" symptom. The nav
-                                                    // bar + mini player don't need a fresh backdrop while
-                                                    // the page is mid-transition, so we skip the recording
-                                                    // for the ~320ms window and restore it once settled.
                                                     Modifier.layerBackdrop(liquidGlassBackdrop)
                                                 } else {
                                                     Modifier
@@ -3647,16 +3614,6 @@ val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No Downl
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
 
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
-
-// How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the new fluid NavHost fade-through (220ms exit + 260ms enter
-// with 60ms delay — total ~320ms visible motion) plus a small settle margin so the
-// expensive full-NavHost re-record is skipped for the entire visible animation window.
-// Crucially: because the exit and enter overlap (~160ms of overlap), the NavHost content
-// is animating during almost the whole window — recording the GraphicsLayer every frame
-// in that window is the dominant cost of the page-switch lag, so the suspend needs to
-// cover the overlap too, not just the entry duration.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 340L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1141,6 +1141,27 @@ class MainActivity : ComponentActivity() {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val (previousTab) = rememberSaveable { mutableStateOf("home") }
                     val currentRoute = navBackStackEntry?.destination?.route
+                    // True while a NavHost page-switch transition is animating. The app-wide
+                    // `Modifier.layerBackdrop(liquidGlassBackdrop)` on the NavHost root re-records
+                    // the ENTIRE NavHost into a GraphicsLayer every frame its content changes. During
+                    // a page switch the whole NavHost animates (fade/scale/slide), so that re-record
+                    // runs every frame and is the dominant cost of the "lag when switching pages"
+                    // symptom (worst with the mini player visible, which also samples the backdrop).
+                    // The nav bar + mini player don't need a fresh backdrop while the page is
+                    // mid-transition — the content behind them is moving anyway — so we suspend the
+                    // recording for the ~300ms transition window. Nothing is removed or sacrificed:
+                    // the liquid glass effect is fully restored the moment the transition settles.
+                    var navTransitionInProgress by remember { mutableStateOf(false) }
+                    LaunchedEffect(navController) {
+                        navController.currentBackStackEntryFlow
+                            .map { it.destination.route }
+                            .distinctUntilChanged()
+                            .collectLatest { _ ->
+                                navTransitionInProgress = true
+                                delay(NAV_TRANSITION_SUSPEND_MILLIS)
+                                navTransitionInProgress = false
+                            }
+                    }
                     val onlineSearchEncodedQuery =
                         navBackStackEntry
                             ?.takeIf {
@@ -3017,7 +3038,11 @@ class MainActivity : ComponentActivity() {
                                                     Modifier
                                                 },
                                             ).then(
-                                                if (liquidGlassBackdrop != null && !isPlayerLyricsFullScreen) {
+                                                if (
+                                                    liquidGlassBackdrop != null &&
+                                                    !isPlayerLyricsFullScreen &&
+                                                    !navTransitionInProgress
+                                                ) {
                                                     // Suspend the outer app-wide layerBackdrop while the
                                                     // full-screen lyrics overlay is open. The overlay is
                                                     // opaque, so nothing visible samples this backdrop
@@ -3025,6 +3050,15 @@ class MainActivity : ComponentActivity() {
                                                     // player is expanded). Recording the entire NavHost
                                                     // into a GraphicsLayer every frame steals GPU budget
                                                     // from the 60 Hz karaoke sweep on top.
+                                                    //
+                                                    // Also suspend it during a page-switch transition
+                                                    // (navTransitionInProgress): the NavHost content
+                                                    // animates every frame, so the full-NavHost re-record
+                                                    // would otherwise run every frame — the dominant cost
+                                                    // of the "lag when switching pages" symptom. The nav
+                                                    // bar + mini player don't need a fresh backdrop while
+                                                    // the page is mid-transition, so we skip the recording
+                                                    // for the ~320ms window and restore it once settled.
                                                     Modifier.layerBackdrop(liquidGlassBackdrop)
                                                 } else {
                                                     Modifier
@@ -3588,6 +3622,12 @@ val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No Downl
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
 
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
+
+// How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
+// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
+// animation window and resumes once the page has settled.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -239,14 +239,7 @@ fun FloatingNavigationToolbar(
     // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    // Per user report (2026-08-30): "extra space between navigation bar icons in
-    // liquid glass". SukiSU applies 4.dp on ALL sides of the items Row, but our
-    // ShortNavigationBarItem already adds its own internal horizontal padding
-    // around the icon/label slot — so the extra 4.dp on the Row translates to a
-    // visible gap between icons. Keep the vertical 4.dp (which the active
-    // Liquid Glass pill depends on for sizing), but use 0.dp horizontally —
-    // matching the non-Liquid-Glass variants.
-    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
+    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
             RoundedCornerShape(percent = 50)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -231,18 +231,29 @@ fun FloatingNavigationToolbar(
     // liquid glass surface tints itself with `surfaceContainerHigh`, so it stays
     // visible even when the rest of the UI is pitch black. The user explicitly
     // opts in via the Liquid Glass toggle, so honour that choice in pure dark too.
-    val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
+val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
+    // Per user request (2026-08-30): "Dimensions customisation should also be
+    // available for liquid glass navigation bar." The Liquid Glass bar
+    // honours the user's Height multiplier (applied on top of SukiSU's 64dp
+    // baseline), Label spacing (between icon and label inside the bar), and
+    // Corner radius (lets the user opt OUT of the perfect-circle 50% pill
+    // and pick any rounded-rect shape). Opacity/Transparency don't apply —
+    // the bar surface is `Color.Transparent` because the kyant shader
+    // controls the visible tint, so modulating alpha has no visible effect.
     val resolvedBarHeight =
-        if (canLiquidGlass) SukiSUBarHeight else NavigationBarHeight * navBarHeightMultiplier
-    // SukiSU-Ultra: when the Liquid Glass nav bar is active, the items Row uses
-    // 4.dp padding on ALL sides (matching SukiSU's Row.padding(4.dp)). The non-
-    // Liquid-Glass variants keep the original 8.dp vertical-only padding.
+        if (canLiquidGlass) SukiSUBarHeight * navBarHeightMultiplier
+        else NavigationBarHeight * navBarHeightMultiplier
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
+    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
-            RoundedCornerShape(percent = 50)
+            // SukiSU uses a perfect-circle pill (percent=50). Honour the
+            // user's corner-radius preference so they can pick any
+            // rounded-rect shape — clamp to a sensible range so the shape
+            // stays a pill (never square, never inverted corners on a
+            // shorter-than-tall bar).
+            RoundedCornerShape(navBarCornerRadius.dp.coerceIn(0f, 48f))
         } else {
             remember(isPairedWithMiniPlayer, isFloating, navBarCornerRadius) {
                 when {
@@ -487,7 +498,7 @@ fun FloatingNavigationToolbar(
         if (canLiquidGlass) {
             if (tabWidthPx <= 0f) return@LaunchedEffect
             liquidGlassPillWidth = with(density) { tabWidthPx.toDp() }
-            liquidGlassPillHeight = SukiSUBarHeight - SukiSUItemPadding * 2 // 64 - 8 = 56.dp
+            liquidGlassPillHeight = resolvedBarHeight - SukiSUItemPadding * 2 // bar height - 8dp vertical padding
             // Position the pill at the items Row's content area top (which is
             // `itemVerticalPadding` below the bar's top edge). The items Row
             // fills the Surface height (64.dp) with 4.dp vertical padding, so
@@ -799,10 +810,15 @@ fun FloatingNavigationToolbar(
                                 } else {
                                     {
                                         if (canLiquidGlass) {
+                                            // Liquid Glass: small negative offset to bring the
+                                            // underlying label closer to the icon (matching
+                                            // SukiSU's tighter vertical rhythm). The user's
+                                            // Label-spacing preference modulates this offset
+                                            // — more spacing pushes the label further down.
                                             Text(
                                                 text = stringResource(screen.titleId),
                                                 maxLines = 1,
-                                                modifier = Modifier.offset(y = (-4).dp),
+                                                modifier = Modifier.offset(y = -(4f - navBarLabelSpacing).coerceAtLeast(-12f).dp),
                                                 // Liquid Glass: underlying label is always Normal.
                                                 // The pill overlay renders the active label in
                                                 // SemiBold (primary color) on top of the glass.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -239,7 +239,14 @@ fun FloatingNavigationToolbar(
     // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
+    // Per user report (2026-08-30): "extra space between navigation bar icons in
+    // liquid glass". SukiSU applies 4.dp on ALL sides of the items Row, but our
+    // ShortNavigationBarItem already adds its own internal horizontal padding
+    // around the icon/label slot — so the extra 4.dp on the Row translates to a
+    // visible gap between icons. Keep the vertical 4.dp (which the active
+    // Liquid Glass pill depends on for sizing), but use 0.dp horizontally —
+    // matching the non-Liquid-Glass variants.
+    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
             RoundedCornerShape(percent = 50)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
@@ -313,12 +313,21 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                 }
             }
 
-            // Customization sliders: only meaningfully affect the FLOATING style (and the
-            // corner radius for DEFAULT). They are shown unconditionally so the user can
-            // pre-configure the floating look before switching to it. Each slider opens a
+            // Customization sliders: affect both the FLOATING and Liquid Glass styles,
+            // plus the corner radius for DEFAULT. They are shown unconditionally so the
+            // user can pre-configure a look before switching to it. Each slider opens a
             // dialog with a live preview that reflects the in-progress value (and the
             // committed values of the other dimensions) so the user can see exactly how
             // the bar will look before committing.
+            //
+            // Per user request (2026-08-30): "Dimensions customisation should also be
+            // available for liquid glass navigation bar." Previously these sliders were
+            // disabled when the Liquid Glass nav bar toggle was on (the bar used SukiSU's
+            // fixed 64dp / 4dp / percent=50 dimensions). Now the Liquid Glass bar honours
+            // the user's Height multiplier, Label spacing, and Corner radius preferences
+            // — only Opacity and Transparency stay no-ops on Liquid Glass because the bar
+            // surface is `Color.Transparent` (the kyant shader controls the visible tint,
+            // so alpha modulation has no visible effect there).
             PreferenceGroup(
                 modifier = positions.modifierFor("navigation_bar_dimensions"),
                 title = stringResource(R.string.navigation_bar_dimensions),
@@ -344,7 +353,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -369,7 +377,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -394,7 +401,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -419,7 +425,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -444,7 +449,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -469,16 +473,15 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
                 // Reset all six dimension values to their defaults in one tap. The button is
                 // disabled (greyed out) when every value is already at its default, so the
                 // user can see at a glance whether they have any unsaved customizations.
-                // Also disabled when Liquid Glass nav bar is active (the Liquid Glass bar
-                // uses SukiSU's exact dimensions and ignores the user's preferences, so
-                // resetting them has no visible effect).
+                // Always enabled regardless of Liquid Glass toggle — the Liquid Glass bar
+                // honours the same preference keys, so resetting them visibly resets the
+                // Liquid Glass bar too.
                 item {
                     val allDefaults =
                         navigationBarWidth == NAVIGATION_BAR_WIDTH_DEFAULT &&
@@ -497,7 +500,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                             onNavigationBarLabelSpacingChange(NAVIGATION_BAR_LABEL_SPACING_DEFAULT)
                             onNavigationBarCornerRadiusChange(NAVIGATION_BAR_CORNER_RADIUS_DEFAULT)
                         },
-                        enabled = !allDefaults && !liquidGlassNavBarEnabled,
+                        enabled = !allDefaults,
                         shapes = ButtonDefaults.shapes(),
                         modifier = Modifier
                             .fillMaxWidth()
@@ -539,12 +542,6 @@ private fun SliderPreferenceRow(
     valueLabel: (Float) -> String,
     default: Float? = null,
     preview: (@Composable (Float) -> Unit)? = null,
-    // SukiSU-Ultra: when the Liquid Glass nav bar is active, the customization
-    // sliders are DISABLED (greyed out) because the Liquid Glass bar uses
-    // SukiSU's exact dimensions and ignores the user's preferences. The user
-    // explicitly asked for this: "Customisation of navigation bar in Liquid
-    // Glass should be unavailable because it should use the exact same
-    // dimensions from suki su for everything".
     enabled: Boolean = true,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }


### PR DESCRIPTION
Reverts commit 0ed0ade74541c129c9869e5e550a1154cb4994d7 per user request (2026-08-30).

Removes the `navTransitionInProgress` state, the `LaunchedEffect` that
sets it on every backstack entry change, the `!navTransitionInProgress`
gate on the app-wide `Modifier.layerBackdrop(liquidGlassBackdrop)` on
the NavHost root, and the `NAV_TRANSITION_SUSPEND_MILLIS` constant.

The fluid fade-through page-switch animation from cfcc366e2 is kept
verbatim.