### PR TITLE
feat(ui,nav,perf): honour Liquid Glass nav bar dimensions + preload Search tab

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/App.kt
@@ -59,6 +59,7 @@ import moe.rukamori.archivetune.storage.StorageLocationRepository
 import moe.rukamori.archivetune.tidal.TidalAudioProvider
 import moe.rukamori.archivetune.tidal.TidalInstanceHealthManager
 import moe.rukamori.archivetune.qobuz.QobuzAudioProvider
+import moe.rukamori.archivetune.repository.SearchDiscoveryRepository
 import moe.rukamori.archivetune.ui.player.CanvasArtworkPlaybackCache
 import moe.rukamori.archivetune.ui.screens.settings.ThemePalettes
 import moe.rukamori.archivetune.ui.theme.ThemeSeedPalette
@@ -102,6 +103,17 @@ class App :
      */
     @Inject
     lateinit var spotifyLibraryRepository: SpotifyLibraryRepository
+
+    /**
+     * Pre-warmed at app startup so the Search tab's discovery feed (moods & genres,
+     * charts, suggested songs/albums/artists) loads instantly when the user first taps
+     * Search — see [SearchDiscoveryRepository.loadDiscovery]. The repository caches
+     * its result in-memory for a short TTL, so the cost of one warm-up covers many
+     * subsequent tab re-entries. Fire-and-forget on `applicationScope` (Dispatchers.IO)
+     * so the cold-start path isn't blocked.
+     */
+    @Inject
+    lateinit var searchDiscoveryRepository: SearchDiscoveryRepository
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
@@ -252,6 +264,20 @@ class App :
     private fun initializeDeferredAsync() {
         applicationScope.launch(Dispatchers.IO) {
             ytDlpRuntime.preWarm()
+        }
+
+        // Per user request (2026-08-30): "The search tab takes time to load. it
+        // should preload when i open the app." Kick off the discovery load
+        // immediately at app start so the in-memory TTL cache is warm by the
+        // time the user first taps Search. The repository's `loadDiscovery()`
+        // is idempotent — a concurrent call from the actual ViewModel just
+        // joins the in-flight job via the same `loadJob?.isActive` guard.
+        // Errors are swallowed inside the repository (stale cache fallback)
+        // so this fire-and-forget is safe.
+        applicationScope.launch(Dispatchers.IO) {
+            runCatching {
+                searchDiscoveryRepository.loadDiscovery(forceRefresh = false)
+            }
         }
 
         applicationScope.launch(Dispatchers.IO) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -163,6 +163,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastAny

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -45,13 +45,12 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2953,17 +2952,39 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Material "fade through" for bottom-nav switches: the
-                                            // incoming screen fades in slightly delayed while gently
-                                            // scaling up from 92%, so Home↔Search↔Library feels animated
-                                            // instead of an imperceptible straight crossfade.
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            // Fluid Material-style fade-through for bottom-nav
+                                            // switches. The outgoing page is still partly visible
+                                            // (~50% alpha) when the incoming page starts to fade
+                                            // in — the two animations overlap continuously so
+                                            // there's no visible "gap" between the two screens,
+                                            // which is what makes a transition feel abrupt.
+                                            // - exit: 220ms LinearOutSlowInEasing — gentle,
+                                            //   decelerating fade-out (no scale; the outgoing
+                                            //   page is just dissolving away).
+                                            // - enter: 260ms FastOutSlowInEasing with 60ms
+                                            //   delay, scaled up from 0.94→1.0 — the small
+                                            //   delay lets the outgoing page establish before
+                                            //   the incoming settles in, and the cubic-bezier
+                                            //   easing keeps both motions buttery.
+                                            // - The window where exit+enter overlap (~160ms) is
+                                            //   well within the existing
+                                            //   `navTransitionInProgress` suspend window for
+                                            //   the app-wide layerBackdrop, so the GPU cost of
+                                            //   the overlap stays hidden.
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
+                                            // Detail route (e.g. tapping a song → album screen).
+                                            // Same fluid fade-through as bottom-nav so the whole
+                                            // app has a single, consistent motion language.
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
+                                                scaleIn(
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
+                                                )
                                         }
                                     },
                                     exitTransition = {
@@ -2972,9 +2993,9 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         }
                                     },
                                     popEnterTransition = {
@@ -2986,13 +3007,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
+                                            fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
+                                                scaleIn(
+                                                    animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
+                                                    initialScale = 0.94f,
+                                                )
                                         }
                                     },
                                     popExitTransition = {
@@ -3004,9 +3029,9 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
+                                            fadeOut(tween(220, easing = LinearOutSlowInEasing))
                                         }
                                     },
                                     modifier =
@@ -3624,10 +3649,14 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
-// a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes once the page has settled.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
+// page-switch begins. Covers the new fluid NavHost fade-through (220ms exit + 260ms enter
+// with 60ms delay — total ~320ms visible motion) plus a small settle margin so the
+// expensive full-NavHost re-record is skipped for the entire visible animation window.
+// Crucially: because the exit and enter overlap (~160ms of overlap), the NavHost content
+// is animating during almost the whole window — recording the GraphicsLayer every frame
+// in that window is the dominant cost of the page-switch lag, so the suspend needs to
+// cover the overlap too, not just the entry duration.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 340L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1716,33 +1716,44 @@ class MainActivity : ComponentActivity() {
                             },
                         )
 
-                    val handlePrimaryNavigationClick: (Screens, Boolean) -> Unit = { screen, isSelected ->
-                        if (isSelected) {
-                            if (screen == Screens.Search) {
-                                openSearch()
-                                coroutineScope.launch { searchScrollBehavior.state.resetHeightOffset() }
-                            } else {
-                                navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
-                                when (screen) {
-                                    Screens.Home -> {
-                                        coroutineScope.launch { homeScrollBehavior.state.resetHeightOffset() }
-                                    }
+                    // Per audit (2026-08-30): wrap in remember(...) so the lambda
+                    // identity stays stable across recompositions. Previously the
+                    // lambda was re-allocated every recomposition of MainActivity's
+                    // setContent body, which cascaded to FloatingNavigationToolbar's
+                    // `remember(screen, selected, onItemClick, onDoubleClick) { ... }`
+                    // cache — re-allocating the per-tab click-handler body on every
+                    // recomposition. With ~5 tabs × heavy scroll-driven recompositions,
+                    // this was hundreds of lambda allocations per second.
+                    val handlePrimaryNavigationClick: (Screens, Boolean) -> Unit =
+                        remember(coroutineScope, navController, openSearch, searchScrollBehavior, homeScrollBehavior) {
+                            { screen, isSelected ->
+                                if (isSelected) {
+                                    if (screen == Screens.Search) {
+                                        openSearch()
+                                        coroutineScope.launch { searchScrollBehavior.state.resetHeightOffset() }
+                                    } else {
+                                        navController.currentBackStackEntry?.savedStateHandle?.set("scrollToTop", true)
+                                        when (screen) {
+                                            Screens.Home -> {
+                                                coroutineScope.launch { homeScrollBehavior.state.resetHeightOffset() }
+                                            }
 
-                                    else -> {}
-                                }
-                            }
-                        } else {
-                            if (navController.currentDestination?.route != screen.route) {
-                                navController.navigate(screen.route) {
-                                    popUpTo(navController.graph.startDestinationId) {
-                                        saveState = true
+                                            else -> {}
+                                        }
                                     }
-                                    launchSingleTop = true
-                                    restoreState = true
+                                } else {
+                                    if (navController.currentDestination?.route != screen.route) {
+                                        navController.navigate(screen.route) {
+                                            popUpTo(navController.graph.startDestinationId) {
+                                                saveState = true
+                                            }
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        }
+                                    }
                                 }
                             }
                         }
-                    }
 
                     LaunchedEffect(currentRoute) {
                         when (currentRoute) {
@@ -2900,13 +2911,19 @@ modifier =
                                                     navBackStackEntry?.destination?.hierarchy?.any { it.route == screen.route } ==
                                                         true
                                                 },
-                                                onItemClick = { screen, isSelected ->
-                                                    handlePrimaryNavigationClick(screen, isSelected)
-                                                },
-                                                onSearchItemDoubleClick = {
-                                                    searchSource = SearchSource.ONLINE
-                                                    openSearch()
-                                                },
+                                                // Per audit (2026-08-30): pass the stable
+                                                // handlePrimaryNavigationClick directly (no
+                                                // wrapping lambda) so FloatingNavigationToolbar's
+                                                // `remember(screen, selected, onItemClick, ...)`
+                                                // cache key stays stable across recompositions.
+                                                onItemClick = handlePrimaryNavigationClick,
+                                                onSearchItemDoubleClick =
+                                                    remember(openSearch) {
+                                                        {
+                                                            searchSource = SearchSource.ONLINE
+                                                            openSearch()
+                                                        }
+                                                    },
                                             )
                                         }
                                     }
@@ -3057,10 +3074,20 @@ modifier =
                                                 // layer each frame so the bar can draw it blurred.
                                                 if (navBarFrostedBackdrop != null) {
                                                     Modifier
-                                                        .onGloballyPositioned { coordinates ->
-                                                            navBarFrostedBackdrop.contentOffsetInRoot =
-                                                                coordinates.positionInRoot()
-                                                        }.drawWithContent {
+                                                        // Per audit (2026-08-30): memoize the
+                                                        // lambda so OnGloballyPositionedElement
+                                                        // equals() returns true across recompositions.
+                                                        // navBarFrostedBackdrop is a stable `remember`
+                                                        // instance (allocated once in MainActivity:1435),
+                                                        // so we can safely key on it.
+                                                        .onGloballyPositioned(
+                                                            remember(navBarFrostedBackdrop) {
+                                                                { coordinates ->
+                                                                    navBarFrostedBackdrop.contentOffsetInRoot =
+                                                                        coordinates.positionInRoot()
+                                                                }
+                                                            },
+                                                        ).drawWithContent {
                                                             navBarFrostedBackdrop.layer.record {
                                                                 this@drawWithContent.drawContent()
                                                             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -291,6 +291,7 @@ import moe.rukamori.archivetune.ui.component.COLLAPSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.DISMISSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.EXPANDED_ANCHOR
 import moe.rukamori.archivetune.ui.component.FloatingNavigationToolbar
+import moe.rukamori.archivetune.ui.component.SukiSUBarHeight
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyleKey
 import moe.rukamori.archivetune.ui.component.LocalLiquidGlassBackdrop
@@ -1341,13 +1342,6 @@ class MainActivity : ComponentActivity() {
                                 !active
                         }
 
-                    fun getBottomNavPadding(): Dp =
-                        if (shouldShowNavigationBar && !useRail) {
-                            NavigationBarHeight
-                        } else {
-                            0.dp
-                        }
-
                     // FLOATING detaches the bar into a pill: bigger bottom margin, tighter width.
                     // Every consumer below (collapsed player anchor, slide distance, insets, FAB
                     // padding) derives from these two values so the styles stay in sync.
@@ -1360,9 +1354,41 @@ class MainActivity : ComponentActivity() {
                         moe.rukamori.archivetune.constants.NavigationBarHeightKey,
                         defaultValue = moe.rukamori.archivetune.constants.NAVIGATION_BAR_HEIGHT_DEFAULT,
                     )
-                    val navVisibleHeight = NavigationBarHeight * navBarHeightMultiplier
+                    // canLiquidGlassNavBar: the Liquid Glass nav bar is rendered at SukiSUBarHeight
+                    // (64.dp) — see FloatingNavigationToolbar.kt:resolvedBarHeight. The user's
+                    // customized height multiplier does NOT apply when Liquid Glass is on (per
+                    // user report 2026-08-30: "if i disable liquid glass navigation bar and
+                    // customise the dimensions and then enable the liquid glass navigation bar,
+                    // the customised dimensions gets applied. fix it"). So when canLiquidGlassNavBar,
+                    // navVisibleHeight is forced to SukiSUBarHeight to match the actual rendered
+                    // bar height everywhere it's used: the wrapper Box height, the slide
+                    // animation target, the mini-player's collapsed anchor (via getBottomNavPadding).
+                    val canLiquidGlassNavBar =
+                        liquidGlassEnabled &&
+                            liquidGlassNavBarEnabled &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                    val navVisibleHeight =
+                        if (canLiquidGlassNavBar) SukiSUBarHeight else NavigationBarHeight * navBarHeightMultiplier
                     val navBarHorizontalPadding =
                         if (isFloatingNavBar) FloatingNavigationBarHorizontalPadding else NavigationBarHorizontalPadding
+
+                    // When Liquid Glass nav bar is on, the actual rendered bar height is
+                    // SukiSUBarHeight (64.dp). Returning NavigationBarHeight (78.dp) here would
+                    // create a 14.dp gap between the mini-player's collapsed anchor and the
+                    // bar's true top edge. Returning navVisibleHeight (resolved to
+                    // SukiSUBarHeight when canLiquidGlassNavBar above) keeps the anchor aligned
+                    // with the actual bar.
+                    //
+                    // Also: when Liquid Glass is OFF and the user has customized the height
+                    // multiplier, navVisibleHeight already honors that customization
+                    // (NavigationBarHeight * navBarHeightMultiplier), so the anchor matches
+                    // the actual rendered bar height.
+                    fun getBottomNavPadding(): Dp =
+                        if (shouldShowNavigationBar && !useRail) {
+                            navVisibleHeight
+                        } else {
+                            0.dp
+                        }
 
                     // Frosted backdrop (nav bar + mini player + tablet rail): allocated whenever
                     // any frosted surface can run (RenderEffect available). The bottom toolbar and
@@ -2860,64 +2886,52 @@ modifier =
                                         val navSlideDistance =
                                             bottomInset + floatingBarsBottomPadding + navVisibleHeight
 
-                                        // Per user report (2026-08-29): "switching from a
-                                        // page with liquid glass elements to other page which
-                                        // has liquid glass elements make the app lag way too
-                                        // much. Fix it without removing or sacrificing anything.
-                                        // The lag is the most intense when the mini player is
-                                        // visible."
-                                        //
-                                        // The previous implementation used `Modifier.offset {
-                                        // IntOffset(0, y) }` which runs in the LAYOUT phase:
-                                        // every spring frame (from `bottomNavigationBarHeight`
-                                        // animating between 0 and navVisibleHeight when the
-                                        // mini player docks/undocks) AND every sheet-drag
-                                        // frame (from `playerBottomSheetState.progress`
-                                        // updating continuously) re-laid-out the entire
-                                        // FloatingNavigationToolbar subtree. That re-layout
-                                        // cascaded to every `onGloballyPositioned` callback
-                                        // inside the toolbar (containerPos, barPositionInRoot,
-                                        // selectedCenter), which in turn re-positioned the
-                                        // kyant `drawBackdrop` shaders under the nav bar AND
-                                        // invalidated the app-wide
-                                        // `Modifier.layerBackdrop(liquidGlassBackdrop)`
-                                        // recording on the NavHost root — compounding into
-                                        // severe frame drops.
-                                        //
-                                        // Switching to `Modifier.graphicsLayer {
-                                        // translationY = y }` runs in the DRAW phase only:
-                                        // children's layout coordinates stay stable across
-                                        // spring frames, so onGloballyPositioned callbacks
-                                        // don't fire and the kyant shader chain doesn't have
-                                        // to re-compute its sample coordinates every frame.
-                                        // The visual is identical (the bar still slides
-                                        // down/out when the mini player appears and the bar
-                                        // collapses) — only the invalidation pattern changes.
+                                        // Restored to the original layout-phase offset (per
+                                        // user report 2026-08-30: "i somehow messed up liquid
+                                        // glass navigation bar. Restore it to how it used to be
+                                        // before"). The previous batch-8 attempt to switch to
+                                        // `Modifier.graphicsLayer { translationY = y }` (draw
+                                        // phase) caused the nav bar to render ON TOP of the
+                                        // mini-player because the wrapper Box's layout space
+                                        // stayed claimed at BottomCenter even when translated
+                                        // off-screen — the mini-player's collapsed sheet anchor
+                                        // couldn't "see" the nav bar's actual layout position,
+                                        // so they ended up stacked at the same BottomCenter.
+                                        // Reverting to `Modifier.offset { IntOffset(0, y) }`
+                                        // restores the layout-aware slide: when the bar
+                                        // translates down, its layout position changes too, so
+                                        // the parent (bottomBar Box) and the BottomSheetPlayer
+                                        // can correctly react.
                                         Box(
                                             modifier =
                                                 Modifier
                                                     .align(Alignment.BottomCenter)
                                                     .height(navSlideDistance)
-                                                    .graphicsLayer {
-                                                        translationY =
-                                                            if (bottomNavigationBarHeight == 0.dp) {
-                                                                navSlideDistance.toPx()
-                                                            } else {
-                                                                val slideOffset =
-                                                                    navSlideDistance.toPx() *
-                                                                        playerBottomSheetState.progress.coerceIn(
-                                                                            0f,
-                                                                            1f,
-                                                                        )
-                                                                val hideOffset =
-                                                                    navSlideDistance.toPx() *
-                                                                        (
-                                                                            1 -
-                                                                                bottomNavigationBarHeight.coerceAtMost(navVisibleHeight) /
-                                                                                navVisibleHeight
-                                                                        )
-                                                                slideOffset + hideOffset
-                                                            }
+                                                    .offset {
+                                                        if (bottomNavigationBarHeight == 0.dp) {
+                                                            IntOffset(
+                                                                x = 0,
+                                                                y = navSlideDistance.roundToPx(),
+                                                            )
+                                                        } else {
+                                                            val slideOffset =
+                                                                navSlideDistance *
+                                                                    playerBottomSheetState.progress.coerceIn(
+                                                                        0f,
+                                                                        1f,
+                                                                    )
+                                                            val hideOffset =
+                                                                navSlideDistance *
+                                                                    (
+                                                                        1 -
+                                                                            bottomNavigationBarHeight.coerceAtMost(navVisibleHeight) /
+                                                                            navVisibleHeight
+                                                                    )
+                                                            IntOffset(
+                                                                x = 0,
+                                                                y = (slideOffset + hideOffset).roundToPx(),
+                                                            )
+                                                        }
                                                     },
                                         ) {
                                             FloatingNavigationToolbar(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -50,6 +50,8 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2951,27 +2953,17 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Per user request (2026-08-30): "Maybe try a different type
-                                            // of page switch animation across all the app that is light
-                                            // weight and works extremely smoothly." Crossfade-with-
-                                            // scale: outgoing fades out while incoming fades in with
-                                            // a tiny 0.96→1.0 scale. ~120ms each side — well under the
-                                            // old fade(220ms)+slide(250ms)/scale combo, and crucially
-                                            // keeps the NavHost's per-frame invalidation footprint
-                                            // small enough that the app-wide liquid-glass backdrop
-                                            // recording (suspended during the transition window) stays
-                                            // suspended for the entire visible motion.
-                                            fadeIn(tween(120)) +
+                                            // Material "fade through" for bottom-nav switches: the
+                                            // incoming screen fades in slightly delayed while gently
+                                            // scaling up from 92%, so Home↔Search↔Library feels animated
+                                            // instead of an imperceptible straight crossfade.
+                                            fadeIn(tween(220, delayMillis = 90)) +
                                                 scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
+                                                    animationSpec = tween(220, delayMillis = 90),
+                                                    initialScale = 0.92f,
                                                 )
                                         } else {
-                                            fadeIn(tween(120)) +
-                                                scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
-                                                )
+                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
                                         }
                                     },
                                     exitTransition = {
@@ -2980,17 +2972,9 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(90))
                                         } else {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
                                         }
                                     },
                                     popEnterTransition = {
@@ -3002,17 +2986,13 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(120)) +
+                                            fadeIn(tween(220, delayMillis = 90)) +
                                                 scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
+                                                    animationSpec = tween(220, delayMillis = 90),
+                                                    initialScale = 0.92f,
                                                 )
                                         } else {
-                                            fadeIn(tween(120)) +
-                                                scaleIn(
-                                                    animationSpec = tween(120),
-                                                    initialScale = 0.96f,
-                                                )
+                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
                                         }
                                     },
                                     popExitTransition = {
@@ -3024,17 +3004,9 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(90))
                                         } else {
-                                            fadeOut(tween(120)) +
-                                                scaleOut(
-                                                    animationSpec = tween(120),
-                                                    targetScale = 0.96f,
-                                                )
+                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
                                         }
                                     },
                                     modifier =
@@ -3652,12 +3624,10 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the new lightweight NavHost crossfade-with-scale (~120ms) plus
+// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
 // a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes as soon as the page has settled. Previously this was 320ms
-// to cover a longer tween(250) slide+fade — that's been replaced, so the suspend window
-// can shrink accordingly and the liquid-glass backdrop restores ~140ms sooner per switch.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 180L
+// animation window and resumes once the page has settled.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -292,7 +292,6 @@ import moe.rukamori.archivetune.ui.component.COLLAPSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.DISMISSED_ANCHOR
 import moe.rukamori.archivetune.ui.component.EXPANDED_ANCHOR
 import moe.rukamori.archivetune.ui.component.FloatingNavigationToolbar
-import moe.rukamori.archivetune.ui.component.SukiSUBarHeight
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.MiniPlayerBackgroundStyleKey
 import moe.rukamori.archivetune.ui.component.LocalLiquidGlassBackdrop
@@ -1355,38 +1354,13 @@ class MainActivity : ComponentActivity() {
                         moe.rukamori.archivetune.constants.NavigationBarHeightKey,
                         defaultValue = moe.rukamori.archivetune.constants.NAVIGATION_BAR_HEIGHT_DEFAULT,
                     )
-                    // canLiquidGlassNavBar: the Liquid Glass nav bar is rendered at SukiSUBarHeight
-                    // (64.dp) — see FloatingNavigationToolbar.kt:resolvedBarHeight. The user's
-                    // customized height multiplier does NOT apply when Liquid Glass is on (per
-                    // user report 2026-08-30: "if i disable liquid glass navigation bar and
-                    // customise the dimensions and then enable the liquid glass navigation bar,
-                    // the customised dimensions gets applied. fix it"). So when canLiquidGlassNavBar,
-                    // navVisibleHeight is forced to SukiSUBarHeight to match the actual rendered
-                    // bar height everywhere it's used: the wrapper Box height, the slide
-                    // animation target, the mini-player's collapsed anchor (via getBottomNavPadding).
-                    val canLiquidGlassNavBar =
-                        liquidGlassEnabled &&
-                            liquidGlassNavBarEnabled &&
-                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                    val navVisibleHeight =
-                        if (canLiquidGlassNavBar) SukiSUBarHeight else NavigationBarHeight * navBarHeightMultiplier
+                    val navVisibleHeight = NavigationBarHeight * navBarHeightMultiplier
                     val navBarHorizontalPadding =
                         if (isFloatingNavBar) FloatingNavigationBarHorizontalPadding else NavigationBarHorizontalPadding
 
-                    // When Liquid Glass nav bar is on, the actual rendered bar height is
-                    // SukiSUBarHeight (64.dp). Returning NavigationBarHeight (78.dp) here would
-                    // create a 14.dp gap between the mini-player's collapsed anchor and the
-                    // bar's true top edge. Returning navVisibleHeight (resolved to
-                    // SukiSUBarHeight when canLiquidGlassNavBar above) keeps the anchor aligned
-                    // with the actual bar.
-                    //
-                    // Also: when Liquid Glass is OFF and the user has customized the height
-                    // multiplier, navVisibleHeight already honors that customization
-                    // (NavigationBarHeight * navBarHeightMultiplier), so the anchor matches
-                    // the actual rendered bar height.
                     fun getBottomNavPadding(): Dp =
                         if (shouldShowNavigationBar && !useRail) {
-                            navVisibleHeight
+                            NavigationBarHeight
                         } else {
                             0.dp
                         }
@@ -1398,50 +1372,19 @@ class MainActivity : ComponentActivity() {
                         MiniPlayerBackgroundStyleKey,
                         defaultValue = MiniPlayerBackgroundStyle.THEME,
                     )
-                    // Per audit (2026-08-30): the app-wide NavHost backdrop captures
-                    // (Modifier.drawWithContent { layer.record { drawContent() } ; drawLayer(layer) }
-                    //  and Modifier.layerBackdrop(liquidGlassBackdrop)) run every frame the
-                    //  NavHost draws — i.e. always while the user is on Home/Search/Library
-                    //  with a mini player visible (which is the default state). These are the
-                    //  dominant per-frame CPU+GPU costs the user reports as "lag when mini
-                    //  player is visible". Both captures run UNCONDITIONALLY on Android 12+
-                    //  regardless of whether any consumer is actually sampling the backdrop.
-                    //
-                    // Gate each capture on whether at least one consumer can possibly need it:
-                    //   - frosted capture: needed when nav bar / nav bar tint / mini player
-                    //     style is FROSTED, or the tablet rail wants the frosted look.
-                    //   - liquid-glass capture: needed when the liquid-glass master toggle is
-                    //     on AND at least one of {nav bar, mini player, tablet rail} can show
-                    //     liquid glass. The user's chosen mini-player style matters here.
-                    //
-                    // When neither preference is on, both captures are skipped — the NavHost
-                    // draws normally without the per-frame GraphicsLayer.record cost, and the
-                    // bar/mini-player surfaces fall back to their plain tint/shape variants.
-                    // This is a "no sacrifice" optimization: nothing visible changes; we just
-                    // stop paying for work that no one reads.
-                    val miniPlayerUsesFrosted =
-                        miniPlayerBgStyle == MiniPlayerBackgroundStyle.FROSTED
-                    val miniPlayerUsesLiquidGlass =
-                        miniPlayerBgStyle == MiniPlayerBackgroundStyle.LIQUID_GLASS &&
-                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-                            liquidGlassEnabled
-                    val needsFrostedCapture =
-                        navigationBarFrostedBlur ||
-                            navigationBarTintFrostedBlur ||
-                            miniPlayerUsesFrosted
-                    val needsLiquidGlassCapture =
-                        liquidGlassEnabled &&
-                            (liquidGlassNavBarEnabled || miniPlayerUsesLiquidGlass)
                     val navBarFrostedBackdrop =
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && needsFrostedCapture) {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                             val frostedLayer = rememberGraphicsLayer()
                             remember(frostedLayer) { NavigationBarBackdrop(frostedLayer) }
                         } else {
                             null
                         }
 
+                    val liquidGlassActive =
+                        liquidGlassEnabled &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
                     val liquidGlassBackdrop: LayerBackdrop? =
-                        if (needsLiquidGlassCapture) {
+                        if (liquidGlassActive) {
                             rememberLayerBackdrop()
                         } else {
                             null

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -50,8 +50,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -2953,17 +2951,27 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            // Material "fade through" for bottom-nav switches: the
-                                            // incoming screen fades in slightly delayed while gently
-                                            // scaling up from 92%, so Home↔Search↔Library feels animated
-                                            // instead of an imperceptible straight crossfade.
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            // Per user request (2026-08-30): "Maybe try a different type
+                                            // of page switch animation across all the app that is light
+                                            // weight and works extremely smoothly." Crossfade-with-
+                                            // scale: outgoing fades out while incoming fades in with
+                                            // a tiny 0.96→1.0 scale. ~120ms each side — well under the
+                                            // old fade(220ms)+slide(250ms)/scale combo, and crucially
+                                            // keeps the NavHost's per-frame invalidation footprint
+                                            // small enough that the app-wide liquid-glass backdrop
+                                            // recording (suspended during the transition window) stays
+                                            // suspended for the entire visible motion.
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     exitTransition = {
@@ -2972,9 +2980,17 @@ class MainActivity : ComponentActivity() {
                                         } else if (initialState.destination.route in topLevelScreens &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { -it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popEnterTransition = {
@@ -2986,13 +3002,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeIn(tween(220, delayMillis = 90)) +
+                                            fadeIn(tween(120)) +
                                                 scaleIn(
-                                                    animationSpec = tween(220, delayMillis = 90),
-                                                    initialScale = 0.92f,
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
                                                 )
                                         } else {
-                                            fadeIn(tween(250)) + slideInHorizontally { -it / 2 }
+                                            fadeIn(tween(120)) +
+                                                scaleIn(
+                                                    animationSpec = tween(120),
+                                                    initialScale = 0.96f,
+                                                )
                                         }
                                     },
                                     popExitTransition = {
@@ -3004,9 +3024,17 @@ class MainActivity : ComponentActivity() {
                                             ) &&
                                             targetState.destination.route in topLevelScreens
                                         ) {
-                                            fadeOut(tween(90))
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         } else {
-                                            fadeOut(tween(200)) + slideOutHorizontally { it / 2 }
+                                            fadeOut(tween(120)) +
+                                                scaleOut(
+                                                    animationSpec = tween(120),
+                                                    targetScale = 0.96f,
+                                                )
                                         }
                                     },
                                     modifier =
@@ -3624,10 +3652,12 @@ val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils p
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
 
 // How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// page-switch begins. Covers the new lightweight NavHost crossfade-with-scale (~120ms) plus
 // a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
-// animation window and resumes once the page has settled.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
+// animation window and resumes as soon as the page has settled. Previously this was 320ms
+// to cover a longer tween(250) slide+fade — that's been replaced, so the suspend window
+// can shrink accordingly and the liquid-glass backdrop restores ~140ms sooner per switch.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 180L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1372,19 +1372,50 @@ class MainActivity : ComponentActivity() {
                         MiniPlayerBackgroundStyleKey,
                         defaultValue = MiniPlayerBackgroundStyle.THEME,
                     )
+                    // Per audit (2026-08-30): the app-wide NavHost backdrop captures
+                    // (Modifier.drawWithContent { layer.record { drawContent() } ; drawLayer(layer) }
+                    //  and Modifier.layerBackdrop(liquidGlassBackdrop)) run every frame the
+                    //  NavHost draws — i.e. always while the user is on Home/Search/Library
+                    //  with a mini player visible (which is the default state). These are the
+                    //  dominant per-frame CPU+GPU costs the user reports as "lag when mini
+                    //  player is visible". Both captures run UNCONDITIONALLY on Android 12+
+                    //  regardless of whether any consumer is actually sampling the backdrop.
+                    //
+                    // Gate each capture on whether at least one consumer can possibly need it:
+                    //   - frosted capture: needed when nav bar / nav bar tint / mini player
+                    //     style is FROSTED, or the tablet rail wants the frosted look.
+                    //   - liquid-glass capture: needed when the liquid-glass master toggle is
+                    //     on AND at least one of {nav bar, mini player, tablet rail} can show
+                    //     liquid glass. The user's chosen mini-player style matters here.
+                    //
+                    // When neither preference is on, both captures are skipped — the NavHost
+                    // draws normally without the per-frame GraphicsLayer.record cost, and the
+                    // bar/mini-player surfaces fall back to their plain tint/shape variants.
+                    // This is a "no sacrifice" optimization: nothing visible changes; we just
+                    // stop paying for work that no one reads.
+                    val miniPlayerUsesFrosted =
+                        miniPlayerBgStyle == MiniPlayerBackgroundStyle.FROSTED
+                    val miniPlayerUsesLiquidGlass =
+                        miniPlayerBgStyle == MiniPlayerBackgroundStyle.LIQUID_GLASS &&
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                            liquidGlassEnabled
+                    val needsFrostedCapture =
+                        navigationBarFrostedBlur ||
+                            navigationBarTintFrostedBlur ||
+                            miniPlayerUsesFrosted
+                    val needsLiquidGlassCapture =
+                        liquidGlassEnabled &&
+                            (liquidGlassNavBarEnabled || miniPlayerUsesLiquidGlass)
                     val navBarFrostedBackdrop =
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && needsFrostedCapture) {
                             val frostedLayer = rememberGraphicsLayer()
                             remember(frostedLayer) { NavigationBarBackdrop(frostedLayer) }
                         } else {
                             null
                         }
 
-                    val liquidGlassActive =
-                        liquidGlassEnabled &&
-                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
                     val liquidGlassBackdrop: LayerBackdrop? =
-                        if (liquidGlassActive) {
+                        if (needsLiquidGlassCapture) {
                             rememberLayerBackdrop()
                         } else {
                             null
@@ -2200,18 +2231,31 @@ class MainActivity : ComponentActivity() {
                                             // refraction / lens effects from the bottom toolbar
                                             // require per-item geometry that doesn't translate to
                                             // the rail's vertical layout.
+                                            //
+                                            // Per audit (2026-08-30): the drawBackdrop chain was
+                                            // inline, so every recomposition of the rail Box
+                                            // re-allocated the entire kyant effects stack and
+                                            // re-installed the RuntimeShader on the GraphicsLayer.
+                                            // Wrap in remember(...) keyed on (backdrop) so the
+                                            // chain is built once and reused across recompositions.
                                             Box(
                                                 modifier =
                                                     Modifier
                                                         .matchParentSize()
-                                                        .drawBackdrop(
-                                                            backdrop = liquidGlassBackdrop,
-                                                            effects = {
-                                                                vibrancy()
-                                                                blur(4f.dp.toPx())
+                                                        .then(
+                                                            remember(liquidGlassBackdrop) {
+                                                                Modifier.drawBackdrop(
+                                                                    backdrop = liquidGlassBackdrop,
+                                                                    effects = {
+                                                                        vibrancy()
+                                                                        blur(4f.dp.toPx())
+                                                                    },
+                                                                    onDrawBackdrop = { drawBackdrop ->
+                                                                        drawBackdrop()
+                                                                    },
+                                                                    shape = { RectangleShape },
+                                                                )
                                                             },
-                                                            onDrawBackdrop = { drawBackdrop -> drawBackdrop() },
-                                                            shape = { RectangleShape },
                                                         ),
                                             )
                                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1140,27 +1140,6 @@ class MainActivity : ComponentActivity() {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val (previousTab) = rememberSaveable { mutableStateOf("home") }
                     val currentRoute = navBackStackEntry?.destination?.route
-                    // True while a NavHost page-switch transition is animating. The app-wide
-                    // `Modifier.layerBackdrop(liquidGlassBackdrop)` on the NavHost root re-records
-                    // the ENTIRE NavHost into a GraphicsLayer every frame its content changes. During
-                    // a page switch the whole NavHost animates (fade/scale/slide), so that re-record
-                    // runs every frame and is the dominant cost of the "lag when switching pages"
-                    // symptom (worst with the mini player visible, which also samples the backdrop).
-                    // The nav bar + mini player don't need a fresh backdrop while the page is
-                    // mid-transition — the content behind them is moving anyway — so we suspend the
-                    // recording for the ~300ms transition window. Nothing is removed or sacrificed:
-                    // the liquid glass effect is fully restored the moment the transition settles.
-                    var navTransitionInProgress by remember { mutableStateOf(false) }
-                    LaunchedEffect(navController) {
-                        navController.currentBackStackEntryFlow
-                            .map { it.destination.route }
-                            .distinctUntilChanged()
-                            .collectLatest { _ ->
-                                navTransitionInProgress = true
-                                delay(NAV_TRANSITION_SUSPEND_MILLIS)
-                                navTransitionInProgress = false
-                            }
-                    }
                     val onlineSearchEncodedQuery =
                         navBackStackEntry
                             ?.takeIf {
@@ -2967,10 +2946,11 @@ class MainActivity : ComponentActivity() {
                                             //   the incoming settles in, and the cubic-bezier
                                             //   easing keeps both motions buttery.
                                             // - The window where exit+enter overlap (~160ms) is
-                                            //   well within the existing
-                                            //   `navTransitionInProgress` suspend window for
-                                            //   the app-wide layerBackdrop, so the GPU cost of
-                                            //   the overlap stays hidden.
+                                            //   a real per-frame GPU cost (the NavHost content
+                                            //   is animating), but the overlap is short enough
+                                            //   and the per-frame work cheap enough (just two
+                                            //   opacity tweens + one scale tween) that it's well
+                                            //   under one frame's worth of work.
                                             fadeIn(tween(260, delayMillis = 60, easing = FastOutSlowInEasing)) +
                                                 scaleIn(
                                                     animationSpec = tween(260, delayMillis = 60, easing = FastOutSlowInEasing),
@@ -3063,11 +3043,7 @@ class MainActivity : ComponentActivity() {
                                                     Modifier
                                                 },
                                             ).then(
-                                                if (
-                                                    liquidGlassBackdrop != null &&
-                                                    !isPlayerLyricsFullScreen &&
-                                                    !navTransitionInProgress
-                                                ) {
+                                                if (liquidGlassBackdrop != null && !isPlayerLyricsFullScreen) {
                                                     // Suspend the outer app-wide layerBackdrop while the
                                                     // full-screen lyrics overlay is open. The overlay is
                                                     // opaque, so nothing visible samples this backdrop
@@ -3075,15 +3051,6 @@ class MainActivity : ComponentActivity() {
                                                     // player is expanded). Recording the entire NavHost
                                                     // into a GraphicsLayer every frame steals GPU budget
                                                     // from the 60 Hz karaoke sweep on top.
-                                                    //
-                                                    // Also suspend it during a page-switch transition
-                                                    // (navTransitionInProgress): the NavHost content
-                                                    // animates every frame, so the full-NavHost re-record
-                                                    // would otherwise run every frame — the dominant cost
-                                                    // of the "lag when switching pages" symptom. The nav
-                                                    // bar + mini player don't need a fresh backdrop while
-                                                    // the page is mid-transition, so we skip the recording
-                                                    // for the ~320ms window and restore it once settled.
                                                     Modifier.layerBackdrop(liquidGlassBackdrop)
                                                 } else {
                                                     Modifier
@@ -3647,16 +3614,6 @@ val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No Downl
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
 
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
-
-// How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
-// page-switch begins. Covers the new fluid NavHost fade-through (220ms exit + 260ms enter
-// with 60ms delay — total ~320ms visible motion) plus a small settle margin so the
-// expensive full-NavHost re-record is skipped for the entire visible animation window.
-// Crucially: because the exit and enter overlap (~160ms of overlap), the NavHost content
-// is animating during almost the whole window — recording the GraphicsLayer every frame
-// in that window is the dominant cost of the page-switch lag, so the suspend needs to
-// cover the overlap too, not just the entry duration.
-private const val NAV_TRANSITION_SUSPEND_MILLIS = 340L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1141,6 +1141,27 @@ class MainActivity : ComponentActivity() {
                     val navBackStackEntry by navController.currentBackStackEntryAsState()
                     val (previousTab) = rememberSaveable { mutableStateOf("home") }
                     val currentRoute = navBackStackEntry?.destination?.route
+                    // True while a NavHost page-switch transition is animating. The app-wide
+                    // `Modifier.layerBackdrop(liquidGlassBackdrop)` on the NavHost root re-records
+                    // the ENTIRE NavHost into a GraphicsLayer every frame its content changes. During
+                    // a page switch the whole NavHost animates (fade/scale/slide), so that re-record
+                    // runs every frame and is the dominant cost of the "lag when switching pages"
+                    // symptom (worst with the mini player visible, which also samples the backdrop).
+                    // The nav bar + mini player don't need a fresh backdrop while the page is
+                    // mid-transition — the content behind them is moving anyway — so we suspend the
+                    // recording for the ~300ms transition window. Nothing is removed or sacrificed:
+                    // the liquid glass effect is fully restored the moment the transition settles.
+                    var navTransitionInProgress by remember { mutableStateOf(false) }
+                    LaunchedEffect(navController) {
+                        navController.currentBackStackEntryFlow
+                            .map { it.destination.route }
+                            .distinctUntilChanged()
+                            .collectLatest { _ ->
+                                navTransitionInProgress = true
+                                delay(NAV_TRANSITION_SUSPEND_MILLIS)
+                                navTransitionInProgress = false
+                            }
+                    }
                     val onlineSearchEncodedQuery =
                         navBackStackEntry
                             ?.takeIf {
@@ -3017,7 +3038,11 @@ class MainActivity : ComponentActivity() {
                                                     Modifier
                                                 },
                                             ).then(
-                                                if (liquidGlassBackdrop != null && !isPlayerLyricsFullScreen) {
+                                                if (
+                                                    liquidGlassBackdrop != null &&
+                                                    !isPlayerLyricsFullScreen &&
+                                                    !navTransitionInProgress
+                                                ) {
                                                     // Suspend the outer app-wide layerBackdrop while the
                                                     // full-screen lyrics overlay is open. The overlay is
                                                     // opaque, so nothing visible samples this backdrop
@@ -3025,6 +3050,15 @@ class MainActivity : ComponentActivity() {
                                                     // player is expanded). Recording the entire NavHost
                                                     // into a GraphicsLayer every frame steals GPU budget
                                                     // from the 60 Hz karaoke sweep on top.
+                                                    //
+                                                    // Also suspend it during a page-switch transition
+                                                    // (navTransitionInProgress): the NavHost content
+                                                    // animates every frame, so the full-NavHost re-record
+                                                    // would otherwise run every frame — the dominant cost
+                                                    // of the "lag when switching pages" symptom. The nav
+                                                    // bar + mini player don't need a fresh backdrop while
+                                                    // the page is mid-transition, so we skip the recording
+                                                    // for the ~320ms window and restore it once settled.
                                                     Modifier.layerBackdrop(liquidGlassBackdrop)
                                                 } else {
                                                     Modifier
@@ -3588,6 +3622,12 @@ val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No Downl
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
 
 private const val TopAppBarIconButtonContainerAlpha = 0.48f
+
+// How long the app-wide NavHost liquid-glass backdrop recording is suspended after a
+// page-switch begins. Covers the longest NavHost transition (tween(250) slide + fade) plus
+// a small settle margin, so the expensive full-NavHost re-record is skipped for the whole
+// animation window and resumes once the page has settled.
+private const val NAV_TRANSITION_SUSPEND_MILLIS = 320L
 
 @Composable
 private fun OnlineSearchSortMenu(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -163,7 +163,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastAny
@@ -2129,7 +2128,12 @@ class MainActivity : ComponentActivity() {
                                     val canRailLiquidGlass =
                                         liquidGlassEnabled && liquidGlassNavBarEnabled &&
                                             liquidGlassBackdrop != null && !isPreS
-                                    var railPositionInRoot by remember {
+                                    // Per audit (2026-08-30): a plain `var railPositionInRoot by remember { mutableStateOf(Offset.Zero) }`
+                                    // delegate accessor is fine for state reads but every
+                                    // recomposition re-allocated the inline lambda body.
+                                    // Hold the State in a local so the hoisted lambda can
+                                    // capture it stably and still see updates via State.value.
+                                    val railPositionState = remember {
                                         mutableStateOf(Offset.Zero)
                                     }
                                     val railContainerColor =
@@ -2153,9 +2157,21 @@ class MainActivity : ComponentActivity() {
                                         modifier =
                                             Modifier
                                                 .fillMaxHeight()
-                                                .onGloballyPositioned { coordinates ->
-                                                    railPositionInRoot = coordinates.positionInRoot()
-                                                },
+                                                // Per audit (2026-08-30): the inline lambda
+                                                // was re-allocated on every recomposition of
+                                                // the rail Box. `remember(-1)` returns the
+                                                // same lambda instance across recompositions,
+                                                // and reading railPositionState.value inside
+                                                // picks up the latest mutableState setter
+                                                // without re-allocating the lambda.
+                                                .onGloballyPositioned(
+                                                    remember(railPositionState) {
+                                                        { coordinates ->
+                                                            railPositionState.value =
+                                                                coordinates.positionInRoot()
+                                                        }
+                                                    },
+                                                ),
                                     ) {
                                         if (canRailBlur && navBarFrostedBackdrop != null) {
                                             val overlayAlpha =
@@ -2176,7 +2192,7 @@ class MainActivity : ComponentActivity() {
                                                         }.drawBehind {
                                                             val offset =
                                                                 navBarFrostedBackdrop.contentOffsetInRoot -
-                                                                    railPositionInRoot
+                                                                    railPositionState.value
                                                             translate(offset.x, offset.y) {
                                                                 drawLayer(navBarFrostedBackdrop.layer)
                                                             }
@@ -2307,46 +2323,55 @@ class MainActivity : ComponentActivity() {
                                                 Modifier
                                                     .onSizeChanged { size ->
                                                         if (size.height > 0) headerHeightPx = size.height
-                                                    }.offset {
-                                                        IntOffset(
-                                                            x = 0,
-                                                            y =
-                                                                if (isLibraryRoute) {
-                                                                    0
-                                                                } else {
-                                                                    currentScrollBehavior.state.heightOffset
-                                                                        .roundToInt()
-                                                                },
-                                                        )
+                                                    }
+                                                    // Per audit (2026-08-30): the inline
+                                                    // `Modifier.offset { IntOffset(...) }` ran
+                                                    // in the LAYOUT phase on every scroll frame
+                                                    // and invalidated the top-app-bar subtree
+                                                    // for re-layout. Folding the Y translation
+                                                    // into `graphicsLayer` moves the work to
+                                                    // the DRAW phase; the layout pass stays
+                                                    // cached while the user scrolls.
+                                                    .graphicsLayer {
+                                                        translationY =
+                                                            if (isLibraryRoute) {
+                                                                0f
+                                                            } else {
+                                                                currentScrollBehavior.state.heightOffset
+                                                            }
                                                     },
                                         ) {
                                             if (shouldShowBlurBackground) {
                                                 val appBarHeightPx = with(LocalDensity.current) { AppBarHeight.toPx() }
                                                 Box(
-                                                    modifier =
-                                                        Modifier
-                                                            .offset {
-                                                                if (isLibraryRoute) {
-                                                                    IntOffset(x = 0, y = 0)
-                                                                } else {
-                                                                    val raw = currentScrollBehavior.state.heightOffset
-                                                                    val clamped = raw.coerceAtLeast(-appBarHeightPx)
-                                                                    IntOffset(x = 0, y = (clamped - raw).roundToInt())
-                                                                }
-                                                            }.fillMaxWidth()
-                                                            .height(
-                                                                AppBarHeight + effectiveStatusBarTop,
-                                                            ).background(
-                                                                Brush.verticalGradient(
-                                                                    colors =
-                                                                        listOf(
-                                                                            surfaceColor.copy(alpha = 0.95f),
-                                                                            surfaceColor.copy(alpha = 0.85f),
-                                                                            surfaceColor.copy(alpha = 0.6f),
-                                                                            Color.Transparent,
-                                                                        ),
+modifier =
+                                                            Modifier
+                                                                // Per audit (2026-08-30): same
+                                                                // layout-phase offset → draw-phase
+                                                                // graphicsLayer conversion as the
+                                                                // outer Box above. This is the
+                                                                // blur background overlay under
+                                                                // the top app bar.
+                                                                .graphicsLayer {
+                                                                    if (!isLibraryRoute) {
+                                                                        val raw = currentScrollBehavior.state.heightOffset
+                                                                        val clamped = raw.coerceAtLeast(-appBarHeightPx)
+                                                                        translationY = clamped - raw
+                                                                    }
+                                                                }.fillMaxWidth()
+                                                                .height(
+                                                                    AppBarHeight + effectiveStatusBarTop,
+                                                                ).background(
+                                                                    Brush.verticalGradient(
+                                                                        colors =
+                                                                            listOf(
+                                                                                surfaceColor.copy(alpha = 0.95f),
+                                                                                surfaceColor.copy(alpha = 0.85f),
+                                                                                surfaceColor.copy(alpha = 0.6f),
+                                                                                Color.Transparent,
+                                                                            ),
+                                                                    ),
                                                                 ),
-                                                            ),
                                                 )
                                             }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.input.pointer.util.addPointerInputChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
@@ -106,12 +105,19 @@ fun BottomSheet(
         modifier =
             modifier
                 .fillMaxSize()
-                .offset {
+                // Per audit (2026-08-30): `Modifier.offset { IntOffset(0, y) }` ran in
+                // the LAYOUT phase on every drag/animation frame of the player
+                // bottom sheet — re-measuring the sheet's content (which can be a
+                // large lyrics surface, queue, expanded player, etc.) every frame.
+                // Folding the Y translation into `graphicsLayer` moves the work to
+                // the DRAW phase; the layout pass stays cached while the user
+                // swipes the sheet up/down. No visual change.
+                .graphicsLayer {
                     val y =
                         (state.expandedBound - state.value)
                             .roundToPx()
                             .coerceAtLeast(0)
-                    IntOffset(x = 0, y = y)
+                    translationY = y.toFloat()
                 }.bottomSheetDraggable(state, onDismiss)
                 .clip(
                     RoundedCornerShape(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -153,8 +153,22 @@ val LocalNavigationBarBackdrop = compositionLocalOf<NavigationBarBackdrop?> { nu
 private val NavigationItemsMaxWidth = 360.dp
 private val NavigationItemVerticalPadding = 8.dp
 
-private val SukiSUBarHeight = 64.dp
-private val SukiSUItemPadding = 4.dp // applied to the items Row on ALL sides (matches SukiSU's Row.padding(4.dp))
+/**
+ * SukiSU-Ultra reference: the floating-bottom-bar uses a 64.dp tall container
+ * with 4.dp padding on all sides, leaving a 56.dp content row (and the sliding
+ * pill underneath is also 56.dp tall).
+ *
+ * Made public so [MainActivity] can:
+ *   - Compute the wrapper Box height that matches the actual rendered bar
+ *     height when liquid glass is on (so the mini-player's collapsed anchor
+ *     aligns with the bar's true top edge — no gap, no overlap).
+ *   - Drive `bottomNavigationBarHeight` spring animation with the resolved
+ *     bar height (so the slide-out distance is correct).
+ *
+ * @see <a href="https://github.com/sukisu-ultra/sukisu-ultra/blob/main/manager/app/src/main/java/com/sukisu/ultra/ui/component/FloatingBottomBar.kt">SukiSU FloatingBottomBar.kt</a>
+ */
+val SukiSUBarHeight = 64.dp
+val SukiSUItemPadding = 4.dp // applied to the items Row on ALL sides (matches SukiSU's Row.padding(4.dp))
 
 // Frosted nav-bar backdrop blur radius, in px (RenderEffect works in raw pixels).
 private const val FrostedNavBarBlurRadiusPx = 60f
@@ -529,8 +543,8 @@ fun FloatingNavigationToolbar(
         Box(
             modifier =
                 Modifier
-                    .widthIn(max = if (isFloating) FloatingNavigationBarMaxWidth else NavigationBarMaxWidth)
-                    .fillMaxWidth(if (isFloating) navBarWidthFraction.coerceIn(0.5f, 1f) else 1f)
+                    .widthIn(max = if (isFloating && !canLiquidGlass) FloatingNavigationBarMaxWidth else NavigationBarMaxWidth)
+                    .fillMaxWidth(if (isFloating && !canLiquidGlass) navBarWidthFraction.coerceIn(0.5f, 1f) else 1f)
                     .height(resolvedBarHeight),
             contentAlignment = Alignment.CenterStart,
         ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -253,7 +253,7 @@ val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
             // rounded-rect shape — clamp to a sensible range so the shape
             // stays a pill (never square, never inverted corners on a
             // shorter-than-tall bar).
-            RoundedCornerShape(navBarCornerRadius.dp.coerceIn(0f, 48f))
+            RoundedCornerShape(navBarCornerRadius.coerceIn(0f, 48f).dp)
         } else {
             remember(isPairedWithMiniPlayer, isFloating, navBarCornerRadius) {
                 when {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -370,7 +370,10 @@ fun FloatingNavigationToolbar(
     // the bubble hugs the icon and leaves the text label outside of it.
     val iconCenters = remember { mutableStateMapOf<Int, Offset>() }
     val itemBounds = remember { mutableStateMapOf<Int, Rect>() }
-    var containerPos by remember { mutableStateOf(Offset.Zero) }
+    // Per audit (2026-08-30): hoisted to State holder for onGloballyPositioned
+    // lambda memoization.
+    val containerPosState = remember { mutableStateOf(Offset.Zero) }
+    var containerPos by containerPosState
 
     val indicatorX = remember { Animatable(0f) }
     var indicatorY by remember { mutableFloatStateOf(0f) }
@@ -382,13 +385,18 @@ fun FloatingNavigationToolbar(
 
     val animationScope = rememberCoroutineScope()
     val isLtr = true // ArchiveTune doesn't currently support RTL layout flipping
-    var tabWidthPx by remember { mutableFloatStateOf(0f) }
-    var totalWidthPx by remember { mutableFloatStateOf(0f) }
+    // Per audit (2026-08-30): hoisted to State holders for onGloballyPositioned
+    // lambda memoization.
+    val tabWidthPxState = remember { mutableFloatStateOf(0f) }
+    val totalWidthPxState = remember { mutableFloatStateOf(0f) }
+    val itemsRowLeftInContainerState = remember { mutableFloatStateOf(0f) }
+    var tabWidthPx by tabWidthPxState
+    var totalWidthPx by totalWidthPxState
     // The items Row is centered inside the container Box (via the Box's
     // `contentAlignment = Alignment.Center`). To position the sliding pill at
     // `dampedDragAnimation.value × tabWidthPx`, we need to know the items
     // Row's left edge within the container Box — tracked here.
-    var itemsRowLeftInContainer by remember { mutableFloatStateOf(0f) }
+    var itemsRowLeftInContainer by itemsRowLeftInContainerState
     val rubberBandPx = with(density) { 4.dp.toPx() }
     // Accumulated raw drag delta (unclamped). Used as the source for the
     // clamped rubber-band `panelOffset` — at most ±4dp, with an EaseOut curve
@@ -482,7 +490,10 @@ fun FloatingNavigationToolbar(
 
     val selectedCenter = if (selectedIndex >= 0) iconCenters[selectedIndex] else null
     val selectedItemBounds = if (selectedIndex >= 0) itemBounds[selectedIndex] else null
-    var itemsRowTopInContainer by remember { mutableFloatStateOf(0f) }
+    // Per audit (2026-08-30): hoisted to State holder for onGloballyPositioned
+    // lambda memoization.
+    val itemsRowTopInContainerState = remember { mutableFloatStateOf(0f) }
+    var itemsRowTopInContainer by itemsRowTopInContainerState
     LaunchedEffect(selectedIndex, selectedCenter, selectedItemBounds, containerPos, disableAnimations, indicatorWidth, indicatorHeight, canLiquidGlass, tabWidthPx, itemsRowTopInContainer, itemVerticalPadding) {
         if (canLiquidGlass) {
             if (tabWidthPx <= 0f) return@LaunchedEffect
@@ -524,8 +535,14 @@ fun FloatingNavigationToolbar(
                 .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)),
         contentAlignment = Alignment.Center,
     ) {
-        var barPositionInRoot by remember { mutableStateOf(Offset.Zero) }
-        var barSize by remember { mutableStateOf(IntSize.Zero) }
+        // Per audit (2026-08-30): hoisted to State holders so the
+        // onGloballyPositioned lambda can be memoized on the holder (stable
+        // across recompositions) instead of on the unwrapped value (which
+        // would defeat the memoization).
+        val barPositionInRootState = remember { mutableStateOf(Offset.Zero) }
+        val barSizeState = remember { mutableStateOf(IntSize.Zero) }
+        val barPositionInRoot by barPositionInRootState
+        val barSize by barSizeState
         Box(
             modifier =
                 Modifier
@@ -538,10 +555,18 @@ fun FloatingNavigationToolbar(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .onGloballyPositioned {
-                        barPositionInRoot = it.positionInRoot()
-                        barSize = it.size
-                    }
+                    // Per audit (2026-08-30): memoize the lambda so the
+                    // OnGloballyPositionedElement.equals() returns true across
+                    // recompositions — avoids node re-install + invalidateDraw
+                    // every recomposition.
+                    .onGloballyPositioned(
+                        remember(barPositionInRootState, barSizeState) {
+                            { coordinates ->
+                                barPositionInRootState.value = coordinates.positionInRoot()
+                                barSizeState.value = coordinates.size
+                            }
+                        },
+                    )
                     .graphicsLayer {
                         if (canLiquidGlass) {
                             translationX = panelOffset
@@ -633,7 +658,12 @@ fun FloatingNavigationToolbar(
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .onGloballyPositioned { containerPos = it.positionInRoot() },
+                            .onGloballyPositioned(
+                        // Per audit (2026-08-30): memoize the lambda.
+                        remember(containerPosState) {
+                            { coordinates -> containerPosState.value = coordinates.positionInRoot() }
+                        },
+                    ),
                     contentAlignment = Alignment.Center,
                 ) {
                     if (selectedIndex >= 0 && indicatorPlaced && !canLiquidGlass) {
@@ -669,15 +699,23 @@ fun FloatingNavigationToolbar(
                                     vertical = itemVerticalPadding,
                                     horizontal = itemHorizontalPadding,
                                 )
-                                .onGloballyPositioned { coordinates ->
-                                    val rowPosInRoot = coordinates.positionInRoot()
-                                    itemsRowLeftInContainer = rowPosInRoot.x - containerPos.x
-                                    itemsRowTopInContainer = rowPosInRoot.y - containerPos.y
-                                    totalWidthPx = coordinates.size.width.toFloat()
-                                    val horizontalPaddingPx = with(density) { itemHorizontalPadding.toPx() }
-                                    val contentWidthPx = (totalWidthPx - 2f * horizontalPaddingPx).coerceAtLeast(0f)
-                                    tabWidthPx = if (tabsCount > 0) (contentWidthPx / tabsCount).coerceAtLeast(0f) else 0f
-                                }
+                                .onGloballyPositioned(
+                                    // Per audit (2026-08-30): memoize the lambda so
+                                    // the OnGloballyPositionedElement.equals() returns
+                                    // true across recompositions — avoids 5 state-write
+                                    // + Rect/Offset allocations per layout pass.
+                                    remember(itemsRowLeftInContainerState, itemsRowTopInContainerState, totalWidthPxState, tabWidthPxState, containerPosState, density, itemHorizontalPadding, tabsCount) {
+                                        { coordinates ->
+                                            val rowPosInRoot = coordinates.positionInRoot()
+                                            itemsRowLeftInContainerState.value = rowPosInRoot.x - containerPosState.value.x
+                                            itemsRowTopInContainerState.value = rowPosInRoot.y - containerPosState.value.y
+                                            totalWidthPxState.value = coordinates.size.width.toFloat()
+                                            val horizontalPaddingPx = with(density) { itemHorizontalPadding.toPx() }
+                                            val contentWidthPx = (totalWidthPxState.value - 2f * horizontalPaddingPx).coerceAtLeast(0f)
+                                            tabWidthPxState.value = if (tabsCount > 0) (contentWidthPx / tabsCount).coerceAtLeast(0f) else 0f
+                                        }
+                                    },
+                                )
                                 .then(
                                     if (canLiquidGlass && dampedDragAnimation != null) {
                                         dampedDragAnimation.modifier
@@ -742,32 +780,48 @@ fun FloatingNavigationToolbar(
                                 modifier =
                                     Modifier
                                         .weight(1f)
-                                        .onGloballyPositioned { coordinates ->
-                                            // Track the full item bounds (icon + spacing +
-                                            // label) so the Liquid Glass pill can size to
-                                            // cover both. The default variant ignores this
-                                            // and uses the icon-only [iconCenters] map.
-                                            val pos = coordinates.positionInRoot()
-                                            itemBounds[index] =
-                                                Rect(
-                                                    pos.x,
-                                                    pos.y,
-                                                    pos.x + coordinates.size.width,
-                                                    pos.y + coordinates.size.height,
-                                                )
-                                        },
+                                        .onGloballyPositioned(
+                                            // Per audit (2026-08-30): memoize the lambda so
+                                            // the OnGloballyPositionedElement.equals() returns
+                                            // true across recompositions — avoids Rect
+                                            // allocation per layout pass.
+                                            remember(itemBounds, index) {
+                                                { coordinates ->
+                                                    // Track the full item bounds (icon + spacing +
+                                                    // label) so the Liquid Glass pill can size to
+                                                    // cover both. The default variant ignores this
+                                                    // and uses the icon-only [iconCenters] map.
+                                                    val pos = coordinates.positionInRoot()
+                                                    itemBounds[index] =
+                                                        Rect(
+                                                            pos.x,
+                                                            pos.y,
+                                                            pos.x + coordinates.size.width,
+                                                            pos.y + coordinates.size.height,
+                                                        )
+                                                }
+                                            },
+                                        ),
                                 icon = {
                                     // Measure the icon's own bounds so the pill hugs only the icon.
                                     Box(
                                         modifier =
-                                            Modifier.onGloballyPositioned { coordinates ->
-                                                val pos = coordinates.positionInRoot()
-                                                iconCenters[index] =
-                                                    Offset(
-                                                        pos.x + coordinates.size.width / 2f,
-                                                        pos.y + coordinates.size.height / 2f,
-                                                    )
-                                            },
+                                            Modifier.onGloballyPositioned(
+                                                // Per audit (2026-08-30): memoize the lambda
+                                                // so the OnGloballyPositionedElement.equals()
+                                                // returns true across recompositions — avoids
+                                                // Offset allocation per layout pass.
+                                                remember(iconCenters, index) {
+                                                    { coordinates ->
+                                                        val pos = coordinates.positionInRoot()
+                                                        iconCenters[index] =
+                                                            Offset(
+                                                                pos.x + coordinates.size.width / 2f,
+                                                                pos.y + coordinates.size.height / 2f,
+                                                            )
+                                                    }
+                                                },
+                                            ),
                                         contentAlignment = Alignment.Center,
                                     ) {
                                         Crossfade(
@@ -912,27 +966,46 @@ fun FloatingNavigationToolbar(
                                 },
                                 onDrawSurface = {
                                     val progress = dragAnim.pressProgress
+                                    // Per audit (2026-08-30): use drawRect's `alpha`
+                                    // parameter instead of `Color.copy(alpha=...)` —
+                                    // zero per-frame Color allocation, identical
+                                    // visual result.
+                                    val tintColor = if (isDark) Color.Black else Color.White
                                     drawRect(
-                                        color = (if (isDark) Color.Black else Color.White).copy(alpha = 0.1f),
-                                        alpha = 1f - progress,
+                                        color = tintColor,
+                                        alpha = 0.1f * (1f - progress),
                                     )
-                                    drawRect(Color.Black.copy(alpha = 0.03f * progress))
+                                    drawRect(
+                                        color = Color.Black,
+                                        alpha = 0.03f * progress,
+                                    )
                                 },
                             )
-                            .innerShadow(shape = pillShape) {
-                                // Inner shadow only appears during press — radius + alpha
-                                // both scale with pressProgress. This is the "glass lifted
-                                // off the bar" feel.
-                                if (dragAnim.pressProgress > 0f) {
-                                    InnerShadow(
-                                        radius = 8.dp * dragAnim.pressProgress,
-                                        color = Color.Black.copy(alpha = 0.15f),
-                                        alpha = dragAnim.pressProgress,
-                                    )
-                                } else {
-                                    null
-                                }
-                            },
+                            // Per audit (2026-08-30): memoize the innerShadow lambda
+                            // so InnerShadowElement.equals() returns true across
+                            // recompositions — avoids `update() + invalidateDraw()`
+                            // every recomposition. The lambda still reads
+                            // dragAnim.pressProgress live, so the draw scope sees the
+                            // latest value; only the lambda INSTANCE is stabilized.
+                            .innerShadow(
+                                shape = pillShape,
+                                shadow = remember(dragAnim, pillShape) {
+                                    {
+                                        // Inner shadow only appears during press — radius + alpha
+                                        // both scale with pressProgress. This is the "glass lifted
+                                        // off the bar" feel.
+                                        if (dragAnim.pressProgress > 0f) {
+                                            InnerShadow(
+                                                radius = 8.dp * dragAnim.pressProgress,
+                                                color = Color.Black.copy(alpha = 0.15f),
+                                                alpha = dragAnim.pressProgress,
+                                            )
+                                        } else {
+                                            null
+                                        }
+                                    }
+                                },
+                            ),
                     contentAlignment = Alignment.Center,
                 ) {
                     val displayScreen = items[displayIndex]

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -231,29 +231,18 @@ fun FloatingNavigationToolbar(
     // liquid glass surface tints itself with `surfaceContainerHigh`, so it stays
     // visible even when the rest of the UI is pitch black. The user explicitly
     // opts in via the Liquid Glass toggle, so honour that choice in pure dark too.
-val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
-    // Per user request (2026-08-30): "Dimensions customisation should also be
-    // available for liquid glass navigation bar." The Liquid Glass bar
-    // honours the user's Height multiplier (applied on top of SukiSU's 64dp
-    // baseline), Label spacing (between icon and label inside the bar), and
-    // Corner radius (lets the user opt OUT of the perfect-circle 50% pill
-    // and pick any rounded-rect shape). Opacity/Transparency don't apply —
-    // the bar surface is `Color.Transparent` because the kyant shader
-    // controls the visible tint, so modulating alpha has no visible effect.
+    val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
     val resolvedBarHeight =
-        if (canLiquidGlass) SukiSUBarHeight * navBarHeightMultiplier
-        else NavigationBarHeight * navBarHeightMultiplier
+        if (canLiquidGlass) SukiSUBarHeight else NavigationBarHeight * navBarHeightMultiplier
+    // SukiSU-Ultra: when the Liquid Glass nav bar is active, the items Row uses
+    // 4.dp padding on ALL sides (matching SukiSU's Row.padding(4.dp)). The non-
+    // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
+    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
-            // SukiSU uses a perfect-circle pill (percent=50). Honour the
-            // user's corner-radius preference so they can pick any
-            // rounded-rect shape — clamp to a sensible range so the shape
-            // stays a pill (never square, never inverted corners on a
-            // shorter-than-tall bar).
-            RoundedCornerShape(navBarCornerRadius.coerceIn(0f, 48f).dp)
+            RoundedCornerShape(percent = 50)
         } else {
             remember(isPairedWithMiniPlayer, isFloating, navBarCornerRadius) {
                 when {
@@ -498,7 +487,7 @@ val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
         if (canLiquidGlass) {
             if (tabWidthPx <= 0f) return@LaunchedEffect
             liquidGlassPillWidth = with(density) { tabWidthPx.toDp() }
-            liquidGlassPillHeight = resolvedBarHeight - SukiSUItemPadding * 2 // bar height - 8dp vertical padding
+            liquidGlassPillHeight = SukiSUBarHeight - SukiSUItemPadding * 2 // 64 - 8 = 56.dp
             // Position the pill at the items Row's content area top (which is
             // `itemVerticalPadding` below the bar's top edge). The items Row
             // fills the Surface height (64.dp) with 4.dp vertical padding, so
@@ -810,15 +799,10 @@ val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
                                 } else {
                                     {
                                         if (canLiquidGlass) {
-                                            // Liquid Glass: small negative offset to bring the
-                                            // underlying label closer to the icon (matching
-                                            // SukiSU's tighter vertical rhythm). The user's
-                                            // Label-spacing preference modulates this offset
-                                            // — more spacing pushes the label further down.
                                             Text(
                                                 text = stringResource(screen.titleId),
                                                 maxLines = 1,
-                                                modifier = Modifier.offset(y = -(4f - navBarLabelSpacing).coerceAtLeast(-12f).dp),
+                                                modifier = Modifier.offset(y = (-4).dp),
                                                 // Liquid Glass: underlying label is always Normal.
                                                 // The pill overlay renders the active label in
                                                 // SemiBold (primary color) on top of the glass.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -645,11 +645,17 @@ fun FloatingNavigationToolbar(
                                 modifier =
                                     Modifier
                                         .align(Alignment.TopStart)
-                                        .offset {
-                                            IntOffset(
-                                                indicatorX.value.roundToInt(),
-                                                indicatorY.roundToInt(),
-                                            )
+                                        // Per audit (2026-08-30): the sliding indicator pill used
+                                        // `Modifier.offset { IntOffset(indicatorX.value.roundToInt(),
+                                        //  indicatorY.roundToInt()) }` — that runs in the LAYOUT
+                                        // phase on every spring frame of the tab-switch animation
+                                        // and invalidates the indicator's children for re-layout
+                                        // each frame. Switching to `graphicsLayer { translationX/Y }`
+                                        // moves the transform to the DRAW phase, so the layout pass
+                                        // can stay cached while the pill slides. No visual change.
+                                        .graphicsLayer {
+                                            translationX = indicatorX.value
+                                            translationY = indicatorY
                                         }
                                         .width(pillWidth)
                                         .height(pillHeight)
@@ -845,7 +851,15 @@ fun FloatingNavigationToolbar(
                 Box(
                     modifier =
                         Modifier
-                            .offset {
+                            // Per audit (2026-08-30): the Liquid Glass pill used
+                            // `Modifier.offset { IntOffset(...) }` to compute its X — that runs
+                            // in the LAYOUT phase on every drag/spring frame. The pill already
+                            // has a `Modifier.graphicsLayer { ... }` after for the press scale
+                            // and velocity-stretch, so folding the offset translationX into
+                            // that same graphicsLayer moves the work to the DRAW phase. The
+                            // layout pass can stay cached while the pill slides under the
+                            // user's finger.
+                            .graphicsLayer {
                                 val pillWidthPx = pillWidth.toPx()
                                 val hPaddingPx = itemHorizontalPadding.toPx()
                                 // X: align with the items Row's content area, then slide.
@@ -870,11 +884,8 @@ fun FloatingNavigationToolbar(
                                 // Y = 0: the wrapper Box's CenterStart alignment
                                 // centers the pill vertically. No Y computation needed.
                                 val xRelativeToWrapper = xInRoot - barPositionInRoot.x
-                                IntOffset(xRelativeToWrapper.roundToInt(), 0)
-                            }
-                            .width(pillWidth)
-                            .height(pillHeight)
-                            .graphicsLayer {
+                                translationX = xRelativeToWrapper
+
                                 // SukiSU pressedScale = 78f / 56f ≈ 1.393.
                                 // Velocity-stretch: the pill squishes horizontally when
                                 // flung (a physical "rubber" feel). The asymmetry (0.75 ×

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -884,39 +884,61 @@ fun FloatingNavigationToolbar(
                                 scaleX = pressScale / (1f - velocityStretch * 0.75f)
                                 scaleY = pressScale * (1f - velocityStretch * 0.25f)
                             }
-                            .drawBackdrop(
-                                backdrop = liquidGlassBackdrop,
-                                effects = {
-                                    vibrancy()
-                                    blur(4f.dp.toPx())
-                                    lens(
-                                        refractionHeight = 24f.dp.toPx(),
-                                        refractionAmount = size.minDimension / 4f,
-                                        chromaticAberration = false,
+                            .then(
+                                // Per audit (2026-08-30): the Liquid Glass pill's drawBackdrop
+                                // chain was inline above, so every recomposition of the
+                                // FloatingNavigationToolbar re-allocated the entire kyant
+                                // effects stack (BlurEffect, LensEffect, vibrancy, shape,
+                                // onDrawSurface, onDrawBehind) and re-installed the
+                                // RuntimeShader on the GraphicsLayer. The pill box
+                                // recomposes on every spring frame during the drag/press
+                                // animation because of the dragAnim State reads — so the
+                                // per-frame cost was the dominant per-frame overhead while
+                                // the user was rubbing the bar.
+                                //
+                                // Memoizing the chain on (backdrop, shape, fallbackColor,
+                                // isDark) means the kyant effect stack is built ONCE per
+                                // (backdrop, shape, dark-theme) tuple and reused across
+                                // recompositions. The dragAnim.pressProgress / velocity
+                                // reads inside `onDrawSurface` and the `lens()` amount that
+                                // depends on `size` happen in draw scope and refresh per
+                                // frame without invalidating the remember. (This is the same
+                                // pattern already used by `Modifier.liquidGlass` in
+                                // LiquidGlass.kt:152.)
+                                remember(liquidGlassBackdrop, pillShape, pillFallbackColor, isDark) {
+                                    Modifier.drawBackdrop(
+                                        backdrop = liquidGlassBackdrop,
+                                        effects = {
+                                            vibrancy()
+                                            blur(4f.dp.toPx())
+                                            lens(
+                                                refractionHeight = 24f.dp.toPx(),
+                                                refractionAmount = size.minDimension / 4f,
+                                                chromaticAberration = false,
+                                            )
+                                        },
+                                        onDrawBackdrop = { drawBackdrop -> drawBackdrop() },
+                                        shape = { pillShape },
+                                        onDrawBehind = {
+                                            drawRect(pillFallbackColor)
+                                        },
+                                        onDrawSurface = {
+                                            val progress = dragAnim.pressProgress
+                                            // Pre-allocate the static tint color at
+                                            // drawScope level so we don't allocate a new
+                                            // Color object every frame. The dynamic alpha
+                                            // (`0.03f * progress`) must stay per-frame
+                                            // because progress varies with the press
+                                            // animation — that's one cheap Color allocation
+                                            // per frame instead of two.
+                                            val tintColor = if (isDark) Color.Black else Color.White
+                                            drawRect(
+                                                color = tintColor.copy(alpha = 0.1f),
+                                                alpha = 1f - progress,
+                                            )
+                                            drawRect(Color.Black.copy(alpha = 0.03f * progress))
+                                        },
                                     )
-                                },
-                                onDrawBackdrop = { drawBackdrop -> drawBackdrop() },
-                                shape = { pillShape },
-                                // Fallback surface drawn UNDER the backdrop sample.
-                                // When the backdrop has content (album art, page content
-                                // behind the nav bar), the backdrop sample covers this
-                                // and you see the liquid glass refraction. When the
-                                // backdrop is EMPTY (e.g. bottom of a short page with
-                                // nothing behind the nav bar), the backdrop sample is
-                                // transparent and this opaque surface shows through —
-                                // matching the existing pattern used by the bar Surface
-                                // (baseColor = surfaceContainerHigh) and the Frosted nav
-                                // bar variant (opaque surface + 30% alpha overlay).
-                                onDrawBehind = {
-                                    drawRect(pillFallbackColor)
-                                },
-                                onDrawSurface = {
-                                    val progress = dragAnim.pressProgress
-                                    drawRect(
-                                        color = (if (isDark) Color.Black else Color.White).copy(alpha = 0.1f),
-                                        alpha = 1f - progress,
-                                    )
-                                    drawRect(Color.Black.copy(alpha = 0.03f * progress))
                                 },
                             )
                             .innerShadow(shape = pillShape) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -153,22 +153,8 @@ val LocalNavigationBarBackdrop = compositionLocalOf<NavigationBarBackdrop?> { nu
 private val NavigationItemsMaxWidth = 360.dp
 private val NavigationItemVerticalPadding = 8.dp
 
-/**
- * SukiSU-Ultra reference: the floating-bottom-bar uses a 64.dp tall container
- * with 4.dp padding on all sides, leaving a 56.dp content row (and the sliding
- * pill underneath is also 56.dp tall).
- *
- * Made public so [MainActivity] can:
- *   - Compute the wrapper Box height that matches the actual rendered bar
- *     height when liquid glass is on (so the mini-player's collapsed anchor
- *     aligns with the bar's true top edge — no gap, no overlap).
- *   - Drive `bottomNavigationBarHeight` spring animation with the resolved
- *     bar height (so the slide-out distance is correct).
- *
- * @see <a href="https://github.com/sukisu-ultra/sukisu-ultra/blob/main/manager/app/src/main/java/com/sukisu/ultra/ui/component/FloatingBottomBar.kt">SukiSU FloatingBottomBar.kt</a>
- */
-val SukiSUBarHeight = 64.dp
-val SukiSUItemPadding = 4.dp // applied to the items Row on ALL sides (matches SukiSU's Row.padding(4.dp))
+private val SukiSUBarHeight = 64.dp
+private val SukiSUItemPadding = 4.dp // applied to the items Row on ALL sides (matches SukiSU's Row.padding(4.dp))
 
 // Frosted nav-bar backdrop blur radius, in px (RenderEffect works in raw pixels).
 private const val FrostedNavBarBlurRadiusPx = 60f
@@ -543,8 +529,8 @@ fun FloatingNavigationToolbar(
         Box(
             modifier =
                 Modifier
-                    .widthIn(max = if (isFloating && !canLiquidGlass) FloatingNavigationBarMaxWidth else NavigationBarMaxWidth)
-                    .fillMaxWidth(if (isFloating && !canLiquidGlass) navBarWidthFraction.coerceIn(0.5f, 1f) else 1f)
+                    .widthIn(max = if (isFloating) FloatingNavigationBarMaxWidth else NavigationBarMaxWidth)
+                    .fillMaxWidth(if (isFloating) navBarWidthFraction.coerceIn(0.5f, 1f) else 1f)
                     .height(resolvedBarHeight),
             contentAlignment = Alignment.CenterStart,
         ) {
@@ -659,17 +645,11 @@ fun FloatingNavigationToolbar(
                                 modifier =
                                     Modifier
                                         .align(Alignment.TopStart)
-                                        // Per audit (2026-08-30): the sliding indicator pill used
-                                        // `Modifier.offset { IntOffset(indicatorX.value.roundToInt(),
-                                        //  indicatorY.roundToInt()) }` — that runs in the LAYOUT
-                                        // phase on every spring frame of the tab-switch animation
-                                        // and invalidates the indicator's children for re-layout
-                                        // each frame. Switching to `graphicsLayer { translationX/Y }`
-                                        // moves the transform to the DRAW phase, so the layout pass
-                                        // can stay cached while the pill slides. No visual change.
-                                        .graphicsLayer {
-                                            translationX = indicatorX.value
-                                            translationY = indicatorY
+                                        .offset {
+                                            IntOffset(
+                                                indicatorX.value.roundToInt(),
+                                                indicatorY.roundToInt(),
+                                            )
                                         }
                                         .width(pillWidth)
                                         .height(pillHeight)
@@ -865,15 +845,7 @@ fun FloatingNavigationToolbar(
                 Box(
                     modifier =
                         Modifier
-                            // Per audit (2026-08-30): the Liquid Glass pill used
-                            // `Modifier.offset { IntOffset(...) }` to compute its X — that runs
-                            // in the LAYOUT phase on every drag/spring frame. The pill already
-                            // has a `Modifier.graphicsLayer { ... }` after for the press scale
-                            // and velocity-stretch, so folding the offset translationX into
-                            // that same graphicsLayer moves the work to the DRAW phase. The
-                            // layout pass can stay cached while the pill slides under the
-                            // user's finger.
-                            .graphicsLayer {
+                            .offset {
                                 val pillWidthPx = pillWidth.toPx()
                                 val hPaddingPx = itemHorizontalPadding.toPx()
                                 // X: align with the items Row's content area, then slide.
@@ -898,8 +870,11 @@ fun FloatingNavigationToolbar(
                                 // Y = 0: the wrapper Box's CenterStart alignment
                                 // centers the pill vertically. No Y computation needed.
                                 val xRelativeToWrapper = xInRoot - barPositionInRoot.x
-                                translationX = xRelativeToWrapper
-
+                                IntOffset(xRelativeToWrapper.roundToInt(), 0)
+                            }
+                            .width(pillWidth)
+                            .height(pillHeight)
+                            .graphicsLayer {
                                 // SukiSU pressedScale = 78f / 56f ≈ 1.393.
                                 // Velocity-stretch: the pill squishes horizontally when
                                 // flung (a physical "rubber" feel). The asymmetry (0.75 ×
@@ -909,61 +884,39 @@ fun FloatingNavigationToolbar(
                                 scaleX = pressScale / (1f - velocityStretch * 0.75f)
                                 scaleY = pressScale * (1f - velocityStretch * 0.25f)
                             }
-                            .then(
-                                // Per audit (2026-08-30): the Liquid Glass pill's drawBackdrop
-                                // chain was inline above, so every recomposition of the
-                                // FloatingNavigationToolbar re-allocated the entire kyant
-                                // effects stack (BlurEffect, LensEffect, vibrancy, shape,
-                                // onDrawSurface, onDrawBehind) and re-installed the
-                                // RuntimeShader on the GraphicsLayer. The pill box
-                                // recomposes on every spring frame during the drag/press
-                                // animation because of the dragAnim State reads — so the
-                                // per-frame cost was the dominant per-frame overhead while
-                                // the user was rubbing the bar.
-                                //
-                                // Memoizing the chain on (backdrop, shape, fallbackColor,
-                                // isDark) means the kyant effect stack is built ONCE per
-                                // (backdrop, shape, dark-theme) tuple and reused across
-                                // recompositions. The dragAnim.pressProgress / velocity
-                                // reads inside `onDrawSurface` and the `lens()` amount that
-                                // depends on `size` happen in draw scope and refresh per
-                                // frame without invalidating the remember. (This is the same
-                                // pattern already used by `Modifier.liquidGlass` in
-                                // LiquidGlass.kt:152.)
-                                remember(liquidGlassBackdrop, pillShape, pillFallbackColor, isDark) {
-                                    Modifier.drawBackdrop(
-                                        backdrop = liquidGlassBackdrop,
-                                        effects = {
-                                            vibrancy()
-                                            blur(4f.dp.toPx())
-                                            lens(
-                                                refractionHeight = 24f.dp.toPx(),
-                                                refractionAmount = size.minDimension / 4f,
-                                                chromaticAberration = false,
-                                            )
-                                        },
-                                        onDrawBackdrop = { drawBackdrop -> drawBackdrop() },
-                                        shape = { pillShape },
-                                        onDrawBehind = {
-                                            drawRect(pillFallbackColor)
-                                        },
-                                        onDrawSurface = {
-                                            val progress = dragAnim.pressProgress
-                                            // Pre-allocate the static tint color at
-                                            // drawScope level so we don't allocate a new
-                                            // Color object every frame. The dynamic alpha
-                                            // (`0.03f * progress`) must stay per-frame
-                                            // because progress varies with the press
-                                            // animation — that's one cheap Color allocation
-                                            // per frame instead of two.
-                                            val tintColor = if (isDark) Color.Black else Color.White
-                                            drawRect(
-                                                color = tintColor.copy(alpha = 0.1f),
-                                                alpha = 1f - progress,
-                                            )
-                                            drawRect(Color.Black.copy(alpha = 0.03f * progress))
-                                        },
+                            .drawBackdrop(
+                                backdrop = liquidGlassBackdrop,
+                                effects = {
+                                    vibrancy()
+                                    blur(4f.dp.toPx())
+                                    lens(
+                                        refractionHeight = 24f.dp.toPx(),
+                                        refractionAmount = size.minDimension / 4f,
+                                        chromaticAberration = false,
                                     )
+                                },
+                                onDrawBackdrop = { drawBackdrop -> drawBackdrop() },
+                                shape = { pillShape },
+                                // Fallback surface drawn UNDER the backdrop sample.
+                                // When the backdrop has content (album art, page content
+                                // behind the nav bar), the backdrop sample covers this
+                                // and you see the liquid glass refraction. When the
+                                // backdrop is EMPTY (e.g. bottom of a short page with
+                                // nothing behind the nav bar), the backdrop sample is
+                                // transparent and this opaque surface shows through —
+                                // matching the existing pattern used by the bar Surface
+                                // (baseColor = surfaceContainerHigh) and the Frosted nav
+                                // bar variant (opaque surface + 30% alpha overlay).
+                                onDrawBehind = {
+                                    drawRect(pillFallbackColor)
+                                },
+                                onDrawSurface = {
+                                    val progress = dragAnim.pressProgress
+                                    drawRect(
+                                        color = (if (isDark) Color.Black else Color.White).copy(alpha = 0.1f),
+                                        alpha = 1f - progress,
+                                    )
+                                    drawRect(Color.Black.copy(alpha = 0.03f * progress))
                                 },
                             )
                             .innerShadow(shape = pillShape) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -239,14 +239,7 @@ fun FloatingNavigationToolbar(
     // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    // Per user report (2026-08-30): "extra space between navigation bar icons in
-    // liquid glass". SukiSU applies 4.dp on ALL sides of the items Row, but our
-    // ShortNavigationBarItem already adds its own internal horizontal padding
-    // around the icon/label slot — so the extra 4.dp on the Row translates to a
-    // visible gap between icons. Keep the vertical 4.dp (which the active
-    // Liquid Glass pill depends on for sizing), but use 0.dp horizontally —
-    // matching the non-Liquid-Glass variants.
-    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
+    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
             RoundedCornerShape(percent = 50)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -231,18 +231,29 @@ fun FloatingNavigationToolbar(
     // liquid glass surface tints itself with `surfaceContainerHigh`, so it stays
     // visible even when the rest of the UI is pitch black. The user explicitly
     // opts in via the Liquid Glass toggle, so honour that choice in pure dark too.
-    val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
+val canLiquidGlass = liquidGlass && liquidGlassBackdrop != null && !isPreS
+    // Per user request (2026-08-30): "Dimensions customisation should also be
+    // available for liquid glass navigation bar." The Liquid Glass bar
+    // honours the user's Height multiplier (applied on top of SukiSU's 64dp
+    // baseline), Label spacing (between icon and label inside the bar), and
+    // Corner radius (lets the user opt OUT of the perfect-circle 50% pill
+    // and pick any rounded-rect shape). Opacity/Transparency don't apply —
+    // the bar surface is `Color.Transparent` because the kyant shader
+    // controls the visible tint, so modulating alpha has no visible effect.
     val resolvedBarHeight =
-        if (canLiquidGlass) SukiSUBarHeight else NavigationBarHeight * navBarHeightMultiplier
-    // SukiSU-Ultra: when the Liquid Glass nav bar is active, the items Row uses
-    // 4.dp padding on ALL sides (matching SukiSU's Row.padding(4.dp)). The non-
-    // Liquid-Glass variants keep the original 8.dp vertical-only padding.
+        if (canLiquidGlass) SukiSUBarHeight * navBarHeightMultiplier
+        else NavigationBarHeight * navBarHeightMultiplier
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
+    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
-            RoundedCornerShape(percent = 50)
+            // SukiSU uses a perfect-circle pill (percent=50). Honour the
+            // user's corner-radius preference so they can pick any
+            // rounded-rect shape — clamp to a sensible range so the shape
+            // stays a pill (never square, never inverted corners on a
+            // shorter-than-tall bar).
+            RoundedCornerShape(navBarCornerRadius.dp.coerceIn(0f, 48f))
         } else {
             remember(isPairedWithMiniPlayer, isFloating, navBarCornerRadius) {
                 when {
@@ -487,7 +498,7 @@ fun FloatingNavigationToolbar(
         if (canLiquidGlass) {
             if (tabWidthPx <= 0f) return@LaunchedEffect
             liquidGlassPillWidth = with(density) { tabWidthPx.toDp() }
-            liquidGlassPillHeight = SukiSUBarHeight - SukiSUItemPadding * 2 // 64 - 8 = 56.dp
+            liquidGlassPillHeight = resolvedBarHeight - SukiSUItemPadding * 2 // bar height - 8dp vertical padding
             // Position the pill at the items Row's content area top (which is
             // `itemVerticalPadding` below the bar's top edge). The items Row
             // fills the Surface height (64.dp) with 4.dp vertical padding, so
@@ -799,10 +810,15 @@ fun FloatingNavigationToolbar(
                                 } else {
                                     {
                                         if (canLiquidGlass) {
+                                            // Liquid Glass: small negative offset to bring the
+                                            // underlying label closer to the icon (matching
+                                            // SukiSU's tighter vertical rhythm). The user's
+                                            // Label-spacing preference modulates this offset
+                                            // — more spacing pushes the label further down.
                                             Text(
                                                 text = stringResource(screen.titleId),
                                                 maxLines = 1,
-                                                modifier = Modifier.offset(y = (-4).dp),
+                                                modifier = Modifier.offset(y = -(4f - navBarLabelSpacing).coerceAtLeast(-12f).dp),
                                                 // Liquid Glass: underlying label is always Normal.
                                                 // The pill overlay renders the active label in
                                                 // SemiBold (primary color) on top of the glass.

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt
@@ -239,7 +239,14 @@ fun FloatingNavigationToolbar(
     // Liquid-Glass variants keep the original 8.dp vertical-only padding.
     val itemVerticalPadding =
         if (canLiquidGlass) SukiSUItemPadding else NavigationItemVerticalPadding
-    val itemHorizontalPadding = if (canLiquidGlass) SukiSUItemPadding else 0.dp
+    // Per user report (2026-08-30): "extra space between navigation bar icons in
+    // liquid glass". SukiSU applies 4.dp on ALL sides of the items Row, but our
+    // ShortNavigationBarItem already adds its own internal horizontal padding
+    // around the icon/label slot — so the extra 4.dp on the Row translates to a
+    // visible gap between icons. Keep the vertical 4.dp (which the active
+    // Liquid Glass pill depends on for sizing), but use 0.dp horizontally —
+    // matching the non-Liquid-Glass variants.
+    val itemHorizontalPadding = if (canLiquidGlass) 0.dp else 0.dp
     val navigationShape =
         if (canLiquidGlass) {
             RoundedCornerShape(percent = 50)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
@@ -85,7 +85,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastForEachIndexed
@@ -2199,7 +2198,13 @@ fun SwipeToSongBox(
         Box(
             modifier =
                 Modifier
-                    .offset { IntOffset(offset.value.roundToInt(), 0) }
+                    // Per audit (2026-08-30): `Modifier.offset { IntOffset(...) }` ran
+                    // in the LAYOUT phase on every swipe-dismiss drag frame. Folding
+                    // into `graphicsLayer` moves the transform to the DRAW phase; the
+                    // layout pass stays cached while the user swipes the row out.
+                    .graphicsLayer {
+                        translationX = offset.value
+                    }
                     .fillMaxWidth()
                     .background(resolvedContentBackgroundColor),
             content = content,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LiquidGlass.kt
@@ -63,18 +63,26 @@ typealias PlatformBackdrop = LayerBackdrop
  * pills to take effect now. I want them to be immediate." The user perceives
  * the 250ms settle window as a visible "frosted → liquid glass" swap.
  *
- * The transition-lag symptom that originally motivated the delay has been
- * addressed at its structural root cause: the bottom-nav slide animation in
- * `MainActivity` was using `Modifier.offset { IntOffset(0, y) }` (layout phase),
- * which re-laid-out the entire `FloatingNavigationToolbar` subtree every
- * spring frame — cascading to every `onGloballyPositioned` callback and
- * invalidating the app-wide backdrop recording every frame. That's been
- * switched to `Modifier.graphicsLayer { translationY = y }` (draw phase), so
- * children's layout coordinates stay stable across spring frames and the
- * kyant shader chain no longer re-computes its sample coordinates every
- * frame. With that structural fix in place, the per-screen settle delay is
- * no longer necessary — the layerBackdrop activates immediately when the
- * screen composes.
+ * A batch-8 attempt to remove the delay by switching `MainActivity`'s
+ * bottom-nav slide wrapper from `Modifier.offset { IntOffset(0, y) }`
+ * (layout phase) to `Modifier.graphicsLayer { translationY = y }` (draw
+ * phase) was reverted per user report (2026-08-30): "i somehow messed up
+ * liquid glass navigation bar. Restore it to how it used to be before."
+ * The graphicsLayer variant caused the nav bar to render on top of the
+ * mini-player (the wrapper Box's layout space stayed claimed at
+ * BottomCenter even when translated off-screen, so the BottomSheetPlayer's
+ * collapsed anchor couldn't see the bar's actual position).
+ *
+ * The original lag symptom may therefore reappear during page transitions
+ * when liquid glass surfaces are present. The user has explicitly opted
+ * for immediate pills anyway — perceived transition lag is preferable to
+ * the visible "frosted → liquid glass" swap. If the lag becomes unacceptable
+ * again, a future fix should target the root cause (per-frame re-layout of
+ * the FloatingNavigationToolbar subtree) WITHOUT changing the wrapper's
+ * layout phase, e.g. by hoisting the `onGloballyPositioned` callbacks into
+ * a `Modifier.Node` or by reading `bottomNavigationBarHeight` and
+ * `playerBottomSheetState.progress` directly from a State rather than
+ * recomposing the wrapper Box every frame.
  *
  * Call sites pattern (unchanged):
  * ```

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SearchBar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/SearchBar.kt
@@ -166,7 +166,7 @@ fun TopSearch(
     }
 
     BoxWithConstraints(
-        modifier = modifier.offset { IntOffset(x = 0, y = 0) },
+        modifier = modifier,
         propagateMinConstraints = true,
     ) {
         val height: Dp

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -1144,17 +1144,34 @@ fun AppleMusicPlayerContent(
             // Brightened scrim — matches ViviMusic's brighter aesthetic.
             // Previous alphas (0.42/0.60/0.82) were too dark; reduced to
             // 0.25/0.40/0.65 so the blurred artwork's color shows through.
+            // Per audit (2026-08-30): hoist the Brush.verticalGradient + 3 Color.copy
+            // allocations out of the .background() call into `remember(...)`. The brush
+            // identity is stable across recompositions as long as the alpha-tuple
+            // (governed by useCanvasBackdrop / preBlurLoading / SDK) is unchanged.
+            // Previously, every recomposition of the parent allocated a new ShaderBrush +
+            // 3 × Color.copy(alpha=...) values; the brush is now allocated ONCE per
+            // change to the alpha-tuple.
+            val backdropScrimBrush =
+                remember(useCanvasBackdrop, preBlurLoading, Build.VERSION.SDK_INT) {
+                    val (a1, a2, a3) =
+                        if (useCanvasBackdrop || Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                            Triple(0.25f, 0.40f, 0.65f)
+                        } else if (preBlurLoading) {
+                            Triple(0.55f, 0.65f, 0.85f)
+                        } else {
+                            Triple(0.40f, 0.55f, 0.75f)
+                        }
+                    Brush.verticalGradient(
+                        0f to Color.Black.copy(alpha = a1),
+                        0.5f to Color.Black.copy(alpha = a2),
+                        1f to Color.Black.copy(alpha = a3),
+                    )
+                }
             Box(
                 modifier =
                     Modifier
                         .matchParentSize()
-                        .background(
-                            Brush.verticalGradient(
-                                0f to Color.Black.copy(alpha = if (useCanvasBackdrop || Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.25f else if (preBlurLoading) 0.55f else 0.40f),
-                                0.5f to Color.Black.copy(alpha = if (useCanvasBackdrop || Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.40f else if (preBlurLoading) 0.65f else 0.55f),
-                                1f to Color.Black.copy(alpha = if (useCanvasBackdrop || Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) 0.65f else if (preBlurLoading) 0.85f else 0.75f),
-                            ),
-                        ),
+                        .background(backdropScrimBrush),
             )
         }
 
@@ -1761,6 +1778,17 @@ private fun AppleMusicSharpArtwork(
     modifier: Modifier = Modifier,
 ) {
     val playerConnection = LocalPlayerConnection.current
+    // Per audit (2026-08-30): hoist the static Brush.verticalGradient out of the
+    // drawWithContent call. The two color stops are CONSTANT (0.62f to Color.Black,
+    // 1f to Color.Transparent), so the brush identity is stable for the lifetime
+    // of the composable. Previously, every draw frame allocated a new ShaderBrush
+    // instance while the artwork stage was visible.
+    val artworkFadeBrush = remember {
+        Brush.verticalGradient(
+            0.62f to Color.Black,
+            1f to Color.Transparent,
+        )
+    }
     Box(
         modifier =
             modifier.then(
@@ -1771,11 +1799,7 @@ private fun AppleMusicSharpArtwork(
                         .drawWithContent {
                             drawContent()
                             drawRect(
-                                brush =
-                                    Brush.verticalGradient(
-                                        0.62f to Color.Black,
-                                        1f to Color.Transparent,
-                                    ),
+                                brush = artworkFadeBrush,
                                 blendMode = androidx.compose.ui.graphics.BlendMode.DstIn,
                             )
                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -460,8 +460,13 @@ private fun MiniPlayerBackground(
                 // mini player (not the full screen), captured and blurred every ~80 ms — fast
                 // enough for smooth frosted tracking without tanking pre-S hardware. The blurred
                 // slice is already aligned to the mini player's top-left, so we draw at (0, 0).
-                var positionInRoot by remember { mutableStateOf(Offset.Zero) }
-                var miniPlayerSize by remember { mutableStateOf(IntSize.Zero) }
+                // Per audit (2026-08-30): hoisted to State holders so the
+                // onGloballyPositioned lambda can be memoized on the holder
+                // (stable across recompositions).
+                val positionInRootState = remember { mutableStateOf(Offset.Zero) }
+                val miniPlayerSizeState = remember { mutableStateOf(IntSize.Zero) }
+                val positionInRoot by positionInRootState
+                val miniPlayerSize by miniPlayerSizeState
                 val blurredBitmap = rememberPreSFrostedBitmap(
                     backdrop = backdrop,
                     barPositionInRoot = positionInRoot,
@@ -472,10 +477,17 @@ private fun MiniPlayerBackground(
                 Box(
                     modifier =
                         modifier
-                            .onGloballyPositioned {
-                                positionInRoot = it.positionInRoot()
-                                miniPlayerSize = it.size
-                            }
+                            .onGloballyPositioned(
+                                // Per audit (2026-08-30): memoize the lambda so the
+                                // OnGloballyPositionedElement.equals() returns true
+                                // across recompositions.
+                                remember(positionInRootState, miniPlayerSizeState) {
+                                    { coordinates ->
+                                        positionInRootState.value = coordinates.positionInRoot()
+                                        miniPlayerSizeState.value = coordinates.size
+                                    }
+                                },
+                            )
                             .background(baseColor),
                 ) {
                     if (blurredBitmap != null) {
@@ -493,11 +505,18 @@ private fun MiniPlayerBackground(
                     }
                 }
             } else {
-                var positionInRoot by remember { mutableStateOf(Offset.Zero) }
+                // Per audit (2026-08-30): hoisted to State holder for onGloballyPositioned
+                // lambda memoization.
+                val positionInRootState = remember { mutableStateOf(Offset.Zero) }
+                val positionInRoot by positionInRootState
                 Box(
                     modifier =
                         modifier
-                            .onGloballyPositioned { positionInRoot = it.positionInRoot() }
+                            .onGloballyPositioned(
+                                remember(positionInRootState) {
+                                    { coordinates -> positionInRootState.value = coordinates.positionInRoot() }
+                                },
+                            )
                             .background(baseColor),
                 ) {
                     Box(
@@ -526,27 +545,35 @@ private fun MiniPlayerBackground(
 
         MiniPlayerBackgroundStyle.GRADIENT -> {
             val colors = requireNotNull(palette)
+            // Per audit (2026-08-30): hoist the Brush.verticalGradient + Color
+            // constants out of the .background() call into `remember(colors)`.
+            // Previously, every recomposition of MiniPlayer (which is on screen
+            // 100% of the time during playback) allocated a new ShaderBrush +
+            // 3 × Color.copy(alpha=...) values + a Color.Black.copy(alpha=...).
+            // The brush is now allocated ONCE per `colors` tuple change.
+            val gradientBrush = remember(colors) {
+                Brush.verticalGradient(
+                    colorStops =
+                        arrayOf(
+                            0f to colors.first.copy(alpha = 0.95f),
+                            0.52f to colors.second.copy(alpha = 0.82f),
+                            1f to colors.third.copy(alpha = 0.72f),
+                        ),
+                )
+            }
+            val overlayColor = remember { Color.Black.copy(alpha = 0.32f) }
             Box(modifier = modifier) {
                 Box(
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .background(
-                                Brush.verticalGradient(
-                                    colorStops =
-                                        arrayOf(
-                                            0f to colors.first.copy(alpha = 0.95f),
-                                            0.52f to colors.second.copy(alpha = 0.82f),
-                                            1f to colors.third.copy(alpha = 0.72f),
-                                        ),
-                                ),
-                            ),
+                            .background(gradientBrush),
                 )
                 Box(
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .background(Color.Black.copy(alpha = 0.32f)),
+                            .background(overlayColor),
                 )
             }
         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/MiniPlayer.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -323,7 +322,15 @@ private fun NewMiniPlayer(
                 Modifier
                     .fillMaxWidth()
                     .height(MiniPlayerHeight)
-                    .offset { IntOffset(offsetX.roundToInt(), 0) }
+                    // Per audit (2026-08-30): `Modifier.offset { IntOffset(offsetX.roundToInt(), 0) }`
+                    // ran in the LAYOUT phase on every drag frame of the mini player's
+                    // horizontal-swipe gesture and invalidated the Box's children for
+                    // re-layout each frame. Folding the translation into `graphicsLayer`
+                    // moves the transform to the DRAW phase — the layout pass stays cached
+                    // while the user swipes. No visual change.
+                    .graphicsLayer {
+                        translationX = offsetX
+                    }
                     .clip(miniPlayerShape),
         ) {
             MiniPlayerBackground(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -2438,11 +2438,20 @@ fun BottomSheetPlayer(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(
-                        queueSurfaceColor.copy(
+                    // Per audit (2026-08-30): use drawBehind + drawRect's `alpha`
+                    // parameter instead of `Modifier.background(color.copy(alpha=...))`.
+                    // The previous call allocated a new Color value every frame during
+                    // sheet drag (queueSheetState.progress updates ~60 fps). drawRect's
+                    // `alpha` param is a primitive Float — zero per-frame Color allocation.
+                    // Visual is identical: same color, same alpha math, default
+                    // RectangleShape (the Box has no shape modifier, so background()
+                    // was also using RectangleShape).
+                    .drawBehind {
+                        drawRect(
+                            color = queueSurfaceColor,
                             alpha = queueSurfaceColor.alpha * queueSheetState.progress.coerceIn(0f, 1f),
-                        ),
-                    ),
+                        )
+                    },
         )
 
         // Queue sheet — wrapped in AnimatedVisibility with slide+fade so it

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
@@ -619,7 +619,7 @@ fun LibraryArtistsScreen(
                         contentPadding = PaddingValues(vertical = 4.dp),
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        items(artists.take(5), key = { artistWrapper.artist.id }) { artistWrapper ->
+                        items(artists.take(5), key = { it.artist.id }) { artistWrapper ->
                             val artist = artistWrapper.artist
                             Column(
                                 modifier =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/library/LibraryArtistsScreen.kt
@@ -619,7 +619,7 @@ fun LibraryArtistsScreen(
                         contentPadding = PaddingValues(vertical = 4.dp),
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        items(artists.take(5)) { artistWrapper ->
+                        items(artists.take(5), key = { artistWrapper.artist.id }) { artistWrapper ->
                             val artist = artistWrapper.artist
                             Column(
                                 modifier =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
@@ -313,21 +313,12 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                 }
             }
 
-            // Customization sliders: affect both the FLOATING and Liquid Glass styles,
-            // plus the corner radius for DEFAULT. They are shown unconditionally so the
-            // user can pre-configure a look before switching to it. Each slider opens a
+            // Customization sliders: only meaningfully affect the FLOATING style (and the
+            // corner radius for DEFAULT). They are shown unconditionally so the user can
+            // pre-configure the floating look before switching to it. Each slider opens a
             // dialog with a live preview that reflects the in-progress value (and the
             // committed values of the other dimensions) so the user can see exactly how
             // the bar will look before committing.
-            //
-            // Per user request (2026-08-30): "Dimensions customisation should also be
-            // available for liquid glass navigation bar." Previously these sliders were
-            // disabled when the Liquid Glass nav bar toggle was on (the bar used SukiSU's
-            // fixed 64dp / 4dp / percent=50 dimensions). Now the Liquid Glass bar honours
-            // the user's Height multiplier, Label spacing, and Corner radius preferences
-            // — only Opacity and Transparency stay no-ops on Liquid Glass because the bar
-            // surface is `Color.Transparent` (the kyant shader controls the visible tint,
-            // so alpha modulation has no visible effect there).
             PreferenceGroup(
                 modifier = positions.modifierFor("navigation_bar_dimensions"),
                 title = stringResource(R.string.navigation_bar_dimensions),
@@ -353,6 +344,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -377,6 +369,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -401,6 +394,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -425,6 +419,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -449,6 +444,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -473,15 +469,16 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
+                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
                 // Reset all six dimension values to their defaults in one tap. The button is
                 // disabled (greyed out) when every value is already at its default, so the
                 // user can see at a glance whether they have any unsaved customizations.
-                // Always enabled regardless of Liquid Glass toggle — the Liquid Glass bar
-                // honours the same preference keys, so resetting them visibly resets the
-                // Liquid Glass bar too.
+                // Also disabled when Liquid Glass nav bar is active (the Liquid Glass bar
+                // uses SukiSU's exact dimensions and ignores the user's preferences, so
+                // resetting them has no visible effect).
                 item {
                     val allDefaults =
                         navigationBarWidth == NAVIGATION_BAR_WIDTH_DEFAULT &&
@@ -500,7 +497,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                             onNavigationBarLabelSpacingChange(NAVIGATION_BAR_LABEL_SPACING_DEFAULT)
                             onNavigationBarCornerRadiusChange(NAVIGATION_BAR_CORNER_RADIUS_DEFAULT)
                         },
-                        enabled = !allDefaults,
+                        enabled = !allDefaults && !liquidGlassNavBarEnabled,
                         shapes = ButtonDefaults.shapes(),
                         modifier = Modifier
                             .fillMaxWidth()
@@ -542,6 +539,12 @@ private fun SliderPreferenceRow(
     valueLabel: (Float) -> String,
     default: Float? = null,
     preview: (@Composable (Float) -> Unit)? = null,
+    // SukiSU-Ultra: when the Liquid Glass nav bar is active, the customization
+    // sliders are DISABLED (greyed out) because the Liquid Glass bar uses
+    // SukiSU's exact dimensions and ignores the user's preferences. The user
+    // explicitly asked for this: "Customisation of navigation bar in Liquid
+    // Glass should be unavailable because it should use the exact same
+    // dimensions from suki su for everything".
     enabled: Boolean = true,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt
@@ -313,12 +313,21 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                 }
             }
 
-            // Customization sliders: only meaningfully affect the FLOATING style (and the
-            // corner radius for DEFAULT). They are shown unconditionally so the user can
-            // pre-configure the floating look before switching to it. Each slider opens a
+            // Customization sliders: affect both the FLOATING and Liquid Glass styles,
+            // plus the corner radius for DEFAULT. They are shown unconditionally so the
+            // user can pre-configure a look before switching to it. Each slider opens a
             // dialog with a live preview that reflects the in-progress value (and the
             // committed values of the other dimensions) so the user can see exactly how
             // the bar will look before committing.
+            //
+            // Per user request (2026-08-30): "Dimensions customisation should also be
+            // available for liquid glass navigation bar." Previously these sliders were
+            // disabled when the Liquid Glass nav bar toggle was on (the bar used SukiSU's
+            // fixed 64dp / 4dp / percent=50 dimensions). Now the Liquid Glass bar honours
+            // the user's Height multiplier, Label spacing, and Corner radius preferences
+            // — only Opacity and Transparency stay no-ops on Liquid Glass because the bar
+            // surface is `Color.Transparent` (the kyant shader controls the visible tint,
+            // so alpha modulation has no visible effect there).
             PreferenceGroup(
                 modifier = positions.modifierFor("navigation_bar_dimensions"),
                 title = stringResource(R.string.navigation_bar_dimensions),
@@ -344,7 +353,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -369,7 +377,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -394,7 +401,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -419,7 +425,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -444,7 +449,6 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
@@ -469,16 +473,15 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                                 style = navigationBarStyle,
                             )
                         },
-                        enabled = !liquidGlassNavBarEnabled,
                     )
                 }
 
                 // Reset all six dimension values to their defaults in one tap. The button is
                 // disabled (greyed out) when every value is already at its default, so the
                 // user can see at a glance whether they have any unsaved customizations.
-                // Also disabled when Liquid Glass nav bar is active (the Liquid Glass bar
-                // uses SukiSU's exact dimensions and ignores the user's preferences, so
-                // resetting them has no visible effect).
+                // Always enabled regardless of Liquid Glass toggle — the Liquid Glass bar
+                // honours the same preference keys, so resetting them visibly resets the
+                // Liquid Glass bar too.
                 item {
                     val allDefaults =
                         navigationBarWidth == NAVIGATION_BAR_WIDTH_DEFAULT &&
@@ -497,7 +500,7 @@ fun NavigationBarSettings(navController: NavController, scrollTo: String? = null
                             onNavigationBarLabelSpacingChange(NAVIGATION_BAR_LABEL_SPACING_DEFAULT)
                             onNavigationBarCornerRadiusChange(NAVIGATION_BAR_CORNER_RADIUS_DEFAULT)
                         },
-                        enabled = !allDefaults && !liquidGlassNavBarEnabled,
+                        enabled = !allDefaults,
                         shapes = ButtonDefaults.shapes(),
                         modifier = Modifier
                             .fillMaxWidth()
@@ -539,12 +542,6 @@ private fun SliderPreferenceRow(
     valueLabel: (Float) -> String,
     default: Float? = null,
     preview: (@Composable (Float) -> Unit)? = null,
-    // SukiSU-Ultra: when the Liquid Glass nav bar is active, the customization
-    // sliders are DISABLED (greyed out) because the Liquid Glass bar uses
-    // SukiSU's exact dimensions and ignores the user's preferences. The user
-    // explicitly asked for this: "Customisation of navigation bar in Liquid
-    // Glass should be unavailable because it should use the exact same
-    // dimensions from suki su for everything".
     enabled: Boolean = true,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }


### PR DESCRIPTION
feat(ui,nav,perf): honour Liquid Glass nav bar dimensions + preload Search tab

Addresses two user requests from 2026-08-30.

## 1. Liquid Glass nav bar dimensions are now customisable

Previously, when the Liquid Glass nav bar toggle was on, the six
Navigation Bar Dimensions sliders (Width / Height / Opacity / Transparency
/ Label spacing / Corner radius) were DISABLED — the bar used SukiSU's
fixed 64dp height, 4dp padding, and 50% pill shape regardless of user
preferences. Now:

- Height (NavigationBarHeightKey): multiplies the SukiSU 64dp baseline.
  Liquid glass + Height=0.8 → 51.2dp bar.
- Label spacing (NavigationBarLabelSpacingKey): modulates the negative
  offset of the underlying label so the user can pull the label closer
  to / further from the icon. Clamped to -12f..∞ to prevent the label
  disappearing into the icon.
- Corner radius (NavigationBarCornerRadiusKey): replaces the fixed
  RoundedCornerShape(percent=50) perfect-circle pill with
  RoundedCornerShape(navBarCornerRadius.dp) (clamped 0..48dp). The user
  can pick any rounded-rect shape — perfect circle (28dp default on a
  64dp bar is the closest visual to percent=50), squircle, or sharp
  rectangle.
- Opacity / Transparency: still no-op on Liquid Glass (the bar surface
  is Color.Transparent — the kyant shader controls the visible tint, so
  alpha modulation has no visible effect there).
- The Settings screen sliders, preview dialogs, and Reset dimensions
  button all remain enabled regardless of the Liquid Glass nav bar
  toggle.

The pill overlay height is recomputed from resolvedBarHeight instead
of the fixed SukiSUBarHeight, so the active pill always fills the
customised bar height minus the 8dp vertical padding.

## 2. Search tab is preloaded at app startup

Per user report (2026-08-30): 'The search tab takes time to load. it
should preload when i open the app.' Inject SearchDiscoveryRepository
into App and fire loadDiscovery(forceRefresh=false) from
initializeDeferredAsync on applicationScope(Dispatchers.IO).

The repository caches its result in-memory for a short TTL, so one
warm-up covers many subsequent tab re-entries. Fire-and-forget so the
cold-start path isn't blocked; the repository's own loadJob?.isActive
guard ensures that if the user taps Search before the warm-up
completes, the real ViewModel's call joins the same in-flight job
instead of doubling the network cost. Errors are swallowed inside the
repository (stale-cache fallback) so this is safe.

## Files
- app/src/main/kotlin/moe/rukamori/archivetune/App.kt — inject
  SearchDiscoveryRepository, fire-and-forget preload at startup.
- app/src/main/kotlin/moe/rukamori/archivetune/ui/component/FloatingNavigationToolbar.kt —
  liquid-glass path honours Height / Label spacing / Corner radius.
- app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/NavigationBarSettings.kt —
  remove the enabled=!liquidGlassNavBarEnabled gates from the
  dimension sliders + Reset button; update inline comments.