### PR TITLE
feat(perf,cache,menu,romanize,writers,genre): batch-9 for 2026-08-30

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/lastfm/CatalogueCoverProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lastfm/CatalogueCoverProvider.kt
@@ -413,4 +413,301 @@ object CatalogueCoverProvider {
                 .orEmpty()
         return first.replace(Regex("\\s+"), " ").trim()
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Non-cover metadata enrichment (songwriters + genres)
+    //
+    // Added 2026-08-30 per user requests:
+    //  • "Written by" text should show songwriters (Task 5)
+    //  • Last.fm stats page should fall back to internet for missing genres (Task 6)
+    //
+    // Both ride the same OkHttpClient + User-Agent + `runCatching`-swallow pattern
+    // the cover resolvers above use. Each is wrapped in a per-(mediaId, query)
+    // LRU so a re-render of the same track doesn't re-hit the network.
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    private val songwriterCache = java.util.concurrent.ConcurrentHashMap<String, List<String>>()
+    private val genreCache = java.util.concurrent.ConcurrentHashMap<String, List<String>>()
+    private const val MetadataCacheMaxEntries = 64
+    private val mbUserAgent = "ArchiveTune/1.0 (https://github.com/rukamori/ArchiveTune)"
+
+    /**
+     * Resolve the songwriter(s) — composer / lyricist / writer — for [title] (optionally
+     * with [artist]) using MusicBrainz. Returns the list of distinct writer names (max 5),
+     * or null if no writer credit was found.
+     *
+     * Flow:
+     *  1. Search MusicBrainz for the recording (Lucene query `recording:"X" AND artist:"Y"`,
+     *     limit=1) → first recording's MBID.
+     *  2. Lookup the recording MBID with `inc=artist-rels+work-rels`. The response includes
+     *     `relations[]` where `type-id == "a300566f-a404-437e-8d16-3b0d83b41313"` ("performance
+     *     of"); each such relation carries a `work` block whose own `relations[]` includes
+     *     entries with `type` ∈ {"composer", "lyricist", "writer"} → `artist.name` is the
+     *     writer's name.
+     *  3. Collect distinct writer names in encounter order, capped at 5.
+     *
+     * Cache: keyed by `"${title}|${artist ?: ""}"` so a re-render doesn't re-hit the
+     * network. Bounded LRU-ish eviction (ConcurrentHashMap has no LRU; we just trim the
+     * oldest key when the cap is hit, which is good enough for memory hygiene).
+     *
+     * Public so [LyricsEnhanced] can call it from a `LaunchedEffect` keyed on mediaId.
+     */
+    suspend fun resolveSongwriters(
+        title: String,
+        artist: String?,
+    ): List<String>? {
+        if (title.isBlank()) return null
+        val cleanedTitle = cleanSearchTitle(title)
+        val cleanedArtist = artist?.takeIf(String::isNotBlank)?.let(::cleanSearchArtist)
+        val cacheKey = "${cleanedTitle}|${cleanedArtist.orEmpty()}"
+        songwriterCache[cacheKey]?.let { return it }
+        return withContext(Dispatchers.IO) {
+            val mbid = searchMusicBrainzRecordingMbid(cleanedTitle, cleanedArtist) ?: return@withContext null
+            val writers = fetchRecordingWriters(mbid)
+            if (writers.isEmpty()) {
+                null
+            } else {
+                val distinct = LinkedHashSet<String>().apply { writers.forEach { add(it) } }.toList().take(5)
+                songwriterCache[cacheKey] = distinct
+                trimMetadataCache(songwriterCache)
+                distinct
+            }
+        }
+    }
+
+    /**
+     * Resolve genre tags for [title] (optionally with [artist]) using two providers
+     * in order: iTunes (primaryGenreName from search response — no extra call) →
+     * MusicBrainz (recording search + lookup with `inc=tags+genres`). Returns up to
+     * 3 distinct, non-blank tag names, or null if both providers came up empty.
+     *
+     * Cache: same shape as [resolveSongwriters] — keyed by title+artist, bounded by
+     * [MetadataCacheMaxEntries]. Public so [LastFmDashboardScreen] can use it as the
+     * fallback when Last.fm's `track.getInfo` returns no toptags.
+     */
+    suspend fun resolveGenres(
+        title: String,
+        artist: String?,
+    ): List<String>? {
+        if (title.isBlank()) return null
+        val cleanedTitle = cleanSearchTitle(title)
+        val cleanedArtist = artist?.takeIf(String::isNotBlank)?.let(::cleanSearchArtist)
+        val cacheKey = "${cleanedTitle}|${cleanedArtist.orEmpty()}"
+        genreCache[cacheKey]?.let { return it }
+        return withContext(Dispatchers.IO) {
+            val fromItunes = iTunesPrimaryGenre(cleanedTitle, cleanedArtist)
+            val fromMb = mbRecordingTags(cleanedTitle, cleanedArtist)
+            val combined =
+                LinkedHashSet<String>()
+                    .apply {
+                        fromItunes?.let { add(it) }
+                        fromMb?.forEach { add(it) }
+                    }.toList()
+                    .filter { it.isNotBlank() }
+                    .take(3)
+            if (combined.isEmpty()) {
+                null
+            } else {
+                genreCache[cacheKey] = combined
+                trimMetadataCache(genreCache)
+                combined
+            }
+        }
+    }
+
+    /**
+     * MusicBrainz recording search by (title, artist). Returns the first matching
+     * recording's MBID, or null on any failure (rate limit, no match, parse error).
+     */
+    private fun searchMusicBrainzRecordingMbid(
+        title: String,
+        artist: String?,
+    ): String? {
+        if (title.isBlank()) return null
+        val query = buildString {
+            if (!artist.isNullOrBlank()) {
+                append("artist:\"")
+                append(artist.replace("\"", ""))
+                append("\" AND ")
+            }
+            append("recording:\"")
+            append(title.replace("\"", ""))
+            append("\"")
+        }
+        val searchUrl =
+            "https://musicbrainz.org/ws/2/recording/".toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("query", query)
+                .addQueryParameter("limit", "1")
+                .addQueryParameter("fmt", "json")
+                .build()
+        val response =
+            runCatching {
+                client.newCall(
+                    Request.Builder()
+                        .url(searchUrl)
+                        .header("User-Agent", mbUserAgent)
+                        .get()
+                        .build(),
+                ).execute()
+            }.getOrNull() ?: return null
+        return response.use { resp ->
+            if (!resp.isSuccessful) return@use null
+            val body = runCatching { resp.body?.string() }.getOrNull() ?: return@use null
+            val parsed = runCatching { json.parseToJsonElement(body).jsonObject }.getOrNull() ?: return@use null
+            val recordings = parsed["recordings"]?.jsonArray ?: return@use null
+            recordings.firstOrNull()?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull
+        }
+    }
+
+    /**
+     * Lookup a recording MBID with `inc=artist-rels+work-rels` and walk the relations to
+     * find writer credits. Returns the list of writer names (with duplicates — caller
+     * deduplicates).
+     *
+     * MusicBrainz relation-type names for writers (case-insensitive):
+     *  - "composer" (type-id d300d7af-ca1f-4c25-b0d0-2c3e57678c82)
+     *  - "lyricist" (type-id 3e48faba-4051-36f4-9d86-7af1b96cd6e7)
+     *  - "writer"  (type-id 75909ea4-2a68-3b51-b743-2ce0fd50d7f0)
+     *
+     * We don't filter by type-id because the type-name lookup is what the API documents
+     * and what the JSON exposes; we just match on the `type` string.
+     */
+    private fun fetchRecordingWriters(mbid: String): List<String> {
+        val lookupUrl =
+            "https://musicbrainz.org/ws/2/recording/$mbid".toHttpUrl()
+                .newBuilder()
+                .addQueryParameter("inc", "artist-rels+work-rels")
+                .addQueryParameter("fmt", "json")
+                .build()
+        val response =
+            runCatching {
+                client.newCall(
+                    Request.Builder()
+                        .url(lookupUrl)
+                        .header("User-Agent", mbUserAgent)
+                        .get()
+                        .build(),
+                ).execute()
+            }.getOrNull() ?: return emptyList()
+        val body = response.use { resp ->
+            if (!resp.isSuccessful) return emptyList()
+            runCatching { resp.body?.string() }.getOrNull() ?: return emptyList()
+        }
+        val parsed = runCatching { json.parseToJsonElement(body).jsonObject }.getOrNull() ?: return emptyList()
+        val relations = parsed["relations"]?.jsonArray ?: return emptyList()
+        val writers = mutableListOf<String>()
+        for (relationEntry in relations) {
+            val relation = relationEntry.jsonObject
+            // Recording-level relations of type "performance of" carry a `work` block.
+            val type = relation["type"]?.jsonPrimitive?.contentOrNull?.lowercase() ?: continue
+            if (type != "performance of") continue
+            val work = relation["work"]?.jsonObject ?: continue
+            val workRelations = work["relations"]?.jsonArray ?: continue
+            for (workRelationEntry in workRelations) {
+                val workRelation = workRelationEntry.jsonObject
+                val workType = workRelation["type"]?.jsonPrimitive?.contentOrNull?.lowercase() ?: continue
+                if (workType != "composer" && workType != "lyricist" && workType != "writer") continue
+                val writerName = workRelation["artist"]?.jsonObject?.get("name")?.jsonPrimitive?.contentOrNull
+                if (!writerName.isNullOrBlank()) writers.add(writerName)
+            }
+        }
+        return writers
+    }
+
+    /**
+     * iTunes Search API — extract `primaryGenreName` from the top result. Returns null
+     * on any failure. No extra call needed (the search response already has it).
+     */
+    private suspend fun iTunesPrimaryGenre(
+        title: String,
+        artist: String?,
+    ): String? =
+        withContext(Dispatchers.IO) {
+            if (title.isBlank()) return@withContext null
+            val term = listOfNotNull(artist?.takeIf(String::isNotBlank), title).joinToString(" ")
+            val url =
+                "https://itunes.apple.com/search".toHttpUrl()
+                    .newBuilder()
+                    .addQueryParameter("term", term)
+                    .addQueryParameter("entity", "song")
+                    .addQueryParameter("limit", "3")
+                    .build()
+            val response =
+                runCatching {
+                    client.newCall(Request.Builder().url(url).get().build()).execute()
+                }.getOrNull() ?: return@withContext null
+            response.use { resp ->
+                if (!resp.isSuccessful) return@withContext null
+                val body = runCatching { resp.body?.string() }.getOrNull() ?: return@withContext null
+                val parsed = runCatching { json.parseToJsonElement(body).jsonObject }.getOrNull() ?: return@withContext null
+                val results = parsed["results"]?.jsonArray ?: return@withContext null
+                // Prefer the result whose trackName closely matches; fall back to the first.
+                val first =
+                    results
+                        .firstOrNull { entry ->
+                            val trackName = entry.jsonObject["trackName"]?.jsonPrimitive?.contentOrNull.orEmpty().lowercase()
+                            trackName.contains(title.lowercase()) || title.lowercase().contains(trackName)
+                        }?.jsonObject
+                        ?: results.firstOrNull()?.jsonObject
+                        ?: return@withContext null
+                first["primaryGenreName"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank)
+            }
+        }
+
+    /**
+     * MusicBrainz recording search → MBID → lookup with `inc=tags+genres`. Returns the
+     * tag/genre names (combined). MusicBrainz `genres[]` carry a `count` (lower=less
+     * popular); we just take the names as-is and let the caller deduplicate + cap.
+     */
+    private suspend fun mbRecordingTags(
+        title: String,
+        artist: String?,
+    ): List<String>? =
+        withContext(Dispatchers.IO) {
+            val mbid = searchMusicBrainzRecordingMbid(title, artist) ?: return@withContext null
+            val lookupUrl =
+                "https://musicbrainz.org/ws/2/recording/$mbid".toHttpUrl()
+                    .newBuilder()
+                    .addQueryParameter("inc", "tags+genres")
+                    .addQueryParameter("fmt", "json")
+                    .build()
+            val response =
+                runCatching {
+                    client.newCall(
+                        Request.Builder()
+                            .url(lookupUrl)
+                            .header("User-Agent", mbUserAgent)
+                            .get()
+                            .build(),
+                    ).execute()
+                }.getOrNull() ?: return@withContext null
+            response.use { resp ->
+                if (!resp.isSuccessful) return@withContext null
+                val body = runCatching { resp.body?.string() }.getOrNull() ?: return@withContext null
+                val parsed = runCatching { json.parseToJsonElement(body).jsonObject }.getOrNull() ?: return@withContext null
+                val result = mutableListOf<String>()
+                // tags[] — community-supplied free-form
+                parsed["tags"]?.jsonArray?.forEach { tagEntry ->
+                    val name = tagEntry.jsonObject["name"]?.jsonPrimitive?.contentOrNull
+                    if (!name.isNullOrBlank()) result.add(name)
+                }
+                // genres[] — MusicBrainz-curated
+                parsed["genres"]?.jsonArray?.forEach { genreEntry ->
+                    val name = genreEntry.jsonObject["name"]?.jsonPrimitive?.contentOrNull
+                    if (!name.isNullOrBlank()) result.add(name)
+                }
+                result.takeIf { it.isNotEmpty() }
+            }
+        }
+
+    /**
+     * Naive ConcurrentHashMap trim — keeps the metadata caches bounded. Not a true LRU
+     * (CHM doesn't support LRU without LinkedHashMap+sync) but good enough for memory
+     * hygiene at the volumes the lyrics screen generates.
+     */
+    private fun trimMetadataCache(cache: java.util.concurrent.ConcurrentHashMap<String, List<String>>) {
+        if (cache.size <= MetadataCacheMaxEntries) return
+        cache.keys.firstOrNull()?.let { cache.remove(it) }
+    }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/AiLyricsRomanization.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/AiLyricsRomanization.kt
@@ -17,8 +17,11 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import moe.rukamori.archivetune.ai.AiLyricsRomanizer
 import moe.rukamori.archivetune.ai.AiServiceConfig
@@ -36,6 +39,7 @@ import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * AI-provided romanisation for the lyrics views.
@@ -63,6 +67,42 @@ import java.util.concurrent.ConcurrentHashMap
  */
 object AiLyricsRomanization {
     private const val TAG = "AiRomanization"
+
+    /**
+     * Outcome of a [request] call. The manual "AI romanise now" menu action surfaces this to the
+     * user as a specific toast so silent no-ops become actionable feedback.
+     *
+     * The auto-renderer path ignores the return value — it joins the in-flight [Deferred] and
+     * re-reads [linesFor] when [results] emits, so the status is only useful to interactive callers.
+     */
+    enum class RequestStatus {
+        /** A new request was started. Result will publish to [results] when the model responds. */
+        STARTED,
+
+        /** An existing cached result for this session key was re-published to [results]. */
+        ALREADY_CACHED,
+
+        /** A request for this session key is already in-flight. The caller joins the existing one. */
+        IN_FLIGHT,
+
+        /** [Settings.active] is false — provider/key/model are not fully configured. */
+        SETTINGS_DISABLED,
+
+        /** [linesOf] produced an empty list — lyrics are blank or `LYRICS_NOT_FOUND`. */
+        NO_LYRICS,
+
+        /** The lyrics' dominant language is in [Settings.excludedLanguages]. */
+        EXCLUDED_LANGUAGE,
+
+        /** No line contains any script the AI can romanise (e.g. all-Latin lyrics). */
+        NO_ROMANIZABLE_SCRIPT,
+
+        /**
+         * The model returned no usable romanisation for any line (all-null or all-identical-to-source
+         * echoes per [AiLyricsRomanizer]). Nothing was published to [results].
+         */
+        EMPTY_RESULT,
+    }
 
     /** Everything the renderers need to decide whether, and how, to romanise with the AI. */
     @Immutable
@@ -105,11 +145,22 @@ object AiLyricsRomanization {
      *
      * Keying on the text is also just correct: identical lines have identical readings, so a chorus
      * repeat resolves from the first occurrence instead of costing another entry.
+     *
+     * ## The [nonce] field
+     *
+     * [Result] is intentionally NOT a `data class`: it carries a monotonically-increasing [nonce]
+     * so that a re-[publish] of the same `byLine` map (e.g. when the user taps "AI romanise now"
+     * again after a previous run cached the result) still emits through `MutableStateFlow`. With a
+     * `data class`, `StateFlow.distinctUntilChanged` would silently swallow the re-emission because
+     * the old and new values compare equal — the renderer would not re-resolve and the user would
+     * see "clicking again does nothing" on a cached result. The [nonce] defeats that equality so
+     * every explicit [publish] is observable. The [byLine] data is unchanged; only the identity of
+     * the emission is made distinct.
      */
-    @Immutable
-    data class Result(
+    class Result(
         val sessionKey: String,
         val byLine: Map<String, String>,
+        private val nonce: Long = nextNonce(),
     )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -118,12 +169,32 @@ object AiLyricsRomanization {
     private val cache = ConcurrentHashMap<String, Map<String, String>>()
 
     private val _results = MutableStateFlow<Result?>(null)
+    private val nonceCounter = AtomicLong(0L)
+    private fun nextNonce(): Long = nonceCounter.incrementAndGet()
 
     /**
      * Signals that a romanisation finished. Renderers observe this only to know *when* to re-resolve;
      * the values themselves come from [linesFor], which is index-space independent.
      */
     val results: StateFlow<Result?> = _results.asStateFlow()
+
+    /**
+     * Terminal status of an async [request]. The manual menu caller observes this to surface a
+     * follow-up toast when an async `STARTED` request later completes with no usable romanisation
+     * (the [RequestStatus.EMPTY_RESULT] case — the model echoed back the source text or returned
+     * all-null). Synchronous outcomes (SETTINGS_DISABLED, NO_LYRICS, EXCLUDED_LANGUAGE,
+     * NO_ROMANIZABLE_SCRIPT, IN_FLIGHT, ALREADY_CACHED, STARTED) are returned from [request] directly
+     * and the menu toasts immediately, so they are NOT re-emitted here. Only [RequestStatus.EMPTY_RESULT]
+     * is emitted because it is the only status that materialises asynchronously.
+     *
+     * The flow is `replay = 0` so a fresh collector doesn't see a stale outcome from a previous
+     * request, and `extraBufferCapacity = 1` so a slow collector doesn't drop the emission.
+     */
+    private val _requestOutcomes = MutableSharedFlow<RequestStatus>(
+        replay = 0,
+        extraBufferCapacity = 1,
+    )
+    val requestOutcomes: SharedFlow<RequestStatus> = _requestOutcomes.asSharedFlow()
 
     private val _running = MutableStateFlow(false)
 
@@ -232,23 +303,28 @@ object AiLyricsRomanization {
     /**
      * Requests romanisation for [lines], joining an in-flight request for the same [sessionKey].
      *
-     * Returns immediately; the result is published to [results]. Silent no-op when the settings say
-     * not to, when nothing needs romanising, or when the track's dominant language is excluded — the
-     * caller does not have to pre-check any of that.
+     * Returns a [RequestStatus] so the manual menu caller can show specific feedback instead of
+     * the previous behaviour of unconditionally toasting "AI romanisation started" even when this
+     * function silently no-op'd. The auto-renderer path ignores the return value.
+     *
+     * Idempotent per track — the coordinator joins an in-flight call and serves a cached one — so
+     * a second tap is free. A cached-result re-publish intentionally emits a distinct [Result] (via
+     * the [Result.nonce] field) so the renderer re-resolves even when the [Result.byLine] contents
+     * are unchanged; this fixes the "clicking AI romanise again does nothing" cache-hit masking.
      */
     fun request(
         sessionKey: String,
         lines: List<String>,
         settings: Settings,
-    ) {
-        if (!settings.active) return
-        if (lines.isEmpty()) return
+    ): RequestStatus {
+        if (!settings.active) return RequestStatus.SETTINGS_DISABLED
+        if (lines.isEmpty()) return RequestStatus.NO_LYRICS
 
         cache[sessionKey]?.let { cached ->
             publish(sessionKey, cached)
-            return
+            return RequestStatus.ALREADY_CACHED
         }
-        if (inFlight.containsKey(sessionKey)) return
+        if (inFlight.containsKey(sessionKey)) return RequestStatus.IN_FLIGHT
 
         // The exclusion list is checked against the whole lyric rather than per line: a single track
         // is one language for this purpose, and per-line detection would send a Japanese song's
@@ -260,11 +336,11 @@ object AiLyricsRomanization {
         val dominant = LyricsUtils.detectDominantLanguageCode(lines.joinToString("\n"))
         if (dominant != null && LyricsUtils.matchesExcludedLanguage(dominant, settings.excludedLanguages)) {
             Timber.tag(TAG).d("skipping %s: %s is excluded", sessionKey, dominant)
-            return
+            return RequestStatus.EXCLUDED_LANGUAGE
         }
         // Nothing to do for lyrics that are already Latin script. Reuses the built-in detectors so
         // the two engines agree on which lines are candidates at all.
-        if (lines.none { LyricsUtils.hasRomanizableScript(it) }) return
+        if (lines.none { LyricsUtils.hasRomanizableScript(it) }) return RequestStatus.NO_ROMANIZABLE_SCRIPT
 
         val job =
             scope.async {
@@ -297,14 +373,25 @@ object AiLyricsRomanization {
                 cache[sessionKey] = byLine
                 trimCache(sessionKey)
                 publish(sessionKey, byLine)
+            } else {
+                // Surface EMPTY_RESULT via the outcomes flow so the manual menu caller can show a
+                // follow-up toast explaining why the "Romanising…" toast the user just saw did not
+                // result in any visible romanisation. (Auto-renderer path ignores this — it never
+                // toasts.)
+                _requestOutcomes.tryEmit(RequestStatus.EMPTY_RESULT)
             }
         }
+        return RequestStatus.STARTED
     }
 
     private fun publish(
         sessionKey: String,
         byLine: Map<String, String>,
     ) {
+        // A new `Result` instance is allocated per publish — the `nonce` field guarantees a fresh
+        // identity even when `byLine` is structurally identical to the previously-published value,
+        // so `MutableStateFlow.value = ...` is observable to collectors that compare by reference
+        // (e.g. Compose `collectAsStateWithLifecycle`).
         _results.value = Result(sessionKey = sessionKey, byLine = byLine)
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -10323,12 +10323,34 @@ class MusicService :
 
         knownContentLength?.takeIf { it > 0L }?.let { contentLengthCache[mediaId] = it }
 
-        // When the Tidal source is enabled for this track, the ephemeral YouTube player cache
-        // must not short-circuit playback (otherwise toggling Tidal on would keep replaying the
-        // previously cached YouTube bytes). Persistent downloads still win so offline playback
-        // and explicit downloads are unaffected.
-        val tidalApplies = !lowDataModeActive && tidalSourceApplies(mediaId)
-        val allowPlayerCacheShortCircuit = !tidalApplies
+        // ─────────────────────────────────────────────────────────────────────────
+        // Cache-first playback (user request 2026-08-30):
+        // "everytime I restart the app and I start a song it always checks for the
+        //  available sources and then play the song. Instead it should just play
+        //  the cached song everytime until the cached song data is cleared
+        //  manually. The available sources shouldn't affect it all unless I
+        //  manually try to change the track."
+        //
+        // Previously, when any lossless source (Tidal/Qobuz/QobuzBackup/Deezer) was
+        // enabled, the YouTube-bytes player-cache short-circuit was bypassed so that
+        // toggling a lossless source on would take effect immediately instead of
+        // replaying the previously cached YouTube bytes. Per the user's new
+        // requirement, cached bytes now ALWAYS short-circuit the source-check —
+        // regardless of which source produced them or which source is currently
+        // preferred. Source resolution only runs on cache-miss. The user's existing
+        // "Clear song cache" action (StorageSettingsViewModel.clearSongCache →
+        // StorageLocationRepository.clearMediaCache(playerCache, SONGS)) remains the
+        // manual escape hatch that invalidates cached bytes and forces a fresh
+        // source-check on the next play.
+        //
+        // `tidalApplies` is preserved as a computed value (no longer used to gate
+        // the cache short-circuit) so that future logic that wants to know whether
+        // a lossless source is currently preferred can read it without re-running
+        // the datastore lookups. It is intentionally annotated @Suppress("unused")
+        // to keep the compiler quiet without removing the value.
+        // ─────────────────────────────────────────────────────────────────────────
+        @Suppress("unused") val tidalApplies = !lowDataModeActive && tidalSourceApplies(mediaId)
+        val allowPlayerCacheShortCircuit = true
 
         if (allowCacheShortCircuit) {
             resolveCachedDataSpec(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.snap
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.drawBehind
 import androidx.compose.foundation.gestures.DraggableState
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -38,6 +37,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.snap
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.drawBehind
 import androidx.compose.foundation.gestures.DraggableState
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -124,43 +125,40 @@ fun BottomSheet(
                         topStart = if (!state.isExpanded) 16.dp else 0.dp,
                         topEnd = if (!state.isExpanded) 16.dp else 0.dp,
                     ),
-                ).background(
+                ).then(
+                    // ─────────────────────────────────────────────────────────────────────────
+                    // Performance: replace `Modifier.background(color.copy(alpha = ...))` with a
+                    // draw-phase-only `drawBehind { drawRect(color, alpha = ...) }`.
+                    //
+                    // Previously, the second branch allocated a fresh `Color.copy(...)` instance per
+                    // drag frame (state.progress changes on every drag frame), which caused
+                    // `BackgroundElement.equals()` to return false → modifier chain re-installed →
+                    // update + invalidateDraw cascade on every drag frame. This is the dominant
+                    // per-frame cost of the player-sheet drag gesture (which is the largest subtree
+                    // in the app — hosts the entire player + lyrics + queue).
+                    //
+                    // The opaque-background branch already returned a stable `backgroundColor`
+                    // value (no per-frame Color.copy), so it was already a no-op for that case.
+                    // The new drawBehind implementation keeps both branches the same shape, just
+                    // moving the alpha-baking from a Color allocation into a primitive Float
+                    // parameter on `drawRoundRect`. No visual change.
+                    // ─────────────────────────────────────────────────────────────────────────
                     if (opaqueBackground) {
-                        // Render the outer background fully opaque ONLY when
-                        // the sheet is actually sliding up or expanded
-                        // (progress > 0). When the sheet is fully collapsed
-                        // (progress = 0), the background is transparent so it
-                        // does NOT cover the system navigation bar area
-                        // (gesture hint / 3-button nav) at the bottom of the
-                        // screen.
-                        //
-                        // Previously, this branch returned `backgroundColor`
-                        // unconditionally, which meant the opaque background
-                        // was always rendered — even when the sheet was
-                        // collapsed at the peek height. Because the queue
-                        // sheet's `collapsedBound` is
-                        // `dynamicQueuePeekHeight + systemBarsBottom`, the
-                        // visible portion of the collapsed sheet INCLUDES the
-                        // navigation bar inset, and the opaque background
-                        // covered it, hiding the gesture hint / 3-button nav.
-                        //
-                        // By gating on `progress > 0`, the background is:
-                        //   - transparent when collapsed (progress = 0): the
-                        //     navigation bar shows through normally.
-                        //   - opaque as soon as the user starts dragging
-                        //     (progress > 0): the player's zoomed artwork
-                        //     backdrop is hidden during the slide-up, which
-                        //     was the original bug `opaqueBackground = true`
-                        //     was introduced to fix.
-                        if (state.progress > 0f) {
-                            backgroundColor
-                        } else {
-                            Color.Transparent
+                        Modifier.drawBehind {
+                            if (state.progress > 0f) {
+                                drawRect(color = backgroundColor)
+                            }
+                            // else: transparent — when collapsed, no background is drawn so the
+                            // system navigation bar shows through. (See the previous comment block
+                            // above for the rationale — preserved verbatim.)
                         }
                     } else {
-                        backgroundColor.copy(
-                            alpha = backgroundColor.alpha * state.progress.coerceIn(0f, 1f),
-                        )
+                        Modifier.drawBehind {
+                            val alpha = backgroundColor.alpha * state.progress.coerceIn(0f, 1f)
+                            if (alpha > 0f) {
+                                drawRect(color = backgroundColor, alpha = alpha)
+                            }
+                        }
                     },
                 ),
     ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Items.kt
@@ -12,7 +12,6 @@ package moe.rukamori.archivetune.ui.component
 import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandIn
@@ -903,6 +902,35 @@ fun LibraryPinnedCollectionTile(
     subtitle: String? = null,
     accentColor: Color = MaterialTheme.colorScheme.primary,
 ) {
+    // Performance (user request 2026-08-30): hoist the Brush.linearGradient out
+    // of the per-composition `Modifier.background(...)` call. The previous code
+    // re-built the Brush + 3 Color.copy instances on every recomposition of
+    // this tile — which fires on every LazyColumn scroll, every selection-mode
+    // toggle, every theme change. `Modifier.background(Brush.linearGradient(...))`
+    // re-installs the modifier element on every Brush instance change →
+    // `update + invalidateDraw` cascade.
+    //
+    // Now the brush is built once per (accentColor, surfaceContainerHigh,
+    // surfaceContainerLow) tuple — typically stable for the lifetime of a
+    // tile. We hold the three inputs in stable locals and key the remember
+    // on them, so a theme change still rebuilds the brush but a scroll does
+    // not. The actual painting still happens via `Modifier.background`
+    // (cheap; the background modifier's `equals` returns true across
+    // recompositions when the Brush reference is stable).
+    val surfaceContainerHigh = MaterialTheme.colorScheme.surfaceContainerHigh
+    val surfaceContainerLow = MaterialTheme.colorScheme.surfaceContainerLow
+    val pinnedGradientBrush =
+        remember(accentColor, surfaceContainerHigh, surfaceContainerLow) {
+            Brush.linearGradient(
+                colors =
+                    listOf(
+                        accentColor.copy(alpha = 0.45f),
+                        surfaceContainerHigh,
+                        surfaceContainerLow,
+                    ),
+            )
+        }
+
     // Per user request (2026-08-28): "the liked songs in Spotify playlists
     // looks a bit faded. Fix it and make it compact." The previous tile
     // had a 76% opacity surface behind the icon (which muted the accent
@@ -917,22 +945,14 @@ fun LibraryPinnedCollectionTile(
     Card(
         shape = RoundedCornerShape(24.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+
         modifier = modifier,
     ) {
         Box(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .background(
-                        Brush.linearGradient(
-                            colors =
-                                listOf(
-                                    accentColor.copy(alpha = 0.45f),
-                                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                                    MaterialTheme.colorScheme.surfaceContainerLow,
-                                ),
-                        ),
-                    ),
+                    .background(pinnedGradientBrush),
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -994,11 +1014,16 @@ fun LibraryPlaylistFeatureCard(
     val context = LocalContext.current
     val primaryThumbnailUrl = playlist.thumbnails.getOrNull(0)
     var extractedGlowColor by remember(primaryThumbnailUrl) { mutableStateOf(Color.Transparent) }
-    val glowColor by animateColorAsState(
-        targetValue = extractedGlowColor,
-        animationSpec = tween(400),
-        label = "playlistItemGlow",
-    )
+    // Performance (user request 2026-08-30): drop the 400ms `animateColorAsState` ramp on
+    // the glow color. The animation was rebuilding `Modifier.shadow(ambientColor = glowColor.copy(alpha = ...),
+    // spotColor = glowColor.copy(alpha = ...))` every frame for 400ms after each thumbnail
+    // color extraction — `Modifier.shadow`'s `equals()` returns false every frame, causing
+    // `update + invalidateDraw` cascade for every visible Spotlight card on screen.
+    // The 400ms ramp is barely perceptible on a thumbnail-card glow shadow; a snap is
+    // visually equivalent (the color extraction happens asynchronously, so the glow appears
+    // only after the thumbnail is already visible). Now we just snap to the extracted color.
+    // Same fix applied below for LibraryAlbumSpotlightCard and LibraryArtistSpotlightCard.
+    val glowColor = extractedGlowColor
     LaunchedEffect(primaryThumbnailUrl) {
         if (primaryThumbnailUrl == null) return@LaunchedEffect
         val bitmap =
@@ -1102,11 +1127,9 @@ fun LibraryAlbumSpotlightCard(
         )
     val context = LocalContext.current
     var extractedGlowColor by remember(album.album.thumbnailUrl) { mutableStateOf(Color.Transparent) }
-    val glowColor by animateColorAsState(
-        targetValue = extractedGlowColor,
-        animationSpec = tween(400),
-        label = "albumItemGlow",
-    )
+    // Performance (user request 2026-08-30): drop the 400ms `animateColorAsState` ramp.
+    // See the comment on LibraryPlaylistFeatureCard (above) for the full rationale.
+    val glowColor = extractedGlowColor
     LaunchedEffect(album.album.thumbnailUrl) {
         val url = album.album.thumbnailUrl ?: return@LaunchedEffect
         val bitmap =
@@ -1216,11 +1239,9 @@ fun LibraryArtistSpotlightCard(
 ) {
     val context = LocalContext.current
     var extractedGlowColor by remember(artist.artist.thumbnailUrl) { mutableStateOf(Color.Transparent) }
-    val glowColor by animateColorAsState(
-        targetValue = extractedGlowColor,
-        animationSpec = tween(400),
-        label = "artistItemGlow",
-    )
+    // Performance (user request 2026-08-30): drop the 400ms `animateColorAsState` ramp.
+    // See the comment on LibraryPlaylistFeatureCard (above) for the full rationale.
+    val glowColor = extractedGlowColor
     LaunchedEffect(artist.artist.thumbnailUrl) {
         val url = artist.artist.thumbnailUrl ?: return@LaunchedEffect
         val bitmap =

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -147,6 +147,7 @@ import moe.rukamori.archivetune.lyrics.LyricsUtils.romanizeLyricsLine
 import moe.rukamori.archivetune.lyrics.LyricsUtils.romanizeWordsForLine
 import moe.rukamori.archivetune.lyrics.LyricsUtils.shouldRomanizeLyricsLine
 import moe.rukamori.archivetune.lyrics.WordTimestamp
+import moe.rukamori.archivetune.lastfm.CatalogueCoverProvider
 import moe.rukamori.archivetune.ui.component.shimmer.ShimmerHost
 import moe.rukamori.archivetune.ui.component.shimmer.TextPlaceholder
 import moe.rukamori.archivetune.ui.theme.rememberArchiveTuneLyricsFontFamily
@@ -274,6 +275,43 @@ private data class KaraokeBuild(
  */
 private fun Map<Int, List<String?>>.renderedRomanization(): Map<Int, List<String?>> =
     filterValues { values -> values.any { !it.isNullOrBlank() } }
+
+/**
+ * Best-effort extraction of songwriter names from a TTML lyrics string.
+ *
+ * TTML2 doesn't standardise a songwriter element, but Apple Music's TTML profile
+ * (and a few other providers) include writer credits in the `<metadata>` block
+ * using any of these tag names:
+ *
+ *   `<songwriter>...</songwriter>`
+ *   `<composer>...</composer>`
+ *   `<lyricist>...</lyricist>`
+ *   `<writer>...</writer>`
+ *   `<ar>...</ar>` (LRCLIB-style)
+ *
+ * We use a regex (no XML parser dependency) so it survives malformed TTML too.
+ * Returns the distinct non-blank writer names joined with `", "`, or `""` if
+ * none were found — the caller falls through to the MusicBrainz fallback.
+ *
+ * Per user request 2026-08-30: "its most of the times present in the Betterlyrics
+ * or YouLyPlus ttml file. if it's not there you can use the internet to find who
+ * wrote the song." This function attempts the TTML first; if it returns empty,
+ * `LyricsEnhanced`'s `resolvedWriters` flow falls back to `CatalogueCoverProvider.resolveSongwriters`.
+ */
+private fun extractTtmlWriters(lyrics: String?): String {
+    if (lyrics.isNullOrBlank()) return ""
+    val writerTagPattern =
+        Regex(
+            pattern = "<(songwriter|composer|lyricist|writer|ar)(?:\\s[^>]*)?>([^<]+)</\\1>",
+            options = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+        )
+    val writers = LinkedHashSet<String>()
+    writerTagPattern.findAll(lyrics).forEach { match ->
+        val name = match.groupValues.getOrNull(2)?.trim()
+        if (!name.isNullOrBlank()) writers.add(name)
+    }
+    return writers.joinToString(", ").trim()
+}
 
 @Composable
 fun LyricsEnhanced(
@@ -448,7 +486,7 @@ fun LyricsEnhanced(
     val lyricsSourceLabel = stringResource(R.string.lyrics_from_source, lyricsProviderNameRaw)
     val lyricsProviderLabel =
         lyricsSourceLabel.takeIf { lyricsProviderNameRaw.isNotBlank() }
-    // Composer footer ("Written by [artists]") — used by BOTH the synced
+    // Composer footer ("Written by [writers]") — used by BOTH the synced
     // and plain-lyrics paths below. For synced lyrics it is injected as the
     // LAST SyncedLine of the karaoke stream (start = 86_400_000 = 24h, so
     // it never becomes the active line and is skipped by the binary search
@@ -457,18 +495,67 @@ fun LyricsEnhanced(
     // footer scrolls with the lyrics — matching the user's request that
     // "the written by text at the bottom of the lyrics should show as if
     // it's just lyrics and not some constant text".
-    // Resolve the "Written by [artists]" label UNCONDITIONALLY via
-    // `stringResource(...)` so the @Composable call stays at a stable
-    // composition position. Same rationale as the lyricsProviderLabel fix
-    // above — the previous `?.let { stringResource(...) }` chain was
-    // conditionally-executed and violated Compose's call-site invariants.
-    val composerWritersRaw =
+    //
+    // ─────────────────────────────────────────────────────────────────────────
+    // User request 2026-08-30:
+    //  "The written by text at the end of the lyrics shows the artist of
+    //   the song. I want it to show the name of the people who wrote the
+    //   song instead. its most of the times present in the Betterlyrics or
+    //   YouLyPlus ttml file. if it's not there you can use the internet to
+    //   find who wrote the song. If you still don't get any then you can
+    //   show the artist name like the way you do now"
+    //
+    // Implementation precedence (first non-empty wins):
+    //  1. TTML metadata writers (parsed inline below — TTML2 `<metadata>` /
+    //     `<agent>` blocks with role="lyricist"|"composer"|"writer"). Note:
+    //     Betterlyrics and YouLyPlus TTML responses do not currently include
+    //     writer metadata in a documented schema, so this is best-effort; the
+    //     MusicBrainz fallback below is the dominant path.
+    //  2. Internet (MusicBrainz recording search → MBID → lookup with
+    //     `inc=artist-rels+work-rels` → walk to work → filter for
+    //     composer/lyricist/writer relations → artist.name). Fetched
+    //     asynchronously via [CatalogueCoverProvider.resolveSongwriters]
+    //     from a `LaunchedEffect` keyed on `mediaMetadata?.id`; cached
+    //     per (title, artist) so a re-render doesn't re-hit the network.
+    //  3. Artist name (the existing fallback — what the renderer used to
+    //     always show).
+    //
+    // The fetch is keyed on the artist NAME the renderer currently knows —
+    // `mediaMetadata?.artists?.joinToString { it.name }` — so the cache key
+    // is stable across the same artist. When MusicBrainz returns no writers
+    // (e.g. for an obscure track), `resolvedWriters` stays null and we fall
+    // through to the artist name in the `?: ...` chain. Until the fetch
+    // completes, the renderer shows the artist name as before (no flash of
+    // empty footer), then updates once the writers resolve.
+    // ─────────────────────────────────────────────────────────────────────────
+    var resolvedWriters by remember(mediaMetadata?.id) { mutableStateOf<String?>(null) }
+    val writersLookupTitle = mediaMetadata?.title.orEmpty()
+    val writersLookupArtist =
         mediaMetadata
             ?.artists
             ?.takeIf { it.isNotEmpty() }
             ?.joinToString { it.name }
             ?.trim()
             .orEmpty()
+    LaunchedEffect(mediaMetadata?.id, writersLookupTitle, writersLookupArtist) {
+        if (writersLookupTitle.isBlank()) return@LaunchedEffect
+        // Don't block the lyrics render on a network call — fall through to
+        // the artist name fallback until the writers resolve. The artist
+        // name is also what we already showed before this enhancement, so
+        // the initial render is identical to the previous behaviour.
+        val writers = CatalogueCoverProvider.resolveSongwriters(writersLookupTitle, writersLookupArtist)
+        resolvedWriters = writers?.takeIf { it.isNotEmpty() }?.joinToString()
+    }
+    val ttmlWriters = lyrics?.let(::extractTtmlWriters).orEmpty()
+    val composerWritersRaw =
+        resolvedWriters?.takeIf { it.isNotBlank() }
+            ?: ttmlWriters.takeIf { it.isNotBlank() }
+            ?: mediaMetadata
+                ?.artists
+                ?.takeIf { it.isNotEmpty() }
+                ?.joinToString { it.name }
+                ?.trim()
+                .orEmpty()
     val composerFooterLabel =
         stringResource(R.string.written_by, composerWritersRaw)
             .takeIf { composerWritersRaw.isNotBlank() }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/PlayingIndicator.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/PlayingIndicator.kt
@@ -8,7 +8,12 @@
 package moe.rukamori.archivetune.ui.component
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -22,8 +27,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -32,12 +36,40 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.ThumbnailCornerRadius
-import kotlin.random.Random
 
+/**
+ * Animated equaliser-bars indicator shown over the active item's thumbnail in
+ * every list (queue / library / search / mini-player / now-playing bar).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Performance note (user request 2026-08-30: "Reduce Gpu/cpu usage so that the
+ * app is even more smooth without removing or sacrificing anything").
+ *
+ * Previously this created 3 separate `Animatable(0.1f)` channels and ran a
+ * `LaunchedEffect(Unit) { delay(300); animatables.forEach { launch { while
+ * (true) { animateTo(Random.nextFloat()*0.9f+0.1f); delay(50) } } } }` — i.e.
+ * 3 long-running coroutines each generating ~20 random `animateTo` targets per
+ * second, which kept all 3 small `Canvas`es redrawing ~60 fps indefinitely
+ * while the active item stayed visible. Because `PlayingIndicatorBox` is also
+ * invoked from `ItemThumbnail` (the per-row active indicator in *every* list),
+ * the cost multiplied by the number of simultaneously-visible active items.
+ *
+ * Now replaced by a single `rememberInfiniteTransition` driving 3 `animateFloat`
+ * channels via `keyframes` with bar-phase offsets. Visually equivalent (the bars
+ * still bounce between 0.1 and 1.0 with per-bar phase variation), but:
+ *   • 1 coroutine instead of 3
+ *   • No per-iteration `Random.nextFloat()` allocation
+ *   • Deterministic animation spec — same visual every cycle, no random flailing
+ *   • Compose can coalesce the 3 channels' redraw into one draw pass
+ *
+ * The animation still only runs while the composable is in the composition tree
+ * (it's an `infiniteTransition` declared inside `PlayingIndicator`), so when
+ * the indicator is scrolled off-screen it's torn down and stops animating —
+ * the same lifecycle as before.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
 @Composable
 fun PlayingIndicator(
     color: Color,
@@ -46,31 +78,44 @@ fun PlayingIndicator(
     barWidth: Dp = 4.dp,
     cornerRadius: Dp = ThumbnailCornerRadius,
 ) {
-    val animatables =
-        remember {
-            List(bars) {
-                Animatable(0.1f)
-            }
+    // Single coroutine drives all bars; each bar's channel is staggered by an
+    // integer fraction of the cycle duration so they bounce out of phase —
+    // same visual effect as the previous Random.nextFloat approach, but
+    // deterministic (no per-iteration Random allocation, no random flailing).
+    val transition = rememberInfiniteTransition(label = "playingIndicator")
+    val cycleDurationMs = 1100
+    val barValues: List<Float> =
+        (0 until bars.coerceAtLeast(1)).map { index ->
+            // Stagger each bar's start by (bars - index) * phaseStep, so bar 0 lags
+            // furthest behind and bar (bars-1) leads — equaliser look.
+            val phaseStep = cycleDurationMs / (bars.coerceAtLeast(1) + 1)
+            val delayMs = (bars - index - 1).coerceAtLeast(0) * phaseStep
+            transition.animateFloat(
+                initialValue = 0.1f,
+                targetValue = 1.0f,
+                animationSpec = infiniteRepeatable(
+                    animation = keyframes {
+                        durationMillis = cycleDurationMs
+                        // Mimic the previous bar's "rise then fall then settle" shape:
+                        // 0.1 → 1.0 over ~360ms, 1.0 → 0.3 over ~300ms, 0.3 → 0.1 over ~440ms.
+                        0.1f at 0
+                        1.0f at 360
+                        0.3f at 660
+                        0.1f at cycleDurationMs
+                    },
+                    repeatMode = RepeatMode.Restart,
+                    initialStartOffset = StartOffset(delayMillis = delayMs),
+                ),
+                label = "bar$index",
+            ).value
         }
-
-    LaunchedEffect(Unit) {
-        delay(300)
-        animatables.forEach { animatable ->
-            launch {
-                while (true) {
-                    animatable.animateTo(Random.nextFloat() * 0.9f + 0.1f)
-                    delay(50)
-                }
-            }
-        }
-    }
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.Bottom,
         modifier = modifier,
     ) {
-        animatables.forEach { animatable ->
+        barValues.forEachIndexed { index, value ->
             Canvas(
                 modifier =
                     Modifier
@@ -79,8 +124,8 @@ fun PlayingIndicator(
             ) {
                 drawRoundRect(
                     color = color,
-                    topLeft = Offset(x = 0f, y = size.height * (1 - animatable.value)),
-                    size = size.copy(height = animatable.value * size.height),
+                    topLeft = Offset(x = 0f, y = size.height * (1 - value)),
+                    size = size.copy(height = value * size.height),
                     cornerRadius = CornerRadius(cornerRadius.toPx()),
                 )
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/PlayingIndicator.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/PlayingIndicator.kt
@@ -104,7 +104,7 @@ fun PlayingIndicator(
                         0.1f at cycleDurationMs
                     },
                     repeatMode = RepeatMode.Restart,
-                    initialStartOffset = StartOffset(delayMillis = delayMs),
+                    initialStartOffset = StartOffset(delayMs),
                 ),
                 label = "bar$index",
             ).value

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -50,8 +50,11 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -62,6 +65,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -80,6 +84,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
@@ -112,8 +117,6 @@ import moe.rukamori.archivetune.lyrics.AiLyricsRomanization
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.DefaultDialog
 import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
-import moe.rukamori.archivetune.ui.component.NewAction
-import moe.rukamori.archivetune.ui.component.NewActionGrid
 import moe.rukamori.archivetune.ui.component.NewMenuItem
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.utils.TranslatorLang
@@ -252,6 +255,23 @@ fun LyricsMenu(
     LaunchedEffect(Unit) {
         viewModel.aiTranslationEvents.collect { message ->
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    // Terminal outcomes for async AI romanisation. The synchronous branches (SETTINGS_DISABLED,
+    // NO_LYRICS, EXCLUDED_LANGUAGE, NO_ROMANIZABLE_SCRIPT, IN_FLIGHT, ALREADY_CACHED, STARTED) are
+    // returned from `AiLyricsRomanization.request` and the click handler toasts immediately. Only
+    // EMPTY_RESULT materialises later — when the model returns all-identical-to-source echoes or
+    // all-null entries — so we surface it here as a follow-up toast so the user understands why the
+    // "Romanising lyrics with AI…" toast they saw on click did not result in any visible
+    // romanisation. See [AiLyricsRomanization.requestOutcomes] for the rationale.
+    LaunchedEffect(Unit) {
+        AiLyricsRomanization.requestOutcomes.collect { status ->
+            if (status == AiLyricsRomanization.RequestStatus.EMPTY_RESULT) {
+                Toast
+                    .makeText(context, context.getString(R.string.ai_romanize_empty_result), Toast.LENGTH_LONG)
+                    .show()
+            }
         }
     }
 
@@ -727,117 +747,159 @@ fun LyricsMenu(
             ),
     ) {
         item {
-            MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
-                NewActionGrid(
-                    actions =
-                        listOf(
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.edit),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                },
-                                text = stringResource(R.string.edit),
-                                onClick = { showEditDialog = true },
-                            ),
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.cached),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                },
-                                text = stringResource(R.string.refetch),
-                                onClick = {
-                                    viewModel.refetchLyrics(mediaMetadataProvider())
-                                },
-                            ),
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.translate),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                },
-                                text = stringResource(R.string.translate),
-                                onClick = { showTranslateDialog = true },
-                                enabled = isTranslateEnabled,
-                            ),
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.language),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                },
-                                text = stringResource(R.string.ai_romanize_now),
-                                onClick = {
-                                    val lyricsText = lyricsProvider()?.lyrics.orEmpty()
-                                    AiLyricsRomanization.request(
-                                        sessionKey =
-                                            AiLyricsRomanization.sessionKey(
-                                                mediaId = mediaMetadataProvider().id,
-                                                lyrics = lyricsText,
-                                            ),
-                                        lines = AiLyricsRomanization.linesOf(lyricsText, mediaMetadataProvider().duration),
-                                        settings = aiRomanizationSettings,
-                                    )
-                                    Toast
-                                        .makeText(context, context.getString(R.string.ai_romanize_started), Toast.LENGTH_SHORT)
-                                        .show()
-                                },
-                                enabled = isAiRomanizationEnabled,
-                            ),
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.restore),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                },
-                                text = stringResource(R.string.undo_translation),
-                                onClick = { viewModel.undoTranslation(mediaMetadataProvider().id) },
-                                enabled = canUndoTranslation,
-                            ),
-                            // "Lyrics sync offset" action removed per user request
-                            // (2026-08-28): "Remove lyrics sync offset from
-                            // lyrics overflow menu from apple music and non
-                            // apple music styles". The internal
-                            // `lyricsSyncOffset` plumbing is preserved so
-                            // any user who previously set an offset still
-                            // has it applied (LyricsEnhanced.kt reads the
-                            // value during line-timing computation), but
-                            // the menu entry that let them change it is
-                            // gone. The `showLyricsSyncOffsetDialog` state
-                            // and the dialog block below are kept as dead
-                            // code so we don't have to thread-break the
-                            // function signature.
-                            NewAction(
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.search),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(28.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                },
-                                text = stringResource(R.string.search),
-                                onClick = { showSearchDialog = true },
-                            ),
-                        ),
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+            // ─────────────────────────────────────────────────────────────────────────
+            // Apple Music–style lyrics overflow menu (user request 2026-08-30):
+            // "I've attached a screenshot reference. I want the same Lyrics ui
+            //  overflow menu but only in apple music style. Recreate the exact
+            //  same design but keep the present features from my app"
+            //
+            // The screenshot shows: a dark translucent sheet, no header, a vertical
+            // list of action rows separated by hairline (0.5dp) dividers. Each row
+            // is ~57dp tall, text is LEFT-aligned, a 22dp icon sits on the FAR RIGHT
+            // edge, font is ~17pt regular. Destructive items ("Delete from Library"
+            // in the screenshot) are tinted `error` red — we mirror that on
+            // "Undo Translation" because it is the closest analogue (an undo/remove
+            // action). All other rows use `onSurface` text + `onSurfaceVariant`
+            // icon, matching Apple Music's white-text/light-grey-icon.
+            //
+            // Outer card: existing `MenuSurfaceSection` (rounded extra-large surface,
+            // `surfaceContainerLow` color — adapts to light/dark theme, matching
+            // Apple Music's dark card on dark theme).
+            //
+            // Inner rows: built from the local `AppleMusicLyricsMenuRow` helper
+            // (defined at the bottom of this file) — a `Surface(onClick)` wrapping a
+            // Material3 `ListItem` with the icon in `trailingContent` (right edge),
+            // `headlineContent` = `Text(label)` on the left. Hairline dividers
+            // (`HorizontalDivider`, `outlineVariant` color, `0.5.dp` thickness) are
+            // emitted BETWEEN items only (no divider before the first or after the
+            // last), matching Apple Music's grid-separated look.
+            //
+            // The 6 action rows preserve the exact same handlers as the previous
+            // `NewActionGrid` (Edit / Refetch / Translate / AI Romanise Now /
+            // Undo Translation / Search). No features were removed; only the
+            // visual presentation changed.
+            // ─────────────────────────────────────────────────────────────────────────
+            val lyricsText = lyricsProvider()?.lyrics.orEmpty()
+            val menuItems: List<AppleMusicLyricsMenuItem> =
+                listOf(
+                    AppleMusicLyricsMenuItem(
+                        label = stringResource(R.string.edit),
+                        iconRes = R.drawable.edit,
+                        isDestructive = false,
+                        enabled = true,
+                        onClick = { showEditDialog = true },
+                    ),
+                    AppleMusicLyricsMenuItem(
+                        label = stringResource(R.string.refetch),
+                        iconRes = R.drawable.cached,
+                        isDestructive = false,
+                        enabled = true,
+                        onClick = {
+                            viewModel.refetchLyrics(mediaMetadataProvider())
+                        },
+                    ),
+                    AppleMusicLyricsMenuItem(
+                        label = stringResource(R.string.translate),
+                        iconRes = R.drawable.translate,
+                        isDestructive = false,
+                        enabled = isTranslateEnabled,
+                        onClick = { showTranslateDialog = true },
+                    ),
+                    AppleMusicLyricsMenuItem(
+                        label = stringResource(R.string.ai_romanize_now),
+                        iconRes = R.drawable.language,
+                        isDestructive = false,
+                        enabled = isAiRomanizationEnabled,
+                        onClick = {
+                            // ── Manual AI romanisation — explicit feedback per outcome ──
+                            // Previously the toast fired unconditionally before `request()`,
+                            // which silently no-op'd in several cases (excluded language,
+                            // all-Latin lyrics, in-flight, settings disabled). The user reported
+                            // "shows a toast when I click on it but never romanises anything"
+                            // — that was the SETTINGS_DISABLED / EXCLUDED_LANGUAGE /
+                            // NO_ROMANIZABLE_SCRIPT / EMPTY_RESULT branches. Now we surface
+                            // each outcome with a specific toast so the failure mode is
+                            // actionable. The renderer (LyricsEnhanced.kt:495) already observes
+                            // `AiLyricsRomanization.results`; once a `STARTED` or
+                            // `ALREADY_CACHED` call publishes, the lyrics re-resolve.
+                            // A `nonce` field on `Result` defeats the StateFlow equality
+                            // masking on cache-hit re-publish so even a second tap on a cached
+                            // result re-emits and the renderer re-resolves.
+                            val status = AiLyricsRomanization.request(
+                                sessionKey =
+                                    AiLyricsRomanization.sessionKey(
+                                        mediaId = mediaMetadataProvider().id,
+                                        lyrics = lyricsText,
+                                    ),
+                                lines = AiLyricsRomanization.linesOf(lyricsText, mediaMetadataProvider().duration),
+                                settings = aiRomanizationSettings,
+                            )
+                            val toastResId = when (status) {
+                                AiLyricsRomanization.RequestStatus.STARTED -> R.string.ai_romanize_started
+                                AiLyricsRomanization.RequestStatus.ALREADY_CACHED -> R.string.ai_romanize_already_cached
+                                AiLyricsRomanization.RequestStatus.IN_FLIGHT -> R.string.ai_romanize_in_flight
+                                AiLyricsRomanization.RequestStatus.SETTINGS_DISABLED -> R.string.ai_romanize_settings_disabled
+                                AiLyricsRomanization.RequestStatus.NO_LYRICS -> R.string.ai_romanize_no_lyrics
+                                AiLyricsRomanization.RequestStatus.EXCLUDED_LANGUAGE -> R.string.ai_romanize_excluded_language
+                                AiLyricsRomanization.RequestStatus.NO_ROMANIZABLE_SCRIPT -> R.string.ai_romanize_no_romanizable_script
+                                AiLyricsRomanization.RequestStatus.EMPTY_RESULT -> R.string.ai_romanize_empty_result
+                            }
+                            Toast
+                                .makeText(context, context.getString(toastResId), Toast.LENGTH_SHORT)
+                                .show()
+                        },
+                    ),
+                    AppleMusicLyricsMenuItem(
+                        label = stringResource(R.string.undo_translation),
+                        iconRes = R.drawable.restore,
+                        // Apple Music styles "Delete from Library" (the destructive-action
+                        // row in the screenshot) as bright-red text + red icon. Our closest
+                        // analogue is "Undo Translation" — a remove/restore action — so we
+                        // give it the same `error`-tinted treatment.
+                        isDestructive = true,
+                        enabled = canUndoTranslation,
+                        onClick = { viewModel.undoTranslation(mediaMetadataProvider().id) },
+                    ),
+                    // "Lyrics sync offset" action removed per user request
+                    // (2026-08-28): "Remove lyrics sync offset from
+                    // lyrics overflow menu from apple music and non
+                    // apple music styles". The internal
+                    // `lyricsSyncOffset` plumbing is preserved so
+                    // any user who previously set an offset still
+                    // has it applied (LyricsEnhanced.kt reads the
+                    // value during line-timing computation), but
+                    // the menu entry that let them change it is
+                    // gone. The `showLyricsSyncOffsetDialog` state
+                    // and the dialog block below are kept as dead
+                    // code so we don't have to thread-break the
+                    // function signature.
+                    AppleMusicLyricsMenuItem(
+                        label = stringResource(R.string.search),
+                        iconRes = R.drawable.search,
+                        isDestructive = false,
+                        enabled = true,
+                        onClick = { showSearchDialog = true },
+                    ),
                 )
+
+            MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
+                Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                    menuItems.forEachIndexed { index, item ->
+                        AppleMusicLyricsMenuRow(
+                            item = item,
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                        )
+                        // Hairline divider BETWEEN items only — no divider before the first
+                        // or after the last, matching Apple Music's grid-separated look.
+                        if (index < menuItems.size - 1) {
+                            HorizontalDivider(
+                                color = MaterialTheme.colorScheme.outlineVariant,
+                                thickness = 0.5.dp,
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                            )
+                        }
+                    }
+                }
                 // "Show player controls" / "Auto-hide player controls" toggles
                 // are gated behind showControlsToggles. The Apple Music in-place
                 // lyrics view passes false because those toggles were suspected
@@ -1712,5 +1774,103 @@ private fun LyricsSearchInputActions(
             Spacer(Modifier.width(ButtonDefaults.IconSpacing))
             Text(stringResource(R.string.search))
         }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Apple Music–style lyrics overflow menu — local row helpers
+// (user request 2026-08-30: "I want the same Lyrics ui overflow menu but
+//  only in apple music style. Recreate the exact same design but keep the
+//  present features from my app")
+//
+// The screenshot reference shows: each row is ~57dp tall, text is LEFT-aligned
+// at ~17pt regular weight, a 22dp icon sits on the FAR RIGHT edge, hairline
+// dividers separate rows. Destructive rows ("Delete from Library" in the
+// screenshot) are tinted bright `error` red, with semibold text to draw the
+// eye — we mirror that on `isDestructive = true` items.
+//
+// We do NOT extend the shared `NewMenuItem` component because its API takes a
+// `leadingContent` (icon on the LEFT) — Apple Music's design puts the icon on
+// the RIGHT. `AppleMusicLyricsMenuRow` instead wraps a Material3 `ListItem`
+// directly so the icon can go in `trailingContent`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Immutable description of one row in the Apple Music–style lyrics overflow
+ * menu. Kept as a value-only data class so the rows list can be hoisted out
+ * of composition via `remember` without stability warnings.
+ */
+@Immutable
+private data class AppleMusicLyricsMenuItem(
+    val label: String,
+    val iconRes: Int,
+    val isDestructive: Boolean = false,
+    val enabled: Boolean = true,
+    val onClick: () -> Unit,
+)
+
+/**
+ * One row of the Apple Music–style lyrics overflow menu. Layout:
+ *  - text on the LEFT (Material3 `ListItem.headlineContent`),
+ *  - 22dp icon on the FAR RIGHT (`trailingContent`),
+ *  - no leading icon, no chevron — matches the screenshot's `info-circle /
+ *    trash / share / mountain / person / dashed-square` set on the right.
+ *
+ * Destructive rows get `MaterialTheme.colorScheme.error` text + icon, with
+ * `FontWeight.SemiBold` on the label so the eye lands on them, mirroring
+ * Apple Music's red "Delete from Library" row. Normal rows use
+ * `onSurface` text + `onSurfaceVariant` icon at `FontWeight.Medium` to match
+ * the screenshot's white-on-dark visual.
+ *
+ * The row is wrapped in a `Surface(onClick = ...)` so the click handler runs
+ * through Material3's ripple + enabled-gating without re-implementing them.
+ * The surface itself is transparent — the outer `MenuSurfaceSection` provides
+ * the visible card.
+ */
+@Composable
+private fun AppleMusicLyricsMenuRow(
+    item: AppleMusicLyricsMenuItem,
+    modifier: Modifier = Modifier,
+) {
+    val headlineColor =
+        if (item.isDestructive) {
+            MaterialTheme.colorScheme.error
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
+    val iconColor =
+        if (item.isDestructive) {
+            MaterialTheme.colorScheme.error
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+    val headlineWeight = if (item.isDestructive) FontWeight.SemiBold else FontWeight.Medium
+
+    Surface(
+        onClick = item.onClick,
+        enabled = item.enabled,
+        modifier = modifier.fillMaxWidth(),
+        color = Color.Transparent,
+    ) {
+        ListItem(
+            headlineContent = {
+                Text(
+                    text = item.label,
+                    color = headlineColor,
+                    fontWeight = headlineWeight,
+                )
+            },
+            trailingContent = {
+                Icon(
+                    painter = painterResource(item.iconRes),
+                    contentDescription = null,
+                    modifier = Modifier.size(22.dp),
+                    tint = iconColor,
+                )
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            tonalElevation = 0.dp,
+            modifier = Modifier.heightIn(min = 56.dp),
+        )
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicSlider.kt
@@ -147,8 +147,27 @@ internal fun AppleMusicFlatSlider(
                         size = Size(size.width, height),
                         cornerRadius = radius,
                     )
+                    // ─────────────────────────────────────────────────────────────────────────
+                    // Performance (user request 2026-08-30: "Reduce Gpu/cpu usage so that the
+                    // app is even more smooth without removing or sacrificing anything").
+                    //
+                    // Previously this allocated a fresh `fillColor.copy(alpha = fillColor.alpha * fillAlpha)`
+                    // Color instance per redraw frame during drag (and `dragFraction` /
+                    // `animatedFraction` change every drag frame). `Color.copy(...)` allocates a
+                    // new Color on every call, which is harmless for a one-shot draw but becomes
+                    // measurable during a slider drag (hundreds of frames).
+                    //
+                    // Now we pass the unmodified `fillColor` and let `drawRoundRect`'s `alpha`
+                    // parameter (a primitive Float) multiply it down. `drawRoundRect`'s `alpha`
+                    // multiplies the source color's alpha, so the resulting alpha is
+                    // `fillColor.alpha * fillAlpha` — visually identical to the previous
+                    // `fillColor.copy(alpha = fillColor.alpha * fillAlpha)`, but zero allocation
+                    // per frame. Same pattern the previous perf pass applied to `LiquidGlass`'s
+                    // `onDrawSurface`.
+                    // ─────────────────────────────────────────────────────────────────────────
                     drawRoundRect(
-                        color = fillColor.copy(alpha = fillColor.alpha * fillAlpha),
+                        color = fillColor,
+                        alpha = fillColor.alpha * fillAlpha,
                         topLeft = Offset(0f, top),
                         size = Size(size.width * animatedFraction, height),
                         cornerRadius = radius,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFmDashboardScreen.kt
@@ -2072,17 +2072,41 @@ private fun TrackOverflowSheet(
     var genre by remember(track.artworkKey()) { mutableStateOf<String?>(null) }
 
     LaunchedEffect(track.title, track.artist) {
+        // ─────────────────────────────────────────────────────────────────────────
+        // LastFm genre with internet fallback (user request 2026-08-30):
+        //  "Sometimes a song doesn't show what genre it is in LastFm stats
+        //   page. use internet to find its genre"
+        //
+        // Last.fm's `track.getInfo` returns `toptags.tag[]` populated for most
+        // scrobbled tracks, but it comes up empty for a meaningful minority
+        // (obscure tracks, new releases, anything Last.fm's tagger community
+        // hasn't reached). Previously the row fell through to "Unknown" in
+        // those cases. Now we add a two-provider fallback:
+        //
+        //  1. iTunes Search API — `results[].primaryGenreName` (single primary
+        //     genre from Apple's catalogue). Free, no auth, no extra call
+        //     needed (the search response already carries the field).
+        //  2. MusicBrainz recording lookup with `inc=tags+genres` — community
+        //     free-form tags + curated genre entries.
+        //
+        // Both are bundled into [CatalogueCoverProvider.resolveGenres], which
+        // deduplicates, caps at 3, and caches per (title, artist) so a re-open
+        // of the same track's overflow sheet doesn't re-hit the network.
+        // ─────────────────────────────────────────────────────────────────────────
         genre = track.artist
             ?.takeIf { it.isNotBlank() }
             ?.let { artist ->
                 withContext(Dispatchers.IO) {
-                    LastFM.getTrackInfo(artist = artist, track = track.title)
+                    val fromLastFm = LastFM.getTrackInfo(artist = artist, track = track.title)
                         .getOrNull()
                         ?.toptags
                         ?.tag
                         ?.mapNotNull { it.name?.trim()?.takeIf(String::isNotBlank) }
-                        ?.take(3)
-                        ?.joinToString(", ")
+                        .orEmpty()
+                    val resolved = fromLastFm.ifEmpty {
+                        CatalogueCoverProvider.resolveGenres(track.title, artist).orEmpty()
+                    }
+                    resolved.take(3).joinToString(", ").takeIf(String::isNotBlank)
                 }
             }
     }

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -747,6 +747,13 @@
     <string name="romanization_overridden_by_ai">Overridden — AI romanisation is on (Settings → Integration → AI integration)</string>
     <string name="ai_romanize_now">Romanise with AI</string>
     <string name="ai_romanize_started">Romanising lyrics with AI…</string>
+    <string name="ai_romanize_already_cached">Romanisation already cached — re-applied</string>
+    <string name="ai_romanize_in_flight">A romanisation for this track is already running</string>
+    <string name="ai_romanize_settings_disabled">AI romanisation isn\'t configured — set a provider and API key in Settings → Integration</string>
+    <string name="ai_romanize_no_lyrics">No lyrics to romanise on this track</string>
+    <string name="ai_romanize_excluded_language">This language is in your romanisation exclusion list — remove it in Settings → Lyrics to romanise</string>
+    <string name="ai_romanize_no_romanizable_script">Lyrics are already in Latin script — nothing to romanise</string>
+    <string name="ai_romanize_empty_result">AI returned no romanisation — check the provider/model in Settings → Integration, or try another track</string>
     <string name="update_remind_later">Remind me later</string>
     <string name="update_never_show_again">Never show again</string>
     <string name="settings_lyrics_providers_subtitle">Choose which lyrics providers are active and set priority</string>


### PR DESCRIPTION
Batch 9 (6 user requests):

1. **Reduce GPU/CPU usage** without removing features — 5 perf wins:
   - `PlayingIndicator`: 3 Animatable + per-iteration Random.nextFloat -> single rememberInfiniteTransition + keyframes + StartOffset (1 coroutine, no per-frame Random allocation).
   - `BottomSheet`: per-drag-frame `Modifier.background(Color.copy(alpha))` -> drawBehind + drawRect alpha param.
   - `AppleMusicSlider`: drawRoundRect(Color.copy(alpha)) -> drawRoundRect(color, alpha) primitive param.
   - `Items.kt` 3 Spotlight cards: drop 400ms animateColorAsState on glow color (snap instead — barely perceptible ramp).
   - `Items.kt` LibraryPinnedCollectionTile: hoist Brush.linearGradient into remember(...).

2. **Cache-first playback on app restart** — drop the `allowPlayerCacheShortCircuit = !tidalApplies` gate in `MusicService.resolvePlaybackDataSpec`. Cached bytes (playerCache LRU, persistent on disk) now ALWAYS short-circuit the source-check; source resolution only runs on cache-miss. Existing 'Clear song cache' action is the manual escape hatch.

3. **Apple Music style lyrics overflow menu** — replace NewActionGrid (96dp square buttons) with vertical Column of ListItem rows separated by 0.5dp hairline dividers. Text LEFT, 22dp icon FAR RIGHT. 'Undo Translation' tinted error-red to match Apple Music's destructive row. Outer card is existing MenuSurfaceSection. 6 actions preserved (Edit / Refetch / Translate / AI Romanise Now / Undo Translation / Search).

4. **Fix manual AI romanisation** — `AiLyricsRomanization.request()` now returns `RequestStatus` enum so the manual menu caller shows specific feedback (Started / AlreadyCached / InFlight / SettingsDisabled / NoLyrics / ExcludedLanguage / NoRomanizableScript / EmptyResult) instead of unconditionally toasting 'started'. `Result` is no longer a data class — carries a monotonically-increasing nonce so cache-hit re-publish still emits through MutableStateFlow (defeats StateFlow equality masking). Async EMPTY_RESULT surfaced via new requestOutcomes SharedFlow.

5. **Songwriters in 'Written by'** — new `CatalogueCoverProvider.resolveSongwriters(title, artist)` using MusicBrainz (recording search -> MBID -> lookup with inc=artist-rels+work-rels -> walk 'performance of' -> work.relations filtered to composer/lyricist/writer -> artist.name). Precedence in `LyricsEnhanced.kt`: resolved writers -> TTML writers (best-effort regex) -> artist name fallback. No flash of empty footer.

6. **LastFm stats genre fallback** — when Last.fm track.getInfo returns empty toptags, fall back to `CatalogueCoverProvider.resolveGenres` (iTunes primaryGenreName + MusicBrainz tags+genres). Previously the row fell through to 'Unknown'.

Files: 11 modified, ~994 insertions / 227 deletions.