### PR TITLE
dev -> main: batch-11 popup/lyrics/artist + batch-12 popup blur/size/bounce fixes

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsEnhanced.kt
@@ -1447,22 +1447,24 @@ fun LyricsEnhanced(
                     //   row), the parent BoxWithConstraints's maxHeight shrinks, and the
                     //   proportional offset shrinks with it. Clamp to a 112dp floor so
                     //   the attribution stays visible regardless of bottom controls.
-                    // - User follow-up (2026-08-30): "The active lyrics have shifted down a
-                    //   bit. It used to be a bit upwards. Shift it up a bit around the
-                    //   header of the song but the visibility of the Lyrics from text
-                    //   shouldn't be affected and it should not be cut off." Compromise:
-                    //   0.12f proportion with a 96dp floor. On a 700dp viewport that's
-                    //   84dp (clamped to 96dp); the attribution at 96 - 50 = ~46dp from
-                    //   the top is still comfortably visible (more than the ~6dp that was
-                    //   clipped originally, and less than the 62dp of the previous 16%
-                    //   value — but well clear of the top inset). On a 500dp viewport with
-                    //   bottom controls showing, 0.12 × 500 = 60dp also clamps to 96dp,
-                    //   so the attribution is preserved across the viewport-size range
-                    //   that the bottom-controls-visible bug required us to handle.
+                    // - User follow-up (2026-08-30) batch-10: shifted to 0.12f / 96dp
+                    //   to bring the active line closer to the header. Side effect: the
+                    //   "Lyrics from [provider]" attribution also moved up (from ~62dp to
+                    //   ~46dp from the top), which the user flagged as "way too up".
+                    // - User follow-up (2026-08-30) batch-11: "The lyrics from text is
+                    //   way too up now. I want it like before but the active lyrics
+                    //   should be close to the header of the song." Reverted to the
+                    //   pre-batch-10 0.16f / 112dp. The attribution returns to ~62dp from
+                    //   the top, and the active line at 112dp from the top is still close
+                    //   to the song header (the header occupies the top ~72dp area, so
+                    //   112dp is just ~40dp below the header — well within "close to the
+                    //   header of the song"). The 112dp floor also preserves the
+                    //   attribution visibility when the bottom controls expand and
+                    //   shrink the parent BoxWithConstraints's maxHeight.
                     val lyricsViewportOffset =
                         remember(maxHeight) {
-                            val proportional = maxHeight * 0.12f
-                            if (proportional > 96.dp) proportional else 96.dp
+                            val proportional = maxHeight * 0.16f
+                            if (proportional > 112.dp) proportional else 112.dp
                         }
 
                     // Keyed on the session + a position-reset counter so that when

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -92,6 +92,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
@@ -932,14 +933,14 @@ fun LyricsMenu(
             // keeps the same `extraLarge` corner shape so the rounded clip
             // still matches the popup's outer clip (no dark gap).
             //
-            // Vertical padding reduced 6dp -> 4dp per "make the popup a bit
-            // more compact" (2026-08-30). Combined with the inner Column's
-            // vertical padding reduction (4dp -> 0dp), the top/bottom
-            // breathing room around the menu items dropped from 10dp to 4dp.
+            // Vertical padding 4dp -> 8dp per "redesign the lyrics popup —
+            // match the second reference image" (2026-08-30). The reference
+            // shows generous breathing room above the first row and below
+            // the last row (~24px at reference scale ≈ 8dp at mdpi).
             Surface(
                 shape = MaterialTheme.shapes.extraLarge,
                 color = if (transparentSurface) Color.Transparent else MaterialTheme.colorScheme.surfaceContainerLow,
-                modifier = Modifier.padding(vertical = 4.dp).fillMaxWidth(),
+                modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(),
             ) {
                 Column(modifier = Modifier.padding(vertical = 0.dp)) {
                     menuItems.forEachIndexed { index, item ->
@@ -948,11 +949,16 @@ fun LyricsMenu(
                         )
                         // Hairline divider BETWEEN items only — no divider before the first
                         // or after the last, matching Apple Music's grid-separated look.
+                        // Color: white at 12% opacity (was `outlineVariant`) per reference
+                        //   "Divider lines should be approximately 10–18% white/gray opacity".
+                        // Thickness: 0.5dp -> 1.dp per reference "1 px at reference scale".
+                        // Horizontal padding: 16dp -> 20dp to align with the row's
+                        //   text and icon (both at horizontal = 20.dp now).
                         if (index < menuItems.size - 1) {
                             HorizontalDivider(
-                                color = MaterialTheme.colorScheme.outlineVariant,
-                                thickness = 0.5.dp,
-                                modifier = Modifier.padding(horizontal = 16.dp),
+                                color = Color.White.copy(alpha = 0.12f),
+                                thickness = 1.dp,
+                                modifier = Modifier.padding(horizontal = 20.dp),
                             )
                         }
                     }
@@ -1889,49 +1895,58 @@ private fun AppleMusicLyricsMenuRow(
     item: AppleMusicLyricsMenuItem,
     modifier: Modifier = Modifier,
 ) {
+    // Per "redesign the lyrics popup — match the second reference image"
+    // (2026-08-30): the reference uses pure white text + off-white icons on
+    // a dark translucent vibrancy surface, with the destructive row in
+    // bright system red. The previous implementation used Material3
+    // `onSurface`/`onSurfaceVariant` (theme-tinted) which adapts to light/
+    // dark theme — but the reference popup is ALWAYS dark charcoal glass,
+    // so theme-tinted colors are wrong. Hardcoding white + red matches the
+    // reference's "white/off-white" + "bright system-style red" spec.
     val headlineColor =
         if (item.isDestructive) {
-            MaterialTheme.colorScheme.error
+            Color(0xFFFF453A) // iOS System Red (dark mode)
         } else {
-            MaterialTheme.colorScheme.onSurface
+            Color.White
         }
     val iconColor =
         if (item.isDestructive) {
-            MaterialTheme.colorScheme.error
+            Color(0xFFFF453A)
         } else {
-            MaterialTheme.colorScheme.onSurfaceVariant
+            Color.White
         }
     val headlineWeight = if (item.isDestructive) FontWeight.SemiBold else FontWeight.Medium
 
-    // Replaced Material3 `ListItem` (inside a wrapping `Surface(onClick)`) with
-    // a custom `Row` for tighter control over text-to-text spacing. The original
-    // ListItem imposed ~8dp top + 8dp bottom internal content padding (16dp per
-    // row of breathing room) on top of the 56dp min row height — so consecutive
-    // labels were ~16.5dp apart (ListItem bottom pad + 0.5dp divider + ListItem
-    // top pad). User report 2026-08-30: "reduce the spacing between text".
+    // Reference row geometry (720x1536 screenshot):
+    //   - each row ~80px tall (~5.2% of screen height)
+    //   - text begins ~30px from popup left edge
+    //   - icon center ~48px from popup right edge
+    //   - icon size ~28-32px
+    //   - text size ~28-30px (≈17-18sp on a typical Android device)
     //
-    // The custom Row uses 4dp vertical padding + 44dp min row height, so the
-    // gap between consecutive labels is now ~8.5dp (4dp + 0.5dp + 4dp) — about
-    // half the previous spacing. Icon size reduced 22dp -> 20dp for a more
-    // compact Apple-Music-style feel. Horizontal padding 16dp keeps the text
-    // aligned with the divider's `horizontal = 16.dp` padding.
-    //
-    // `clickable` (with no indication override) preserves the existing
-    // ripple behaviour — the previous `Surface(onClick = ...)` also showed a
-    // ripple, so there's no regression.
+    // Mapped to dp/sp using responsive proportions:
+    //   - row min height 56dp (was 44dp, was 56dp via ListItem) — generous
+    //     Apple-Music-style touch target.
+    //   - horizontal padding 20dp (was 16dp) — text starts ~20dp from
+    //     popup edge, matches the reference's ~30px at mdpi.
+    //   - vertical padding 8dp (was 4dp) — keeps the label vertically
+    //     centered within the taller row.
+    //   - icon size 24dp (was 20dp) — matches reference's ~28-32px range.
+    //   - text fontSize 17sp (was 16sp) — matches reference's ~28-30px
+    //     range on a typical xxhdpi Android device.
     val interactionSource = remember { MutableInteractionSource() }
     Row(
         modifier =
             modifier
                 .fillMaxWidth()
-                .heightIn(min = 44.dp)
+                .heightIn(min = 56.dp)
                 .clickable(
                     interactionSource = interactionSource,
                     indication = ripple(),
                     enabled = item.enabled,
                     onClick = item.onClick,
                 )
-                .padding(horizontal = 16.dp, vertical = 4.dp),
+                .padding(horizontal = 20.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -1939,12 +1954,12 @@ private fun AppleMusicLyricsMenuRow(
             text = item.label,
             color = headlineColor,
             fontWeight = headlineWeight,
-            fontSize = 16.sp,
+            fontSize = 17.sp,
         )
         Icon(
             painter = painterResource(item.iconRes),
             contentDescription = null,
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(24.dp),
             tint = iconColor,
         )
     }
@@ -1963,10 +1978,10 @@ private fun AppleMusicLyricsMenuRow(
  * - Anchored to [iconBoundsInRoot.right] x [iconBoundsInRoot.bottom] so the
  *   popup's right edge aligns with the icon's right edge, with the popup
  *   appearing just below the icon.
- * - 220dp max width (was 280dp, then 240dp, then 220dp — progressive
- *   reduction per "reduce the size of popup a bit" (batch-12) and "make the
- *   popup a bit more compact" (batch-13) user requests), 16dp corner radius,
- *   frosted-glass background — when the
+ * - 65% of screen width (per reference "65% of screen width"), 16dp corner
+ *   radius (was `MaterialTheme.shapes.extraLarge` ~28dp, reduced 2026-08-30
+ *   per reference "24 px corner radius at the reference scale"), frosted-glass
+ *   vibrancy background — when the
  *   caller provides a non-null [backdrop] (a kyant [PlatformBackdrop] that
  *   captures the player content behind the popup), the popup samples that
  *   backdrop with a 20dp blur, producing a real "frosted glass" effect that
@@ -2066,6 +2081,15 @@ fun AnchoredLyricsOverflowMenu(
 
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
+    // Per "redesign the lyrics popup — match the second reference image"
+    // (2026-08-30): the reference popup occupies ~65% of screen width and is
+    // positioned toward the RIGHT side of the screen. We capture
+    // `LocalConfiguration.current` here (composable scope) so the offset
+    // lambda (a non-composable `Density.() -> IntOffset`) can compute the
+    // popup's pixel width from the screen's dp width without re-calling the
+    // composable function on every recomposition.
+    val configuration = LocalConfiguration.current
+    val screenWidthDp = configuration.screenWidthDp
 
     // Scale: starts at 0.3f (small, centred on top-right corner) on first
     // composition, animates to 1.0f via LaunchedEffect(Unit) below. On
@@ -2159,7 +2183,11 @@ fun AnchoredLyricsOverflowMenu(
                 backdrop = backdrop,
                 effects = {
                     vibrancy()
-                    blur(20f.dp.toPx())
+                    // Blur radius 20f -> 32f per reference "strong backdrop
+                    // blur". The reference popup is a dark charcoal translucent
+                    // glass with heavy blur of the content behind — 20dp was
+                    // too subtle; 32dp produces a more premium vibrancy look.
+                    blur(32f.dp.toPx())
                 },
                 onDrawBackdrop = { drawBackdrop ->
                     drawBackdrop()
@@ -2174,11 +2202,18 @@ fun AnchoredLyricsOverflowMenu(
     // Full-screen scrim — translucent black so the lyrics view is still
     // visible behind (matches Apple Music's "dim the background but don't
     // black it out" style). Clickable to trigger dismissal.
+    //
+    // Scrim alpha 0.35f -> 0.45f per reference "darkened/dimmed background
+    // ... existing lyrics remain faintly visible". The reference shows a
+    // stronger dim than the previous 35% — 45% matches the reference's
+    // ~40-50% dim. The `* alpha` multiplier is preserved so the scrim
+    // continues to fade in/out with the existing enter/exit animation —
+    // THIS IS A STATIC COLOR CHANGE, NOT AN ANIMATION CHANGE.
     Box(
         modifier =
             Modifier
                 .fillMaxSize()
-                .background(Color.Black.copy(alpha = 0.35f * alpha))
+                .background(Color.Black.copy(alpha = 0.45f * alpha))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
@@ -2195,16 +2230,40 @@ fun AnchoredLyricsOverflowMenu(
         // where the popup meets the icon the user just tapped. This is
         // the "morph from the overflow icon" effect the user asked for.
         //
-        // Popup width reduced 280dp -> 240dp -> 220dp per user requests
-        // 2026-08-30: "reduce the size of popup a bit" then "make the
-        // popup a bit more compact". The widthIn max and the offset's
-        // `popupWidthPx` must stay in sync so the popup's right edge
-        // continues to align with the icon's right edge.
+        // Per "redesign the lyrics popup — match the second reference image"
+        // (2026-08-30), the popup was widened from `widthIn(max = 220.dp)` to
+        // `fillMaxWidth(0.65f)` (65% of the screen width, matching the
+        // reference popup's ~65% screen-width proportion). The popup remains
+        // anchored to the overflow icon's right edge so the existing
+        // enter/exit scale animation (transformOrigin = top-right) continues
+        // to look like the popup "grows out of" the icon — THE ANIMATION IS
+        // COMPLETELY UNCHANGED.
+        //
+        // Visual stack (outermost -> innermost):
+        //   1. offset — positions the popup's top-right corner at the icon.
+        //   2. fillMaxWidth(0.65f) — responsive width (65% of screen).
+        //   3. heightIn(max = 520.dp) — safety bound for tall content.
+        //   4. graphicsLayer — UNCHANGED (alpha + scale + transformOrigin).
+        //      The animation reads scaleAnim.value / alphaAnim.value and
+        //      applies them via this graphicsLayer. Untouched per user spec.
+        //   5. shadow(16.dp, RoundedCornerShape(16.dp)) — NEW: soft elevated
+        //      shadow per reference "soft shadow, large shadow blur, subtle
+        //      depth". Applied AFTER graphicsLayer so the shadow scales +
+        //      fades with the popup's enter/exit animation (no janky
+        //      full-size shadow during the small-scale enter frame).
+        //   6. frostedBlurModifier (or fallback dark tint) — backdrop blur.
+        //   7. background(Color.Black at 55%) — NEW: dark charcoal tint over
+        //      the blur, per reference "dark charcoal/black translucent
+        //      material". The graphicsLayer's alpha animates this tint in/out.
+        //   8. clip(RoundedCornerShape(16.dp)) — was `extraLarge` (~28dp);
+        //      reduced to 16dp per reference "24 px corner radius at the
+        //      reference scale" (24px ≈ 16dp at mdpi).
+        //   9. clickable — consumes taps inside the popup.
         Box(
             modifier =
                 Modifier
                     .offset {
-                        val popupWidthPx = with(density) { 220.dp.toPx() }.toInt()
+                        val popupWidthPx = with(density) { (screenWidthDp * 0.65f).dp.toPx() }.toInt()
                         val horizontalMarginPx = with(density) { 16.dp.toPx() }.toInt()
                         val verticalOffsetPx = with(density) { 4.dp.toPx() }.toInt()
                         val iconRight = iconBoundsInRoot.right.toInt()
@@ -2215,7 +2274,7 @@ fun AnchoredLyricsOverflowMenu(
                         val y = iconBottom + verticalOffsetPx
                         IntOffset(x = x, y = y)
                     }
-                    .widthIn(max = 220.dp)
+                    .fillMaxWidth(0.65f)
                     .heightIn(max = 520.dp)
                     .graphicsLayer {
                         this.alpha = alpha
@@ -2223,6 +2282,11 @@ fun AnchoredLyricsOverflowMenu(
                         this.scaleY = scale
                         this.transformOrigin = TransformOrigin(1f, 0f)
                     }
+                    .shadow(
+                        elevation = 16.dp,
+                        shape = RoundedCornerShape(16.dp),
+                        clip = false,
+                    )
                     // Apply the frosted-blur backdrop sampler FIRST
                     // (before clip + background), so the blur samples the
                     // full backdrop at the popup's location, then the clip
@@ -2234,7 +2298,15 @@ fun AnchoredLyricsOverflowMenu(
                         frostedBlurModifier
                             ?: Modifier.background(Color.Black.copy(alpha = 0.65f * alpha)),
                     )
-                    .clip(MaterialTheme.shapes.extraLarge)
+                    // Dark charcoal tint over the blur. The reference popup
+                    // is NOT a clear glass window — it is a dark translucent
+                    // vibrancy surface. Without this tint, the blurred
+                    // content shows through too brightly (e.g., album art
+                    // colors would dominate). 55% black over the blur
+                    // produces the reference's "dark charcoal" feel while
+                    // still letting the blur's vibrancy show through.
+                    .background(Color.Black.copy(alpha = 0.55f))
+                    .clip(RoundedCornerShape(16.dp))
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -75,6 +75,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
@@ -107,6 +108,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -929,16 +931,20 @@ fun LyricsMenu(
             // on top of the liquid glass effect". The transparent surface
             // keeps the same `extraLarge` corner shape so the rounded clip
             // still matches the popup's outer clip (no dark gap).
+            //
+            // Vertical padding reduced 6dp -> 4dp per "make the popup a bit
+            // more compact" (2026-08-30). Combined with the inner Column's
+            // vertical padding reduction (4dp -> 0dp), the top/bottom
+            // breathing room around the menu items dropped from 10dp to 4dp.
             Surface(
                 shape = MaterialTheme.shapes.extraLarge,
                 color = if (transparentSurface) Color.Transparent else MaterialTheme.colorScheme.surfaceContainerLow,
-                modifier = Modifier.padding(vertical = 6.dp).fillMaxWidth(),
+                modifier = Modifier.padding(vertical = 4.dp).fillMaxWidth(),
             ) {
-                Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                Column(modifier = Modifier.padding(vertical = 0.dp)) {
                     menuItems.forEachIndexed { index, item ->
                         AppleMusicLyricsMenuRow(
                             item = item,
-                            modifier = Modifier.padding(horizontal = 8.dp),
                         )
                         // Hairline divider BETWEEN items only — no divider before the first
                         // or after the last, matching Apple Music's grid-separated look.
@@ -1897,31 +1903,49 @@ private fun AppleMusicLyricsMenuRow(
         }
     val headlineWeight = if (item.isDestructive) FontWeight.SemiBold else FontWeight.Medium
 
-    Surface(
-        onClick = item.onClick,
-        enabled = item.enabled,
-        modifier = modifier.fillMaxWidth(),
-        color = Color.Transparent,
+    // Replaced Material3 `ListItem` (inside a wrapping `Surface(onClick)`) with
+    // a custom `Row` for tighter control over text-to-text spacing. The original
+    // ListItem imposed ~8dp top + 8dp bottom internal content padding (16dp per
+    // row of breathing room) on top of the 56dp min row height — so consecutive
+    // labels were ~16.5dp apart (ListItem bottom pad + 0.5dp divider + ListItem
+    // top pad). User report 2026-08-30: "reduce the spacing between text".
+    //
+    // The custom Row uses 4dp vertical padding + 44dp min row height, so the
+    // gap between consecutive labels is now ~8.5dp (4dp + 0.5dp + 4dp) — about
+    // half the previous spacing. Icon size reduced 22dp -> 20dp for a more
+    // compact Apple-Music-style feel. Horizontal padding 16dp keeps the text
+    // aligned with the divider's `horizontal = 16.dp` padding.
+    //
+    // `clickable` (with no indication override) preserves the existing
+    // ripple behaviour — the previous `Surface(onClick = ...)` also showed a
+    // ripple, so there's no regression.
+    val interactionSource = remember { MutableInteractionSource() }
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 44.dp)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = ripple(),
+                    enabled = item.enabled,
+                    onClick = item.onClick,
+                )
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        ListItem(
-            headlineContent = {
-                Text(
-                    text = item.label,
-                    color = headlineColor,
-                    fontWeight = headlineWeight,
-                )
-            },
-            trailingContent = {
-                Icon(
-                    painter = painterResource(item.iconRes),
-                    contentDescription = null,
-                    modifier = Modifier.size(22.dp),
-                    tint = iconColor,
-                )
-            },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-            tonalElevation = 0.dp,
-            modifier = Modifier.heightIn(min = 56.dp),
+        Text(
+            text = item.label,
+            color = headlineColor,
+            fontWeight = headlineWeight,
+            fontSize = 16.sp,
+        )
+        Icon(
+            painter = painterResource(item.iconRes),
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = iconColor,
         )
     }
 }
@@ -1939,9 +1963,10 @@ private fun AppleMusicLyricsMenuRow(
  * - Anchored to [iconBoundsInRoot.right] x [iconBoundsInRoot.bottom] so the
  *   popup's right edge aligns with the icon's right edge, with the popup
  *   appearing just below the icon.
- * - 240dp max width (was 280dp, reduced 2026-08-30 per "reduce the size of
- *   popup a bit" user request), 16dp corner radius, frosted-glass background —
- *   when the
+ * - 220dp max width (was 280dp, then 240dp, then 220dp — progressive
+ *   reduction per "reduce the size of popup a bit" (batch-12) and "make the
+ *   popup a bit more compact" (batch-13) user requests), 16dp corner radius,
+ *   frosted-glass background — when the
  *   caller provides a non-null [backdrop] (a kyant [PlatformBackdrop] that
  *   captures the player content behind the popup), the popup samples that
  *   backdrop with a 20dp blur, producing a real "frosted glass" effect that
@@ -2170,15 +2195,16 @@ fun AnchoredLyricsOverflowMenu(
         // where the popup meets the icon the user just tapped. This is
         // the "morph from the overflow icon" effect the user asked for.
         //
-        // Popup width reduced from 280dp to 240dp per user request
-        // 2026-08-30: "reduce the size of popup a bit". The widthIn max
-        // and the offset's `popupWidthPx` must stay in sync so the popup's
-        // right edge continues to align with the icon's right edge.
+        // Popup width reduced 280dp -> 240dp -> 220dp per user requests
+        // 2026-08-30: "reduce the size of popup a bit" then "make the
+        // popup a bit more compact". The widthIn max and the offset's
+        // `popupWidthPx` must stay in sync so the popup's right edge
+        // continues to align with the icon's right edge.
         Box(
             modifier =
                 Modifier
                     .offset {
-                        val popupWidthPx = with(density) { 240.dp.toPx() }.toInt()
+                        val popupWidthPx = with(density) { 220.dp.toPx() }.toInt()
                         val horizontalMarginPx = with(density) { 16.dp.toPx() }.toInt()
                         val verticalOffsetPx = with(density) { 4.dp.toPx() }.toInt()
                         val iconRight = iconBoundsInRoot.right.toInt()
@@ -2189,7 +2215,7 @@ fun AnchoredLyricsOverflowMenu(
                         val y = iconBottom + verticalOffsetPx
                         IntOffset(x = x, y = y)
                     }
-                    .widthIn(max = 240.dp)
+                    .widthIn(max = 220.dp)
                     .heightIn(max = 520.dp)
                     .graphicsLayer {
                         this.alpha = alpha

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -172,6 +172,15 @@ fun LyricsMenu(
     onShowPlayerControlsChange: ((Boolean) -> Unit)? = null,
     onAutoHidePlayerControlsChange: (Boolean) -> Unit = {},
     showControlsToggles: Boolean = true,
+    // When true, the outer `MenuSurfaceSection` card (which is otherwise an
+    // OPAQUE `surfaceContainerLow` Surface) is replaced with a TRANSPARENT
+    // Surface of the same shape. Used by `AnchoredLyricsOverflowMenu` so the
+    // frosted-glass blur applied to the popup's outer Box is NOT hidden by
+    // an opaque white card sitting on top of it. Without this, the user
+    // sees a plain white popup instead of the intended frosted-glass look
+    // (user report 2026-08-30: "the white popup is loading on top of the
+    // liquid glass effect").
+    transparentSurface: Boolean = false,
 ) {
     val context = LocalContext.current
     val showPlayerControls = showPlayerControlsState?.value ?: true
@@ -912,7 +921,19 @@ fun LyricsMenu(
                     ),
                 )
 
-            MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
+            // When `transparentSurface` is true (popup context), use a
+            // transparent Surface so the frosted-glass blur applied to the
+            // popup's outer Box is visible. The opaque `surfaceContainerLow`
+            // background of `MenuSurfaceSection` would otherwise completely
+            // cover the blur — the user reported "the white popup is loading
+            // on top of the liquid glass effect". The transparent surface
+            // keeps the same `extraLarge` corner shape so the rounded clip
+            // still matches the popup's outer clip (no dark gap).
+            Surface(
+                shape = MaterialTheme.shapes.extraLarge,
+                color = if (transparentSurface) Color.Transparent else MaterialTheme.colorScheme.surfaceContainerLow,
+                modifier = Modifier.padding(vertical = 6.dp).fillMaxWidth(),
+            ) {
                 Column(modifier = Modifier.padding(vertical = 4.dp)) {
                     menuItems.forEachIndexed { index, item ->
                         AppleMusicLyricsMenuRow(
@@ -1918,7 +1939,9 @@ private fun AppleMusicLyricsMenuRow(
  * - Anchored to [iconBoundsInRoot.right] x [iconBoundsInRoot.bottom] so the
  *   popup's right edge aligns with the icon's right edge, with the popup
  *   appearing just below the icon.
- * - 280dp max width, 16dp corner radius, frosted-glass background — when the
+ * - 240dp max width (was 280dp, reduced 2026-08-30 per "reduce the size of
+ *   popup a bit" user request), 16dp corner radius, frosted-glass background —
+ *   when the
  *   caller provides a non-null [backdrop] (a kyant [PlatformBackdrop] that
  *   captures the player content behind the popup), the popup samples that
  *   backdrop with a 20dp blur, producing a real "frosted glass" effect that
@@ -2038,6 +2061,12 @@ fun AnchoredLyricsOverflowMenu(
     // (from the initial Animatable values to the new targets) so the
     // animations actually play, unlike the previous animateFloatAsState
     // approach where the first frame was already at the target.
+    //
+    // Damping: `DampingRatioNoBouncy` (was `MediumBouncy`) — user report
+    // 2026-08-30: "I don't want the bounce effect at the end of the opening
+    // animation". The previous medium-bouncy spring produced a visible
+    // overshoot at the end of the scale-in, which the user found jarring.
+    // NoBouncy gives a clean ease-out deceleration with zero overshoot.
     LaunchedEffect(Unit) {
         // Don't play if already dismissing (defensive — shouldn't happen
         // on first composition but guards against edge cases).
@@ -2048,7 +2077,7 @@ fun AnchoredLyricsOverflowMenu(
                 targetValue = 1f,
                 animationSpec =
                     spring(
-                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        dampingRatio = Spring.DampingRatioNoBouncy,
                         stiffness = Spring.StiffnessMediumLow,
                     ),
             )
@@ -2141,16 +2170,15 @@ fun AnchoredLyricsOverflowMenu(
         // where the popup meets the icon the user just tapped. This is
         // the "morph from the overflow icon" effect the user asked for.
         //
-        // No outer dark tint, no border — the inner MenuSurfaceSection
-        // provides the popup's visible surface (opaque surfaceContainerLow
-        // color, extraLarge corner radius). The popup's clip radius
-        // matches the inner card's `MaterialTheme.shapes.extraLarge` so
-        // there's no dark gap around the inner card.
+        // Popup width reduced from 280dp to 240dp per user request
+        // 2026-08-30: "reduce the size of popup a bit". The widthIn max
+        // and the offset's `popupWidthPx` must stay in sync so the popup's
+        // right edge continues to align with the icon's right edge.
         Box(
             modifier =
                 Modifier
                     .offset {
-                        val popupWidthPx = with(density) { 280.dp.toPx() }.toInt()
+                        val popupWidthPx = with(density) { 240.dp.toPx() }.toInt()
                         val horizontalMarginPx = with(density) { 16.dp.toPx() }.toInt()
                         val verticalOffsetPx = with(density) { 4.dp.toPx() }.toInt()
                         val iconRight = iconBoundsInRoot.right.toInt()
@@ -2161,7 +2189,7 @@ fun AnchoredLyricsOverflowMenu(
                         val y = iconBottom + verticalOffsetPx
                         IntOffset(x = x, y = y)
                     }
-                    .widthIn(max = 280.dp)
+                    .widthIn(max = 240.dp)
                     .heightIn(max = 520.dp)
                     .graphicsLayer {
                         this.alpha = alpha
@@ -2195,6 +2223,12 @@ fun AnchoredLyricsOverflowMenu(
             // MenuSurfaceSection card that LyricsMenu draws inside itself
             // is now the popup's only visible surface (we removed the outer
             // dark tint + border above so there's no gap around the card).
+            // Pass transparentSurface = true so the inner MenuSurfaceSection
+            // (an opaque `surfaceContainerLow` card) is replaced with a
+            // transparent surface — otherwise the white popup card sits ON
+            // TOP of the frosted-glass blur and hides it (user report:
+            // "liquid glass effect is behind the white popup but the white
+            // popup is loading on top of it").
             LyricsMenu(
                 lyricsProvider = lyricsProvider,
                 mediaMetadataProvider = mediaMetadataProvider,
@@ -2209,6 +2243,7 @@ fun AnchoredLyricsOverflowMenu(
                 onShowPlayerControlsChange = onShowPlayerControlsChange,
                 onAutoHidePlayerControlsChange = onAutoHidePlayerControlsChange,
                 showControlsToggles = showControlsToggles,
+                transparentSurface = true,
             )
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -12,6 +12,7 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -110,6 +111,9 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.kyant.backdrop.effects.blur
+import com.kyant.backdrop.effects.vibrancy
+import com.kyant.backdrop.drawBackdrop
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -132,8 +136,10 @@ import moe.rukamori.archivetune.db.entities.LyricsEntity
 import moe.rukamori.archivetune.lyrics.AiLyricsRomanization
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.component.LocalLiquidGlassBackdrop
 import moe.rukamori.archivetune.ui.component.MenuSurfaceSection
 import moe.rukamori.archivetune.ui.component.NewMenuItem
+import moe.rukamori.archivetune.ui.component.PlatformBackdrop
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.utils.TranslatorLang
 import moe.rukamori.archivetune.utils.TranslatorLanguages
@@ -1909,17 +1915,29 @@ private fun AppleMusicLyricsMenuRow(
  *
  * ## Visual design
  *
- * - Anchored to [iconBoundsInRoot.right] × [iconBoundsInRoot.bottom] so the
+ * - Anchored to [iconBoundsInRoot.right] x [iconBoundsInRoot.bottom] so the
  *   popup's right edge aligns with the icon's right edge, with the popup
  *   appearing just below the icon.
- * - 280dp max width, 16dp corner radius, 0.7 alpha dark background — the
- *   translucent dark tint over the lyrics view produces the frosted-glass
- *   look (true backdrop blur would require either the parent Box to have
- *   [Modifier.layerBackdrop] or the popup to live in a separate window with
- *   FLAG_BLUR_BEHIND; we approximate the effect with a translucent tint so
- *   it works on all Android versions and stays performant during scroll).
- * - 0.5dp white-at-0.1-alpha border to define the popup edge against busy
- *   backgrounds (matching Apple Music's "Action Sheet" style).
+ * - 280dp max width, 16dp corner radius, frosted-glass background — when the
+ *   caller provides a non-null [backdrop] (a kyant [PlatformBackdrop] that
+ *   captures the player content behind the popup), the popup samples that
+ *   backdrop with a 20dp blur, producing a real "frosted glass" effect that
+ *   shows the blurred album art / lyrics behind it. When [backdrop] is null
+ *   (e.g. on pre-Android-12 or when Liquid Glass is disabled), the popup
+ *   falls back to a translucent dark tint — still visible against any
+ *   background but without the real blur.
+ * - NO outer border and NO outer dark tint around the inner [MenuSurfaceSection]
+ *   card. The previous implementation layered a translucent dark background
+ *   (`Color.Black.copy(alpha = 0.7f)`) and a faint white border AROUND the
+ *   inner [MenuSurfaceSection], which has its own opaque `surfaceContainerLow`
+ *   surface with a different corner radius (`MaterialTheme.shapes.extraLarge`
+ *   ~ 28dp) than the popup's 16dp outer clip. The radius mismatch left a
+ *   visible dark gap around the inner card that the user perceived as a
+ *   "thick black border". The fix: drop the outer dark tint + border, and
+ *   match the popup's clip radius to the inner card's surface shape
+ *   (`extraLarge`) so the inner card fills the popup's entire surface. The
+ *   popup's only visible surface is now the inner card itself — clean,
+ *   single-card appearance matching Apple Music's anchored action sheet.
  *
  * ## Morph animation
  *
@@ -1932,9 +1950,22 @@ private fun AppleMusicLyricsMenuRow(
  * to the icon position), then the parent removes the composable from
  * composition via [onDismiss].
  *
- * The scrim behind the popup fades in/out in lock-step so the user perceives
- * a single coordinated animation rather than scrim-then-popup or
- * popup-then-scrim.
+ * ## Opening animation fix (batch-11)
+ *
+ * The previous implementation used `animateFloatAsState` keyed on the
+ * `dismissed` flag. `animateFloatAsState` initialises its first frame to
+ * the target value (1f for scale, 1f for alpha on enter) — so the OPENING
+ * animation never played; the popup just appeared at full size/opacity
+ * immediately. Only the CLOSING animation played (because the target
+ * changed from 1f to 0f / 0.3f when `dismissed` flipped to true).
+ *
+ * The fix: use [Animatable] initialised to the ENTER values (0.3f scale,
+ * 0f alpha), and a `LaunchedEffect(Unit)` that fires once on first
+ * composition to call `animateTo(1f, ...)` — this is a real state change
+ * from 0.3f -> 1f, so the opening animation plays. A separate
+ * `LaunchedEffect(dismissed)` fires when `dismissed` flips to true and
+ * animates back to the EXIT values (0.3f scale, 0f alpha), then calls
+ * [onDismiss] after the exit animation completes.
  *
  * ## Taps
  *
@@ -1950,6 +1981,14 @@ private fun AppleMusicLyricsMenuRow(
  *   coords.boundsInRoot() }`). The popup's right edge aligns with
  *   [Rect.right] and the popup's top edge sits [Rect.bottom] + 4dp below
  *   the icon's bottom edge.
+ * @param backdrop Optional kyant [PlatformBackdrop] that captures the
+ *   player content behind the popup. When non-null, the popup samples this
+ *   backdrop with a 20dp blur to produce a real frosted-glass effect. The
+ *   backdrop MUST be set up by the caller via [rememberBackdrop] + applied
+ *   to a sibling Box via [Modifier.layerBackdrop] so the popup is NOT
+ *   nested inside the layer-capturing Box (the kyant library warns that
+ *   nesting a drawBackdrop sampler inside the layer-capturing Box creates a
+ *   render-feedback loop that crashes the RuntimeShader).
  * @param onDismiss Called after the exit animation finishes — the parent
  *   should set `showLyricsMenu = false` (or equivalent) in response so the
  *   composable leaves composition.
@@ -1968,45 +2007,113 @@ fun AnchoredLyricsOverflowMenu(
     onShowPlayerControlsChange: ((Boolean) -> Unit)? = null,
     onAutoHidePlayerControlsChange: (Boolean) -> Unit = {},
     showControlsToggles: Boolean = true,
+    backdrop: PlatformBackdrop? = null,
 ) {
     // Local dismissal state — set to true when the user requests dismissal
     // (tap on scrim / a menu item that closes). Drives the exit animation
-    // (alpha → 0, scale → 0.3). The animation's completion is observed by
+    // (alpha -> 0, scale -> 0.3). The animation's completion is observed by
     // a LaunchedEffect which then calls [onDismiss] so the parent removes
     // the composable from composition.
     var dismissed by remember { mutableStateOf(false) }
 
     val density = LocalDensity.current
+    val scope = rememberCoroutineScope()
 
-    // Scale: 0.3 → 1.0 on enter, 1.0 → 0.3 on exit. Spring for a slight
-    // overshoot that matches Apple Music's "morph" feel.
-    val scale by animateFloatAsState(
-        targetValue = if (dismissed) 0.3f else 1f,
-        animationSpec =
-            spring(
-                dampingRatio = Spring.DampingRatioMediumBouncy,
-                stiffness = Spring.StiffnessMediumLow,
-            ),
-        label = "anchored-overflow-scale",
-    )
+    // Scale: starts at 0.3f (small, centred on top-right corner) on first
+    // composition, animates to 1.0f via LaunchedEffect(Unit) below. On
+    // dismissal, animates back to 0.3f. Spring for a slight overshoot that
+    // matches Apple Music's "morph" feel.
+    //
+    // NOTE: Animatable (not animateFloatAsState) is critical here. The
+    // previous implementation used animateFloatAsState which initialises its
+    // first frame to the target value — so the OPENING animation never
+    // played; the popup just appeared at full scale immediately. Animatable
+    // lets us set an explicit initial value (0.3f) and then drive a real
+    // state change (0.3f -> 1f) via LaunchedEffect, which IS animated.
+    val scaleAnim = remember { Animatable(0.3f) }
+    val alphaAnim = remember { Animatable(0f) }
 
-    // Alpha: 0 → 1 on enter, 1 → 0 on exit. Tween so the fade doesn't bounce.
-    // The finishedListener fires once the EXIT animation completes (alpha == 0)
-    // so we can call [onDismiss] and remove the composable from composition.
-    val alpha by animateFloatAsState(
-        targetValue = if (dismissed) 0f else 1f,
-        animationSpec = tween(180),
-        label = "anchored-overflow-alpha",
-    )
+    // Enter animation: fires ONCE on first composition. Animates 0.3f -> 1f
+    // scale and 0f -> 1f alpha in parallel. The state changes are real
+    // (from the initial Animatable values to the new targets) so the
+    // animations actually play, unlike the previous animateFloatAsState
+    // approach where the first frame was already at the target.
+    LaunchedEffect(Unit) {
+        // Don't play if already dismissing (defensive — shouldn't happen
+        // on first composition but guards against edge cases).
+        if (dismissed) return@LaunchedEffect
+        // Animate scale and alpha in parallel via two launched coroutines.
+        val scaleJob = scope.launch {
+            scaleAnim.animateTo(
+                targetValue = 1f,
+                animationSpec =
+                    spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessMediumLow,
+                    ),
+            )
+        }
+        val alphaJob = scope.launch {
+            alphaAnim.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(180),
+            )
+        }
+        scaleJob.join()
+        alphaJob.join()
+    }
 
-    // Trigger onDismiss after exit animation completes — the alpha target is
-    // 0 only during dismissal, and the finishedListener fires when the
-    // animation reaches that target. (Also fires on enter when alpha reaches
-    // 1, but the `dismissed` check ensures we only call onDismiss on the way
-    // OUT.)
-    LaunchedEffect(alpha) {
-        if (dismissed && alpha == 0f) {
-            onDismiss()
+    // Exit animation: fires when `dismissed` flips to true. Animates
+    // 1f -> 0.3f scale and 1f -> 0f alpha, then calls onDismiss after both
+    // complete so the parent removes the composable from composition.
+    LaunchedEffect(dismissed) {
+        if (!dismissed) return@LaunchedEffect
+        val scaleJob = scope.launch {
+            scaleAnim.animateTo(
+                targetValue = 0.3f,
+                animationSpec =
+                    spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = Spring.StiffnessMedium,
+                    ),
+            )
+        }
+        val alphaJob = scope.launch {
+            alphaAnim.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(180),
+            )
+        }
+        scaleJob.join()
+        alphaJob.join()
+        // Both exit animations have completed — tell the parent to remove
+        // us from composition.
+        onDismiss()
+    }
+
+    val scale = scaleAnim.value
+    val alpha = alphaAnim.value
+
+    // Memoize the drawBackdrop modifier chain so it isn't rebuilt on every
+    // recomposition. The chain depends only on `backdrop` — stable across
+    // scroll-driven recompositions of the host screen. Without this,
+    // every recomposition rebuilt the kyant effect stack and re-installed
+    // the RuntimeShader on the GraphicsLayer.
+    val frostedBlurModifier = remember(backdrop) {
+        if (backdrop != null) {
+            Modifier.drawBackdrop(
+                backdrop = backdrop,
+                effects = {
+                    vibrancy()
+                    blur(20f.dp.toPx())
+                },
+                onDrawBackdrop = { drawBackdrop ->
+                    drawBackdrop()
+                },
+                shape = { RoundedCornerShape(16.dp) },
+            )
+        } else {
+            null
         }
     }
 
@@ -2033,6 +2140,12 @@ fun AnchoredLyricsOverflowMenu(
         // scale animation grows from the top-right corner, the corner
         // where the popup meets the icon the user just tapped. This is
         // the "morph from the overflow icon" effect the user asked for.
+        //
+        // No outer dark tint, no border — the inner MenuSurfaceSection
+        // provides the popup's visible surface (opaque surfaceContainerLow
+        // color, extraLarge corner radius). The popup's clip radius
+        // matches the inner card's `MaterialTheme.shapes.extraLarge` so
+        // there's no dark gap around the inner card.
         Box(
             modifier =
                 Modifier
@@ -2056,13 +2169,18 @@ fun AnchoredLyricsOverflowMenu(
                         this.scaleY = scale
                         this.transformOrigin = TransformOrigin(1f, 0f)
                     }
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(Color.Black.copy(alpha = 0.7f * alpha))
-                    .border(
-                        width = 0.5.dp,
-                        color = Color.White.copy(alpha = 0.12f * alpha),
-                        shape = RoundedCornerShape(16.dp),
+                    // Apply the frosted-blur backdrop sampler FIRST
+                    // (before clip + background), so the blur samples the
+                    // full backdrop at the popup's location, then the clip
+                    // + background draw on top. When `backdrop` is null
+                    // (pre-S / Liquid Glass off), fall back to a plain
+                    // translucent dark tint — still visible but without
+                    // the real blur.
+                    .then(
+                        frostedBlurModifier
+                            ?: Modifier.background(Color.Black.copy(alpha = 0.65f * alpha)),
                     )
+                    .clip(MaterialTheme.shapes.extraLarge)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
@@ -2075,10 +2193,8 @@ fun AnchoredLyricsOverflowMenu(
             // composable — same Edit / Refetch / Translate / Romanise /
             // Undo / Search list, same click handlers, same dialogs. The
             // MenuSurfaceSection card that LyricsMenu draws inside itself
-            // is transparent against the popup's dark frosted background,
-            // so the visual result is a flat list of menu rows — matching
-            // Apple Music's anchored action sheet (see screenshot
-            // reference: Screenshot_20260827-235641_Accord.png).
+            // is now the popup's only visible surface (we removed the outer
+            // dark tint + border above so there's no gap around the card).
             LyricsMenu(
                 lyricsProvider = lyricsProvider,
                 mediaMetadataProvider = mediaMetadataProvider,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt
@@ -933,14 +933,16 @@ fun LyricsMenu(
             // keeps the same `extraLarge` corner shape so the rounded clip
             // still matches the popup's outer clip (no dark gap).
             //
-            // Vertical padding 4dp -> 8dp per "redesign the lyrics popup —
-            // match the second reference image" (2026-08-30). The reference
-            // shows generous breathing room above the first row and below
-            // the last row (~24px at reference scale ≈ 8dp at mdpi).
+            // Vertical padding 8dp -> 4dp per "apply the dimensions and
+            // scaling from this commit" (batch-13 reference, 2026-08-31).
+            // The user reported the batch-14 redesign made the popup too
+            // big; reverting to batch-13's compact surface padding while
+            // keeping batch-14's dark-glass visual style (white text,
+            // dark tint, blur, shadow).
             Surface(
                 shape = MaterialTheme.shapes.extraLarge,
                 color = if (transparentSurface) Color.Transparent else MaterialTheme.colorScheme.surfaceContainerLow,
-                modifier = Modifier.padding(vertical = 8.dp).fillMaxWidth(),
+                modifier = Modifier.padding(vertical = 4.dp).fillMaxWidth(),
             ) {
                 Column(modifier = Modifier.padding(vertical = 0.dp)) {
                     menuItems.forEachIndexed { index, item ->
@@ -949,16 +951,17 @@ fun LyricsMenu(
                         )
                         // Hairline divider BETWEEN items only — no divider before the first
                         // or after the last, matching Apple Music's grid-separated look.
-                        // Color: white at 12% opacity (was `outlineVariant`) per reference
-                        //   "Divider lines should be approximately 10–18% white/gray opacity".
-                        // Thickness: 0.5dp -> 1.dp per reference "1 px at reference scale".
-                        // Horizontal padding: 16dp -> 20dp to align with the row's
-                        //   text and icon (both at horizontal = 20.dp now).
+                        // Color: white at 12% opacity per reference "Divider lines
+                        //   should be approximately 10–18% white/gray opacity"
+                        //   (kept from batch-14 visual style).
+                        // Thickness: 1dp -> 0.5dp and horizontal padding 20dp ->
+                        //   16dp per batch-13 dimensions (2026-08-31) — the
+                        //   batch-14 redesign was reported as too big.
                         if (index < menuItems.size - 1) {
                             HorizontalDivider(
                                 color = Color.White.copy(alpha = 0.12f),
-                                thickness = 1.dp,
-                                modifier = Modifier.padding(horizontal = 20.dp),
+                                thickness = 0.5.dp,
+                                modifier = Modifier.padding(horizontal = 16.dp),
                             )
                         }
                     }
@@ -1917,36 +1920,30 @@ private fun AppleMusicLyricsMenuRow(
         }
     val headlineWeight = if (item.isDestructive) FontWeight.SemiBold else FontWeight.Medium
 
-    // Reference row geometry (720x1536 screenshot):
-    //   - each row ~80px tall (~5.2% of screen height)
-    //   - text begins ~30px from popup left edge
-    //   - icon center ~48px from popup right edge
-    //   - icon size ~28-32px
-    //   - text size ~28-30px (≈17-18sp on a typical Android device)
-    //
-    // Mapped to dp/sp using responsive proportions:
-    //   - row min height 56dp (was 44dp, was 56dp via ListItem) — generous
-    //     Apple-Music-style touch target.
-    //   - horizontal padding 20dp (was 16dp) — text starts ~20dp from
-    //     popup edge, matches the reference's ~30px at mdpi.
-    //   - vertical padding 8dp (was 4dp) — keeps the label vertically
-    //     centered within the taller row.
-    //   - icon size 24dp (was 20dp) — matches reference's ~28-32px range.
-    //   - text fontSize 17sp (was 16sp) — matches reference's ~28-30px
-    //     range on a typical xxhdpi Android device.
+    // Row geometry reverted to batch-13 compact dimensions (2026-08-31)
+    // per user report that the batch-14 redesign made the popup too big.
+    // The batch-14 visual style (white text + iOS System Red destructive)
+    // is preserved above — only the dimensions revert:
+    //   - row min height 56dp -> 44dp (batch-13 value; still meets touch
+    //     target guidance).
+    //   - horizontal padding 20dp -> 16dp (batch-13 value).
+    //   - vertical padding 8dp -> 4dp (batch-13 value; tighter row
+    //     breathing room).
+    //   - icon size 24dp -> 20dp (batch-13 value).
+    //   - text fontSize 17sp -> 16sp (batch-13 value).
     val interactionSource = remember { MutableInteractionSource() }
     Row(
         modifier =
             modifier
                 .fillMaxWidth()
-                .heightIn(min = 56.dp)
+                .heightIn(min = 44.dp)
                 .clickable(
                     interactionSource = interactionSource,
                     indication = ripple(),
                     enabled = item.enabled,
                     onClick = item.onClick,
                 )
-                .padding(horizontal = 20.dp, vertical = 8.dp),
+                .padding(horizontal = 16.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -1954,12 +1951,12 @@ private fun AppleMusicLyricsMenuRow(
             text = item.label,
             color = headlineColor,
             fontWeight = headlineWeight,
-            fontSize = 17.sp,
+            fontSize = 16.sp,
         )
         Icon(
             painter = painterResource(item.iconRes),
             contentDescription = null,
-            modifier = Modifier.size(24.dp),
+            modifier = Modifier.size(20.dp),
             tint = iconColor,
         )
     }
@@ -1978,7 +1975,8 @@ private fun AppleMusicLyricsMenuRow(
  * - Anchored to [iconBoundsInRoot.right] x [iconBoundsInRoot.bottom] so the
  *   popup's right edge aligns with the icon's right edge, with the popup
  *   appearing just below the icon.
- * - 65% of screen width (per reference "65% of screen width"), 16dp corner
+ * - 220dp width (compact fixed width per batch-13 reference, restored 2026-08-31
+ *   after batch-14's 65%-of-screen width was reported as too big), 16dp corner
  *   radius (was `MaterialTheme.shapes.extraLarge` ~28dp, reduced 2026-08-30
  *   per reference "24 px corner radius at the reference scale"), frosted-glass
  *   vibrancy background — when the
@@ -2081,15 +2079,10 @@ fun AnchoredLyricsOverflowMenu(
 
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
-    // Per "redesign the lyrics popup — match the second reference image"
-    // (2026-08-30): the reference popup occupies ~65% of screen width and is
-    // positioned toward the RIGHT side of the screen. We capture
-    // `LocalConfiguration.current` here (composable scope) so the offset
-    // lambda (a non-composable `Density.() -> IntOffset`) can compute the
-    // popup's pixel width from the screen's dp width without re-calling the
-    // composable function on every recomposition.
-    val configuration = LocalConfiguration.current
-    val screenWidthDp = configuration.screenWidthDp
+    // NOTE: batch-14 captured `LocalConfiguration.current` here to compute
+    // a 65%-of-screen popup width. batch-15 (2026-08-31) reverts to a fixed
+    // 220dp width per user request "apply the dimensions and scaling from
+    // this commit" (batch-13 reference). The capture is no longer needed.
 
     // Scale: starts at 0.3f (small, centred on top-right corner) on first
     // composition, animates to 1.0f via LaunchedEffect(Unit) below. On
@@ -2230,30 +2223,34 @@ fun AnchoredLyricsOverflowMenu(
         // where the popup meets the icon the user just tapped. This is
         // the "morph from the overflow icon" effect the user asked for.
         //
-        // Per "redesign the lyrics popup — match the second reference image"
-        // (2026-08-30), the popup was widened from `widthIn(max = 220.dp)` to
-        // `fillMaxWidth(0.65f)` (65% of the screen width, matching the
-        // reference popup's ~65% screen-width proportion). The popup remains
-        // anchored to the overflow icon's right edge so the existing
-        // enter/exit scale animation (transformOrigin = top-right) continues
-        // to look like the popup "grows out of" the icon — THE ANIMATION IS
-        // COMPLETELY UNCHANGED.
+        // Per "apply the dimensions and scaling from this commit"
+        // (2026-08-31, batch-13 reference), the popup width reverts from
+        // batch-14's `fillMaxWidth(0.65f)` (65% screen) back to batch-13's
+        // compact `widthIn(max = 220.dp)`. The user reported the batch-14
+        // redesign made the popup too big; we keep batch-14's visual style
+        // (dark-glass material, white text, blur, shadow, red destructive)
+        // but restore batch-13's compact dimensions.
+        //
+        // The popup remains anchored to the overflow icon's right edge so
+        // the existing enter/exit scale animation (transformOrigin =
+        // top-right) continues to look like the popup "grows out of" the
+        // icon — THE ANIMATION IS COMPLETELY UNCHANGED.
         //
         // Visual stack (outermost -> innermost):
         //   1. offset — positions the popup's top-right corner at the icon.
-        //   2. fillMaxWidth(0.65f) — responsive width (65% of screen).
+        //   2. widthIn(max = 220.dp) — compact fixed width (batch-13 value).
         //   3. heightIn(max = 520.dp) — safety bound for tall content.
         //   4. graphicsLayer — UNCHANGED (alpha + scale + transformOrigin).
         //      The animation reads scaleAnim.value / alphaAnim.value and
         //      applies them via this graphicsLayer. Untouched per user spec.
-        //   5. shadow(16.dp, RoundedCornerShape(16.dp)) — NEW: soft elevated
+        //   5. shadow(16.dp, RoundedCornerShape(16.dp)) — soft elevated
         //      shadow per reference "soft shadow, large shadow blur, subtle
         //      depth". Applied AFTER graphicsLayer so the shadow scales +
         //      fades with the popup's enter/exit animation (no janky
         //      full-size shadow during the small-scale enter frame).
         //   6. frostedBlurModifier (or fallback dark tint) — backdrop blur.
-        //   7. background(Color.Black at 55%) — NEW: dark charcoal tint over
-        //      the blur, per reference "dark charcoal/black translucent
+        //   7. background(Color.Black at 55%) — dark charcoal tint over the
+        //      blur, per reference "dark charcoal/black translucent
         //      material". The graphicsLayer's alpha animates this tint in/out.
         //   8. clip(RoundedCornerShape(16.dp)) — was `extraLarge` (~28dp);
         //      reduced to 16dp per reference "24 px corner radius at the
@@ -2263,7 +2260,7 @@ fun AnchoredLyricsOverflowMenu(
             modifier =
                 Modifier
                     .offset {
-                        val popupWidthPx = with(density) { (screenWidthDp * 0.65f).dp.toPx() }.toInt()
+                        val popupWidthPx = with(density) { 220.dp.toPx() }.toInt()
                         val horizontalMarginPx = with(density) { 16.dp.toPx() }.toInt()
                         val verticalOffsetPx = with(density) { 4.dp.toPx() }.toInt()
                         val iconRight = iconBoundsInRoot.right.toInt()
@@ -2274,7 +2271,7 @@ fun AnchoredLyricsOverflowMenu(
                         val y = iconBottom + verticalOffsetPx
                         IntOffset(x = x, y = y)
                     }
-                    .fillMaxWidth(0.65f)
+                    .widthIn(max = 220.dp)
                     .heightIn(max = 520.dp)
                     .graphicsLayer {
                         this.alpha = alpha

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -859,18 +859,26 @@ fun AppleMusicPlayerContent(
     }
 
     BoxWithConstraints(modifier = modifier) {
-        // Inner Box wraps ALL the player content (backdrop + landscape/portrait
-        // layouts) and carries the `Modifier.layerBackdrop(popupBackdrop)` so
-        // the kyant backdrop captures the player content every frame. The
-        // anchored popup (rendered as a SIBLING of this inner Box below)
+        // Inner BoxWithConstraints wraps ALL the player content (backdrop +
+        // landscape/portrait layouts) and carries the
+        // `Modifier.layerBackdrop(popupBackdrop)` so the kyant backdrop
+        // captures the player content every frame. The anchored popup
+        // (rendered as a SIBLING of this inner BoxWithConstraints below)
         // samples from this backdrop with a 20dp blur to produce the real
         // frosted-glass effect — keeping the popup OUT of the layer-capturing
         // Box avoids the kyant render-feedback loop warning.
         //
-        // `matchParentSize()` is a BoxScope modifier — the inner Box is a
-        // direct child of BoxWithConstraints (which IS a BoxScope), so this
-        // works.
-        Box(
+        // BoxWithConstraints (not Box) so the inner content keeps access to
+        // `maxWidth`/`maxHeight` from the BoxWithConstraintsScope — many
+        // child lines (sharpArtworkHeight, fullPlayerHeightForArtwork,
+        // blurBackdropFootprint's remember key, the morph area's nested
+        // BoxWithConstraints) read these. A plain `Box` would shadow the
+        // scope and break the build.
+        //
+        // `matchParentSize()` is a BoxScope modifier — the inner
+        // BoxWithConstraints is a direct child of the outer BoxWithConstraints
+        // (which IS a BoxScope), so this works.
+        BoxWithConstraints(
             modifier =
                 Modifier
                     .matchParentSize()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/AppleMusicPlayer.kt
@@ -80,6 +80,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -92,6 +93,7 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -108,6 +110,8 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToUp
 import kotlin.math.abs
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -153,7 +157,10 @@ import moe.rukamori.archivetune.ui.component.BottomSheetPageState
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.LyricsEnhanced
-import moe.rukamori.archivetune.ui.menu.LyricsMenu
+import moe.rukamori.archivetune.ui.component.PlatformBackdrop
+import moe.rukamori.archivetune.ui.component.layerBackdrop
+import moe.rukamori.archivetune.ui.component.rememberBackdrop
+import moe.rukamori.archivetune.ui.menu.AnchoredLyricsOverflowMenu
 import moe.rukamori.archivetune.ui.menu.PlayerMenu
 import moe.rukamori.archivetune.ui.menu.rememberCastPlayerMenuAction
 import moe.rukamori.archivetune.ui.utils.ShowMediaInfo
@@ -777,31 +784,51 @@ fun AppleMusicPlayerContent(
             playerConnection.player.togglePlayPause()
         }
     }
+
+    // ── Anchored Apple-Music-style overflow popup state ──
+    //
+    // Per user request (2026-08-30) batch-10 & batch-11: "The new overflow
+    // lyrics menu in apple music is a bottom slide up popup. I want it to
+    // be attached to the overflow menu icon like the image was in. it also
+    // has blur/frosted blur behind it. Add it. Also the popup shouldn't
+    // open abruptly. it should play as if it enlarged smoothly from the
+    // overflow menu icon just like the morph animation" (batch-10), then
+    // "i wanted you to redesign the popup in only apple music player style.
+    // Not the non apple music player styles. ... Fix all these and also
+    // revert the redesign for only non apple music player styles"
+    // (batch-11). The Apple Music-style inline player (this file) hosts
+    // the anchored popup; the legacy/non-Apple-Music BottomSheetPlayer
+    // (Player.kt -> LyricsScreen.kt) keeps the original ModalBottomSheet.
+    //
+    // `moreIconBounds` is captured continuously via `onGloballyPositioned`
+    // wired through `AppleMusicChip` -> the more-icon chip's outer Box. The
+    // anchored popup composable uses the most-recently-captured bounds to
+    // position itself anchored to the icon's top-right corner.
+    var showAnchoredLyricsMenu by remember { mutableStateOf(false) }
+    var moreIconBounds by remember { mutableStateOf(Rect.Zero) }
+
+    // Local backdrop that captures the player content behind the popup. The
+    // popup samples this backdrop with a 20dp blur to produce a real
+    // frosted-glass effect (see `AnchoredLyricsOverflowMenu`). The backdrop
+    // is applied via `Modifier.layerBackdrop(...)` to the inner content Box
+    // below, and the popup is rendered as a SIBLING of that inner Box (NOT
+    // nested inside it) — the kyant library warns that nesting a
+    // `drawBackdrop` sampler inside the layer-capturing Box creates a
+    // render-feedback loop that crashes the RuntimeShader.
+    val popupBackdrop: PlatformBackdrop? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            rememberBackdrop(Color.Transparent)
+        } else {
+            null
+        }
+
     val onMoreClick = {
         if (lyricsOpen) {
-            // When lyrics is open, the overflow menu shows lyric actions. The
-            // "Show player controls" / "Auto-hide controls" toggles used to live here
-            // too, but were removed by user request — the controls now always show
-            // and always auto-hide after 5 s. showControlsToggles = false hides those
-            // rows in LyricsMenu.
-            menuState.show {
-                LyricsMenu(
-                    lyricsProvider = { currentLyrics },
-                    mediaMetadataProvider = { mediaMetadata },
-                    lyricsSyncOffset = lyricsSyncOffset,
-                    onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                    // showPlayerControlsState / onShowPlayerControlsChange / onAutoHidePlayerControlsChange
-                    // are no-ops / null because the toggles were removed from the UI. The backing
-                    // preferences are still hardcoded to true in this composable (see
-                    // showLyricsPlayerControls / autoHideLyricsPlayerControls above), so the
-                    // controls always show and always auto-hide after 5 s.
-                    showPlayerControlsState = null,
-                    onShowPlayerControlsChange = null,
-                    onAutoHidePlayerControlsChange = {},
-                    onDismiss = menuState::dismiss,
-                    showControlsToggles = false,
-                )
-            }
+            // When lyrics is open, the overflow menu shows lyric actions.
+            // Per batch-10/11: use the anchored Apple-Music-style popup
+            // (scales up from the more icon with a frosted blur backdrop),
+            // NOT the ModalBottomSheet that the legacy player still uses.
+            showAnchoredLyricsMenu = true
         } else {
             menuState.show {
                 PlayerMenu(
@@ -832,6 +859,29 @@ fun AppleMusicPlayerContent(
     }
 
     BoxWithConstraints(modifier = modifier) {
+        // Inner Box wraps ALL the player content (backdrop + landscape/portrait
+        // layouts) and carries the `Modifier.layerBackdrop(popupBackdrop)` so
+        // the kyant backdrop captures the player content every frame. The
+        // anchored popup (rendered as a SIBLING of this inner Box below)
+        // samples from this backdrop with a 20dp blur to produce the real
+        // frosted-glass effect — keeping the popup OUT of the layer-capturing
+        // Box avoids the kyant render-feedback loop warning.
+        //
+        // `matchParentSize()` is a BoxScope modifier — the inner Box is a
+        // direct child of BoxWithConstraints (which IS a BoxScope), so this
+        // works.
+        Box(
+            modifier =
+                Modifier
+                    .matchParentSize()
+                    .let { base ->
+                        if (popupBackdrop != null) {
+                            base.layerBackdrop(popupBackdrop)
+                        } else {
+                            base
+                        }
+                    },
+        ) {
         val sharpArtworkHeight = if (landscape) maxHeight else maxHeight * 0.55f
         // The FULL player height — used as the artwork sizing reference so the
         // artwork stays a constant size whether the system navigation bar is
@@ -1241,6 +1291,7 @@ fun AppleMusicPlayerContent(
                         onQualityChipClick = {
                             bottomSheetPageState.show { ShowMediaInfo(mediaMetadata.id) }
                         },
+                        onMorePositioned = { moreIconBounds = it },
                         modifier =
                             Modifier
                                 .fillMaxSize()
@@ -1485,6 +1536,7 @@ fun AppleMusicPlayerContent(
                                         // cover radius ensures corners are properly
                                         // rounded from the very first frame.
                                         artworkCornerRadiusDp = artworkCornerRadiusDp,
+                                        onMorePositioned = { moreIconBounds = it },
                                         modifier = Modifier.fillMaxWidth(),
                                     )
                                     if (targetState == AppleMusicPlayerState.QUEUE) {
@@ -1728,6 +1780,7 @@ fun AppleMusicPlayerContent(
                         showTitleRow = !morphOpen,
                         isQueueActive = queueOpen,
                         isLyricsActive = lyricsOpen,
+                        onMorePositioned = { moreIconBounds = it },
                         modifier =
                             Modifier
                                 .fillMaxWidth()
@@ -1741,6 +1794,42 @@ fun AppleMusicPlayerContent(
                     )
                 }
             } // end Column (morph area + controls)
+        }
+        } // end inner layer-capturing Box (player content for the popup backdrop)
+
+        // ── Anchored Apple-Music-style overflow popup ──
+        //
+        // Rendered as a SIBLING of the inner layer-capturing Box above so
+        // the popup's `Modifier.drawBackdrop(popupBackdrop, ...)` samples
+        // the backdrop (which captures the player content) WITHOUT nesting
+        // inside the layer-capturing Box — that nesting pattern is what the
+        // kyant library warns creates a render-feedback loop. The popup is
+        // in composition only when the user taps the more icon while lyrics
+        // is open (see `onMoreClick`); the popup itself manages its own
+        // enter/exit animations and calls `onDismiss` after the exit
+        // animation completes so the parent sets `showAnchoredLyricsMenu =
+        // false` and the composable leaves composition.
+        //
+        // `moreIconBounds` is captured continuously by the
+        // `onGloballyPositioned` wired into the more-icon `AppleMusicChip`
+        // invocations at the two `onMoreClick` call sites below (landscape
+        // + portrait layouts). The popup positions itself anchored to the
+        // icon's top-right corner via `Modifier.offset { ... }` (see
+        // `AnchoredLyricsOverflowMenu`).
+        if (showAnchoredLyricsMenu) {
+            AnchoredLyricsOverflowMenu(
+                iconBoundsInRoot = moreIconBounds,
+                lyricsProvider = { currentLyrics },
+                mediaMetadataProvider = { mediaMetadata },
+                lyricsSyncOffset = lyricsSyncOffset,
+                onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
+                showPlayerControlsState = null,
+                onShowPlayerControlsChange = null,
+                onAutoHidePlayerControlsChange = {},
+                onDismiss = { showAnchoredLyricsMenu = false },
+                showControlsToggles = false,
+                backdrop = popupBackdrop,
+            )
         }
     }
 }
@@ -2006,6 +2095,11 @@ private fun AppleMusicControlsColumn(
     isQueueActive: Boolean = false,
     // Whether the in-place lyrics view is currently open. Highlights the lyrics button.
     isLyricsActive: Boolean = false,
+    // Optional callback for capturing the more-icon chip's on-screen Rect
+    // (via `boundsInRoot()`). The Apple-Music-style anchored overflow popup
+    // uses this to position itself anchored to the icon's top-right corner.
+    // Null when the anchored popup is not in use (e.g. legacy callers).
+    onMorePositioned: ((Rect) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     var swipeUpAccumulated by remember { mutableFloatStateOf(0f) }
@@ -2147,6 +2241,7 @@ private fun AppleMusicControlsColumn(
                 tint = Color.White,
                 contentDescription = null,
                 onClick = onMoreClick,
+                onPositioned = onMorePositioned,
             )
         }
     }
@@ -2295,12 +2390,27 @@ private fun AppleMusicChip(
     tint: Color,
     contentDescription: String?,
     onClick: () -> Unit,
+    // Optional callback invoked whenever the chip's layout position changes.
+    // Used by the more-icon chip to capture its on-screen Rect (via
+    // `boundsInRoot()`) so the anchored overflow popup can position itself
+    // anchored to the icon's top-right corner. Null for chips that don't
+    // need position tracking (the default).
+    onPositioned: ((Rect) -> Unit)? = null,
 ) {
     Box(
         contentAlignment = Alignment.Center,
         modifier =
             Modifier
                 .size(AppleMusicChipSize)
+                .let { base ->
+                    if (onPositioned != null) {
+                        base.onGloballyPositioned { coords ->
+                            onPositioned(coords.boundsInRoot())
+                        }
+                    } else {
+                        base
+                    }
+                }
                 .clip(CircleShape)
                 .background(Color.White.copy(alpha = 0.14f))
                 .clickable(onClick = onClick),
@@ -2401,6 +2511,11 @@ private fun SharedTransitionScope.AppleMusicMiniHeader(
     // radius so corners look properly rounded on the large cover bounds at
     // the start of the morph. See the call site for the full rationale.
     artworkCornerRadiusDp: Dp = 16.dp,
+    // Optional callback for capturing the more-icon chip's on-screen Rect
+    // (via `boundsInRoot()`). The Apple-Music-style anchored overflow popup
+    // uses this to position itself anchored to the icon's top-right corner.
+    // Null when the anchored popup is not in use.
+    onMorePositioned: ((Rect) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -2526,6 +2641,7 @@ private fun SharedTransitionScope.AppleMusicMiniHeader(
             tint = Color.White,
             contentDescription = null,
             onClick = onMoreClick,
+            onPositioned = onMorePositioned,
         )
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -148,7 +148,6 @@ import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.LocalMenuState
 import moe.rukamori.archivetune.ui.component.LyricsEnhanced
 import moe.rukamori.archivetune.ui.component.PlayerSliderTrack
-import moe.rukamori.archivetune.ui.menu.AnchoredLyricsOverflowMenu
 import moe.rukamori.archivetune.ui.menu.LyricsMenu
 import moe.rukamori.archivetune.ui.theme.PlayerColorExtractor
 import moe.rukamori.archivetune.ui.theme.PlayerPaletteCache
@@ -553,29 +552,29 @@ fun LyricsScreen(
         }
     }
 
-    // ── Anchored overflow popup state ──
-    // The previous implementation used `menuState.show { LyricsMenu(...) }`
-    // which opened a Material3 ModalBottomSheet (slide-up from bottom). Per
-    // user request (2026-08-30): "The new overflow lyrics menu in apple music
-    // is a bottom slide up popup. I want it to be attached to the overflow
-    // menu icon like the image was in. it also has blur/frosted blur behind
-    // it. Add it. Also the popup shouldn't open abruptly. it should play as
-    // if it enlarged smoothly from the overflow menu icon just like the
-    // morph animation" — we now use [AnchoredLyricsOverflowMenu], which
-    // renders an Apple-Music-style anchored popup that scales up from the
-    // overflow icon with a frosted-glass background.
-    var showAnchoredLyricsMenu by remember { mutableStateOf(false) }
-    var lyricsMenuIconBounds by remember {
-        mutableStateOf(androidx.compose.ui.geometry.Rect.Zero)
-    }
-
+    // ── Lyrics overflow menu ──
+    // The standalone LyricsScreen is invoked from the legacy/non-Apple-Music
+    // BottomSheetPlayer (see Player.kt:2679). Per user request (2026-08-30)
+    // batch-11: "i wanted you to redesign the popup in only apple music player
+    // style. Not the non apple music player styles. ... revert the redesign for
+    // only non apple music player styles" — this screen uses the original
+    // ModalBottomSheet (`menuState.show { LyricsMenu(...) }`) slide-up popup
+    // that was used before the batch-10 anchored-popup redesign. The Apple
+    // Music-style inline player (AppleMusicPlayer.kt) keeps the anchored popup.
     val showLyricsMenu = {
-        // Captured icon bounds are stored in `lyricsMenuIconBounds` via the
-        // `onMorePositioned` callback wired through AppleMusicTrackHeader →
-        // AppleMusicHeaderIconButton → onGloballyPositioned. When the user
-        // taps the icon we just flip the visibility flag — the anchored
-        // popup composable uses the most-recently-captured bounds.
-        showAnchoredLyricsMenu = true
+        menuState.show {
+            LyricsMenu(
+                lyricsProvider = { currentLyrics },
+                mediaMetadataProvider = { mediaMetadata },
+                lyricsSyncOffset = lyricsSyncOffset,
+                onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
+                showPlayerControlsState = null,
+                onShowPlayerControlsChange = null,
+                onAutoHidePlayerControlsChange = {},
+                onDismiss = menuState::dismiss,
+                showControlsToggles = false,
+            )
+        }
     }
 
     val isLoading = playbackState == STATE_BUFFERING || sliderPosition != null
@@ -703,7 +702,6 @@ fun LyricsScreen(
                     onDismissClick = onBackClick,
                     isLiked = currentSongLiked,
                     onToggleLike = playerConnection::toggleLike,
-                    onMorePositioned = { rect -> lyricsMenuIconBounds = rect },
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -825,25 +823,6 @@ fun LyricsScreen(
                 }
             }
             }
-        }
-        // Anchored Apple-Music-style overflow popup. Rendered as the last
-        // child of the lyrics screen's root Box so it overlays every other
-        // child (background / lyrics / controls / header). The popup itself
-        // manages its own enter/exit animations; the parent only gates whether
-        // it's in composition at all.
-        if (showAnchoredLyricsMenu) {
-            AnchoredLyricsOverflowMenu(
-                iconBoundsInRoot = lyricsMenuIconBounds,
-                lyricsProvider = { currentLyrics },
-                mediaMetadataProvider = { mediaMetadata },
-                lyricsSyncOffset = lyricsSyncOffset,
-                onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
-                showPlayerControlsState = null,
-                onShowPlayerControlsChange = null,
-                onAutoHidePlayerControlsChange = {},
-                onDismiss = { showAnchoredLyricsMenu = false },
-                showControlsToggles = false,
-            )
         }
     }
 }
@@ -1288,7 +1267,6 @@ private fun AppleMusicTrackHeader(
     modifier: Modifier = Modifier,
     isLiked: Boolean = false,
     onToggleLike: () -> Unit = {},
-    onMorePositioned: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null,
 ) {
     val artistText =
         remember(mediaMetadata.id, mediaMetadata.artists) {
@@ -1379,7 +1357,6 @@ private fun AppleMusicTrackHeader(
             contentDescription = stringResource(R.string.more_options),
             foregroundColor = foregroundColor,
             onClick = onMoreClick,
-            onPositioned = onMorePositioned,
         )
     }
 }
@@ -1390,37 +1367,11 @@ private fun AppleMusicHeaderIconButton(
     contentDescription: String,
     foregroundColor: Color,
     onClick: () -> Unit,
-    onPositioned: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null,
 ) {
     Box(
         modifier =
             Modifier
                 .size(48.dp)
-                .let { base ->
-                    if (onPositioned != null) {
-                        // `boundsInRoot()` isn't available on this Compose
-                        // version (only `positionInRoot(): Offset` and `size:
-                        // IntSize` are). Compute the Rect from those two —
-                        // positionInRoot gives the top-left of the layout in
-                        // root coordinates, and the layout's size is the
-                        // 48dp Box dimensions.
-                        base.onGloballyPositioned { coords ->
-                            val pos = coords.positionInRoot()
-                            val sz = coords.size
-                            onPositioned(
-                                androidx.compose.ui.geometry.Rect(
-                                    offset = pos,
-                                    size = androidx.compose.ui.geometry.Size(
-                                        width = sz.width.toFloat(),
-                                        height = sz.height.toFloat(),
-                                    ),
-                                ),
-                            )
-                        }
-                    } else {
-                        base
-                    }
-                }
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = ripple(bounded = false, radius = 24.dp),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/artist/ArtistScreen.kt
@@ -758,7 +758,75 @@ fun ArtistScreen(
                 }
 
                 // Content sections
-                if (showLocal) {
+                //
+                // Per user report (2026-08-30) batch-11: "When I open an artist
+                // page i initially see nothing on the artist screen. After two
+                // seconds it loads completely." Root cause: `artistPage` is null
+                // during the silent auto-fetch that runs on screen open (it's
+                // NOT a manual pull-to-refresh, so `isManuallyRefreshing` is
+                // false). The header renders immediately because it falls back
+                // to `libraryArtist` (the cached artist entity from the local
+                // database), but `orderedRemoteSections` is empty (it's derived
+                // from `artistPage?.sections`), so the rest of the screen is
+                // blank for ~2 seconds while the remote fetch completes.
+                //
+                // Fix: render a shimmer skeleton for the content sections
+                // whenever `!showLocal && artistPage == null && !isManuallyRefreshing`
+                // — i.e., the silent auto-fetch is still in flight. The shimmer
+                // mirrors the typical artist-page layout (section title + 5 song
+                // rows) so the user perceives a loading state instead of an empty
+                // screen. The existing manual-refresh shimmer (line ~434 above)
+                // already handles the pull-to-refresh case; this handles the
+                // auto-fetch case that was missed.
+                if (!showLocal && artistPage == null && !isManuallyRefreshing) {
+                    item(key = "auto_fetch_shimmer") {
+                        ShimmerHost {
+                            Column(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                            ) {
+                                // Section title placeholder ("Top songs" / "Latest release")
+                                TextPlaceholder(
+                                    height = 18.dp,
+                                    modifier = Modifier.fillMaxWidth(0.35f),
+                                )
+                                Spacer(modifier = Modifier.height(12.dp))
+                                // 5 song row placeholders — matches the `take(5)` cap
+                                // on the Local Songs Section and the typical Top Songs
+                                // section row count.
+                                repeat(5) {
+                                    ListItemPlaceHolder()
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                }
+                                Spacer(modifier = Modifier.height(16.dp))
+                                // Second section title placeholder ("Albums" / "Singles")
+                                TextPlaceholder(
+                                    height = 18.dp,
+                                    modifier = Modifier.fillMaxWidth(0.30f),
+                                )
+                                Spacer(modifier = Modifier.height(12.dp))
+                                // Horizontal album-row placeholders
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    repeat(3) {
+                                        Box(
+                                            modifier =
+                                                Modifier
+                                                    .size(width = 120.dp, height = 144.dp)
+                                                    .clip(RoundedCornerShape(8.dp))
+                                                    .shimmer()
+                                                    .background(MaterialTheme.colorScheme.surfaceContainerLow),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else if (showLocal) {
                     // Local Songs Section
                     if (librarySongs.isNotEmpty()) {
                         item {


### PR DESCRIPTION
## Overview

Cumulative dev->main PR. Tracks two batches:

- **batch-11** (popup/lyrics/artist fixes): merged into dev as 31fb56cdb via PR #207.
- **batch-12** (popup blur/size/bounce fixes): added as 7b7a88829 on top of dev.

---

## Batch-12 — Popup blur/size/bounce fixes (latest)

User request (2026-08-30):
> 1. I think the liquid glass effect is behind the white popup but the white popup is loading on top of it. Fix it.
> 2. Also reduce the size of popup a bit
> 3. I don't want the bounce effect at the end of the opening animation

### Root cause (blur hidden)

The inner `LyricsMenu` rendered `MenuSurfaceSection` (an opaque `surfaceContainerLow` Surface) inside `AnchoredLyricsOverflowMenu`. The frosted-glass blur (`Modifier.drawBackdrop(backdrop, blur(20.dp))`) is applied to the popup's **outer** Box, BEFORE the inner surface is drawn. The opaque inner card therefore sat ON TOP of the blur and completely hid it — the user saw a plain white popup.

### Changes

File: `app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/LyricsMenu.kt` (45+/10-)

- New `transparentSurface: Boolean = false` param on `LyricsMenu`.
- Replaced the single `MenuSurfaceSection(modifier = ...)` call with a `Surface(shape = extraLarge, color = if (transparentSurface) Color.Transparent else surfaceContainerLow, ...)` — preserves the exact same `extraLarge` corner shape so the inner surface's clip matches the popup's outer clip (no dark gap, no border).
- `AnchoredLyricsOverflowMenu` now passes `transparentSurface = true` to the inner `LyricsMenu`.
- Popup max width reduced **280dp -> 240dp** per "reduce the size of popup a bit" (both `popupWidthPx` in offset calc and `widthIn(max = ...)` constraint — kept in sync so the popup's right edge continues to align with the overflow icon's right edge).
- Opening-animation spring damping changed **`MediumBouncy` -> `NoBouncy`** per "I don't want the bounce effect at the end of the opening animation". Exit animation already used `NoBouncy` — unchanged.

### Non-popup callers unaffected

`LyricsMenu` is also called from:
- `LyricsScreen.kt:566` (non-popup ModalBottomSheet path) — keeps `transparentSurface = false` default, retains the opaque `surfaceContainerLow` surface card.
- `AppleMusicPlayer.kt:792` — comment-only reference (no actual call).

So the standalone lyrics screen and any non-popup lyrics menu still render the original opaque card. Only the Apple-Music-style anchored popup uses the transparent surface.

---

## Batch-11 — popup/lyrics/artist fixes (already on dev)

1. Anchored overflow popup: moved from `LyricsScreen` (legacy BottomSheetPlayer) to `AppleMusicPlayer` (Apple-Music-style inline player). `LyricsScreen` reverts to ModalBottomSheet. So the popup redesign is now scoped to the Apple Music player style only (per user request).
2. `AnchoredLyricsOverflowMenu` bug fixes: opening animation now plays (Animatable), real frosted blur via `drawBackdrop`, removed black border.
3. Lyrics position adjustments.
4. Artist page blank-on-open fix.

---

## CI

Build verification depends on GitHub Actions CI (no local Android SDK).