### PR TITLE
batch-11: popup/lyrics/artist fixes

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -1447,22 +1447,24 @@ fun LyricsEnhanced(
                     //   row), the parent BoxWithConstraints's maxHeight shrinks, and the
                     //   proportional offset shrinks with it. Clamp to a 112dp floor so
                     //   the attribution stays visible regardless of bottom controls.
-                    // - User follow-up (2026-08-30): "The active lyrics have shifted down a
-                    //   bit. It used to be a bit upwards. Shift it up a bit around the
-                    //   header of the song but the visibility of the Lyrics from text
-                    //   shouldn't be affected and it should not be cut off." Compromise:
-                    //   0.12f proportion with a 96dp floor. On a 700dp viewport that's
-                    //   84dp (clamped to 96dp); the attribution at 96 - 50 = ~46dp from
-                    //   the top is still comfortably visible (more than the ~6dp that was
-                    //   clipped originally, and less than the 62dp of the previous 16%
-                    //   value — but well clear of the top inset). On a 500dp viewport with
-                    //   bottom controls showing, 0.12 × 500 = 60dp also clamps to 96dp,
-                    //   so the attribution is preserved across the viewport-size range
-                    //   that the bottom-controls-visible bug required us to handle.
+                    // - User follow-up (2026-08-30) batch-10: shifted to 0.12f / 96dp
+                    //   to bring the active line closer to the header. Side effect: the
+                    //   "Lyrics from [provider]" attribution also moved up (from ~62dp to
+                    //   ~46dp from the top), which the user flagged as "way too up".
+                    // - User follow-up (2026-08-30) batch-11: "The lyrics from text is
+                    //   way too up now. I want it like before but the active lyrics
+                    //   should be close to the header of the song." Reverted to the
+                    //   pre-batch-10 0.16f / 112dp. The attribution returns to ~62dp from
+                    //   the top, and the active line at 112dp from the top is still close
+                    //   to the song header (the header occupies the top ~72dp area, so
+                    //   112dp is just ~40dp below the header — well within "close to the
+                    //   header of the song"). The 112dp floor also preserves the
+                    //   attribution visibility when the bottom controls expand and
+                    //   shrink the parent BoxWithConstraints's maxHeight.
                     val lyricsViewportOffset =
                         remember(maxHeight) {
-                            val proportional = maxHeight * 0.12f
-                            if (proportional > 96.dp) proportional else 96.dp
+                            val proportional = maxHeight * 0.16f
+                            if (proportional > 112.dp) proportional else 112.dp
                         }
 
                     // Keyed on the session + a position-reset counter so that when

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -12,6 +12,7 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -110,6 +111,9 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kyant.backdrop.effects.blur
+import com.kyant.backdrop.effects.vibrancy
+import com.kyant.backdrop.drawBackdrop
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -132,8 +136,10 @@ import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.lyrics.AiLyricsRomanization
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.LocalLiquidGlassBackdrop
 import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
 import moe.rukamori.archivetune.ui.component.NewMenuItem
+import moe.rukamori.archivetune.ui.component.PlatformBackdrop
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.utils.TranslatorLang
 import moe.rukamori.archivetune.utils.TranslatorLanguages
@@ -1909,17 +1915,29 @@ private fun AppleMusicLyricsMenuRow(
  *
  * ## Visual design
  *
- * - Anchored to [iconBoundsInRoot.right] × [iconBoundsInRoot.bottom] so the
+ * - Anchored to [iconBoundsInRoot.right] x [iconBoundsInRoot.bottom] so the
  *   popup's right edge aligns with the icon's right edge, with the popup
  *   appearing just below the icon.
- * - 280dp max width, 16dp corner radius, 0.7 alpha dark background — the
- *   translucent dark tint over the lyrics view produces the frosted-glass
- *   look (true backdrop blur would require either the parent Box to have
- *   [Modifier.layerBackdrop] or the popup to live in a separate window with
- *   FLAG_BLUR_BEHIND; we approximate the effect with a translucent tint so
- *   it works on all Android versions and stays performant during scroll).
- * - 0.5dp white-at-0.1-alpha border to define the popup edge against busy
- *   backgrounds (matching Apple Music's "Action Sheet" style).
+ * - 280dp max width, 16dp corner radius, frosted-glass background — when the
+ *   caller provides a non-null [backdrop] (a kyant [PlatformBackdrop] that
+ *   captures the player content behind the popup), the popup samples that
+ *   backdrop with a 20dp blur, producing a real "frosted glass" effect that
+ *   shows the blurred album art / lyrics behind it. When [backdrop] is null
+ *   (e.g. on pre-Android-12 or when Liquid Glass is disabled), the popup
+ *   falls back to a translucent dark tint — still visible against any
+ *   background but without the real blur.
+ * - NO outer border and NO outer dark tint around the inner [MenuSurfaceSection]
+ *   card. The previous implementation layered a translucent dark background
+ *   (`Color.Black.copy(alpha = 0.7f)`) and a faint white border AROUND the
+ *   inner [MenuSurfaceSection], which has its own opaque `surfaceContainerLow`
+ *   surface with a different corner radius (`MaterialTheme.shapes.extraLarge`
+ *   ~ 28dp) than the popup's 16dp outer clip. The radius mismatch left a
+ *   visible dark gap around the inner card that the user perceived as a
+ *   "thick black border". The fix: drop the outer dark tint + border, and
+ *   match the popup's clip radius to the inner card's surface shape
+ *   (`extraLarge`) so the inner card fills the popup's entire surface. The
+ *   popup's only visible surface is now the inner card itself — clean,
+ *   single-card appearance matching Apple Music's anchored action sheet.
  *
  * ## Morph animation
  *
@@ -1932,9 +1950,22 @@ private fun AppleMusicLyricsMenuRow(
  * to the icon position), then the parent removes the composable from
  * composition via [onDismiss].
  *
- * The scrim behind the popup fades in/out in lock-step so the user perceives
- * a single coordinated animation rather than scrim-then-popup or
- * popup-then-scrim.
+ * ## Opening animation fix (batch-11)
+ *
+ * The previous implementation used `animateFloatAsState` keyed on the
+ * `dismissed` flag. `animateFloatAsState` initialises its first frame to
+ * the target value (1f for scale, 1f for alpha on enter) — so the OPENING
+ * animation never played; the popup just appeared at full size/opacity
+ * immediately. Only the CLOSING animation played (because the target
+ * changed from 1f to 0f / 0.3f when `dismissed` flipped to true).
+ *
+ * The fix: use [Animatable] initialised to the ENTER values (0.3f scale,
+ * 0f alpha), and a `LaunchedEffect(Unit)` that fires once on first
+ * composition to call `animateTo(1f, ...)` — this is a real state change
+ * from 0.3f -> 1f, so the opening animation plays. A separate
+ * `LaunchedEffect(dismissed)` fires when `dismissed` flips to true and
+ * animates back to the EXIT values (0.3f scale, 0f alpha), then calls
+ * [onDismiss] after the exit animation completes.
  *
  * ## Taps
  *
@@ -1950,6 +1981,14 @@ private fun AppleMusicLyricsMenuRow(
  *   coords.boundsInRoot() }`). The popup's right edge aligns with
  *   [Rect.right] and the popup's top edge sits [Rect.bottom] + 4dp below
  *   the icon's bottom edge.
+ * @param backdrop Optional kyant [PlatformBackdrop] that captures the
+ *   player content behind the popup. When non-null, the popup samples this
+ *   backdrop with a 20dp blur to produce a real frosted-glass effect. The
+ *   backdrop MUST be set up by the caller via [rememberBackdrop] + applied
+ *   to a sibling Box via [Modifier.layerBackdrop] so the popup is NOT
+ *   nested inside the layer-capturing Box (the kyant library warns that
+ *   nesting a drawBackdrop sampler inside the layer-capturing Box creates a
+ *   render-feedback loop that crashes the RuntimeShader).
  * @param onDismiss Called after the exit animation finishes — the parent
  *   should set `showLyricsMenu = false` (or equivalent) in response so the
  *   composable leaves composition.
@@ -1968,45 +2007,113 @@ fun AnchoredLyricsOverflowMenu(
     onShowPlayerControlsChange: ((Boolean) -> Unit)? = null,
     onAutoHidePlayerControlsChange: (Boolean) -> Unit = {},
     showControlsToggles: Boolean = true,
+    backdrop: PlatformBackdrop? = null,
 ) {
     // Local dismissal state — set to true when the user requests dismissal
     // (tap on scrim / a menu item that closes). Drives the exit animation
-    // (alpha → 0, scale → 0.3). The animation's completion is observed by
+    // (alpha -> 0, scale -> 0.3). The animation's completion is observed by
     // a LaunchedEffect which then calls [onDismiss] so the parent removes
     // the composable from composition.
     var dismissed by remember { mutableStateOf(false) }
 
     val density = LocalDensity.current
+    val scope = rememberCoroutineScope()
 
-    // Scale: 0.3 → 1.0 on enter, 1.0 → 0.3 on exit. Spring for a slight
-    // overshoot that matches Apple Music's "morph" feel.
-    val scale by animateFloatAsState(
-        targetValue = if (dismissed) 0.3f else 1f,
-        animationSpec =
-            spring(
-                dampingRatio = Spring.DampingRatioMediumBouncy,
-                stiffness = Spring.StiffnessMediumLow,
-            ),
-        label = "anchored-overflow-scale",
-    )
+    // Scale: starts at 0.3f (small, centred on top-right corner) on first
+    // composition, animates to 1.0f via LaunchedEffect(Unit) below. On
+    // dismissal, animates back to 0.3f. Spring for a slight overshoot that
+    // matches Apple Music's "morph" feel.
+    //
+    // NOTE: Animatable (not animateFloatAsState) is critical here. The
+    // previous implementation used animateFloatAsState which initialises its
+    // first frame to the target value — so the OPENING animation never
+    // played; the popup just appeared at full scale immediately. Animatable
+    // lets us set an explicit initial value (0.3f) and then drive a real
+    // state change (0.3f -> 1f) via LaunchedEffect, which IS animated.
+    val scaleAnim = remember { Animatable(0.3f) }
+    val alphaAnim = remember { Animatable(0f) }
 
-    // Alpha: 0 → 1 on enter, 1 → 0 on exit. Tween so the fade doesn't bounce.
-    // The finishedListener fires once the EXIT animation completes (alpha == 0)
-    // so we can call [onDismiss] and remove the composable from composition.
-    val alpha by animateFloatAsState(
-        targetValue = if (dismissed) 0f else 1f,
-        animationSpec = tween(180),
-        label = "anchored-overflow-alpha",
-    )
+    // Enter animation: fires ONCE on first composition. Animates 0.3f -> 1f
+    // scale and 0f -> 1f alpha in parallel. The state changes are real
+    // (from the initial Animatable values to the new targets) so the
+    // animations actually play, unlike the previous animateFloatAsState
+    // approach where the first frame was already at the target.
+    LaunchedEffect(Unit) {
+        // Don't play if already dismissing (defensive — shouldn't happen
+        // on first composition but guards against edge cases).
+        if (dismissed) return@LaunchedEffect
+        // Animate scale and alpha in parallel via two launched coroutines.
+        val scaleJob = scope.launch {
+            scaleAnim.animateTo(
+                targetValue = 1f,
+                animationSpec =
+                    spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessMediumLow,
+                    ),
+            )
+        }
+        val alphaJob = scope.launch {
+            alphaAnim.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(180),
+            )
+        }
+        scaleJob.join()
+        alphaJob.join()
+    }
 
-    // Trigger onDismiss after exit animation completes — the alpha target is
-    // 0 only during dismissal, and the finishedListener fires when the
-    // animation reaches that target. (Also fires on enter when alpha reaches
-    // 1, but the `dismissed` check ensures we only call onDismiss on the way
-    // OUT.)
-    LaunchedEffect(alpha) {
-        if (dismissed && alpha == 0f) {
-            onDismiss()
+    // Exit animation: fires when `dismissed` flips to true. Animates
+    // 1f -> 0.3f scale and 1f -> 0f alpha, then calls onDismiss after both
+    // complete so the parent removes the composable from composition.
+    LaunchedEffect(dismissed) {
+        if (!dismissed) return@LaunchedEffect
+        val scaleJob = scope.launch {
+            scaleAnim.animateTo(
+                targetValue = 0.3f,
+                animationSpec =
+                    spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = Spring.StiffnessMedium,
+                    ),
+            )
+        }
+        val alphaJob = scope.launch {
+            alphaAnim.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(180),
+            )
+        }
+        scaleJob.join()
+        alphaJob.join()
+        // Both exit animations have completed — tell the parent to remove
+        // us from composition.
+        onDismiss()
+    }
+
+    val scale = scaleAnim.value
+    val alpha = alphaAnim.value
+
+    // Memoize the drawBackdrop modifier chain so it isn't rebuilt on every
+    // recomposition. The chain depends only on `backdrop` — stable across
+    // scroll-driven recompositions of the host screen. Without this,
+    // every recomposition rebuilt the kyant effect stack and re-installed
+    // the RuntimeShader on the GraphicsLayer.
+    val frostedBlurModifier = remember(backdrop) {
+        if (backdrop != null) {
+            Modifier.drawBackdrop(
+                backdrop = backdrop,
+                effects = {
+                    vibrancy()
+                    blur(20f.dp.toPx())
+                },
+                onDrawBackdrop = { drawBackdrop ->
+                    drawBackdrop()
+                },
+                shape = { RoundedCornerShape(16.dp) },
+            )
+        } else {
+            null
         }
     }
 
@@ -2033,6 +2140,12 @@ fun AnchoredLyricsOverflowMenu(
         // scale animation grows from the top-right corner, the corner
         // where the popup meets the icon the user just tapped. This is
         // the "morph from the overflow icon" effect the user asked for.
+        //
+        // No outer dark tint, no border — the inner MenuSurfaceSection
+        // provides the popup's visible surface (opaque surfaceContainerLow
+        // color, extraLarge corner radius). The popup's clip radius
+        // matches the inner card's `MaterialTheme.shapes.extraLarge` so
+        // there's no dark gap around the inner card.
         Box(
             modifier =
                 Modifier
@@ -2056,13 +2169,18 @@ fun AnchoredLyricsOverflowMenu(
                         this.scaleY = scale
                         this.transformOrigin = TransformOrigin(1f, 0f)
                     }
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(Color.Black.copy(alpha = 0.7f * alpha))
-                    .border(
-                        width = 0.5.dp,
-                        color = Color.White.copy(alpha = 0.12f * alpha),
-                        shape = RoundedCornerShape(16.dp),
+                    // Apply the frosted-blur backdrop sampler FIRST
+                    // (before clip + background), so the blur samples the
+                    // full backdrop at the popup's location, then the clip
+                    // + background draw on top. When `backdrop` is null
+                    // (pre-S / Liquid Glass off), fall back to a plain
+                    // translucent dark tint — still visible but without
+                    // the real blur.
+                    .then(
+                        frostedBlurModifier
+                            ?: Modifier.background(Color.Black.copy(alpha = 0.65f * alpha)),
                     )
+                    .clip(MaterialTheme.shapes.extraLarge)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
@@ -2075,10 +2193,8 @@ fun AnchoredLyricsOverflowMenu(
             // composable — same Edit / Refetch / Translate / Romanise /
             // Undo / Search list, same click handlers, same dialogs. The
             // MenuSurfaceSection card that LyricsMenu draws inside itself
-            // is transparent against the popup's dark frosted background,
-            // so the visual result is a flat list of menu rows — matching
-            // Apple Music's anchored action sheet (see screenshot
-            // reference: Screenshot_20260827-235641_Accord.png).
+            // is now the popup's only visible surface (we removed the outer
+            // dark tint + border above so there's no gap around the card).
             LyricsMenu(
                 lyricsProvider = lyricsProvider,
                 mediaMetadataProvider = mediaMetadataProvider,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -859,18 +859,26 @@ fun AppleMusicPlayerContent(
     }
 
     BoxWithConstraints(modifier = modifier) {
-        // Inner Box wraps ALL the player content (backdrop + landscape/portrait
-        // layouts) and carries the `Modifier.layerBackdrop(popupBackdrop)` so
-        // the kyant backdrop captures the player content every frame. The
-        // anchored popup (rendered as a SIBLING of this inner Box below)
+        // Inner BoxWithConstraints wraps ALL the player content (backdrop +
+        // landscape/portrait layouts) and carries the
+        // `Modifier.layerBackdrop(popupBackdrop)` so the kyant backdrop
+        // captures the player content every frame. The anchored popup
+        // (rendered as a SIBLING of this inner BoxWithConstraints below)
         // samples from this backdrop with a 20dp blur to produce the real
         // frosted-glass effect — keeping the popup OUT of the layer-capturing
         // Box avoids the kyant render-feedback loop warning.
         //
-        // `matchParentSize()` is a BoxScope modifier — the inner Box is a
-        // direct child of BoxWithConstraints (which IS a BoxScope), so this
-        // works.
-        Box(
+        // BoxWithConstraints (not Box) so the inner content keeps access to
+        // `maxWidth`/`maxHeight` from the BoxWithConstraintsScope — many
+        // child lines (sharpArtworkHeight, fullPlayerHeightForArtwork,
+        // blurBackdropFootprint's remember key, the morph area's nested
+        // BoxWithConstraints) read these. A plain `Box` would shadow the
+        // scope and break the build.
+        //
+        // `matchParentSize()` is a BoxScope modifier — the inner
+        // BoxWithConstraints is a direct child of the outer BoxWithConstraints
+        // (which IS a BoxScope), so this works.
+        BoxWithConstraints(
             modifier =
                 Modifier
                     .matchParentSize()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -80,6 +80,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -92,6 +93,7 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -108,6 +110,8 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import kotlin.math.abs
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -153,7 +157,10 @@ import moe.rukamori.archivetune.ui.component.BottomSheetPageState
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.LyricsEnhanced
-import moe.rukamori.archivetune.ui.menu.LyricsMenu
+import moe.rukamori.archivetune.ui.component.PlatformBackdrop
+import moe.rukamori.archivetune.ui.component.layerBackdrop
+import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.menu.AnchoredLyricsOverflowMenu
 import moe.rukamori.archivetune.ui.menu.PlayerMenu
 import moe.rukamori.archivetune.ui.menu.rememberCastPlayerMenuAction
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
@@ -777,31 +784,51 @@ fun AppleMusicPlayerContent(
             playerConnection.player.togglePlayPause()
         }
     }
+
+    // ── Anchored Apple-Music-style overflow popup state ──
+    //
+    // Per user request (2026-08-30) batch-10 & batch-11: "The new overflow
+    // lyrics menu in apple music is a bottom slide up popup. I want it to
+    // be attached to the overflow menu icon like the image was in. it also
+    // has blur/frosted blur behind it. Add it. Also the popup shouldn't
+    // open abruptly. it should play as if it enlarged smoothly from the
+    // overflow menu icon just like the morph animation" (batch-10), then
+    // "i wanted you to redesign the popup in only apple music player style.
+    // Not the non apple music player styles. ... Fix all these and also
+    // revert the redesign for only non apple music player styles"
+    // (batch-11). The Apple Music-style inline player (this file) hosts
+    // the anchored popup; the legacy/non-Apple-Music BottomSheetPlayer
+    // (Player.kt -> LyricsScreen.kt) keeps the original ModalBottomSheet.
+    //
+    // `moreIconBounds` is captured continuously via `onGloballyPositioned`
+    // wired through `AppleMusicChip` -> the more-icon chip's outer Box. The
+    // anchored popup composable uses the most-recently-captured bounds to
+    // position itself anchored to the icon's top-right corner.
+    var showAnchoredLyricsMenu by remember { mutableStateOf(false) }
+    var moreIconBounds by remember { mutableStateOf(Rect.Zero) }
+
+    // Local backdrop that captures the player content behind the popup. The
+    // popup samples this backdrop with a 20dp blur to produce a real
+    // frosted-glass effect (see `AnchoredLyricsOverflowMenu`). The backdrop
+    // is applied via `Modifier.layerBackdrop(...)` to the inner content Box
+    // below, and the popup is rendered as a SIBLING of that inner Box (NOT
+    // nested inside it) — the kyant library warns that nesting a
+    // `drawBackdrop` sampler inside the layer-capturing Box creates a
+    // render-feedback loop that crashes the RuntimeShader.
+    val popupBackdrop: PlatformBackdrop? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            rememberBackdrop(Color.Transparent)
+        } else {
+            null
+        }
+
     val onMoreClick = {
         if (lyricsOpen) {
-            // When lyrics is open, the overflow menu shows lyric actions. The
-            // "Show player controls" / "Auto-hide controls" toggles used to live here
-            // too, but were removed by user request — the controls now always show
-            // and always auto-hide after 5 s. showControlsToggles = false hides those
-            // rows in LyricsMenu.
-            menuState.show {
-                LyricsMenu(
-                    lyricsProvider = { currentLyrics },
-                    mediaMetadataProvider = { mediaMetadata },
-                    lyricsSyncOffset = lyricsSyncOffset,
-                    onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                    // showPlayerControlsState / onShowPlayerControlsChange / onAutoHidePlayerControlsChange
-                    // are no-ops / null because the toggles were removed from the UI. The backing
-                    // preferences are still hardcoded to true in this composable (see
-                    // showLyricsPlayerControls / autoHideLyricsPlayerControls above), so the
-                    // controls always show and always auto-hide after 5 s.
-                    showPlayerControlsState = null,
-                    onShowPlayerControlsChange = null,
-                    onAutoHidePlayerControlsChange = {},
-                    onDismiss = menuState::dismiss,
-                    showControlsToggles = false,
-                )
-            }
+            // When lyrics is open, the overflow menu shows lyric actions.
+            // Per batch-10/11: use the anchored Apple-Music-style popup
+            // (scales up from the more icon with a frosted blur backdrop),
+            // NOT the ModalBottomSheet that the legacy player still uses.
+            showAnchoredLyricsMenu = true
         } else {
             menuState.show {
                 PlayerMenu(
@@ -832,6 +859,29 @@ fun AppleMusicPlayerContent(
     }
 
     BoxWithConstraints(modifier = modifier) {
+        // Inner Box wraps ALL the player content (backdrop + landscape/portrait
+        // layouts) and carries the `Modifier.layerBackdrop(popupBackdrop)` so
+        // the kyant backdrop captures the player content every frame. The
+        // anchored popup (rendered as a SIBLING of this inner Box below)
+        // samples from this backdrop with a 20dp blur to produce the real
+        // frosted-glass effect — keeping the popup OUT of the layer-capturing
+        // Box avoids the kyant render-feedback loop warning.
+        //
+        // `matchParentSize()` is a BoxScope modifier — the inner Box is a
+        // direct child of BoxWithConstraints (which IS a BoxScope), so this
+        // works.
+        Box(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .let { base ->
+                        if (popupBackdrop != null) {
+                            base.layerBackdrop(popupBackdrop)
+                        } else {
+                            base
+                        }
+                    },
+        ) {
         val sharpArtworkHeight = if (landscape) maxHeight else maxHeight * 0.55f
         // The FULL player height — used as the artwork sizing reference so the
         // artwork stays a constant size whether the system navigation bar is
@@ -1241,6 +1291,7 @@ fun AppleMusicPlayerContent(
                         onQualityChipClick = {
                             bottomSheetPageState.show { ShowMediaInfo(mediaMetadata.id) }
                         },
+                        onMorePositioned = { moreIconBounds = it },
                         modifier =
                             Modifier
                                 .fillMaxSize()
@@ -1485,6 +1536,7 @@ fun AppleMusicPlayerContent(
                                         // cover radius ensures corners are properly
                                         // rounded from the very first frame.
                                         artworkCornerRadiusDp = artworkCornerRadiusDp,
+                                        onMorePositioned = { moreIconBounds = it },
                                         modifier = Modifier.fillMaxWidth(),
                                     )
                                     if (targetState == AppleMusicPlayerState.QUEUE) {
@@ -1728,6 +1780,7 @@ fun AppleMusicPlayerContent(
                         showTitleRow = !morphOpen,
                         isQueueActive = queueOpen,
                         isLyricsActive = lyricsOpen,
+                        onMorePositioned = { moreIconBounds = it },
                         modifier =
                             Modifier
                                 .fillMaxWidth()
@@ -1741,6 +1794,42 @@ fun AppleMusicPlayerContent(
                     )
                 }
             } // end Column (morph area + controls)
+        }
+        } // end inner layer-capturing Box (player content for the popup backdrop)
+
+        // ── Anchored Apple-Music-style overflow popup ──
+        //
+        // Rendered as a SIBLING of the inner layer-capturing Box above so
+        // the popup's `Modifier.drawBackdrop(popupBackdrop, ...)` samples
+        // the backdrop (which captures the player content) WITHOUT nesting
+        // inside the layer-capturing Box — that nesting pattern is what the
+        // kyant library warns creates a render-feedback loop. The popup is
+        // in composition only when the user taps the more icon while lyrics
+        // is open (see `onMoreClick`); the popup itself manages its own
+        // enter/exit animations and calls `onDismiss` after the exit
+        // animation completes so the parent sets `showAnchoredLyricsMenu =
+        // false` and the composable leaves composition.
+        //
+        // `moreIconBounds` is captured continuously by the
+        // `onGloballyPositioned` wired into the more-icon `AppleMusicChip`
+        // invocations at the two `onMoreClick` call sites below (landscape
+        // + portrait layouts). The popup positions itself anchored to the
+        // icon's top-right corner via `Modifier.offset { ... }` (see
+        // `AnchoredLyricsOverflowMenu`).
+        if (showAnchoredLyricsMenu) {
+            AnchoredLyricsOverflowMenu(
+                iconBoundsInRoot = moreIconBounds,
+                lyricsProvider = { currentLyrics },
+                mediaMetadataProvider = { mediaMetadata },
+                lyricsSyncOffset = lyricsSyncOffset,
+                onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
+                showPlayerControlsState = null,
+                onShowPlayerControlsChange = null,
+                onAutoHidePlayerControlsChange = {},
+                onDismiss = { showAnchoredLyricsMenu = false },
+                showControlsToggles = false,
+                backdrop = popupBackdrop,
+            )
         }
     }
 }
@@ -2006,6 +2095,11 @@ private fun AppleMusicControlsColumn(
     isQueueActive: Boolean = false,
     // Whether the in-place lyrics view is currently open. Highlights the lyrics button.
     isLyricsActive: Boolean = false,
+    // Optional callback for capturing the more-icon chip's on-screen Rect
+    // (via `boundsInRoot()`). The Apple-Music-style anchored overflow popup
+    // uses this to position itself anchored to the icon's top-right corner.
+    // Null when the anchored popup is not in use (e.g. legacy callers).
+    onMorePositioned: ((Rect) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     var swipeUpAccumulated by remember { mutableFloatStateOf(0f) }
@@ -2147,6 +2241,7 @@ private fun AppleMusicControlsColumn(
                 tint = Color.White,
                 contentDescription = null,
                 onClick = onMoreClick,
+                onPositioned = onMorePositioned,
             )
         }
     }
@@ -2295,12 +2390,27 @@ private fun AppleMusicChip(
     tint: Color,
     contentDescription: String?,
     onClick: () -> Unit,
+    // Optional callback invoked whenever the chip's layout position changes.
+    // Used by the more-icon chip to capture its on-screen Rect (via
+    // `boundsInRoot()`) so the anchored overflow popup can position itself
+    // anchored to the icon's top-right corner. Null for chips that don't
+    // need position tracking (the default).
+    onPositioned: ((Rect) -> Unit)? = null,
 ) {
     Box(
         contentAlignment = Alignment.Center,
         modifier =
             Modifier
                 .size(AppleMusicChipSize)
+                .let { base ->
+                    if (onPositioned != null) {
+                        base.onGloballyPositioned { coords ->
+                            onPositioned(coords.boundsInRoot())
+                        }
+                    } else {
+                        base
+                    }
+                }
                 .clip(CircleShape)
                 .background(Color.White.copy(alpha = 0.14f))
                 .clickable(onClick = onClick),
@@ -2401,6 +2511,11 @@ private fun SharedTransitionScope.AppleMusicMiniHeader(
     // radius so corners look properly rounded on the large cover bounds at
     // the start of the morph. See the call site for the full rationale.
     artworkCornerRadiusDp: Dp = 16.dp,
+    // Optional callback for capturing the more-icon chip's on-screen Rect
+    // (via `boundsInRoot()`). The Apple-Music-style anchored overflow popup
+    // uses this to position itself anchored to the icon's top-right corner.
+    // Null when the anchored popup is not in use.
+    onMorePositioned: ((Rect) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -2526,6 +2641,7 @@ private fun SharedTransitionScope.AppleMusicMiniHeader(
             tint = Color.White,
             contentDescription = null,
             onClick = onMoreClick,
+            onPositioned = onMorePositioned,
         )
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -148,7 +148,6 @@ import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.LyricsEnhanced
 import moe.rukamori.archivetune.ui.component.PlayerSliderTrack
-import moe.rukamori.archivetune.ui.menu.AnchoredLyricsOverflowMenu
 import moe.rukamori.archivetune.ui.menu.LyricsMenu
 import moe.rukamori.archivetune.ui.theme.PlayerColorExtractor
 import moe.rukamori.archivetune.ui.theme.PlayerPaletteCache
@@ -553,29 +552,29 @@ fun LyricsScreen(
         }
     }
 
-    // ── Anchored overflow popup state ──
-    // The previous implementation used `menuState.show { LyricsMenu(...) }`
-    // which opened a Material3 ModalBottomSheet (slide-up from bottom). Per
-    // user request (2026-08-30): "The new overflow lyrics menu in apple music
-    // is a bottom slide up popup. I want it to be attached to the overflow
-    // menu icon like the image was in. it also has blur/frosted blur behind
-    // it. Add it. Also the popup shouldn't open abruptly. it should play as
-    // if it enlarged smoothly from the overflow menu icon just like the
-    // morph animation" — we now use [AnchoredLyricsOverflowMenu], which
-    // renders an Apple-Music-style anchored popup that scales up from the
-    // overflow icon with a frosted-glass background.
-    var showAnchoredLyricsMenu by remember { mutableStateOf(false) }
-    var lyricsMenuIconBounds by remember {
-        mutableStateOf(androidx.compose.ui.geometry.Rect.Zero)
-    }
-
+    // ── Lyrics overflow menu ──
+    // The standalone LyricsScreen is invoked from the legacy/non-Apple-Music
+    // BottomSheetPlayer (see Player.kt:2679). Per user request (2026-08-30)
+    // batch-11: "i wanted you to redesign the popup in only apple music player
+    // style. Not the non apple music player styles. ... revert the redesign for
+    // only non apple music player styles" — this screen uses the original
+    // ModalBottomSheet (`menuState.show { LyricsMenu(...) }`) slide-up popup
+    // that was used before the batch-10 anchored-popup redesign. The Apple
+    // Music-style inline player (AppleMusicPlayer.kt) keeps the anchored popup.
     val showLyricsMenu = {
-        // Captured icon bounds are stored in `lyricsMenuIconBounds` via the
-        // `onMorePositioned` callback wired through AppleMusicTrackHeader →
-        // AppleMusicHeaderIconButton → onGloballyPositioned. When the user
-        // taps the icon we just flip the visibility flag — the anchored
-        // popup composable uses the most-recently-captured bounds.
-        showAnchoredLyricsMenu = true
+        menuState.show {
+            LyricsMenu(
+                lyricsProvider = { currentLyrics },
+                mediaMetadataProvider = { mediaMetadata },
+                lyricsSyncOffset = lyricsSyncOffset,
+                onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
+                showPlayerControlsState = null,
+                onShowPlayerControlsChange = null,
+                onAutoHidePlayerControlsChange = {},
+                onDismiss = menuState::dismiss,
+                showControlsToggles = false,
+            )
+        }
     }
 
     val isLoading = playbackState == STATE_BUFFERING || sliderPosition != null
@@ -703,7 +702,6 @@ fun LyricsScreen(
                     onDismissClick = onBackClick,
                     isLiked = currentSongLiked,
                     onToggleLike = playerConnection::toggleLike,
-                    onMorePositioned = { rect -> lyricsMenuIconBounds = rect },
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -825,25 +823,6 @@ fun LyricsScreen(
                 }
             }
             }
-        }
-        // Anchored Apple-Music-style overflow popup. Rendered as the last
-        // child of the lyrics screen's root Box so it overlays every other
-        // child (background / lyrics / controls / header). The popup itself
-        // manages its own enter/exit animations; the parent only gates whether
-        // it's in composition at all.
-        if (showAnchoredLyricsMenu) {
-            AnchoredLyricsOverflowMenu(
-                iconBoundsInRoot = lyricsMenuIconBounds,
-                lyricsProvider = { currentLyrics },
-                mediaMetadataProvider = { mediaMetadata },
-                lyricsSyncOffset = lyricsSyncOffset,
-                onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                showPlayerControlsState = null,
-                onShowPlayerControlsChange = null,
-                onAutoHidePlayerControlsChange = {},
-                onDismiss = { showAnchoredLyricsMenu = false },
-                showControlsToggles = false,
-            )
         }
     }
 }
@@ -1288,7 +1267,6 @@ private fun AppleMusicTrackHeader(
     modifier: Modifier = Modifier,
     isLiked: Boolean = false,
     onToggleLike: () -> Unit = {},
-    onMorePositioned: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null,
 ) {
     val artistText =
         remember(mediaMetadata.id, mediaMetadata.artists) {
@@ -1379,7 +1357,6 @@ private fun AppleMusicTrackHeader(
             contentDescription = stringResource(R.string.more_options),
             foregroundColor = foregroundColor,
             onClick = onMoreClick,
-            onPositioned = onMorePositioned,
         )
     }
 }
@@ -1390,37 +1367,11 @@ private fun AppleMusicHeaderIconButton(
     contentDescription: String,
     foregroundColor: Color,
     onClick: () -> Unit,
-    onPositioned: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null,
 ) {
     Box(
         modifier =
             Modifier
                 .size(48.dp)
-                .let { base ->
-                    if (onPositioned != null) {
-                        // `boundsInRoot()` isn't available on this Compose
-                        // version (only `positionInRoot(): Offset` and `size:
-                        // IntSize` are). Compute the Rect from those two —
-                        // positionInRoot gives the top-left of the layout in
-                        // root coordinates, and the layout's size is the
-                        // 48dp Box dimensions.
-                        base.onGloballyPositioned { coords ->
-                            val pos = coords.positionInRoot()
-                            val sz = coords.size
-                            onPositioned(
-                                androidx.compose.ui.geometry.Rect(
-                                    offset = pos,
-                                    size = androidx.compose.ui.geometry.Size(
-                                        width = sz.width.toFloat(),
-                                        height = sz.height.toFloat(),
-                                    ),
-                                ),
-                            )
-                        }
-                    } else {
-                        base
-                    }
-                }
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = ripple(bounded = false, radius = 24.dp),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
@@ -758,7 +758,75 @@ fun ArtistScreen(
                 }
 
                 // Content sections
-                if (showLocal) {
+                //
+                // Per user report (2026-08-30) batch-11: "When I open an artist
+                // page i initially see nothing on the artist screen. After two
+                // seconds it loads completely." Root cause: `artistPage` is null
+                // during the silent auto-fetch that runs on screen open (it's
+                // NOT a manual pull-to-refresh, so `isManuallyRefreshing` is
+                // false). The header renders immediately because it falls back
+                // to `libraryArtist` (the cached artist entity from the local
+                // database), but `orderedRemoteSections` is empty (it's derived
+                // from `artistPage?.sections`), so the rest of the screen is
+                // blank for ~2 seconds while the remote fetch completes.
+                //
+                // Fix: render a shimmer skeleton for the content sections
+                // whenever `!showLocal && artistPage == null && !isManuallyRefreshing`
+                // — i.e., the silent auto-fetch is still in flight. The shimmer
+                // mirrors the typical artist-page layout (section title + 5 song
+                // rows) so the user perceives a loading state instead of an empty
+                // screen. The existing manual-refresh shimmer (line ~434 above)
+                // already handles the pull-to-refresh case; this handles the
+                // auto-fetch case that was missed.
+                if (!showLocal && artistPage == null && !isManuallyRefreshing) {
+                    item(key = "auto_fetch_shimmer") {
+                        ShimmerHost {
+                            Column(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                            ) {
+                                // Section title placeholder ("Top songs" / "Latest release")
+                                TextPlaceholder(
+                                    height = 18.dp,
+                                    modifier = Modifier.fillMaxWidth(0.35f),
+                                )
+                                Spacer(modifier = Modifier.height(12.dp))
+                                // 5 song row placeholders — matches the `take(5)` cap
+                                // on the Local Songs Section and the typical Top Songs
+                                // section row count.
+                                repeat(5) {
+                                    ListItemPlaceHolder()
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                }
+                                Spacer(modifier = Modifier.height(16.dp))
+                                // Second section title placeholder ("Albums" / "Singles")
+                                TextPlaceholder(
+                                    height = 18.dp,
+                                    modifier = Modifier.fillMaxWidth(0.30f),
+                                )
+                                Spacer(modifier = Modifier.height(12.dp))
+                                // Horizontal album-row placeholders
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    repeat(3) {
+                                        Box(
+                                            modifier =
+                                                Modifier
+                                                    .size(width = 120.dp, height = 144.dp)
+                                                    .clip(RoundedCornerShape(8.dp))
+                                                    .shimmer()
+                                                    .background(MaterialTheme.colorScheme.surfaceContainerLow),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else if (showLocal) {
                     // Local Songs Section
                     if (librarySongs.isNotEmpty()) {
                         item {


### PR DESCRIPTION
Batch 11 for 2026-08-30 — 3 user-reported issues:

1. **Anchored overflow popup redesign**: moved from LyricsScreen (legacy BottomSheetPlayer) to AppleMusicPlayer (Apple-Music-style inline player). LyricsScreen reverts to the original ModalBottomSheet so the redesign applies ONLY to the Apple Music player style as the user requested.

2. **AnchoredLyricsOverflowMenu bug fixes**:
   - Opening animation now plays (Animatable + LaunchedEffect(Unit) animates 0.3f to 1f scale + 0f to 1f alpha on first composition; previously animateFloatAsState initialised to the target value so the OPEN animation never played, only the closing one did).
   - Real frosted blur behind the popup via Modifier.drawBackdrop (kyant library). The popup samples the player content backdrop with a 20dp blur. Falls back to a translucent dark tint on pre-Android-12 or when Liquid Glass is disabled.
   - Removed outer dark background + border (caused the visible black border around the inner MenuSurfaceSection card due to corner-radius mismatch). The inner card surface is now the popup only visible surface.

3. **Lyrics position**: revert lyricsViewportOffset from 0.12f / 96dp back to 0.16f / 112dp. The 96dp change moved the Lyrics from attribution from ~62dp to ~46dp from the top, which the user flagged as way too up.

4. **Artist page blank state**: add a shimmer skeleton for the content sections while artistPage is null during the silent auto-fetch. Previously the screen showed only the header for ~2 seconds with a blank lower half because orderedRemoteSections was empty until the remote fetch completed.

Files modified (5): LyricsEnhanced.kt, LyricsMenu.kt, AppleMusicPlayer.kt, LyricsScreen.kt, ArtistScreen.kt